### PR TITLE
PR1: Store config V2 backend foundation + compatibility layer

### DIFF
--- a/packages/athena-webapp/convex/cloudflare/stream.ts
+++ b/packages/athena-webapp/convex/cloudflare/stream.ts
@@ -1,6 +1,7 @@
 import { action } from "../_generated/server";
 import { v } from "convex/values";
 import { api } from "../_generated/api";
+import { normalizeStoreConfig } from "../inventory/storeConfigV2";
 
 const CLOUDFLARE_API_BASE = "https://api.cloudflare.com/client/v4";
 
@@ -148,7 +149,8 @@ export const addStreamReelVersion = action({
       throw new Error("Store not found");
     }
 
-    const existingReels: any[] = store.config?.streamReels || [];
+    const normalizedConfig = normalizeStoreConfig(store.config);
+    const existingReels: any[] = normalizedConfig.media.reels.streamReels || [];
 
     // Auto-increment version
     const maxVersion: number = existingReels.reduce(
@@ -166,11 +168,14 @@ export const addStreamReelVersion = action({
       createdAt: Date.now(),
     };
 
-    await ctx.runMutation(api.inventory.stores.updateConfig, {
+    await ctx.runMutation(api.inventory.stores.patchConfigV2, {
       id: args.storeId,
-      config: {
-        ...store.config,
-        streamReels: [...existingReels, newReel],
+      patch: {
+        media: {
+          reels: {
+            streamReels: [...existingReels, newReel],
+          },
+        },
       },
     });
 
@@ -195,7 +200,8 @@ export const deleteStreamReelVersion = action({
       throw new Error("Store not found");
     }
 
-    const existingReels: any[] = store.config?.streamReels || [];
+    const normalizedConfig = normalizeStoreConfig(store.config);
+    const existingReels: any[] = normalizedConfig.media.reels.streamReels || [];
     const reelToDelete = existingReels.find(
       (r: { version: number }) => r.version === args.version,
     );
@@ -224,18 +230,21 @@ export const deleteStreamReelVersion = action({
     );
 
     // If the deleted version was active, clear it
-    const updatedConfig: Record<string, any> = {
-      ...store.config,
-      streamReels: updatedReels,
+    const patch: Record<string, any> = {
+      media: {
+        reels: {
+          streamReels: updatedReels,
+        },
+      },
     };
-    if (store.config?.activeStreamReel === args.version) {
-      delete updatedConfig.activeStreamReel;
-      delete updatedConfig.activeStreamReelHlsUrl;
+    if (normalizedConfig.media.reels.activeVersion === args.version) {
+      patch.media.reels.activeVersion = null;
+      patch.media.reels.activeHlsUrl = null;
     }
 
-    await ctx.runMutation(api.inventory.stores.updateConfig, {
+    await ctx.runMutation(api.inventory.stores.patchConfigV2, {
       id: args.storeId,
-      config: updatedConfig,
+      patch,
     });
 
     return { success: true };
@@ -260,7 +269,8 @@ export const setActiveStreamReel = action({
       throw new Error("Store not found");
     }
 
-    const existingReels: any[] = store.config?.streamReels || [];
+    const normalizedConfig = normalizeStoreConfig(store.config);
+    const existingReels: any[] = normalizedConfig.media.reels.streamReels || [];
     const reel = existingReels.find(
       (r: { version: number }) => r.version === args.version,
     );
@@ -269,12 +279,15 @@ export const setActiveStreamReel = action({
       throw new Error("Reel version not found");
     }
 
-    await ctx.runMutation(api.inventory.stores.updateConfig, {
+    await ctx.runMutation(api.inventory.stores.patchConfigV2, {
       id: args.storeId,
-      config: {
-        ...store.config,
-        activeStreamReel: args.version,
-        activeStreamReelHlsUrl: args.hlsUrl,
+      patch: {
+        media: {
+          reels: {
+            activeVersion: args.version,
+            activeHlsUrl: args.hlsUrl,
+          },
+        },
       },
     });
 

--- a/packages/athena-webapp/convex/http/domains/storeFront/routes/checkout.ts
+++ b/packages/athena-webapp/convex/http/domains/storeFront/routes/checkout.ts
@@ -7,6 +7,7 @@ import {
   getStorefrontUserFromRequest,
 } from "../../../utils";
 import { Id } from "../../../../_generated/dataModel";
+import { isStoreCheckoutDisabled } from "../../../../inventory/storeConfigV2";
 
 const checkoutRoutes: HonoWithConvex<ActionCtx> = new Hono();
 
@@ -94,10 +95,7 @@ checkoutRoutes.post("/:checkoutSessionId", async (c) => {
 
       const { config } = store || {};
 
-      if (
-        config?.availability?.inMaintenanceMode ||
-        config?.visibility?.inReadOnlyMode
-      ) {
+      if (isStoreCheckoutDisabled(config)) {
         return c.json({
           success: false,
           message: "Store checkout is currently not available",
@@ -216,10 +214,7 @@ checkoutRoutes.post("/:checkoutSessionId", async (c) => {
 
       const { config } = store || {};
 
-      if (
-        config?.availability?.inMaintenanceMode ||
-        config?.visibility?.inReadOnlyMode
-      ) {
+      if (isStoreCheckoutDisabled(config)) {
         return c.json({
           success: false,
           message: "Store checkout is currently not available",

--- a/packages/athena-webapp/convex/inventory/storeConfigV2.test.ts
+++ b/packages/athena-webapp/convex/inventory/storeConfigV2.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it } from "vitest";
+import {
+  isStoreCheckoutDisabled,
+  mirrorLegacyKeys,
+  patchV2Config,
+  toV2Config,
+} from "./storeConfigV2";
+
+const legacyConfigSample = {
+  activeStreamReel: 2,
+  activeStreamReelHlsUrl:
+    "https://customer.cloudflarestream.com/70d86c67/manifest/video.m3u8",
+  availability: {
+    inMaintenanceMode: false,
+  },
+  contactInfo: {
+    location: "2 Jungle Avenue, East Legon, Accra, Ghana",
+    phoneNumber: "+233249771887",
+  },
+  deliveryFees: {
+    international: 800,
+    otherRegions: 70,
+    withinAccra: 40,
+  },
+  fulfillment: {
+    deliveryRestriction: {
+      isActive: false,
+      message: "",
+      reason: "",
+    },
+    disableDelivery: false,
+    disableStorePickup: false,
+    enableDelivery: true,
+    enableStorePickup: true,
+    pickupRestriction: {
+      isActive: false,
+      message: "",
+      reason: "",
+    },
+  },
+  homeHero: {
+    displayType: "reel",
+    headerImage: "https://example.com/header.webp",
+    showOverlay: false,
+    showText: false,
+  },
+  landingPageReelVersion: "3",
+  leaveAReviewDiscountCodeModalPromoCode: {
+    discountType: "percentage",
+    displayText: "30%",
+    promoCodeId: "promo-code-id",
+    value: 30,
+  },
+  maintenance: {
+    countdownEndsAt: 1760875200000,
+    message: "We are stocking products for our clearance sale.",
+  },
+  reelVersions: ["1", "2", "3"],
+  shopTheLookImage: "https://example.com/shop-look.webp",
+  showroomImage: "https://example.com/show-room.webp",
+  streamReels: [
+    {
+      createdAt: 1774422243082,
+      hlsUrl: "https://customer.cloudflarestream.com/d88e985/manifest/video.m3u8",
+      source: "stream",
+      streamUid: "d88e985",
+      thumbnailUrl: "https://customer.cloudflarestream.com/d88e985/thumb.jpg",
+      version: 1,
+    },
+    {
+      createdAt: 1774757837641,
+      hlsUrl: "https://customer.cloudflarestream.com/70d86c67/manifest/video.m3u8",
+      source: "stream",
+      streamUid: "70d86c67",
+      thumbnailUrl: "https://customer.cloudflarestream.com/70d86c67/thumb.jpg",
+      version: 2,
+    },
+  ],
+  tax: {
+    enabled: false,
+    includedInPrice: false,
+    name: "VAT",
+    rate: 9,
+  },
+  ui: {
+    fallbackImageUrl: "https://example.com/fallback.webp",
+  },
+  visibility: {
+    inReadOnlyMode: false,
+  },
+  waiveDeliveryFees: {
+    all: false,
+    international: false,
+    otherRegions: false,
+    withinAccra: false,
+  },
+};
+
+describe("storeConfigV2 helpers", () => {
+  it("projects legacy config into the expected V2 grouped shape", () => {
+    expect(toV2Config(legacyConfigSample)).toEqual({
+      operations: {
+        availability: { inMaintenanceMode: false },
+        visibility: { inReadOnlyMode: false },
+        maintenance: {
+          countdownEndsAt: 1760875200000,
+          message: "We are stocking products for our clearance sale.",
+        },
+      },
+      commerce: {
+        deliveryFees: {
+          international: 800,
+          otherRegions: 70,
+          withinAccra: 40,
+        },
+        waiveDeliveryFees: {
+          all: false,
+          international: false,
+          otherRegions: false,
+          withinAccra: false,
+        },
+        fulfillment: {
+          deliveryRestriction: {
+            isActive: false,
+            message: "",
+            reason: "",
+          },
+          disableDelivery: false,
+          disableStorePickup: false,
+          enableDelivery: true,
+          enableStorePickup: true,
+          pickupRestriction: {
+            isActive: false,
+            message: "",
+            reason: "",
+          },
+        },
+        tax: {
+          enabled: false,
+          includedInPrice: false,
+          name: "VAT",
+          rate: 9,
+        },
+      },
+      media: {
+        homeHero: {
+          displayType: "reel",
+          headerImage: "https://example.com/header.webp",
+          showOverlay: false,
+          showText: false,
+        },
+        reels: {
+          activeVersion: 2,
+          activeHlsUrl:
+            "https://customer.cloudflarestream.com/70d86c67/manifest/video.m3u8",
+          landingPageVersion: "3",
+          versions: ["1", "2", "3"],
+          streamReels: [
+            {
+              createdAt: 1774422243082,
+              hlsUrl:
+                "https://customer.cloudflarestream.com/d88e985/manifest/video.m3u8",
+              source: "stream",
+              streamUid: "d88e985",
+              thumbnailUrl: "https://customer.cloudflarestream.com/d88e985/thumb.jpg",
+              version: 1,
+            },
+            {
+              createdAt: 1774757837641,
+              hlsUrl:
+                "https://customer.cloudflarestream.com/70d86c67/manifest/video.m3u8",
+              source: "stream",
+              streamUid: "70d86c67",
+              thumbnailUrl: "https://customer.cloudflarestream.com/70d86c67/thumb.jpg",
+              version: 2,
+            },
+          ],
+        },
+        images: {
+          fallbackImageUrl: "https://example.com/fallback.webp",
+          shopTheLookImage: "https://example.com/shop-look.webp",
+          showroomImage: "https://example.com/show-room.webp",
+        },
+      },
+      promotions: {
+        leaveAReviewDiscountCodeModalPromoCode: {
+          discountType: "percentage",
+          displayText: "30%",
+          promoCodeId: "promo-code-id",
+          value: 30,
+        },
+      },
+      contact: {
+        location: "2 Jungle Avenue, East Legon, Accra, Ghana",
+        phoneNumber: "+233249771887",
+      },
+    });
+  });
+
+  it("mirrors grouped values back to legacy keys during interim write-through", () => {
+    const v2Config = toV2Config(legacyConfigSample);
+    const mirrored = mirrorLegacyKeys(v2Config, {
+      ...legacyConfigSample,
+      customUnmappedKey: { keep: true },
+    });
+
+    expect(mirrored.operations).toEqual(v2Config.operations);
+    expect(mirrored.commerce).toEqual(v2Config.commerce);
+    expect(mirrored.media).toEqual(v2Config.media);
+    expect(mirrored.promotions).toEqual(v2Config.promotions);
+    expect(mirrored.contact).toEqual(v2Config.contact);
+
+    expect(mirrored.activeStreamReel).toBe(2);
+    expect(mirrored.activeStreamReelHlsUrl).toBe(
+      "https://customer.cloudflarestream.com/70d86c67/manifest/video.m3u8",
+    );
+    expect(mirrored.homeHero).toEqual(v2Config.media.homeHero);
+    expect(mirrored.deliveryFees).toEqual(v2Config.commerce.deliveryFees);
+    expect(mirrored.customUnmappedKey).toEqual({ keep: true });
+
+    const cleared = mirrorLegacyKeys(
+      patchV2Config(mirrored, {
+        media: {
+          reels: {
+            activeVersion: null,
+            activeHlsUrl: null,
+          },
+        },
+      }),
+      mirrored,
+    );
+
+    expect(cleared).not.toHaveProperty("activeStreamReel");
+    expect(cleared).not.toHaveProperty("activeStreamReelHlsUrl");
+  });
+
+  it("evaluates checkout maintenance/read-only gating for legacy and V2 configs", () => {
+    const legacyMaintenanceConfig = {
+      availability: { inMaintenanceMode: true },
+      visibility: { inReadOnlyMode: false },
+    };
+
+    const v2ReadOnlyConfig = {
+      operations: {
+        availability: { inMaintenanceMode: false },
+        visibility: { inReadOnlyMode: true },
+      },
+    };
+
+    const activeConfig = {
+      availability: { inMaintenanceMode: false },
+      visibility: { inReadOnlyMode: false },
+    };
+
+    expect(isStoreCheckoutDisabled(legacyMaintenanceConfig)).toBe(true);
+    expect(isStoreCheckoutDisabled(v2ReadOnlyConfig)).toBe(true);
+    expect(isStoreCheckoutDisabled(activeConfig)).toBe(false);
+  });
+});

--- a/packages/athena-webapp/convex/inventory/storeConfigV2.ts
+++ b/packages/athena-webapp/convex/inventory/storeConfigV2.ts
@@ -1,0 +1,547 @@
+import {
+  StoreConfigV2,
+  StoreWaiveDeliveryFeesConfig,
+  StorePromotionConfig,
+} from "../../types";
+
+const LEGACY_ROOT_KEYS = [
+  "activeStreamReel",
+  "activeStreamReelHlsUrl",
+  "availability",
+  "contactInfo",
+  "deliveryFees",
+  "fulfillment",
+  "heroDisplayType",
+  "heroHeaderImage",
+  "heroShowOverlay",
+  "heroShowText",
+  "homeHero",
+  "homepageDiscountCodeModalPromoCode",
+  "landingPageReelVersion",
+  "leaveAReviewDiscountCodeModalPromoCode",
+  "maintenance",
+  "reelVersions",
+  "shopTheLookImage",
+  "showroomImage",
+  "streamReels",
+  "tax",
+  "ui",
+  "visibility",
+  "waiveDeliveryFees",
+] as const;
+
+const V2_ROOT_KEYS = [
+  "operations",
+  "commerce",
+  "media",
+  "promotions",
+  "contact",
+] as const;
+
+const LEGACY_ROOT_KEY_SET = new Set<string>(LEGACY_ROOT_KEYS);
+const V2_ROOT_KEY_SET = new Set<string>(V2_ROOT_KEYS);
+
+export const KNOWN_STORE_CONFIG_ROOT_KEYS = new Set<string>([
+  ...LEGACY_ROOT_KEYS,
+  ...V2_ROOT_KEYS,
+]);
+
+const isPlainObject = (value: unknown): value is Record<string, any> => {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+};
+
+const asRecord = (value: unknown): Record<string, any> => {
+  return isPlainObject(value) ? value : {};
+};
+
+const asNumber = (value: unknown): number | undefined => {
+  return typeof value === "number" ? value : undefined;
+};
+
+const asString = (value: unknown): string | undefined => {
+  return typeof value === "string" ? value : undefined;
+};
+
+const asBoolean = (value: unknown): boolean | undefined => {
+  return typeof value === "boolean" ? value : undefined;
+};
+
+const asArray = <T>(
+  value: unknown,
+  mapper: (item: unknown) => T | undefined,
+): T[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .map(mapper)
+    .filter((item): item is T => item !== undefined);
+};
+
+const asOptionalArray = <T>(
+  value: unknown,
+  mapper: (item: unknown) => T | undefined,
+): T[] | undefined => {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  return asArray(value, mapper);
+};
+
+const firstDefined = <T>(...values: Array<T | undefined | null>): T | undefined => {
+  for (const value of values) {
+    if (value !== undefined && value !== null) {
+      return value;
+    }
+  }
+
+  return undefined;
+};
+
+const mapPromotion = (value: unknown): StorePromotionConfig | undefined => {
+  return isPlainObject(value) ? { ...value } : undefined;
+};
+
+const mapStreamReel = (value: unknown) => {
+  if (!isPlainObject(value)) {
+    return undefined;
+  }
+
+  const version = asNumber(value.version);
+  if (version === undefined) {
+    return undefined;
+  }
+
+  return {
+    version,
+    source: asString(value.source),
+    streamUid: asString(value.streamUid),
+    hlsUrl: asString(value.hlsUrl),
+    thumbnailUrl: asString(value.thumbnailUrl),
+    createdAt: asNumber(value.createdAt),
+  };
+};
+
+const normalizeWaiveDeliveryFees = (
+  value: unknown,
+): StoreWaiveDeliveryFeesConfig => {
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  const record = asRecord(value);
+
+  return {
+    all: asBoolean(record.all),
+    international: asBoolean(record.international),
+    otherRegions: asBoolean(record.otherRegions),
+    withinAccra: asBoolean(record.withinAccra),
+  };
+};
+
+const cleanUndefined = <T extends Record<string, any>>(value: T): T => {
+  const next = { ...value };
+
+  for (const [key, fieldValue] of Object.entries(next)) {
+    if (fieldValue === undefined) {
+      delete next[key as keyof T];
+    }
+  }
+
+  return next;
+};
+
+export const toV2Config = (config: unknown): StoreConfigV2 => {
+  const root = asRecord(config);
+
+  const operations = asRecord(root.operations);
+  const operationsAvailability = asRecord(operations.availability);
+  const operationsVisibility = asRecord(operations.visibility);
+  const operationsMaintenance = asRecord(operations.maintenance);
+
+  const commerce = asRecord(root.commerce);
+  const commerceDeliveryFees = asRecord(commerce.deliveryFees);
+  const commerceFulfillment = asRecord(commerce.fulfillment);
+  const commerceTax = asRecord(commerce.tax);
+
+  const media = asRecord(root.media);
+  const mediaHomeHero = asRecord(media.homeHero);
+  const mediaReels = asRecord(media.reels);
+  const mediaImages = asRecord(media.images);
+
+  const promotions = asRecord(root.promotions);
+  const contact = asRecord(root.contact);
+
+  const legacyAvailability = asRecord(root.availability);
+  const legacyVisibility = asRecord(root.visibility);
+  const legacyMaintenance = asRecord(root.maintenance);
+  const legacyDeliveryFees = asRecord(root.deliveryFees);
+  const legacyFulfillment = asRecord(root.fulfillment);
+  const legacyTax = asRecord(root.tax);
+  const legacyHomeHero = asRecord(root.homeHero);
+  const legacyUi = asRecord(root.ui);
+  const legacyContactInfo = asRecord(root.contactInfo);
+
+  return {
+    operations: {
+      availability: {
+        inMaintenanceMode:
+          firstDefined(
+            asBoolean(operationsAvailability.inMaintenanceMode),
+            asBoolean(legacyAvailability.inMaintenanceMode),
+          ) ?? false,
+      },
+      visibility: {
+        inReadOnlyMode:
+          firstDefined(
+            asBoolean(operationsVisibility.inReadOnlyMode),
+            asBoolean(legacyVisibility.inReadOnlyMode),
+          ) ?? false,
+      },
+      maintenance: cleanUndefined({
+        countdownEndsAt: firstDefined(
+          asNumber(operationsMaintenance.countdownEndsAt),
+          asNumber(legacyMaintenance.countdownEndsAt),
+        ),
+        heading: firstDefined(
+          asString(operationsMaintenance.heading),
+          asString(legacyMaintenance.heading),
+        ),
+        message: firstDefined(
+          asString(operationsMaintenance.message),
+          asString(legacyMaintenance.message),
+        ),
+      }),
+    },
+    commerce: {
+      deliveryFees: cleanUndefined({
+        international: firstDefined(
+          asNumber(commerceDeliveryFees.international),
+          asNumber(legacyDeliveryFees.international),
+        ),
+        otherRegions: firstDefined(
+          asNumber(commerceDeliveryFees.otherRegions),
+          asNumber(legacyDeliveryFees.otherRegions),
+        ),
+        withinAccra: firstDefined(
+          asNumber(commerceDeliveryFees.withinAccra),
+          asNumber(legacyDeliveryFees.withinAccra),
+        ),
+      }),
+      waiveDeliveryFees: normalizeWaiveDeliveryFees(
+        firstDefined(commerce.waiveDeliveryFees, root.waiveDeliveryFees),
+      ),
+      fulfillment: cleanUndefined({
+        disableDelivery: firstDefined(
+          asBoolean(commerceFulfillment.disableDelivery),
+          asBoolean(legacyFulfillment.disableDelivery),
+        ),
+        disableStorePickup: firstDefined(
+          asBoolean(commerceFulfillment.disableStorePickup),
+          asBoolean(legacyFulfillment.disableStorePickup),
+        ),
+        enableDelivery: firstDefined(
+          asBoolean(commerceFulfillment.enableDelivery),
+          asBoolean(legacyFulfillment.enableDelivery),
+        ),
+        enableStorePickup: firstDefined(
+          asBoolean(commerceFulfillment.enableStorePickup),
+          asBoolean(legacyFulfillment.enableStorePickup),
+        ),
+        pickupRestriction: cleanUndefined({
+          isActive: firstDefined(
+            asBoolean(asRecord(commerceFulfillment.pickupRestriction).isActive),
+            asBoolean(asRecord(legacyFulfillment.pickupRestriction).isActive),
+          ),
+          reason: firstDefined(
+            asString(asRecord(commerceFulfillment.pickupRestriction).reason),
+            asString(asRecord(legacyFulfillment.pickupRestriction).reason),
+          ),
+          message: firstDefined(
+            asString(asRecord(commerceFulfillment.pickupRestriction).message),
+            asString(asRecord(legacyFulfillment.pickupRestriction).message),
+          ),
+          endTime: firstDefined(
+            asNumber(asRecord(commerceFulfillment.pickupRestriction).endTime),
+            asNumber(asRecord(legacyFulfillment.pickupRestriction).endTime),
+          ),
+        }),
+        deliveryRestriction: cleanUndefined({
+          isActive: firstDefined(
+            asBoolean(
+              asRecord(commerceFulfillment.deliveryRestriction).isActive,
+            ),
+            asBoolean(asRecord(legacyFulfillment.deliveryRestriction).isActive),
+          ),
+          reason: firstDefined(
+            asString(asRecord(commerceFulfillment.deliveryRestriction).reason),
+            asString(asRecord(legacyFulfillment.deliveryRestriction).reason),
+          ),
+          message: firstDefined(
+            asString(asRecord(commerceFulfillment.deliveryRestriction).message),
+            asString(asRecord(legacyFulfillment.deliveryRestriction).message),
+          ),
+          endTime: firstDefined(
+            asNumber(asRecord(commerceFulfillment.deliveryRestriction).endTime),
+            asNumber(asRecord(legacyFulfillment.deliveryRestriction).endTime),
+          ),
+        }),
+      }),
+      tax: cleanUndefined({
+        enabled: firstDefined(asBoolean(commerceTax.enabled), asBoolean(legacyTax.enabled)),
+        includedInPrice: firstDefined(
+          asBoolean(commerceTax.includedInPrice),
+          asBoolean(legacyTax.includedInPrice),
+        ),
+        name: firstDefined(asString(commerceTax.name), asString(legacyTax.name)),
+        rate: firstDefined(asNumber(commerceTax.rate), asNumber(legacyTax.rate)),
+      }),
+    },
+    media: {
+      homeHero: {
+        displayType:
+          firstDefined(
+            asString(mediaHomeHero.displayType),
+            asString(legacyHomeHero.displayType),
+            asString(root.heroDisplayType),
+          ) === "image"
+            ? "image"
+            : "reel",
+        headerImage: firstDefined(
+          asString(mediaHomeHero.headerImage),
+          asString(legacyHomeHero.headerImage),
+          asString(root.heroHeaderImage),
+        ),
+        showOverlay:
+          firstDefined(
+            asBoolean(mediaHomeHero.showOverlay),
+            asBoolean(legacyHomeHero.showOverlay),
+            asBoolean(root.heroShowOverlay),
+          ) ?? false,
+        showText:
+          firstDefined(
+            asBoolean(mediaHomeHero.showText),
+            asBoolean(legacyHomeHero.showText),
+            asBoolean(root.heroShowText),
+          ) ?? false,
+      },
+      reels: {
+        activeVersion: firstDefined(
+          asNumber(mediaReels.activeVersion),
+          asNumber(root.activeStreamReel),
+        ),
+        activeHlsUrl: firstDefined(
+          asString(mediaReels.activeHlsUrl),
+          asString(root.activeStreamReelHlsUrl),
+        ),
+        landingPageVersion: firstDefined(
+          asString(mediaReels.landingPageVersion),
+          asString(root.landingPageReelVersion),
+        ),
+        versions: firstDefined(
+          asOptionalArray(mediaReels.versions, (value) => asString(value)),
+          asOptionalArray(root.reelVersions, (value) => asString(value)),
+        ) || [],
+        streamReels: firstDefined(
+          asOptionalArray(mediaReels.streamReels, mapStreamReel),
+          asOptionalArray(root.streamReels, mapStreamReel),
+        ) || [],
+      },
+      images: cleanUndefined({
+        fallbackImageUrl: firstDefined(
+          asString(mediaImages.fallbackImageUrl),
+          asString(legacyUi.fallbackImageUrl),
+        ),
+        shopTheLookImage: firstDefined(
+          asString(mediaImages.shopTheLookImage),
+          asString(root.shopTheLookImage),
+        ),
+        showroomImage: firstDefined(
+          asString(mediaImages.showroomImage),
+          asString(root.showroomImage),
+        ),
+      }),
+    },
+    promotions: cleanUndefined({
+      leaveAReviewDiscountCodeModalPromoCode: firstDefined(
+        mapPromotion(promotions.leaveAReviewDiscountCodeModalPromoCode),
+        mapPromotion(root.leaveAReviewDiscountCodeModalPromoCode),
+      ),
+      homepageDiscountCodeModalPromoCode: firstDefined(
+        mapPromotion(promotions.homepageDiscountCodeModalPromoCode),
+        mapPromotion(root.homepageDiscountCodeModalPromoCode),
+      ),
+    }),
+    contact: cleanUndefined({
+      location: firstDefined(
+        asString(contact.location),
+        asString(legacyContactInfo.location),
+      ),
+      phoneNumber: firstDefined(
+        asString(contact.phoneNumber),
+        asString(legacyContactInfo.phoneNumber),
+      ),
+    }),
+  };
+};
+
+export const normalizeStoreConfig = (config: unknown): StoreConfigV2 => {
+  return toV2Config(config);
+};
+
+const deepMerge = (
+  base: Record<string, any>,
+  patch: Record<string, any>,
+): Record<string, any> => {
+  const result: Record<string, any> = { ...base };
+
+  for (const [key, patchValue] of Object.entries(patch)) {
+    const baseValue = result[key];
+
+    if (isPlainObject(baseValue) && isPlainObject(patchValue)) {
+      result[key] = deepMerge(baseValue, patchValue);
+      continue;
+    }
+
+    result[key] = patchValue;
+  }
+
+  return result;
+};
+
+export const patchV2Config = (
+  existingConfig: unknown,
+  patch: Record<string, any>,
+): StoreConfigV2 => {
+  const normalized = toV2Config(existingConfig);
+  const merged = deepMerge(normalized as Record<string, any>, patch);
+  return toV2Config(merged);
+};
+
+const assignOrDelete = (
+  target: Record<string, any>,
+  key: string,
+  value: unknown,
+) => {
+  if (value === undefined || value === null) {
+    delete target[key];
+    return;
+  }
+
+  target[key] = value;
+};
+
+export const mirrorLegacyKeys = (
+  v2Config: StoreConfigV2,
+  existingConfig: unknown,
+): Record<string, any> => {
+  const existing = asRecord(existingConfig);
+
+  const nextConfig: Record<string, any> = {
+    ...existing,
+    operations: v2Config.operations,
+    commerce: v2Config.commerce,
+    media: v2Config.media,
+    promotions: v2Config.promotions,
+    contact: v2Config.contact,
+  };
+
+  nextConfig.availability = v2Config.operations.availability;
+  nextConfig.visibility = v2Config.operations.visibility;
+  nextConfig.maintenance = v2Config.operations.maintenance;
+
+  nextConfig.deliveryFees = v2Config.commerce.deliveryFees;
+  nextConfig.waiveDeliveryFees = v2Config.commerce.waiveDeliveryFees;
+  nextConfig.fulfillment = v2Config.commerce.fulfillment;
+  nextConfig.tax = v2Config.commerce.tax;
+
+  nextConfig.contactInfo = {
+    location: v2Config.contact.location,
+    phoneNumber: v2Config.contact.phoneNumber,
+  };
+
+  nextConfig.homeHero = v2Config.media.homeHero;
+  nextConfig.heroDisplayType = v2Config.media.homeHero.displayType;
+  assignOrDelete(nextConfig, "heroHeaderImage", v2Config.media.homeHero.headerImage);
+  nextConfig.heroShowOverlay = v2Config.media.homeHero.showOverlay;
+  nextConfig.heroShowText = v2Config.media.homeHero.showText;
+
+  assignOrDelete(nextConfig, "activeStreamReel", v2Config.media.reels.activeVersion);
+  assignOrDelete(nextConfig, "activeStreamReelHlsUrl", v2Config.media.reels.activeHlsUrl);
+  assignOrDelete(
+    nextConfig,
+    "landingPageReelVersion",
+    v2Config.media.reels.landingPageVersion,
+  );
+  nextConfig.reelVersions = v2Config.media.reels.versions;
+  nextConfig.streamReels = v2Config.media.reels.streamReels;
+
+  assignOrDelete(nextConfig, "shopTheLookImage", v2Config.media.images.shopTheLookImage);
+  assignOrDelete(nextConfig, "showroomImage", v2Config.media.images.showroomImage);
+
+  const ui = asRecord(existing.ui);
+  assignOrDelete(ui, "fallbackImageUrl", v2Config.media.images.fallbackImageUrl);
+  if (Object.keys(ui).length > 0) {
+    nextConfig.ui = ui;
+  } else {
+    delete nextConfig.ui;
+  }
+
+  assignOrDelete(
+    nextConfig,
+    "leaveAReviewDiscountCodeModalPromoCode",
+    v2Config.promotions.leaveAReviewDiscountCodeModalPromoCode,
+  );
+  assignOrDelete(
+    nextConfig,
+    "homepageDiscountCodeModalPromoCode",
+    v2Config.promotions.homepageDiscountCodeModalPromoCode,
+  );
+
+  return nextConfig;
+};
+
+export const getUnknownStoreConfigRootKeys = (config: unknown): string[] => {
+  const root = asRecord(config);
+
+  return Object.keys(root).filter((key) => !KNOWN_STORE_CONFIG_ROOT_KEYS.has(key));
+};
+
+export const isStoreCheckoutDisabled = (config: unknown): boolean => {
+  const normalized = normalizeStoreConfig(config);
+
+  return (
+    normalized.operations.availability.inMaintenanceMode ||
+    normalized.operations.visibility.inReadOnlyMode
+  );
+};
+
+export const removeLegacyRootKeysFromConfig = (
+  config: unknown,
+): Record<string, any> => {
+  const root = asRecord(config);
+  const next: Record<string, any> = {};
+
+  for (const [key, value] of Object.entries(root)) {
+    if (LEGACY_ROOT_KEY_SET.has(key)) {
+      continue;
+    }
+
+    next[key] = value;
+  }
+
+  return next;
+};
+
+export const isLegacyRootKey = (key: string): boolean => {
+  return LEGACY_ROOT_KEY_SET.has(key);
+};
+
+export const isV2RootKey = (key: string): boolean => {
+  return V2_ROOT_KEY_SET.has(key);
+};
+
+export const STORE_CONFIG_V2_ROOT_KEYS = [...V2_ROOT_KEYS];
+export const STORE_CONFIG_LEGACY_ROOT_KEYS = [...LEGACY_ROOT_KEYS];

--- a/packages/athena-webapp/convex/inventory/stores.ts
+++ b/packages/athena-webapp/convex/inventory/stores.ts
@@ -9,8 +9,32 @@ import { storeSchema } from "../schemas/inventory";
 import { listItemsInR2Directory, uploadFileToR2 } from "../cloudflare/r2";
 import { api } from "../_generated/api";
 import { Doc } from "../_generated/dataModel";
+import {
+  getUnknownStoreConfigRootKeys,
+  isLegacyRootKey,
+  mirrorLegacyKeys,
+  normalizeStoreConfig,
+  patchV2Config,
+  removeLegacyRootKeysFromConfig,
+  toV2Config,
+} from "./storeConfigV2";
 
 const entity = "store";
+const CONFIG_MIGRATION_PAGE_SIZE = 50;
+
+const toV2OnlyConfig = (existingConfig: unknown) => {
+  const normalized = toV2Config(existingConfig);
+  const withoutLegacy = removeLegacyRootKeysFromConfig(existingConfig);
+
+  return {
+    ...withoutLegacy,
+    operations: normalized.operations,
+    commerce: normalized.commerce,
+    media: normalized.media,
+    promotions: normalized.promotions,
+    contact: normalized.contact,
+  };
+};
 
 export const getAll = query({
   args: {
@@ -181,9 +205,159 @@ export const updateConfig = mutation({
     config: v.record(v.string(), v.any()),
   },
   handler: async (ctx, args) => {
-    await ctx.db.patch(args.id, { config: args.config });
+    const normalized = toV2Config(args.config);
+    const config = mirrorLegacyKeys(normalized, args.config);
+
+    await ctx.db.patch(args.id, { config });
 
     return await ctx.db.get(args.id);
+  },
+});
+
+export const patchConfigV2 = mutation({
+  args: {
+    id: v.id(entity),
+    patch: v.record(v.string(), v.any()),
+    mirrorLegacy: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    const store = await ctx.db.get(args.id);
+    if (!store) {
+      throw new Error("Store not found");
+    }
+
+    const nextV2Config = patchV2Config(store.config, args.patch);
+    const shouldMirrorLegacy = args.mirrorLegacy !== false;
+    const config = shouldMirrorLegacy
+      ? mirrorLegacyKeys(nextV2Config, store.config)
+      : toV2OnlyConfig(store.config ? { ...store.config, ...nextV2Config } : nextV2Config);
+
+    await ctx.db.patch(args.id, { config });
+
+    return await ctx.db.get(args.id);
+  },
+});
+
+export const preflightConfigKeys = query({
+  args: {},
+  handler: async (ctx) => {
+    const stores = await ctx.db.query(entity).collect();
+
+    const keyCounts: Record<string, number> = {};
+    const unknownKeyCounts: Record<string, number> = {};
+    const storesWithUnknownKeys: Array<{
+      storeId: string;
+      storeName: string;
+      unknownKeys: string[];
+    }> = [];
+
+    let storesWithConfig = 0;
+
+    for (const store of stores) {
+      if (!store.config || typeof store.config !== "object") {
+        continue;
+      }
+
+      storesWithConfig += 1;
+
+      for (const key of Object.keys(store.config)) {
+        keyCounts[key] = (keyCounts[key] || 0) + 1;
+      }
+
+      const unknownKeys = getUnknownStoreConfigRootKeys(store.config);
+      if (unknownKeys.length > 0) {
+        storesWithUnknownKeys.push({
+          storeId: store._id,
+          storeName: store.name,
+          unknownKeys,
+        });
+
+        for (const key of unknownKeys) {
+          unknownKeyCounts[key] = (unknownKeyCounts[key] || 0) + 1;
+        }
+      }
+    }
+
+    return {
+      totalStores: stores.length,
+      storesWithConfig,
+      keyCounts,
+      unknownKeyCounts,
+      storesWithUnknownKeys,
+    };
+  },
+});
+
+export const migrateConfigToV2Page = mutation({
+  args: {
+    cursor: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const page = await ctx.db.query(entity).paginate({
+      numItems: CONFIG_MIGRATION_PAGE_SIZE,
+      cursor: args.cursor ?? null,
+    });
+
+    let migratedCount = 0;
+
+    for (const store of page.page) {
+      const currentConfig = store.config || {};
+      const nextConfig = mirrorLegacyKeys(toV2Config(currentConfig), currentConfig);
+
+      if (JSON.stringify(currentConfig) === JSON.stringify(nextConfig)) {
+        continue;
+      }
+
+      await ctx.db.patch(store._id, { config: nextConfig });
+      migratedCount += 1;
+    }
+
+    return {
+      success: true,
+      processedCount: page.page.length,
+      migratedCount,
+      isDone: page.isDone,
+      cursor: page.continueCursor,
+    };
+  },
+});
+
+export const cleanupLegacyConfigKeysPage = mutation({
+  args: {
+    cursor: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const page = await ctx.db.query(entity).paginate({
+      numItems: CONFIG_MIGRATION_PAGE_SIZE,
+      cursor: args.cursor ?? null,
+    });
+
+    let cleanedCount = 0;
+    let removedLegacyKeyCount = 0;
+
+    for (const store of page.page) {
+      const currentConfig = store.config || {};
+      const currentKeys = Object.keys(currentConfig);
+      const legacyKeys = currentKeys.filter((key) => isLegacyRootKey(key));
+      const nextConfig = toV2OnlyConfig(currentConfig);
+
+      if (JSON.stringify(currentConfig) === JSON.stringify(nextConfig)) {
+        continue;
+      }
+
+      await ctx.db.patch(store._id, { config: nextConfig });
+      cleanedCount += 1;
+      removedLegacyKeyCount += legacyKeys.length;
+    }
+
+    return {
+      success: true,
+      processedCount: page.page.length,
+      cleanedCount,
+      removedLegacyKeyCount,
+      isDone: page.isDone,
+      cursor: page.continueCursor,
+    };
   },
 });
 
@@ -215,8 +389,10 @@ export const calculateTax = query({
   }),
   handler: async (ctx, args) => {
     const store = await ctx.db.get(args.storeId);
+    const normalizedConfig = normalizeStoreConfig(store?.config);
+    const taxConfig = normalizedConfig.commerce.tax;
 
-    if (!store || !store.config?.tax?.enabled) {
+    if (!store || !taxConfig?.enabled) {
       return {
         taxAmount: 0,
         totalWithTax: args.amount,
@@ -225,7 +401,6 @@ export const calculateTax = query({
       };
     }
 
-    const taxConfig = store.config.tax;
     const taxRate = taxConfig.rate || 0;
     const taxName = taxConfig.name || "Tax";
 
@@ -350,7 +525,8 @@ export const clearExpiredRestrictions = internalMutation({
     const stores = await ctx.db.query(entity).collect();
 
     for (const store of stores) {
-      const fulfillment = store.config?.fulfillment;
+      const normalizedConfig = normalizeStoreConfig(store.config);
+      const fulfillment = normalizedConfig.commerce.fulfillment;
       if (!fulfillment) continue;
 
       let needsUpdate = false;
@@ -381,8 +557,15 @@ export const clearExpiredRestrictions = internalMutation({
       }
 
       if (needsUpdate) {
+        const nextConfig = mirrorLegacyKeys(
+          patchV2Config(store.config, {
+            commerce: { fulfillment: updates },
+          }),
+          store.config,
+        );
+
         await ctx.db.patch(store._id, {
-          config: { ...store.config, fulfillment: updates },
+          config: nextConfig,
         });
       }
     }

--- a/packages/athena-webapp/convex/storeFront/checkoutSession.ts
+++ b/packages/athena-webapp/convex/storeFront/checkoutSession.ts
@@ -12,6 +12,7 @@ import {
 } from "../_generated/server";
 import { v } from "convex/values";
 import { orderDetailsSchema } from "../schemas/storeFront";
+import { isStoreCheckoutDisabled } from "../inventory/storeConfigV2";
 
 const entity = "checkoutSession";
 
@@ -63,10 +64,7 @@ export const create = mutation({
 
     const { config } = store || {};
 
-    if (
-      config?.availability?.inMaintenanceMode ||
-      config?.visibility?.inReadOnlyMode
-    ) {
+    if (isStoreCheckoutDisabled(config)) {
       return {
         success: false,
         message: "Store checkout is currrently not available",

--- a/packages/athena-webapp/types.ts
+++ b/packages/athena-webapp/types.ts
@@ -105,6 +105,125 @@ export type Offer = Doc<"offer"> & {
   promoCode?: PromoCode;
 };
 
+export type StoreRestrictionConfig = {
+  isActive?: boolean;
+  reason?: string;
+  message?: string;
+  endTime?: number;
+};
+
+export type StoreFulfillmentConfig = {
+  disableDelivery?: boolean;
+  disableStorePickup?: boolean;
+  enableDelivery?: boolean;
+  enableStorePickup?: boolean;
+  pickupRestriction?: StoreRestrictionConfig;
+  deliveryRestriction?: StoreRestrictionConfig;
+};
+
+export type StoreDeliveryFeesConfig = {
+  international?: number;
+  otherRegions?: number;
+  withinAccra?: number;
+};
+
+export type StoreWaiveDeliveryFeesConfig =
+  | boolean
+  | {
+      all?: boolean;
+      international?: boolean;
+      otherRegions?: boolean;
+      withinAccra?: boolean;
+    };
+
+export type StoreTaxConfig = {
+  enabled?: boolean;
+  includedInPrice?: boolean;
+  name?: string;
+  rate?: number;
+};
+
+export type StoreOperationsConfig = {
+  availability: {
+    inMaintenanceMode: boolean;
+  };
+  visibility: {
+    inReadOnlyMode: boolean;
+  };
+  maintenance: {
+    countdownEndsAt?: number;
+    heading?: string;
+    message?: string;
+  };
+};
+
+export type StoreCommerceConfig = {
+  deliveryFees: StoreDeliveryFeesConfig;
+  waiveDeliveryFees: StoreWaiveDeliveryFeesConfig;
+  fulfillment: StoreFulfillmentConfig;
+  tax: StoreTaxConfig;
+};
+
+export type StoreHeroDisplayType = "reel" | "image";
+
+export type StoreHomeHeroConfig = {
+  displayType: StoreHeroDisplayType;
+  headerImage?: string;
+  showOverlay: boolean;
+  showText: boolean;
+};
+
+export type StoreStreamReelConfig = {
+  version: number;
+  source?: string;
+  streamUid?: string;
+  hlsUrl?: string;
+  thumbnailUrl?: string;
+  createdAt?: number;
+};
+
+export type StoreMediaConfig = {
+  homeHero: StoreHomeHeroConfig;
+  reels: {
+    activeVersion?: number;
+    activeHlsUrl?: string;
+    landingPageVersion?: string;
+    versions: string[];
+    streamReels: StoreStreamReelConfig[];
+  };
+  images: {
+    fallbackImageUrl?: string;
+    shopTheLookImage?: string;
+    showroomImage?: string;
+  };
+};
+
+export type StorePromotionConfig = {
+  discountType?: string;
+  displayText?: string;
+  promoCodeId?: string;
+  value?: number;
+  [key: string]: any;
+};
+
+export type StorePromotionsConfig = {
+  leaveAReviewDiscountCodeModalPromoCode?: StorePromotionConfig;
+  homepageDiscountCodeModalPromoCode?: StorePromotionConfig;
+};
+
+export type StoreContactConfig = {
+  location?: string;
+  phoneNumber?: string;
+};
+
+export type StoreConfigV2 = {
+  operations: StoreOperationsConfig;
+  commerce: StoreCommerceConfig;
+  media: StoreMediaConfig;
+  promotions: StorePromotionsConfig;
+  contact: StoreContactConfig;
+};
+
 // POS System Types
 /**
  * POS (Point of Sale) system types for in-store transactions and customer management.


### PR DESCRIPTION
## Summary
- add `StoreConfigV2` grouped config types in `packages/athena-webapp/types.ts`
- add `convex/inventory/storeConfigV2.ts` helper module with:
  - legacy -> V2 normalization (`toV2Config` / `normalizeStoreConfig`)
  - interim legacy mirroring (`mirrorLegacyKeys`)
  - patch merge helper (`patchV2Config`)
  - checkout gating helper + config key utilities
- add migration/preflight endpoints in `inventory/stores.ts`:
  - `preflightConfigKeys`
  - `migrateConfigToV2Page`
  - `cleanupLegacyConfigKeysPage`
  - `patchConfigV2` (defaults to legacy mirror on)
- update backend readers to use normalized config for compatibility:
  - checkout/read-only gating
  - tax calculation
  - fulfillment restriction cleanup
  - cloudflare reel reads/writes

## Testing
- `bun run test -- convex/inventory/storeConfigV2.test.ts`
- added new tests in `convex/inventory/storeConfigV2.test.ts` covering:
  - legacy -> V2 projection
  - legacy key mirroring
  - maintenance/read-only checkout gating for both legacy and V2 shapes

## Notes
- `bunx convex codegen` is blocked locally without `CONVEX_DEPLOYMENT` configured in this environment.