### PR TITLE
Revert backend HTTP route structure to pre-coverage layout

### DIFF
--- a/packages/athena-webapp/convex/http.ts
+++ b/packages/athena-webapp/convex/http.ts
@@ -4,7 +4,9 @@ import { auth } from "./auth";
 import { HonoWithConvex, HttpRouterWithHono } from "convex-helpers/server/hono";
 import { ActionCtx } from "./_generated/server";
 import {
+  analyticsRoutes,
   authRoutes,
+  bannerMessageRoutes,
   categoryRoutes,
   orgRoutes,
   productRoutes,
@@ -12,15 +14,23 @@ import {
   subcategoryRoutes,
 } from "./http/domains/inventory/routes";
 import {
-  checkoutRoutes,
-  e2eRoutes,
-  paystackRoutes,
+  onlineOrderRoutes,
   userRoutes,
+  bagRoutes,
+  checkoutRoutes,
+  meRoutes,
+  upsellRoutes,
+  reviewRoutes,
+  rewardsRoutes,
+  paystackRoutes,
+  storefrontRoutes,
+  offersRoutes,
+  userOffersRoutes,
 } from "./http/domains/storeFront/routes";
 import { httpRouter } from "convex/server";
 import { guestRoutes } from "./http/domains/storeFront/routes/guest";
 import { colorRoutes } from "./http/domains/inventory/routes/colors";
-import { HOST_URL, SITE_URL } from "./env";
+import { savedBagRoutes } from "./http/domains/storeFront/routes/savedBag";
 
 const app: HonoWithConvex<ActionCtx> = new Hono();
 
@@ -28,61 +38,62 @@ const http = httpRouter();
 
 auth.addHttpRoutes(http);
 
-const allowedOrigins = new Set(
-  [
-    SITE_URL,
-    HOST_URL,
-    "http://localhost:3000",
-    "http://localhost:5173",
-    "https://jovial-wildebeest-179.convex.site",
-  ].filter((origin): origin is string => Boolean(origin))
-);
-
 app.use(
   "*",
   cors({
-    origin: Array.from(allowedOrigins),
-    allowHeaders: ["Content-Type", "Authorization", "x-athena-actor-token"],
-    allowMethods: ["OPTIONS", "GET", "POST", "PUT", "DELETE"],
+    origin: (origin) => {
+      return origin;
+    },
+    allowMethods: ["OPTIONS", "GET", "POST", "PUT", "PATCH", "DELETE"],
     credentials: true,
   })
 );
 
+app.route("/upsells", upsellRoutes);
+
+app.route("/stores", storeRoutes);
+
+app.route("/storefront", storefrontRoutes);
+
 app.route("/webhooks/paystack", paystackRoutes);
+
+app.route("/analytics", analyticsRoutes);
 
 app.route("/auth", authRoutes);
 
+app.route("/banner-message", bannerMessageRoutes);
+
 app.route("/organizations", orgRoutes);
 
-app.route("/organizations/:organizationId/stores", storeRoutes);
+app.route("/bags", bagRoutes);
 
-app.route(
-  "/organizations/:organizationId/stores/:storeId/products",
-  productRoutes
-);
+app.route("/savedBags", savedBagRoutes);
 
-app.route(
-  "/organizations/:organizationId/stores/:storeId/categories",
-  categoryRoutes
-);
+app.route("/products", productRoutes);
 
-app.route(
-  "/organizations/:organizationId/stores/:storeId/subcategories",
-  subcategoryRoutes
-);
+app.route("/categories", categoryRoutes);
 
-app.route("/organizations/:organizationId/stores/:storeId/colors", colorRoutes);
+app.route("/subcategories", subcategoryRoutes);
 
-app.route("/organizations/:organizationId/stores/:storeId/guests", guestRoutes);
+app.route("/colors", colorRoutes);
 
-app.route("/organizations/:organizationId/stores/:storeId/users", userRoutes);
+app.route("/guests", guestRoutes);
 
-app.route(
-  "/organizations/:organizationId/stores/:storeId/checkout",
-  checkoutRoutes
-);
+app.route("/users", userRoutes);
 
-app.route("/organizations/:organizationId/stores/:storeId/e2e", e2eRoutes);
+app.route("/checkout", checkoutRoutes);
+
+app.route("/orders", onlineOrderRoutes);
+
+app.route("/reviews", reviewRoutes);
+
+app.route("/me", meRoutes);
+
+app.route("/rewards", rewardsRoutes);
+
+app.route("/offers", offersRoutes);
+
+app.route("/user-offers", userOffersRoutes);
 
 app.get("/.well-known/openid-configuration", async (c) => {
   const [httpAction] = http.lookup(

--- a/packages/athena-webapp/convex/http/domains/inventory/routes/auth.ts
+++ b/packages/athena-webapp/convex/http/domains/inventory/routes/auth.ts
@@ -2,34 +2,61 @@ import { Hono } from "hono";
 import { HonoWithConvex } from "convex-helpers/server/hono";
 import { ActionCtx } from "../../../../_generated/server";
 import { api } from "../../../../_generated/api";
+import {
+  getStoreDataFromRequest,
+  getStorefrontUserFromRequest,
+} from "../../../utils";
+import { Id } from "../../../../_generated/dataModel";
+import { deleteCookie, getCookie, setCookie } from "hono/cookie";
 
 const authRoutes: HonoWithConvex<ActionCtx> = new Hono();
 
 authRoutes.post("/verify", async (c) => {
+  const { storeId, organizationId } = getStoreDataFromRequest(c);
+
+  const userId = getStorefrontUserFromRequest(c);
+
   const { email, firstName, lastName, code } = await c.req.json();
 
-  // if (code) {
-  //   try {
-  //     const res = await c.env.runMutation(api.storeFront.auth.verifyCode, {
-  //       code,
-  //       email,
-  //       storeId: storeId as Id<"store">,
-  //       organizationId: organizationId as Id<"organization">,
-  //     });
+  if (!storeId || !organizationId) {
+    return c.json({ error: "Store or organization id missing" }, 404);
+  }
 
-  //     return c.json(res);
-  //   } catch (e) {
-  //     return c.json({ error: (e as Error).message }, 400);
-  //   }
-  // }
+  if (code) {
+    try {
+      const res = await c.env.runMutation(api.storeFront.auth.verifyCode, {
+        code,
+        email,
+        storeId: storeId as Id<"store">,
+        organizationId: organizationId as Id<"organization">,
+        userId,
+      });
+
+      if (res.user) {
+        setCookie(c, "user_id", res.user._id, {
+          path: "/",
+          secure: true,
+          domain: "wigclub.store",
+          httpOnly: true,
+          sameSite: "None",
+          maxAge: 90 * 24 * 60 * 60, // 90 days in seconds
+        });
+      }
+
+      return c.json(res);
+    } catch (e) {
+      return c.json({ error: (e as Error).message }, 400);
+    }
+  }
 
   if (email) {
     const res = await c.env.runAction(
-      api.inventory.auth.sendVerificationCodeViaProvider,
+      api.storeFront.auth.sendVerificationCodeViaProvider,
       {
         email,
         firstName,
         lastName,
+        storeId: storeId as Id<"store">,
       }
     );
 
@@ -37,6 +64,25 @@ authRoutes.post("/verify", async (c) => {
   }
 
   return c.json({});
+});
+
+authRoutes.post("/logout", async (c) => {
+  setCookie(c, "user_id", "", {
+    path: "/",
+    secure: true,
+    domain: "wigclub.store",
+    httpOnly: true,
+    sameSite: "None",
+    maxAge: 0, // Expires immediately
+  });
+
+  console.log("deleted cookie");
+
+  const co = getCookie(c, "user_id");
+
+  console.log("cookie: ", co);
+
+  return c.json({ success: true });
 });
 
 export { authRoutes };

--- a/packages/athena-webapp/convex/http/domains/inventory/routes/stores.ts
+++ b/packages/athena-webapp/convex/http/domains/inventory/routes/stores.ts
@@ -1,38 +1,92 @@
 import { Hono } from "hono";
 import { HonoWithConvex } from "convex-helpers/server/hono";
 import { ActionCtx } from "../../../../_generated/server";
-import { api, internal } from "../../../../_generated/api";
+import { api } from "../../../../_generated/api";
 import { Id } from "../../../../_generated/dataModel";
-import { enforceActorAccess } from "../../storeFront/routes/actorAuth";
+import {
+  getStoreDataFromRequest,
+  getStorefrontUserFromRequest,
+} from "../../../utils";
 
 const storeRoutes: HonoWithConvex<ActionCtx> = new Hono();
 
-storeRoutes.use("/:storeId/users/:userId", async (c, next) => {
-  const response = await enforceActorAccess(c, "userId");
-  if (response) {
-    return response;
+storeRoutes.get("/promoCodes", async (c) => {
+  const { storeId } = getStoreDataFromRequest(c);
+
+  if (!storeId) {
+    return c.json({ error: "Store id missing" }, 404);
   }
-  await next();
-});
 
-storeRoutes.use("/:storeId/users/:userId/*", async (c, next) => {
-  const response = await enforceActorAccess(c, "userId");
-  if (response) {
-    return response;
+  try {
+    const res = await c.env.runQuery(api.inventory.promoCode.getAll, {
+      storeId: storeId,
+    });
+
+    return c.json(res);
+  } catch (e) {
+    return c.json({ error: (e as Error).message }, 400);
   }
-  await next();
 });
 
-storeRoutes.post("/", async (c) => {
-  const data = await c.req.json();
+storeRoutes.get("/promoCodeItems", async (c) => {
+  const { storeId } = getStoreDataFromRequest(c);
 
-  return c.json({});
+  if (!storeId) {
+    return c.json({ error: "Store id missing" }, 404);
+  }
+
+  try {
+    const res = await c.env.runQuery(api.inventory.promoCode.getAllItems, {
+      storeId: storeId,
+    });
+
+    return c.json(res);
+  } catch (e) {
+    return c.json({ error: (e as Error).message }, 400);
+  }
 });
 
-storeRoutes.get("/", async (c) => {
-  const organizationId = c.req.param("organizationId");
+storeRoutes.get("/redeemedPromoCodes", async (c) => {
+  const userId = getStorefrontUserFromRequest(c);
 
-  return c.json({});
+  if (!userId) {
+    return c.json({ error: "Customer id missing" }, 404);
+  }
+
+  try {
+    const res = await c.env.runQuery(
+      api.inventory.promoCode.getRedeemedPromoCodesForUser,
+      {
+        storeFrontUserId: userId as Id<"storeFrontUser"> | Id<"guest">,
+      }
+    );
+
+    return c.json(res);
+  } catch (e) {
+    return c.json({ error: (e as Error).message }, 400);
+  }
+});
+
+storeRoutes.post("/promoCodes", async (c) => {
+  const userId = getStorefrontUserFromRequest(c);
+
+  if (!userId) {
+    return c.json({ error: "Customer id missing" }, 404);
+  }
+
+  const { code, checkoutSessionId } = await c.req.json();
+
+  try {
+    const res = await c.env.runMutation(api.inventory.promoCode.redeem, {
+      code,
+      storeFrontUserId: userId as Id<"storeFrontUser"> | Id<"guest">,
+      checkoutSessionId: checkoutSessionId as Id<"checkoutSession">,
+    });
+
+    return c.json(res);
+  } catch (e) {
+    return c.json({ error: (e as Error).message }, 400);
+  }
 });
 
 storeRoutes.get("/:storeId", async (c) => {
@@ -53,505 +107,6 @@ storeRoutes.get("/:storeId", async (c) => {
   }
 
   return c.json(store);
-});
-
-storeRoutes.put("/:storeId", async (c) => {
-  const { storeId } = c.req.param();
-
-  const data = await c.req.json();
-
-  return c.json({});
-});
-
-storeRoutes.delete("/:storeId", async (c) => {
-  const { storeId } = c.req.param();
-
-  return c.json({});
-});
-
-storeRoutes.post("/:storeId/auth/verify", async (c) => {
-  const organizationId = c.req.param("organizationId");
-  const { storeId } = c.req.param();
-  const { email, firstName, lastName, code } = await c.req.json();
-
-  if (code) {
-    try {
-      const res = await c.env.runMutation(api.storeFront.auth.verifyCode, {
-        code,
-        email,
-        storeId: storeId as Id<"store">,
-        organizationId: organizationId as Id<"organization">,
-      });
-
-      return c.json(res);
-    } catch (e) {
-      return c.json({ error: (e as Error).message }, 400);
-    }
-  }
-
-  if (email) {
-    const res = await c.env.runAction(
-      api.storeFront.auth.sendVerificationCodeViaProvider,
-      {
-        email,
-        firstName,
-        lastName,
-        storeId: storeId as Id<"store">,
-      }
-    );
-
-    return c.json(res);
-  }
-
-  return c.json({});
-});
-
-// users
-storeRoutes.get("/:storeId/users", async (c) => {
-  return c.json({});
-});
-
-// Get a specific bag
-storeRoutes.get("/:storeId/users/:userId/bags/:bagId", async (c) => {
-  const { bagId, storeId } = c.req.param();
-
-  if (bagId == "active") {
-    const userId = c.req.param("userId");
-
-    if (!userId) {
-      return c.json({ error: "Customer id missing" }, 404);
-    }
-
-    const bag = await c.env.runQuery(api.storeFront.bag.getByUserId, {
-      storeFrontUserId: userId as Id<"storeFrontUser"> | Id<"guest">,
-    });
-
-    if (!bag) {
-      const b = await c.env.runMutation(api.storeFront.bag.create, {
-        storeFrontUserId: userId as Id<"storeFrontUser"> | Id<"guest">,
-        storeId: storeId as Id<"store">,
-      });
-
-      return c.json(b);
-    }
-    return c.json(bag);
-  }
-
-  return c.json({});
-});
-
-// Create a new bag
-storeRoutes.post("/:storeId/users/:userId/bags", async (c) => {
-  const { userId } = await c.req.json();
-  return c.json({});
-});
-
-// Delete a bag
-storeRoutes.delete("/:storeId/users/:userId/bags/:bagId", async (c) => {
-  const { bagId } = c.req.param();
-  return c.json({});
-});
-
-// Get all items in a bag
-storeRoutes.get("/:storeId/users/:userId/bags/:bagId/items", async (c) => {
-  const { bagId } = c.req.param();
-  return c.json({});
-});
-
-storeRoutes.post("/:storeId/users/:userId/bags/:bagId/items", async (c) => {
-  const { bagId, userId } = c.req.param();
-  const { productId, productSkuId, quantity, productSku } = await c.req.json();
-
-  // console.table({ productId, quantity, price });
-
-  const b = await c.env.runMutation(api.storeFront.bagItem.addItemToBag, {
-    productId: productId as Id<"product">,
-    quantity,
-    storeFrontUserId: userId as Id<"storeFrontUser"> | Id<"guest">,
-    bagId: bagId as Id<"bag">,
-    productSkuId: productSkuId as Id<"productSku">,
-    productSku,
-  });
-
-  return c.json(b);
-});
-
-// Update the owner of the bag
-storeRoutes.post("/:storeId/users/:userId/bags/:bagId/owner", async (c) => {
-  try {
-    const { userId } = c.req.param();
-    const { currentOwnerId, newOwnerId } = await c.req.json();
-
-    if (currentOwnerId !== userId) {
-      return c.json({ error: "Forbidden." }, 403);
-    }
-
-    const b = await c.env.runMutation(api.storeFront.bag.updateOwner, {
-      currentOwner: currentOwnerId as Id<"guest">,
-      newOwner: newOwnerId as Id<"storeFrontUser">,
-    });
-    return c.json(b);
-  } catch (e) {
-    return c.json({ error: "Internal server error" }, 400);
-  }
-});
-
-// Update an item in a bag
-storeRoutes.put(
-  "/:storeId/users/:userId/bags/:bagId/items/:itemId",
-  async (c) => {
-    const { itemId } = c.req.param();
-    const { quantity } = await c.req.json();
-
-    const b = await c.env.runMutation(api.storeFront.bagItem.updateItemInBag, {
-      quantity,
-      itemId: itemId as Id<"bagItem">,
-    });
-    return c.json(b);
-  }
-);
-
-// Delete an item from a bag
-storeRoutes.delete(
-  "/:storeId/users/:userId/bags/:bagId/items/:itemId",
-  async (c) => {
-    const { itemId } = c.req.param();
-
-    await c.env.runMutation(api.storeFront.bagItem.deleteItemFromBag, {
-      itemId: itemId as Id<"bagItem">,
-    });
-
-    return c.json({ success: true });
-  }
-);
-
-// Get a specific saved bag
-storeRoutes.get("/:storeId/users/:userId/savedBags/:savedBagId", async (c) => {
-  const { savedBagId, storeId } = c.req.param();
-
-  if (savedBagId == "active") {
-    const userId = c.req.param("userId");
-
-    if (!userId) {
-      return c.json({ error: "Customer id missing" }, 404);
-    }
-
-    const savedBag = await c.env.runQuery(api.storeFront.savedBag.getByUserId, {
-      storeFrontUserId: userId as Id<"storeFrontUser"> | Id<"guest">,
-    });
-
-    if (!savedBag) {
-      const b = await c.env.runMutation(api.storeFront.savedBag.create, {
-        storeFrontUserId: userId as Id<"storeFrontUser"> | Id<"guest">,
-        storeId: storeId as Id<"store">,
-      });
-
-      return c.json(b);
-    }
-    return c.json(savedBag);
-  }
-
-  return c.json({});
-});
-
-// Create a new bag
-storeRoutes.post("/:storeId/users/:userId/savedBags", async (c) => {
-  const { userId } = await c.req.json();
-  return c.json({});
-});
-
-// Delete a bag
-storeRoutes.delete(
-  "/:storeId/users/:userId/savedBags/:savedBagId",
-  async (c) => {
-    const { savedBagId } = c.req.param();
-    return c.json({});
-  }
-);
-
-// Get all items in a saved bag
-storeRoutes.get(
-  "/:storeId/users/:userId/savedBags/:savedBagId/items",
-  async (c) => {
-    const { savedBagId } = c.req.param();
-    return c.json({});
-  }
-);
-
-storeRoutes.post(
-  "/:storeId/users/:userId/savedBags/:savedBagId/items",
-  async (c) => {
-    const { savedBagId, userId } = c.req.param();
-    const { productId, productSkuId, quantity, productSku } =
-      await c.req.json();
-
-    const b = await c.env.runMutation(
-      api.storeFront.savedBagItem.addItemToBag,
-      {
-        productId: productId as Id<"product">,
-        quantity,
-        storeFrontUserId: userId as Id<"storeFrontUser"> | Id<"guest">,
-        savedBagId: savedBagId as Id<"savedBag">,
-        productSkuId: productSkuId as Id<"productSku">,
-        productSku,
-      }
-    );
-
-    return c.json(b);
-  }
-);
-
-// Update an item in a saved bag
-storeRoutes.put(
-  "/:storeId/users/:userId/savedBags/:savedBagId/items/:itemId",
-  async (c) => {
-    const { savedBagId, itemId } = c.req.param();
-    const { quantity } = await c.req.json();
-
-    const b = await c.env.runMutation(
-      api.storeFront.savedBagItem.updateItemInBag,
-      {
-        quantity,
-        itemId: itemId as Id<"savedBagItem">,
-      }
-    );
-    return c.json(b);
-  }
-);
-
-// Update the owner of the bag
-storeRoutes.post(
-  "/:storeId/users/:userId/savedBags/:savedBagId/owner",
-  async (c) => {
-    try {
-      const { userId } = c.req.param();
-      const { currentOwnerId, newOwnerId } = await c.req.json();
-
-      if (currentOwnerId !== userId) {
-        return c.json({ error: "Forbidden." }, 403);
-      }
-
-      const b = await c.env.runMutation(api.storeFront.savedBag.updateOwner, {
-        currentOwner: currentOwnerId as Id<"guest">,
-        newOwner: newOwnerId as Id<"storeFrontUser">,
-      });
-      return c.json(b);
-    } catch (e) {
-      return c.json({ error: "Internal server error" }, 400);
-    }
-  }
-);
-
-// Delete an item from a bag
-storeRoutes.delete(
-  "/:storeId/users/:userId/savedBags/:savedBagId/items/:itemId",
-  async (c) => {
-    const { itemId } = c.req.param();
-
-    await c.env.runMutation(
-      api.storeFront.savedBagItem.deleteItemFromSavedBag,
-      {
-        itemId: itemId as Id<"savedBagItem">,
-      }
-    );
-
-    return c.json({ success: true });
-  }
-);
-
-storeRoutes.post("/:storeId/users/:userId/checkout", async (c) => {
-  const { storeId } = c.req.param();
-
-  const userId = c.req.param("userId");
-
-  if (!userId) {
-    return c.json({ error: "Customer id missing" }, 404);
-  }
-
-  const { products, bagId, amount } = await c.req.json();
-
-  try {
-    const session = await c.env.runMutation(
-      api.storeFront.checkoutSession.create,
-      {
-        storeId: storeId as Id<"store">,
-        storeFrontUserId: userId as Id<"storeFrontUser"> | Id<"guest">,
-        products,
-        bagId,
-        amount,
-      }
-    );
-
-    return c.json(session);
-  } catch (e) {
-    return c.json({ error: (e as Error).message }, 400);
-  }
-});
-
-storeRoutes.post(
-  "/:storeId/users/:userId/checkout/:checkoutSessionId",
-  async (c) => {
-    const { checkoutSessionId } = c.req.param();
-
-    const userId = c.req.param("userId");
-
-    if (!userId) {
-      return c.json({ error: "Customer id missing" }, 404);
-    }
-
-    const {
-      customerEmail,
-      amount,
-      hasCompletedCheckoutSession,
-      action,
-      orderDetails,
-    } = await c.req.json();
-
-    try {
-      if (action == "finalize-payment") {
-        const payment = await c.env.runAction(
-          api.storeFront.payment.createTransaction,
-          {
-            customerEmail,
-            amount,
-            checkoutSessionId: checkoutSessionId as Id<"checkoutSession">,
-            orderDetails,
-          }
-        );
-
-        return c.json(payment);
-      }
-
-      if (action == "complete-checkout") {
-        const res = await c.env.runMutation(
-          internal.storeFront.checkoutSession.updateCheckoutSession,
-          {
-            id: checkoutSessionId as Id<"checkoutSession">,
-            hasCompletedCheckoutSession,
-            orderDetails,
-          }
-        );
-
-        return c.json(res);
-      }
-
-      if (action == "place-order") {
-        const res = await c.env.runMutation(
-          internal.storeFront.checkoutSession.updateCheckoutSession,
-          {
-            id: checkoutSessionId as Id<"checkoutSession">,
-            hasCompletedCheckoutSession,
-            action,
-          }
-        );
-
-        return c.json(res);
-      }
-
-      if (action == "cancel-order") {
-        const res = await c.env.runAction(
-          api.storeFront.checkoutSession.cancelOrder,
-          {
-            id: checkoutSessionId as Id<"checkoutSession">,
-          }
-        );
-
-        return c.json(res);
-      }
-
-      return c.json({});
-    } catch (e) {
-      return c.json({ error: (e as Error).message }, 400);
-    }
-  }
-);
-
-storeRoutes.get("/:storeId/users/:userId/checkout/active", async (c) => {
-  const { userId } = c.req.param();
-
-  const session = await c.env.runQuery(
-    api.storeFront.checkoutSession.getActiveCheckoutSession,
-    {
-      storeFrontUserId: userId as Id<"storeFrontUser"> | Id<"guest">,
-    }
-  );
-
-  return c.json(session);
-});
-
-storeRoutes.get("/:storeId/users/:userId/checkout/pending", async (c) => {
-  const { userId } = c.req.param();
-
-  const session = await c.env.runQuery(
-    api.storeFront.checkoutSession.getPendingCheckoutSessions,
-    { storeFrontUserId: userId as Id<"storeFrontUser"> | Id<"guest"> }
-  );
-
-  return c.json(session);
-});
-
-storeRoutes.get("/:storeId/users/:userId/checkout/:sessionId", async (c) => {
-  const { sessionId } = c.req.param();
-
-  const session = await c.env.runQuery(api.storeFront.checkoutSession.getById, {
-    sessionId: sessionId as Id<"checkoutSession">,
-  });
-
-  return c.json(session);
-});
-
-storeRoutes.get(
-  "/:storeId/users/:userId/checkout/verify/:reference",
-  async (c) => {
-    const { userId, reference } = c.req.param();
-
-    const res = await c.env.runAction(api.storeFront.payment.verifyPayment, {
-      storeFrontUserId: userId as Id<"storeFrontUser"> | Id<"guest">,
-      externalReference: reference,
-    });
-
-    return c.json(res);
-  }
-);
-
-storeRoutes.get("/:storeId/users/:userId/orders", async (c) => {
-  const { userId } = c.req.param();
-
-  const orders = await c.env.runQuery(api.storeFront.onlineOrder.getAll, {
-    storeFrontUserId: userId as Id<"storeFrontUser"> | Id<"guest">,
-  });
-
-  return c.json(orders);
-});
-
-storeRoutes.get("/:storeId/users/:userId/orders/:orderId", async (c) => {
-  const { orderId } = c.req.param();
-
-  const order = await c.env.runQuery(api.storeFront.onlineOrder.get, {
-    identifier: orderId as Id<"onlineOrder">,
-  });
-
-  return c.json(order);
-});
-
-// Update the owner of the bag
-storeRoutes.post("/:storeId/users/:userId/orders/owner", async (c) => {
-  try {
-    const { userId } = c.req.param();
-    const { currentOwnerId, newOwnerId } = await c.req.json();
-
-    if (currentOwnerId !== userId) {
-      return c.json({ error: "Forbidden." }, 403);
-    }
-
-    const b = await c.env.runMutation(api.storeFront.onlineOrder.updateOwner, {
-      currentOwner: currentOwnerId as Id<"guest">,
-      newOwner: newOwnerId as Id<"storeFrontUser">,
-    });
-    return c.json(b);
-  } catch (e) {
-    return c.json({ error: "Internal server error" }, 400);
-  }
 });
 
 export { storeRoutes };

--- a/packages/athena-webapp/convex/http/domains/storeFront/routes/index.ts
+++ b/packages/athena-webapp/convex/http/domains/storeFront/routes/index.ts
@@ -11,4 +11,3 @@ export * from "./reviews";
 export { rewardsRoutes } from "./rewards";
 export * from "./offers";
 export * from "./userOffers";
-export * from "./e2e";

--- a/packages/athena-webapp/convex/http/domains/storeFront/routes/user.ts
+++ b/packages/athena-webapp/convex/http/domains/storeFront/routes/user.ts
@@ -3,34 +3,41 @@ import { HonoWithConvex } from "convex-helpers/server/hono";
 import { ActionCtx } from "../../../../_generated/server";
 import { api } from "../../../../_generated/api";
 import { Id } from "../../../../_generated/dataModel";
-import { enforceActorAccess } from "./actorAuth";
+import { getCookie } from "hono/cookie";
+import { getStorefrontUserFromRequest } from "../../../utils";
 
 const userRoutes: HonoWithConvex<ActionCtx> = new Hono();
-
-userRoutes.use("/:userId", async (c, next) => {
-  const response = await enforceActorAccess(c, "userId");
-  if (response) {
-    return response;
-  }
-  await next();
-});
-
-userRoutes.use("/:userId/*", async (c, next) => {
-  const response = await enforceActorAccess(c, "userId");
-  if (response) {
-    return response;
-  }
-  await next();
-});
 
 userRoutes.get("/:userId", async (c) => {
   const { userId } = c.req.param();
 
-  const user = await c.env.runQuery(api.storeFront.user.getById, {
-    id: userId as Id<"storeFrontUser">,
-  });
+  if (userId == "me") {
+    const userId = getCookie(c, "user_id");
 
-  return c.json(user);
+    if (!userId) {
+      return c.json(null, 200);
+    }
+
+    try {
+      const user = await c.env.runQuery(api.storeFront.user.getById, {
+        id: userId as Id<"storeFrontUser">,
+      });
+
+      return c.json(user);
+    } catch (e) {
+      return c.json({ error: (e as Error).message }, 400);
+    }
+  }
+
+  try {
+    const user = await c.env.runQuery(api.storeFront.user.getById, {
+      id: userId as Id<"storeFrontUser">,
+    });
+
+    return c.json(user);
+  } catch (e) {
+    return c.json({ error: (e as Error).message }, 400);
+  }
 });
 
 userRoutes.put("/:userId", async (c) => {
@@ -44,6 +51,28 @@ userRoutes.put("/:userId", async (c) => {
     shippingAddress,
     billingAddress,
   } = await c.req.json();
+
+  if (userId == "me") {
+    // const userId = getCookie(c, "user_id");
+
+    const userId = getStorefrontUserFromRequest(c);
+
+    if (!userId) {
+      return c.json(null, 200);
+    }
+
+    const user = await c.env.runMutation(api.storeFront.user.update, {
+      id: userId as Id<"storeFrontUser">,
+      email,
+      firstName,
+      lastName,
+      shippingAddress,
+      billingAddress,
+      phoneNumber,
+    });
+
+    return c.json(user);
+  }
 
   const user = await c.env.runMutation(api.storeFront.user.update, {
     id: userId as Id<"storeFrontUser">,

--- a/packages/athena-webapp/convex/http/utils.ts
+++ b/packages/athena-webapp/convex/http/utils.ts
@@ -1,35 +1,17 @@
 import { Context } from "hono";
 import { getCookie } from "hono/cookie";
 import { Id } from "../_generated/dataModel";
-import { getActorClaims } from "./domains/storeFront/routes/actorAuth";
 
-export const getStoreDataFromRequest = async (c: Context) => {
+export const getStoreDataFromRequest = (c: Context) => {
   const organizationId = getCookie(c, "organization_id") as Id<"organization">;
   const storeId = getCookie(c, "store_id") as Id<"store">;
 
-  if (organizationId && storeId) {
-    return { organizationId, storeId };
-  }
-
-  const claims = await getActorClaims(c);
-
-  return {
-    organizationId: (organizationId ?? claims?.organizationId) as
-      | Id<"organization">
-      | undefined,
-    storeId: (storeId ?? claims?.storeId) as Id<"store"> | undefined,
-  };
+  return { organizationId, storeId };
 };
 
-export const getStorefrontUserFromRequest = async (c: Context) => {
+export const getStorefrontUserFromRequest = (c: Context) => {
   const userId = getCookie(c, "user_id") as Id<"storeFrontUser">;
   const guestId = getCookie(c, "guest_id") as Id<"guest">;
 
-  if (userId || guestId) {
-    return userId || guestId;
-  }
-
-  const claims = await getActorClaims(c);
-
-  return claims?.actorId as Id<"storeFrontUser"> | Id<"guest"> | undefined;
+  return userId || guestId;
 };


### PR DESCRIPTION
## Summary
- restore backend HTTP mount points in packages/athena-webapp/convex/http.ts from nested organization/store paths back to the prior flat routes
- revert inventory/storefront route modules touched by the coverage refactor so endpoint behavior matches the previous structure
- remove e2eRoutes export/wiring from the storefront route index and top-level HTTP router

## Files changed
- packages/athena-webapp/convex/http.ts
- packages/athena-webapp/convex/http/domains/inventory/routes/stores.ts
- packages/athena-webapp/convex/http/domains/inventory/routes/auth.ts
- packages/athena-webapp/convex/http/domains/storeFront/routes/user.ts
- packages/athena-webapp/convex/http/domains/storeFront/routes/index.ts
- packages/athena-webapp/convex/http/utils.ts

## Validation
- ran: bun run test -- convex/http/domains
- result: 119 passed / 14 failed
- failures are in coverage tests that currently assert the newer nested/actor-auth/e2e route structure and need alignment with this rollback
