### PR TITLE
PR2: Migrate Athena admin store config writes to grouped V2 patches

### DIFF
--- a/packages/athena-webapp/src/components/assets/assets-table/assetsColumns.tsx
+++ b/packages/athena-webapp/src/components/assets/assets-table/assetsColumns.tsx
@@ -9,6 +9,7 @@ import { api } from "~/convex/_generated/api";
 import { useState } from "react";
 import { toast } from "sonner";
 import { LoadingButton } from "../../ui/loading-button";
+import { getStoreConfigV2 } from "~/src/lib/storeConfig";
 
 export type Asset = {
   url: string;
@@ -25,18 +26,22 @@ export const assetColumns: ColumnDef<Asset>[] = [
       const [isUpdatingShopTheLook, setIsUpdatingShopTheLook] = useState(false);
       const [isUpdatingFallbackImage, setIsUpdatingFallbackImage] =
         useState(false);
-      const updateConfig = useMutation(api.inventory.stores.updateConfig);
+      const patchConfig = useMutation(api.inventory.stores.patchConfigV2);
       const { activeStore } = useGetActiveStore();
+      const storeConfig = getStoreConfigV2(activeStore);
 
       const handleUpdateShowroomImage = async () => {
         setIsUpdating(true);
 
         try {
-          await updateConfig({
+          await patchConfig({
             id: activeStore?._id!,
-            config: {
-              ...activeStore?.config,
-              showroomImage: row.original.url,
+            patch: {
+              media: {
+                images: {
+                  showroomImage: row.original.url,
+                },
+              },
             },
           });
           toast.success("Showroom image updated");
@@ -54,11 +59,14 @@ export const assetColumns: ColumnDef<Asset>[] = [
         setIsUpdatingShopTheLook(true);
 
         try {
-          await updateConfig({
+          await patchConfig({
             id: activeStore?._id!,
-            config: {
-              ...activeStore?.config,
-              shopTheLookImage: row.original.url,
+            patch: {
+              media: {
+                images: {
+                  shopTheLookImage: row.original.url,
+                },
+              },
             },
           });
           toast.success("Shop the Look image updated");
@@ -79,12 +87,14 @@ export const assetColumns: ColumnDef<Asset>[] = [
         setIsUpdatingFallbackImage(true);
 
         try {
-          await updateConfig({
+          await patchConfig({
             id: activeStore?._id!,
-            config: {
-              ...activeStore?.config,
-              ui: {
-                fallbackImageUrl: row.original.url,
+            patch: {
+              media: {
+                images: {
+                  ...storeConfig.media.images,
+                  fallbackImageUrl: row.original.url,
+                },
               },
             },
           });

--- a/packages/athena-webapp/src/components/assets/index.tsx
+++ b/packages/athena-webapp/src/components/assets/index.tsx
@@ -1,5 +1,5 @@
 import { useAction, useMutation, useQuery } from "convex/react";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { api } from "~/convex/_generated/api";
 import useGetActiveStore from "~/src/hooks/useGetActiveStore";
@@ -8,7 +8,6 @@ import { Input } from "../ui/input";
 import { LoadingButton } from "../ui/loading-button";
 import { Switch } from "../ui/switch";
 import { Label } from "../ui/label";
-import { set } from "zod";
 import { EmptyState } from "../states/empty/empty-state";
 import { ArrowUp, Image, PlusIcon } from "lucide-react";
 import { Button } from "../ui/button";
@@ -17,6 +16,7 @@ import { assetColumns } from "./assets-table/assetsColumns";
 import { useImageUpload } from "~/src/hooks/use-image-upload";
 import ImageUploader, { ImageFile } from "../ui/image-uploader";
 import { convertImagesToWebp } from "~/src/lib/imageUtils";
+import { getStoreConfigV2 } from "~/src/lib/storeConfig";
 
 const Header = () => {
   return (
@@ -28,14 +28,22 @@ const Header = () => {
 
 const FeesView = () => {
   const { activeStore } = useGetActiveStore();
+  const storeConfig = useMemo(
+    () => getStoreConfigV2(activeStore),
+    [activeStore?.config],
+  );
 
   const [isUpdatingFees, setIsUpdatingFees] = useState(false);
 
-  const [enteredOtherRegionsFee, setEnteredOtherRegionsFee] = useState(0);
-  const [enteredWithinAccraFee, setEnteredWithinAccraFee] = useState(0);
-  const [enteredIntlFee, setEnteredIntlFee] = useState(0);
+  const [enteredOtherRegionsFee, setEnteredOtherRegionsFee] = useState<
+    number | undefined
+  >(0);
+  const [enteredWithinAccraFee, setEnteredWithinAccraFee] = useState<
+    number | undefined
+  >(0);
+  const [enteredIntlFee, setEnteredIntlFee] = useState<number | undefined>(0);
 
-  const updateFees = useMutation(api.inventory.stores.updateConfig);
+  const patchConfig = useMutation(api.inventory.stores.patchConfigV2);
 
   const handleUpdateFees = async () => {
     setIsUpdatingFees(true);
@@ -47,11 +55,12 @@ const FeesView = () => {
     };
 
     try {
-      await updateFees({
+      await patchConfig({
         id: activeStore?._id!,
-        config: {
-          ...activeStore?.config,
-          deliveryFees: updates,
+        patch: {
+          commerce: {
+            deliveryFees: updates,
+          },
         },
       });
       toast.success("Delivery fees updated", { position: "top-right" });
@@ -69,13 +78,13 @@ const FeesView = () => {
   useEffect(() => {
     // Sync state with store data when `activeStore` changes
     setEnteredWithinAccraFee(
-      activeStore?.config?.deliveryFees?.withinAccra || undefined
+      storeConfig.commerce.deliveryFees?.withinAccra || undefined
     );
     setEnteredOtherRegionsFee(
-      activeStore?.config?.deliveryFees?.otherRegions || undefined
+      storeConfig.commerce.deliveryFees?.otherRegions || undefined
     );
-    setEnteredIntlFee(activeStore?.config?.deliveryFees?.international || 0);
-  }, [activeStore]);
+    setEnteredIntlFee(storeConfig.commerce.deliveryFees?.international || 0);
+  }, [storeConfig]);
 
   return (
     <View
@@ -132,17 +141,21 @@ const FeesView = () => {
 
 const ContactView = () => {
   const { activeStore } = useGetActiveStore();
+  const storeConfig = useMemo(
+    () => getStoreConfigV2(activeStore),
+    [activeStore?.config],
+  );
 
   const [isUpdatingContactInfo, setIsUpdatingContactInfo] = useState(false);
 
   const [enteredPhoneNumber, setEnteredPhoneNumber] = useState(
-    activeStore?.config?.contactInfo?.phoneNumber || ""
+    storeConfig.contact.phoneNumber || ""
   );
   const [enteredLocation, setEnteredLocation] = useState(
-    activeStore?.config?.contactInfo?.location || ""
+    storeConfig.contact.location || ""
   );
 
-  const updateContactInfo = useMutation(api.inventory.stores.updateConfig);
+  const patchConfig = useMutation(api.inventory.stores.patchConfigV2);
 
   const handleUpdateContactInfo = async () => {
     setIsUpdatingContactInfo(true);
@@ -153,11 +166,10 @@ const ContactView = () => {
     };
 
     try {
-      await updateContactInfo({
+      await patchConfig({
         id: activeStore?._id!,
-        config: {
-          ...activeStore?.config,
-          contactInfo: updates,
+        patch: {
+          contact: updates,
         },
       });
       toast.success("Contact information updated", { position: "top-right" });
@@ -174,9 +186,9 @@ const ContactView = () => {
 
   useEffect(() => {
     // Sync state with store data when `activeStore` changes
-    setEnteredPhoneNumber(activeStore?.config?.contactInfo?.phoneNumber || "");
-    setEnteredLocation(activeStore?.config?.contactInfo?.location || "");
-  }, [activeStore]);
+    setEnteredPhoneNumber(storeConfig.contact.phoneNumber || "");
+    setEnteredLocation(storeConfig.contact.location || "");
+  }, [storeConfig]);
 
   return (
     <View
@@ -220,12 +232,16 @@ const ContactView = () => {
 
 const MaintenanceView = () => {
   const { activeStore } = useGetActiveStore();
+  const storeConfig = useMemo(
+    () => getStoreConfigV2(activeStore),
+    [activeStore?.config],
+  );
 
   const [isUpdatingConfig, setIsUpdatingConfig] = useState(false);
 
   const [isInMaintenanceMode, setIsInMaintenanceMode] = useState(false);
 
-  const updateConfig = useMutation(api.inventory.stores.updateConfig);
+  const patchConfig = useMutation(api.inventory.stores.patchConfigV2);
 
   const saveChanges = async (toggled: boolean) => {
     setIsUpdatingConfig(true);
@@ -238,11 +254,12 @@ const MaintenanceView = () => {
     };
 
     try {
-      await updateConfig({
+      await patchConfig({
         id: activeStore?._id!,
-        config: {
-          ...activeStore?.config,
-          availability: updates,
+        patch: {
+          operations: {
+            availability: updates,
+          },
         },
       });
       const message = toggled
@@ -262,11 +279,11 @@ const MaintenanceView = () => {
 
   useEffect(() => {
     console.log("updating maintenance mode in effect");
-    console.log(activeStore?.config);
+    console.log(storeConfig);
     setIsInMaintenanceMode(
-      activeStore?.config?.availability?.inMaintenanceMode || false
+      storeConfig.operations.availability.inMaintenanceMode || false
     );
-  }, [activeStore?.config?.availability]);
+  }, [storeConfig]);
 
   console.log("in maintenance mode: ", isInMaintenanceMode);
 

--- a/packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx
+++ b/packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useEffect } from "react";
+import React, { useRef, useState, useEffect, useMemo } from "react";
 import { Button } from "../ui/button";
 import { LoadingButton } from "../ui/loading-button";
 import { Image, PencilIcon, ArrowUp, RotateCcw } from "lucide-react";
@@ -9,6 +9,7 @@ import { ImageFile } from "../ui/image-uploader";
 import { useAction, useMutation } from "convex/react";
 import { api } from "~/convex/_generated/api";
 import useGetActiveStore from "~/src/hooks/useGetActiveStore";
+import { getStoreConfigV2 } from "~/src/lib/storeConfig";
 
 interface HeroHeaderImageUploaderProps {
   currentImageUrl?: string;
@@ -33,8 +34,12 @@ export const HeroHeaderImageUploader: React.FC<
 
   // Hooks
   const { activeStore } = useGetActiveStore();
+  const storeConfig = useMemo(
+    () => getStoreConfigV2(activeStore),
+    [activeStore?.config],
+  );
   const uploadStoreAssets = useAction(api.inventory.stores.uploadImageAssets);
-  const updateConfig = useMutation(api.inventory.stores.updateConfig);
+  const patchConfig = useMutation(api.inventory.stores.patchConfigV2);
 
   // Derived state
   const displayImage =
@@ -128,13 +133,14 @@ export const HeroHeaderImageUploader: React.FC<
       const newImageUrl = await uploadImage(selectedFile);
 
       // Update store config (nest under config.homeHero)
-      await updateConfig({
+      await patchConfig({
         id: activeStore._id,
-        config: {
-          ...activeStore.config,
-          homeHero: {
-            ...activeStore.config?.homeHero,
-            headerImage: newImageUrl,
+        patch: {
+          media: {
+            homeHero: {
+              ...storeConfig.media.homeHero,
+              headerImage: newImageUrl,
+            },
           },
         },
       });

--- a/packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx
+++ b/packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx
@@ -1,27 +1,30 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
 import { TvMinimalPlay, Image } from "lucide-react";
 import { LandingPageReelVersion } from "./LandingPageReelVersion";
 import { HeroHeaderImageUploader } from "./HeroHeaderImageUploader";
 import useGetActiveStore from "~/src/hooks/useGetActiveStore";
-import { Id } from "~/convex/_generated/dataModel";
 import { ToggleGroup, ToggleGroupItem } from "../ui/toggle-group";
 import { Switch } from "../ui/switch";
-import { Label } from "../ui/label";
 import { useMutation } from "convex/react";
 import { api } from "~/convex/_generated/api";
 import { toast } from "sonner";
 import { ReelUploader } from "./ReelUploader";
+import { getStoreConfigV2 } from "~/src/lib/storeConfig";
 
 export const HeroSectionTabs: React.FC = () => {
   const { activeStore } = useGetActiveStore();
+  const storeConfig = useMemo(
+    () => getStoreConfigV2(activeStore),
+    [activeStore?.config],
+  );
   const [heroHeaderImage, setHeroHeaderImage] = useState<string | undefined>(
-    activeStore?.config?.homeHero?.headerImage,
+    storeConfig.media.homeHero.headerImage,
   );
 
   const [heroDisplayType, setHeroDisplayType] = useState<
     "reel" | "image" | undefined
-  >(activeStore?.config?.homeHero?.displayType as "reel" | "image");
+  >(storeConfig.media.homeHero.displayType as "reel" | "image");
 
   const [contentOptions, setContentOptions] = useState<{
     showOverlay: boolean;
@@ -31,25 +34,25 @@ export const HeroSectionTabs: React.FC = () => {
     showText: false,
   });
 
-  const updateConfig = useMutation(api.inventory.stores.updateConfig);
+  const patchConfig = useMutation(api.inventory.stores.patchConfigV2);
 
   // Update local state when store config changes
   useEffect(() => {
-    const next = activeStore?.config?.homeHero?.headerImage;
+    const next = storeConfig.media.homeHero.headerImage;
     if (next) setHeroHeaderImage(next);
-  }, [activeStore?.config?.homeHero]);
+  }, [storeConfig.media.homeHero.headerImage]);
 
   useEffect(() => {
-    const next: "reel" | "image" = activeStore?.config?.homeHero?.displayType;
+    const next: "reel" | "image" = storeConfig.media.homeHero.displayType;
     if (next) setHeroDisplayType(next);
-  }, [activeStore?.config?.homeHero]);
+  }, [storeConfig.media.homeHero.displayType]);
 
   useEffect(() => {
     setContentOptions({
-      showOverlay: Boolean(activeStore?.config?.homeHero?.showOverlay),
-      showText: Boolean(activeStore?.config?.homeHero?.showText),
+      showOverlay: Boolean(storeConfig.media.homeHero.showOverlay),
+      showText: Boolean(storeConfig.media.homeHero.showText),
     });
-  }, [activeStore?.config?.homeHero]);
+  }, [storeConfig.media.homeHero.showOverlay, storeConfig.media.homeHero.showText]);
 
   const handleImageUpdate = (newImageUrl: string) => {
     setHeroHeaderImage(newImageUrl);
@@ -69,15 +72,15 @@ export const HeroSectionTabs: React.FC = () => {
     setHeroDisplayType(newType);
 
     try {
-      await updateConfig({
+      await patchConfig({
         id: activeStore._id,
-        config: {
-          ...activeStore.config,
-          homeHero: {
-            ...activeStore.config?.homeHero,
-            ...contentOptions,
-            headerImage: heroHeaderImage,
-            displayType: newType,
+        patch: {
+          media: {
+            homeHero: {
+              ...contentOptions,
+              headerImage: heroHeaderImage ?? null,
+              displayType: newType,
+            },
           },
         },
       });
@@ -88,7 +91,7 @@ export const HeroSectionTabs: React.FC = () => {
       console.error("Failed to update hero display type:", error);
       toast.error("Failed to update hero display type");
       // Revert on error
-      setHeroDisplayType(activeStore.config?.homeHero?.displayType || "reel");
+      setHeroDisplayType(storeConfig.media.homeHero.displayType || "reel");
     }
   };
 
@@ -101,20 +104,20 @@ export const HeroSectionTabs: React.FC = () => {
     };
 
     try {
-      const config = {
+      const patch = {
         id: activeStore._id,
-        config: {
-          ...activeStore.config,
-          homeHero: {
-            ...activeStore.config?.homeHero,
-            displayType: heroDisplayType,
-            headerImage: heroHeaderImage,
-            ...newContentOptions,
+        patch: {
+          media: {
+            homeHero: {
+              displayType: heroDisplayType || "reel",
+              headerImage: heroHeaderImage ?? null,
+              ...newContentOptions,
+            },
           },
         },
       } as const;
 
-      await updateConfig(config);
+      await patchConfig(patch);
       setContentOptions(newContentOptions);
       toast.success(`Hero overlay ${checked ? "enabled" : "disabled"}`);
     } catch (error) {
@@ -123,7 +126,7 @@ export const HeroSectionTabs: React.FC = () => {
       // Revert on error
       setContentOptions({
         ...contentOptions,
-        showOverlay: activeStore.config?.homeHero?.showOverlay !== false,
+        showOverlay: storeConfig.media.homeHero.showOverlay !== false,
       });
     }
   };
@@ -137,19 +140,19 @@ export const HeroSectionTabs: React.FC = () => {
     };
 
     try {
-      const config = {
+      const patch = {
         id: activeStore._id,
-        config: {
-          ...activeStore.config,
-          homeHero: {
-            ...activeStore.config?.homeHero,
-            displayType: heroDisplayType,
-            headerImage: heroHeaderImage,
-            ...newContentOptions,
+        patch: {
+          media: {
+            homeHero: {
+              displayType: heroDisplayType || "reel",
+              headerImage: heroHeaderImage ?? null,
+              ...newContentOptions,
+            },
           },
         },
       } as const;
-      await updateConfig(config);
+      await patchConfig(patch);
       setContentOptions(newContentOptions);
       toast.success(`Hero text ${checked ? "enabled" : "disabled"}`);
     } catch (error) {
@@ -158,7 +161,7 @@ export const HeroSectionTabs: React.FC = () => {
       // Revert on error
       setContentOptions({
         ...newContentOptions,
-        showText: activeStore.config?.homeHero?.showText !== false,
+        showText: storeConfig.media.homeHero.showText !== false,
       });
     }
   };

--- a/packages/athena-webapp/src/components/homepage/LandingPageReelVersion.tsx
+++ b/packages/athena-webapp/src/components/homepage/LandingPageReelVersion.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 import { LoadingButton } from "../ui/loading-button";
 import { SelectNative } from "../ui/select-native";
 import { VideoPlayer } from "./VideoPlayer";
+import { getStoreConfigV2 } from "~/src/lib/storeConfig";
 
 type StreamReel = {
   version: number;
@@ -17,6 +18,10 @@ type StreamReel = {
 
 export const LandingPageReelVersion = () => {
   const { activeStore } = useGetActiveStore();
+  const storeConfig = useMemo(
+    () => getStoreConfigV2(activeStore),
+    [activeStore?.config],
+  );
 
   const [isUpdatingConfig, setIsUpdatingConfig] = useState(false);
 
@@ -31,7 +36,7 @@ export const LandingPageReelVersion = () => {
   );
 
   const streamReels = useMemo(() => {
-    const raw = activeStore?.config?.streamReels;
+    const raw = storeConfig.media.reels.streamReels;
     if (!Array.isArray(raw)) return [] as StreamReel[];
 
     return raw
@@ -40,7 +45,7 @@ export const LandingPageReelVersion = () => {
           typeof reel?.version === "number" && typeof reel?.hlsUrl === "string",
       )
       .sort((a, b) => b.version - a.version);
-  }, [activeStore?.config?.streamReels]);
+  }, [storeConfig.media.reels.streamReels]);
 
   const selectedReel = streamReels.find((reel) => reel.version === reelVersion);
 
@@ -57,7 +62,7 @@ export const LandingPageReelVersion = () => {
       return;
     }
 
-    const activeVersion = activeStore.config?.activeStreamReel;
+    const activeVersion = storeConfig.media.reels.activeVersion;
 
     if (typeof activeVersion === "number") {
       setReelVersion(activeVersion);
@@ -70,10 +75,10 @@ export const LandingPageReelVersion = () => {
     }
 
     setReelVersion(null);
-  }, [activeStore, streamReels, reelVersion]);
+  }, [activeStore, storeConfig, streamReels, reelVersion]);
 
   const hlsUrl =
-    selectedReel?.hlsUrl || activeStore?.config?.activeStreamReelHlsUrl || "";
+    selectedReel?.hlsUrl || storeConfig.media.reels.activeHlsUrl || "";
 
   const handleUpdateConfig = async () => {
     if (!activeStore || !selectedReel) return;
@@ -106,7 +111,7 @@ export const LandingPageReelVersion = () => {
   const isButtonDisabled =
     !reelVersion ||
     !selectedReel ||
-    (reelVersion === activeStore?.config?.activeStreamReel &&
+    (reelVersion === storeConfig.media.reels.activeVersion &&
       !updatedReelVersion) ||
     updatedReelVersion === reelVersion;
 

--- a/packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx
+++ b/packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx
@@ -1,5 +1,5 @@
 import { useMutation } from "convex/react";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { toast } from "sonner";
 import { api } from "~/convex/_generated/api";
 import { Input } from "../ui/input";
@@ -9,6 +9,7 @@ import { Id } from "~/convex/_generated/dataModel";
 import View from "../View";
 import { DateTimePicker } from "../ui/date-time-picker";
 import useGetActiveStore from "~/src/hooks/useGetActiveStore";
+import { getStoreConfigV2 } from "~/src/lib/storeConfig";
 
 interface MaintenanceMessageEditorProps {
   storeId: Id<"store">;
@@ -18,7 +19,11 @@ export function MaintenanceMessageEditor({
   storeId,
 }: MaintenanceMessageEditorProps) {
   const { activeStore } = useGetActiveStore();
-  const updateConfig = useMutation(api.inventory.stores.updateConfig);
+  const storeConfig = useMemo(
+    () => getStoreConfigV2(activeStore),
+    [activeStore?.config],
+  );
+  const patchConfig = useMutation(api.inventory.stores.patchConfigV2);
 
   const [heading, setHeading] = useState("");
   const [message, setMessage] = useState("");
@@ -31,8 +36,8 @@ export function MaintenanceMessageEditor({
   const [isSaving, setIsSaving] = useState(false);
 
   useEffect(() => {
-    if (activeStore?.config?.maintenance) {
-      const maintenance = activeStore.config.maintenance;
+    if (storeConfig.operations.maintenance) {
+      const maintenance = storeConfig.operations.maintenance;
       setHeading(maintenance.heading || "");
       setMessage(maintenance.message || "");
       setCountdownEndsAt(maintenance.countdownEndsAt);
@@ -42,19 +47,20 @@ export function MaintenanceMessageEditor({
           : undefined
       );
     }
-  }, [activeStore?.config?.maintenance]);
+  }, [storeConfig]);
 
   const handleSave = async () => {
     setIsSaving(true);
     try {
-      await updateConfig({
+      await patchConfig({
         id: storeId,
-        config: {
-          ...activeStore?.config,
-          maintenance: {
-            heading: heading.trim() || undefined,
-            message: message.trim() || undefined,
-            countdownEndsAt,
+        patch: {
+          operations: {
+            maintenance: {
+              heading: heading.trim() || null,
+              message: message.trim() || null,
+              countdownEndsAt: countdownEndsAt ?? null,
+            },
           },
         },
       });

--- a/packages/athena-webapp/src/components/homepage/ShopLook.tsx
+++ b/packages/athena-webapp/src/components/homepage/ShopLook.tsx
@@ -5,7 +5,7 @@ import {
   DropResult,
 } from "@hello-pangea/dnd";
 import { useMutation, useQuery } from "convex/react";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { api } from "~/convex/_generated/api";
 import useGetActiveStore from "~/src/hooks/useGetActiveStore";
 import { capitalizeWords, currencyFormatter } from "~/src/lib/utils";
@@ -19,11 +19,16 @@ import { getOrigin } from "~/src/lib/navigationUtils";
 
 import { ShopLookImageUploader } from "./ShopLookImageUploader";
 import { toast } from "sonner";
+import { getStoreConfigV2 } from "~/src/lib/storeConfig";
 
 export const ShopLookSection = () => {
   const [dialogOpen, setDialogOpen] = useState(false);
 
   const { activeStore } = useGetActiveStore();
+  const storeConfig = useMemo(
+    () => getStoreConfigV2(activeStore),
+    [activeStore?.config],
+  );
 
   const [shopTheLookImage, setShopTheLookImage] = useState<
     string | undefined
@@ -50,14 +55,14 @@ export const ShopLookSection = () => {
   }, [featuredItemsQuery, featuredItems]);
 
   useEffect(() => {
-    if (activeStore?.config?.shopTheLookImage) {
-      setShopTheLookImage(activeStore?.config?.shopTheLookImage);
+    if (storeConfig.media.images.shopTheLookImage) {
+      setShopTheLookImage(storeConfig.media.images.shopTheLookImage);
     }
-  }, [activeStore?.config?.shopTheLookImage]);
+  }, [storeConfig.media.images.shopTheLookImage]);
 
   const removeHighlightedItem = useMutation(api.inventory.featuredItem.remove);
   const updateRanks = useMutation(api.inventory.featuredItem.updateRanks);
-  const updateConfig = useMutation(api.inventory.stores.updateConfig);
+  const patchConfig = useMutation(api.inventory.stores.patchConfigV2);
 
   const handleHighlightedItem = async (featuredItem: any) => {
     removeHighlightedItem({
@@ -85,11 +90,14 @@ export const ShopLookSection = () => {
   const handleImageUpdate = async (newImageUrl: string) => {
     console.log("newImageUrl", newImageUrl);
     try {
-      await updateConfig({
+      await patchConfig({
         id: activeStore?._id!,
-        config: {
-          ...activeStore?.config,
-          shopTheLookImage: newImageUrl,
+        patch: {
+          media: {
+            images: {
+              shopTheLookImage: newImageUrl,
+            },
+          },
         },
       });
       setShopTheLookImage(newImageUrl);
@@ -130,7 +138,7 @@ export const ShopLookSection = () => {
       />
       <div className="py-4 space-y-8">
         <ShopLookImageUploader
-          currentImageUrl={activeStore?.config?.shopTheLookImage}
+          currentImageUrl={storeConfig.media.images.shopTheLookImage}
           onImageUpdate={handleImageUpdate}
           disabled={!activeStore}
         />

--- a/packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx
+++ b/packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx
@@ -22,10 +22,15 @@ import PromoCodeHeader from "./PromoCodeHeader";
 import PromoCodeForm from "./PromoCodeForm";
 import PromoCodePreview from "./PromoCodePreview";
 import PromoCodeAnalytics from "./analytics/PromoCodeAnalytics";
+import { getStoreConfigV2 } from "~/src/lib/storeConfig";
 
 function PromoCodeView() {
   const products = useGetProducts();
   const { activeStore } = useGetActiveStore();
+  const storeConfig = useMemo(
+    () => getStoreConfigV2(activeStore),
+    [activeStore?.config],
+  );
   const [discountType, setDiscountType] = useState<DiscountType>("amount");
   const [promoCodeSpan, setPromoCodeSpan] =
     useState<PromoCodeSpan>("entire-order");
@@ -61,7 +66,7 @@ function PromoCodeView() {
 
   const addPromoCode = useMutation(api.inventory.promoCode.create);
   const updatePromoCode = useMutation(api.inventory.promoCode.update);
-  const updateStoreConfig = useMutation(api.inventory.stores.updateConfig);
+  const patchStoreConfig = useMutation(api.inventory.stores.patchConfigV2);
 
   const { promoCodeSlug } = useParams({ strict: false });
 
@@ -93,7 +98,7 @@ function PromoCodeView() {
 
       // Check if this promo code is set as homepage discount code
       if (
-        activeStore?.config?.homepageDiscountCodeModalPromoCode?.promoCodeId ===
+        storeConfig.promotions.homepageDiscountCodeModalPromoCode?.promoCodeId ===
         activePromoCode._id
       ) {
         setIsHomepageDiscountCode(true);
@@ -101,13 +106,13 @@ function PromoCodeView() {
 
       // Check if this promo code is set as leave a review discount code
       if (
-        activeStore?.config?.leaveAReviewDiscountCodeModalPromoCode
+        storeConfig.promotions.leaveAReviewDiscountCodeModalPromoCode
           ?.promoCodeId === activePromoCode._id
       ) {
         setIsLeaveAReviewDiscountCode(true);
       }
     }
-  }, [activePromoCode, activeStore]);
+  }, [activePromoCode, storeConfig]);
 
   // Set selected products when promo code product SKUs are loaded
   useEffect(() => {
@@ -172,15 +177,16 @@ function PromoCodeView() {
 
       // If set as homepage discount code, update store config
       if (isHomepageDiscountCode && newPromoCode.promoCode) {
-        await updateStoreConfig({
+        await patchStoreConfig({
           id: activeStore._id,
-          config: {
-            ...activeStore.config,
-            homepageDiscountCodeModalPromoCode: {
-              promoCodeId: newPromoCode.promoCode._id,
-              value: newPromoCode.promoCode.discountValue,
-              displayText: newPromoCode.promoCode.displayText,
-              discountType: newPromoCode.promoCode.discountType,
+          patch: {
+            promotions: {
+              homepageDiscountCodeModalPromoCode: {
+                promoCodeId: newPromoCode.promoCode._id,
+                value: newPromoCode.promoCode.discountValue,
+                displayText: newPromoCode.promoCode.displayText,
+                discountType: newPromoCode.promoCode.discountType,
+              },
             },
           },
         });
@@ -239,32 +245,35 @@ function PromoCodeView() {
       // Update store config for homepage discount code if needed
       if (activeStore && promoCodeSlug) {
         const currentHomepagePromoCodeId =
-          activeStore.config?.homepageDiscountCodeModalPromoCode;
+          storeConfig.promotions.homepageDiscountCodeModalPromoCode?.promoCodeId;
         const isCurrentlyHomepageCode =
           currentHomepagePromoCodeId === promoCodeSlug;
 
         if (isHomepageDiscountCode) {
           // Add this promo code as homepage discount code
-          await updateStoreConfig({
+          await patchStoreConfig({
             id: activeStore._id,
-            config: {
-              ...activeStore.config,
-              homepageDiscountCodeModalPromoCode: {
-                promoCodeId: promoCodeSlug,
-                value: parseFloat(discount!),
-                displayText: displayText,
-                discountType: discountType,
+            patch: {
+              promotions: {
+                homepageDiscountCodeModalPromoCode: {
+                  promoCodeId: promoCodeSlug,
+                  value: parseFloat(discount!),
+                  displayText: displayText,
+                  discountType: discountType,
+                },
               },
             },
           });
           toast.success("Updated homepage discount code");
         } else if (!isHomepageDiscountCode && isCurrentlyHomepageCode) {
           // Remove this promo code as homepage discount code
-          const { homepageDiscountCodeModalPromoCode, ...restConfig } =
-            activeStore.config || {};
-          await updateStoreConfig({
+          await patchStoreConfig({
             id: activeStore._id,
-            config: restConfig,
+            patch: {
+              promotions: {
+                homepageDiscountCodeModalPromoCode: null,
+              },
+            },
           });
           toast.success("Removed as homepage discount code");
         }
@@ -293,29 +302,38 @@ function PromoCodeView() {
     try {
       setIsUpdatingStoreConfig(true);
 
+      const promoPayload = {
+        promoCodeId: promoCodeSlug,
+        value: activePromoCode?.discountValue ?? parseFloat(discount || "0"),
+        displayText:
+          activePromoCode?.displayText ||
+          (discountType === "amount"
+            ? formatter.format(parseFloat(discount || "0"))
+            : `${discount || 0}%`),
+        discountType: activePromoCode?.discountType ?? discountType,
+      };
+
       if (checked) {
         // Set this promo code as homepage discount code
-        await updateStoreConfig({
+        await patchStoreConfig({
           id: activeStore._id,
-          config: {
-            ...activeStore.config,
-            leaveAReviewDiscountCodeModalPromoCode: undefined,
-            homepageDiscountCodeModalPromoCode: {
-              promoCodeId: promoCodeSlug,
-              value: activePromoCode?.discountValue,
-              displayText: activePromoCode?.displayText,
-              discountType: activePromoCode?.discountType,
+          patch: {
+            promotions: {
+              leaveAReviewDiscountCodeModalPromoCode: null,
+              homepageDiscountCodeModalPromoCode: promoPayload,
             },
           },
         });
         toast.success("Set as homepage discount code");
       } else {
         // Remove this promo code as homepage discount code
-        const { homepageDiscountCodeModalPromoCode, ...restConfig } =
-          activeStore.config || {};
-        await updateStoreConfig({
+        await patchStoreConfig({
           id: activeStore._id,
-          config: restConfig,
+          patch: {
+            promotions: {
+              homepageDiscountCodeModalPromoCode: null,
+            },
+          },
         });
         toast.success("Removed as homepage discount code");
       }
@@ -336,29 +354,38 @@ function PromoCodeView() {
     try {
       setIsUpdatingStoreConfig(true);
 
+      const promoPayload = {
+        promoCodeId: promoCodeSlug,
+        value: activePromoCode?.discountValue ?? parseFloat(discount || "0"),
+        displayText:
+          activePromoCode?.displayText ||
+          (discountType === "amount"
+            ? formatter.format(parseFloat(discount || "0"))
+            : `${discount || 0}%`),
+        discountType: activePromoCode?.discountType ?? discountType,
+      };
+
       if (checked) {
         // Set this promo code as leave a review discount code
-        await updateStoreConfig({
+        await patchStoreConfig({
           id: activeStore._id,
-          config: {
-            ...activeStore.config,
-            homepageDiscountCodeModalPromoCode: undefined,
-            leaveAReviewDiscountCodeModalPromoCode: {
-              promoCodeId: promoCodeSlug,
-              value: activePromoCode?.discountValue,
-              displayText: activePromoCode?.displayText,
-              discountType: activePromoCode?.discountType,
+          patch: {
+            promotions: {
+              homepageDiscountCodeModalPromoCode: null,
+              leaveAReviewDiscountCodeModalPromoCode: promoPayload,
             },
           },
         });
         toast.success("Set as leave a review discount code");
       } else {
         // Remove this promo code as leave a review discount code
-        const { leaveAReviewDiscountCodeModalPromoCode, ...restConfig } =
-          activeStore.config || {};
-        await updateStoreConfig({
+        await patchStoreConfig({
           id: activeStore._id,
-          config: restConfig,
+          patch: {
+            promotions: {
+              leaveAReviewDiscountCodeModalPromoCode: null,
+            },
+          },
         });
         toast.success("Removed as leave a review discount code");
       }

--- a/packages/athena-webapp/src/components/store-configuration/components/ContactView.tsx
+++ b/packages/athena-webapp/src/components/store-configuration/components/ContactView.tsx
@@ -1,19 +1,24 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import useGetActiveStore from "~/src/hooks/useGetActiveStore";
 import View from "../../View";
 import { Input } from "../../ui/input";
 import { LoadingButton } from "../../ui/loading-button";
 import { useStoreConfigUpdate } from "../hooks/useStoreConfigUpdate";
+import { getStoreConfigV2 } from "~/src/lib/storeConfig";
 
 export const ContactView = () => {
   const { activeStore } = useGetActiveStore();
   const { updateConfig, isUpdating } = useStoreConfigUpdate();
+  const storeConfig = useMemo(
+    () => getStoreConfigV2(activeStore),
+    [activeStore?.config],
+  );
 
   const [enteredPhoneNumber, setEnteredPhoneNumber] = useState(
-    activeStore?.config?.contactInfo?.phoneNumber || ""
+    storeConfig.contact.phoneNumber || ""
   );
   const [enteredLocation, setEnteredLocation] = useState(
-    activeStore?.config?.contactInfo?.location || ""
+    storeConfig.contact.location || ""
   );
 
   const handleUpdateContactInfo = async () => {
@@ -24,9 +29,8 @@ export const ContactView = () => {
 
     await updateConfig({
       storeId: activeStore?._id!,
-      config: {
-        ...activeStore?.config,
-        contactInfo: updates,
+      patch: {
+        contact: updates,
       },
       successMessage: "Contact information updated",
       errorMessage: "An error occurred while updating contact information",
@@ -35,9 +39,9 @@ export const ContactView = () => {
 
   useEffect(() => {
     // Sync state with store data when `activeStore` changes
-    setEnteredPhoneNumber(activeStore?.config?.contactInfo?.phoneNumber || "");
-    setEnteredLocation(activeStore?.config?.contactInfo?.location || "");
-  }, [activeStore]);
+    setEnteredPhoneNumber(storeConfig.contact.phoneNumber || "");
+    setEnteredLocation(storeConfig.contact.location || "");
+  }, [storeConfig]);
 
   return (
     <View

--- a/packages/athena-webapp/src/components/store-configuration/components/FeesView.tsx
+++ b/packages/athena-webapp/src/components/store-configuration/components/FeesView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import useGetActiveStore from "~/src/hooks/useGetActiveStore";
 import View from "../../View";
 import { Input } from "../../ui/input";
@@ -6,14 +6,23 @@ import { LoadingButton } from "../../ui/loading-button";
 import { Switch } from "../../ui/switch";
 import { Label } from "../../ui/label";
 import { useStoreConfigUpdate } from "../hooks/useStoreConfigUpdate";
+import { getStoreConfigV2 } from "~/src/lib/storeConfig";
 
 export const FeesView = () => {
   const { activeStore } = useGetActiveStore();
   const { updateConfig, isUpdating } = useStoreConfigUpdate();
+  const storeConfig = useMemo(
+    () => getStoreConfigV2(activeStore),
+    [activeStore?.config],
+  );
 
-  const [enteredOtherRegionsFee, setEnteredOtherRegionsFee] = useState(0);
-  const [enteredWithinAccraFee, setEnteredWithinAccraFee] = useState(0);
-  const [enteredIntlFee, setEnteredIntlFee] = useState(0);
+  const [enteredOtherRegionsFee, setEnteredOtherRegionsFee] = useState<
+    number | undefined
+  >(0);
+  const [enteredWithinAccraFee, setEnteredWithinAccraFee] = useState<
+    number | undefined
+  >(0);
+  const [enteredIntlFee, setEnteredIntlFee] = useState<number | undefined>(0);
 
   // Replace the single waiveDeliveryFees with separate states for each fee type
   const [waiveWithinAccraFee, setWaiveWithinAccraFee] = useState(false);
@@ -38,10 +47,11 @@ export const FeesView = () => {
 
     await updateConfig({
       storeId: activeStore?._id!,
-      config: {
-        ...activeStore?.config,
-        deliveryFees: updates,
-        waiveDeliveryFees: waiveDeliveryFeesConfig,
+      patch: {
+        commerce: {
+          deliveryFees: updates,
+          waiveDeliveryFees: waiveDeliveryFeesConfig,
+        },
       },
       successMessage: "Delivery fees updated",
       errorMessage: "An error occurred while updating delivery fees",
@@ -51,15 +61,15 @@ export const FeesView = () => {
   useEffect(() => {
     // Sync state with store data when `activeStore` changes
     setEnteredWithinAccraFee(
-      activeStore?.config?.deliveryFees?.withinAccra || undefined
+      storeConfig.commerce.deliveryFees?.withinAccra || undefined
     );
     setEnteredOtherRegionsFee(
-      activeStore?.config?.deliveryFees?.otherRegions || undefined
+      storeConfig.commerce.deliveryFees?.otherRegions || undefined
     );
-    setEnteredIntlFee(activeStore?.config?.deliveryFees?.international || 0);
+    setEnteredIntlFee(storeConfig.commerce.deliveryFees?.international || 0);
 
     // Handle both old boolean format and new object format for backward compatibility
-    const waiveConfig = activeStore?.config?.waiveDeliveryFees;
+    const waiveConfig = storeConfig.commerce.waiveDeliveryFees;
     if (typeof waiveConfig === "boolean") {
       // Old format - single boolean
       setWaiveWithinAccraFee(waiveConfig);
@@ -76,7 +86,7 @@ export const FeesView = () => {
       setWaiveOtherRegionsFee(false);
       setWaiveIntlFee(false);
     }
-  }, [activeStore]);
+  }, [storeConfig]);
 
   // Function to check if all fees are being waived
   const areAllFeesWaived =

--- a/packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx
+++ b/packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { StoreIcon, Truck } from "lucide-react";
 import { toast } from "sonner";
 import { useMutation } from "convex/react";
@@ -10,9 +10,14 @@ import { Switch } from "../../ui/switch";
 import { Label } from "../../ui/label";
 import { Textarea } from "../../ui/textarea";
 import { Button } from "../../ui/button";
+import { getStoreConfigV2 } from "~/src/lib/storeConfig";
 
 export const FulfillmentView = () => {
   const { activeStore } = useGetActiveStore();
+  const storeConfig = useMemo(
+    () => getStoreConfigV2(activeStore),
+    [activeStore?.config],
+  );
 
   const [isUpdatingConfig, setIsUpdatingConfig] = useState(false);
   const [enableStorePickup, setEnableStorePickup] = useState(true);
@@ -33,23 +38,21 @@ export const FulfillmentView = () => {
   const [deliveryHasUnsavedChanges, setDeliveryHasUnsavedChanges] =
     useState(false);
 
-  const updateConfig = useMutation(api.inventory.stores.updateConfig);
+  const patchConfig = useMutation(api.inventory.stores.patchConfigV2);
 
   const saveEnableStorePickupChanges = async (toggled: boolean) => {
     setIsUpdatingConfig(true);
     setEnableStorePickup(toggled);
 
-    const updates = {
-      ...activeStore?.config?.fulfillment,
-      enableStorePickup: toggled,
-    };
-
     try {
-      await updateConfig({
+      await patchConfig({
         id: activeStore?._id!,
-        config: {
-          ...activeStore?.config,
-          fulfillment: updates,
+        patch: {
+          commerce: {
+            fulfillment: {
+              enableStorePickup: toggled,
+            },
+          },
         },
       });
       const message = toggled
@@ -73,17 +76,15 @@ export const FulfillmentView = () => {
     setIsUpdatingConfig(true);
     setEnableDelivery(toggled);
 
-    const updates = {
-      ...activeStore?.config?.fulfillment,
-      enableDelivery: toggled,
-    };
-
     try {
-      await updateConfig({
+      await patchConfig({
         id: activeStore?._id!,
-        config: {
-          ...activeStore?.config,
-          fulfillment: updates,
+        patch: {
+          commerce: {
+            fulfillment: {
+              enableDelivery: toggled,
+            },
+          },
         },
       });
       const message = toggled
@@ -103,17 +104,17 @@ export const FulfillmentView = () => {
     setIsUpdatingConfig(false);
   };
 
-  const savePickupRestriction = async (updates: any) => {
+  const savePickupRestriction = async (updates: Record<string, any>) => {
     setIsUpdatingConfig(true);
 
     try {
-      await updateConfig({
+      await patchConfig({
         id: activeStore?._id!,
-        config: {
-          ...activeStore?.config,
-          fulfillment: {
-            ...activeStore?.config?.fulfillment,
-            pickupRestriction: updates,
+        patch: {
+          commerce: {
+            fulfillment: {
+              pickupRestriction: updates,
+            },
           },
         },
       });
@@ -128,17 +129,17 @@ export const FulfillmentView = () => {
     setIsUpdatingConfig(false);
   };
 
-  const saveDeliveryRestriction = async (updates: any) => {
+  const saveDeliveryRestriction = async (updates: Record<string, any>) => {
     setIsUpdatingConfig(true);
 
     try {
-      await updateConfig({
+      await patchConfig({
         id: activeStore?._id!,
-        config: {
-          ...activeStore?.config,
-          fulfillment: {
-            ...activeStore?.config?.fulfillment,
-            deliveryRestriction: updates,
+        patch: {
+          commerce: {
+            fulfillment: {
+              deliveryRestriction: updates,
+            },
           },
         },
       });
@@ -165,8 +166,8 @@ export const FulfillmentView = () => {
         isActive: false,
         message: "",
         reason: "",
-        startTime: undefined,
-        endTime: undefined,
+        startTime: null,
+        endTime: null,
       });
     } else {
       // If turning on pickup restriction, turn off delivery restriction
@@ -179,8 +180,8 @@ export const FulfillmentView = () => {
           isActive: false,
           message: "",
           reason: "",
-          startTime: undefined,
-          endTime: undefined,
+          startTime: null,
+          endTime: null,
         });
       }
 
@@ -204,8 +205,8 @@ export const FulfillmentView = () => {
         isActive: false,
         message: "",
         reason: "",
-        startTime: undefined,
-        endTime: undefined,
+        startTime: null,
+        endTime: null,
       });
     } else {
       // If turning on delivery restriction, turn off pickup restriction
@@ -218,8 +219,8 @@ export const FulfillmentView = () => {
           isActive: false,
           message: "",
           reason: "",
-          startTime: undefined,
-          endTime: undefined,
+          startTime: null,
+          endTime: null,
         });
       }
 
@@ -252,26 +253,25 @@ export const FulfillmentView = () => {
   useEffect(() => {
     // Default to true if not set (for backward compatibility)
     setEnableStorePickup(
-      activeStore?.config?.fulfillment?.enableStorePickup ?? true
+      storeConfig.commerce.fulfillment?.enableStorePickup ?? true
     );
 
-    setEnableDelivery(activeStore?.config?.fulfillment?.enableDelivery ?? true);
+    setEnableDelivery(storeConfig.commerce.fulfillment?.enableDelivery ?? true);
 
     // Load restriction states
-    const pickupRestriction =
-      activeStore?.config?.fulfillment?.pickupRestriction;
+    const pickupRestriction = storeConfig.commerce.fulfillment?.pickupRestriction;
     setPickupRestrictionActive(pickupRestriction?.isActive || false);
     setPickupRestrictionMessage(pickupRestriction?.message || "");
     setPickupRestrictionReason(pickupRestriction?.reason || "");
     setPickupHasUnsavedChanges(false);
 
     const deliveryRestriction =
-      activeStore?.config?.fulfillment?.deliveryRestriction;
+      storeConfig.commerce.fulfillment?.deliveryRestriction;
     setDeliveryRestrictionActive(deliveryRestriction?.isActive || false);
     setDeliveryRestrictionMessage(deliveryRestriction?.message || "");
     setDeliveryRestrictionReason(deliveryRestriction?.reason || "");
     setDeliveryHasUnsavedChanges(false);
-  }, [activeStore?.config?.fulfillment]);
+  }, [storeConfig]);
 
   return (
     <View

--- a/packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.tsx
+++ b/packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Construction, Disc2, EyeIcon } from "lucide-react";
 import { toast } from "sonner";
 import { useMutation } from "convex/react";
@@ -8,16 +8,20 @@ import View from "../../View";
 import { Switch } from "../../ui/switch";
 import { Label } from "../../ui/label";
 import { MaintenanceMessageEditor } from "../../homepage/MaintenanceMessageEditor";
-import { isInMaintenanceMode as checkMaintenanceMode } from "~/src/lib/maintenanceUtils";
+import { getStoreConfigV2 } from "~/src/lib/storeConfig";
 
 export const MaintenanceView = () => {
   const { activeStore } = useGetActiveStore();
+  const storeConfig = useMemo(
+    () => getStoreConfigV2(activeStore),
+    [activeStore?.config],
+  );
 
   const [isUpdatingConfig, setIsUpdatingConfig] = useState(false);
   const [isInMaintenanceMode, setIsInMaintenanceMode] = useState(false);
   const [isInReadOnlyMode, setIsInReadOnlyMode] = useState(false);
 
-  const updateConfig = useMutation(api.inventory.stores.updateConfig);
+  const patchConfig = useMutation(api.inventory.stores.patchConfigV2);
 
   const saveMaintenanceModeChanges = async (toggled: boolean) => {
     setIsUpdatingConfig(true);
@@ -28,11 +32,12 @@ export const MaintenanceView = () => {
     };
 
     try {
-      await updateConfig({
+      await patchConfig({
         id: activeStore?._id!,
-        config: {
-          ...activeStore?.config,
-          availability: updates,
+        patch: {
+          operations: {
+            availability: updates,
+          },
         },
       });
       const message = toggled
@@ -65,11 +70,12 @@ export const MaintenanceView = () => {
     };
 
     try {
-      await updateConfig({
+      await patchConfig({
         id: activeStore?._id!,
-        config: {
-          ...activeStore?.config,
-          visibility: updates,
+        patch: {
+          operations: {
+            visibility: updates,
+          },
         },
       });
       const message = toggled
@@ -94,11 +100,9 @@ export const MaintenanceView = () => {
   };
 
   useEffect(() => {
-    setIsInMaintenanceMode(checkMaintenanceMode(activeStore?.config));
-    setIsInReadOnlyMode(
-      activeStore?.config?.visibility?.inReadOnlyMode || false
-    );
-  }, [activeStore?.config]);
+    setIsInMaintenanceMode(storeConfig.operations.availability.inMaintenanceMode);
+    setIsInReadOnlyMode(storeConfig.operations.visibility.inReadOnlyMode);
+  }, [storeConfig]);
 
   return (
     <div className="space-y-8">

--- a/packages/athena-webapp/src/components/store-configuration/components/TaxView.tsx
+++ b/packages/athena-webapp/src/components/store-configuration/components/TaxView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Receipt } from "lucide-react";
 import useGetActiveStore from "~/src/hooks/useGetActiveStore";
 import View from "../../View";
@@ -7,10 +7,15 @@ import { LoadingButton } from "../../ui/loading-button";
 import { Switch } from "../../ui/switch";
 import { Label } from "../../ui/label";
 import { useStoreConfigUpdate } from "../hooks/useStoreConfigUpdate";
+import { getStoreConfigV2 } from "~/src/lib/storeConfig";
 
 export const TaxView = () => {
   const { activeStore } = useGetActiveStore();
   const { updateConfig, isUpdating } = useStoreConfigUpdate();
+  const storeConfig = useMemo(
+    () => getStoreConfigV2(activeStore),
+    [activeStore?.config],
+  );
 
   const [taxRate, setTaxRate] = useState(0);
   const [taxName, setTaxName] = useState("");
@@ -27,9 +32,10 @@ export const TaxView = () => {
 
     await updateConfig({
       storeId: activeStore?._id!,
-      config: {
-        ...activeStore?.config,
-        tax: taxConfig,
+      patch: {
+        commerce: {
+          tax: taxConfig,
+        },
       },
       successMessage: "Tax settings updated",
       errorMessage: "An error occurred while updating tax settings",
@@ -38,12 +44,12 @@ export const TaxView = () => {
 
   useEffect(() => {
     // Sync state with store data when `activeStore` changes
-    const taxConfig = activeStore?.config?.tax;
-    setEnableTax(taxConfig?.enabled || false);
-    setTaxRate(taxConfig?.rate || 0);
+    const taxConfig = storeConfig.commerce.tax;
+    setEnableTax(taxConfig?.enabled ?? false);
+    setTaxRate(taxConfig?.rate ?? 0);
     setTaxName(taxConfig?.name || "");
-    setIncludeTaxInPrice(taxConfig?.includedInPrice || false);
-  }, [activeStore]);
+    setIncludeTaxInPrice(taxConfig?.includedInPrice ?? false);
+  }, [storeConfig]);
 
   return (
     <View

--- a/packages/athena-webapp/src/components/store-configuration/hooks/useStoreConfigUpdate.ts
+++ b/packages/athena-webapp/src/components/store-configuration/hooks/useStoreConfigUpdate.ts
@@ -6,7 +6,10 @@ import { Id } from "~/convex/_generated/dataModel";
 
 interface UpdateConfigOptions {
   storeId: Id<"store">;
-  config: any;
+  patch?: Record<string, any>;
+  // Backward-compatible alias while callsites migrate to patch payloads.
+  config?: Record<string, any>;
+  mirrorLegacy?: boolean;
   successMessage?: string;
   errorMessage?: string;
   onSuccess?: () => void;
@@ -15,11 +18,13 @@ interface UpdateConfigOptions {
 
 export const useStoreConfigUpdate = () => {
   const [isUpdating, setIsUpdating] = useState(false);
-  const updateConfigMutation = useMutation(api.inventory.stores.updateConfig);
+  const patchConfigMutation = useMutation(api.inventory.stores.patchConfigV2);
 
   const updateConfig = async ({
     storeId,
+    patch,
     config,
+    mirrorLegacy,
     successMessage = "Configuration updated",
     errorMessage = "An error occurred while updating configuration",
     onSuccess,
@@ -28,9 +33,16 @@ export const useStoreConfigUpdate = () => {
     setIsUpdating(true);
 
     try {
-      await updateConfigMutation({
+      const nextPatch = patch ?? config;
+
+      if (!nextPatch) {
+        throw new Error("A config patch payload is required");
+      }
+
+      await patchConfigMutation({
         id: storeId,
-        config,
+        patch: nextPatch,
+        mirrorLegacy,
       });
       toast.success(successMessage, { position: "top-right" });
       onSuccess?.();

--- a/packages/athena-webapp/src/lib/storeConfig.test.ts
+++ b/packages/athena-webapp/src/lib/storeConfig.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { getStoreConfigV2 } from "./storeConfig";
+
+describe("getStoreConfigV2", () => {
+  it("reads legacy-root store config keys into grouped sections", () => {
+    const config = getStoreConfigV2({
+      config: {
+        availability: { inMaintenanceMode: true },
+        visibility: { inReadOnlyMode: false },
+        contactInfo: { phoneNumber: "+233", location: "Accra" },
+        deliveryFees: {
+          withinAccra: 40,
+          otherRegions: 70,
+          international: 800,
+        },
+        waiveDeliveryFees: { all: true },
+        fulfillment: { enableDelivery: true, enableStorePickup: false },
+        tax: { enabled: true, rate: 9, name: "VAT", includedInPrice: false },
+        homeHero: {
+          displayType: "image",
+          headerImage: "https://example.com/hero.webp",
+          showOverlay: true,
+          showText: true,
+        },
+        streamReels: [{ version: 2, hlsUrl: "https://cdn/reel.m3u8" }],
+        activeStreamReel: 2,
+        activeStreamReelHlsUrl: "https://cdn/reel.m3u8",
+        ui: { fallbackImageUrl: "https://example.com/fallback.webp" },
+        showroomImage: "https://example.com/showroom.webp",
+        shopTheLookImage: "https://example.com/shop.webp",
+      },
+    });
+
+    expect(config.operations.availability.inMaintenanceMode).toBe(true);
+    expect(config.contact.phoneNumber).toBe("+233");
+    expect(config.commerce.deliveryFees.withinAccra).toBe(40);
+    expect(config.media.homeHero.displayType).toBe("image");
+    expect(config.media.reels.activeVersion).toBe(2);
+    expect(config.media.images.fallbackImageUrl).toBe(
+      "https://example.com/fallback.webp",
+    );
+  });
+
+  it("prefers grouped V2 keys when both legacy and grouped keys exist", () => {
+    const config = getStoreConfigV2({
+      config: {
+        availability: { inMaintenanceMode: true },
+        operations: {
+          availability: { inMaintenanceMode: false },
+          visibility: { inReadOnlyMode: true },
+        },
+        homeHero: { displayType: "image", showOverlay: false, showText: false },
+        media: {
+          homeHero: { displayType: "reel", showOverlay: true, showText: true },
+          reels: { activeVersion: 3, activeHlsUrl: "https://new/reel.m3u8" },
+        },
+      },
+    });
+
+    expect(config.operations.availability.inMaintenanceMode).toBe(false);
+    expect(config.operations.visibility.inReadOnlyMode).toBe(true);
+    expect(config.media.homeHero.displayType).toBe("reel");
+    expect(config.media.homeHero.showOverlay).toBe(true);
+    expect(config.media.reels.activeVersion).toBe(3);
+    expect(config.media.reels.activeHlsUrl).toBe("https://new/reel.m3u8");
+  });
+});

--- a/packages/athena-webapp/src/lib/storeConfig.ts
+++ b/packages/athena-webapp/src/lib/storeConfig.ts
@@ -1,0 +1,361 @@
+import {
+  Store,
+  StoreConfigV2,
+  StoreDeliveryFeesConfig,
+  StoreFulfillmentConfig,
+  StoreTaxConfig,
+  StoreWaiveDeliveryFeesConfig,
+  StoreContactConfig,
+  StoreHomeHeroConfig,
+  StorePromotionConfig,
+  StoreStreamReelConfig,
+} from "~/types";
+
+type StoreConfigInput =
+  | Store
+  | { config?: unknown }
+  | Record<string, any>
+  | null
+  | undefined;
+
+const asRecord = (value: unknown): Record<string, any> => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+
+  return value as Record<string, any>;
+};
+
+const asString = (value: unknown): string | undefined =>
+  typeof value === "string" ? value : undefined;
+
+const asNumber = (value: unknown): number | undefined =>
+  typeof value === "number" ? value : undefined;
+
+const asBoolean = (value: unknown): boolean | undefined =>
+  typeof value === "boolean" ? value : undefined;
+
+const asOptionalArray = <T>(
+  value: unknown,
+  map: (item: unknown) => T | undefined,
+): T[] | undefined => {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  return value
+    .map(map)
+    .filter((item): item is T => item !== undefined);
+};
+
+const firstDefined = <T>(...values: Array<T | undefined | null>): T | undefined => {
+  for (const value of values) {
+    if (value !== undefined && value !== null) {
+      return value;
+    }
+  }
+
+  return undefined;
+};
+
+const cleanUndefined = <T extends Record<string, any>>(value: T): T => {
+  const next = { ...value };
+
+  for (const [key, fieldValue] of Object.entries(next)) {
+    if (fieldValue === undefined) {
+      delete next[key as keyof T];
+    }
+  }
+
+  return next;
+};
+
+const getRawConfig = (input: StoreConfigInput): Record<string, any> => {
+  if (!input) {
+    return {};
+  }
+
+  if ("config" in (input as Record<string, any>)) {
+    return asRecord((input as { config?: unknown }).config);
+  }
+
+  return asRecord(input);
+};
+
+const mapStreamReel = (value: unknown): StoreStreamReelConfig | undefined => {
+  const reel = asRecord(value);
+  const version = asNumber(reel.version);
+  if (version === undefined) {
+    return undefined;
+  }
+
+  return {
+    version,
+    source: asString(reel.source),
+    streamUid: asString(reel.streamUid),
+    hlsUrl: asString(reel.hlsUrl),
+    thumbnailUrl: asString(reel.thumbnailUrl),
+    createdAt: asNumber(reel.createdAt),
+  };
+};
+
+const mapPromotion = (value: unknown): StorePromotionConfig | undefined => {
+  const promotion = asRecord(value);
+  return Object.keys(promotion).length > 0 ? promotion : undefined;
+};
+
+const normalizeWaiveDeliveryFees = (
+  value: unknown,
+): StoreWaiveDeliveryFeesConfig => {
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  const record = asRecord(value);
+
+  return cleanUndefined({
+    all: asBoolean(record.all),
+    international: asBoolean(record.international),
+    otherRegions: asBoolean(record.otherRegions),
+    withinAccra: asBoolean(record.withinAccra),
+  });
+};
+
+export const getStoreConfigV2 = (input: StoreConfigInput): StoreConfigV2 => {
+  const config = getRawConfig(input);
+
+  const operations = asRecord(config.operations);
+  const commerce = asRecord(config.commerce);
+  const media = asRecord(config.media);
+  const promotions = asRecord(config.promotions);
+  const contact = asRecord(config.contact);
+
+  const homeHero = asRecord(media.homeHero);
+  const reels = asRecord(media.reels);
+  const images = asRecord(media.images);
+
+  const legacyHomeHero = asRecord(config.homeHero);
+  const legacyAvailability = asRecord(config.availability);
+  const legacyVisibility = asRecord(config.visibility);
+  const legacyMaintenance = asRecord(config.maintenance);
+  const legacyDeliveryFees = asRecord(config.deliveryFees);
+  const legacyFulfillment = asRecord(config.fulfillment);
+  const legacyTax = asRecord(config.tax);
+  const legacyUi = asRecord(config.ui);
+  const legacyContactInfo = asRecord(config.contactInfo);
+
+  const operationsConfig = {
+    availability: {
+      inMaintenanceMode:
+        firstDefined(
+          asBoolean(asRecord(operations.availability).inMaintenanceMode),
+          asBoolean(legacyAvailability.inMaintenanceMode),
+        ) ?? false,
+    },
+    visibility: {
+      inReadOnlyMode:
+        firstDefined(
+          asBoolean(asRecord(operations.visibility).inReadOnlyMode),
+          asBoolean(legacyVisibility.inReadOnlyMode),
+        ) ?? false,
+    },
+    maintenance: cleanUndefined({
+      heading: firstDefined(
+        asString(asRecord(operations.maintenance).heading),
+        asString(legacyMaintenance.heading),
+      ),
+      message: firstDefined(
+        asString(asRecord(operations.maintenance).message),
+        asString(legacyMaintenance.message),
+      ),
+      countdownEndsAt: firstDefined(
+        asNumber(asRecord(operations.maintenance).countdownEndsAt),
+        asNumber(legacyMaintenance.countdownEndsAt),
+      ),
+    }),
+  };
+
+  const deliveryFees: StoreDeliveryFeesConfig = cleanUndefined({
+    international: firstDefined(
+      asNumber(asRecord(commerce.deliveryFees).international),
+      asNumber(legacyDeliveryFees.international),
+    ),
+    otherRegions: firstDefined(
+      asNumber(asRecord(commerce.deliveryFees).otherRegions),
+      asNumber(legacyDeliveryFees.otherRegions),
+    ),
+    withinAccra: firstDefined(
+      asNumber(asRecord(commerce.deliveryFees).withinAccra),
+      asNumber(legacyDeliveryFees.withinAccra),
+    ),
+  });
+
+  const fulfillment: StoreFulfillmentConfig = cleanUndefined({
+    disableDelivery: firstDefined(
+      asBoolean(asRecord(commerce.fulfillment).disableDelivery),
+      asBoolean(legacyFulfillment.disableDelivery),
+    ),
+    disableStorePickup: firstDefined(
+      asBoolean(asRecord(commerce.fulfillment).disableStorePickup),
+      asBoolean(legacyFulfillment.disableStorePickup),
+    ),
+    enableDelivery: firstDefined(
+      asBoolean(asRecord(commerce.fulfillment).enableDelivery),
+      asBoolean(legacyFulfillment.enableDelivery),
+    ),
+    enableStorePickup: firstDefined(
+      asBoolean(asRecord(commerce.fulfillment).enableStorePickup),
+      asBoolean(legacyFulfillment.enableStorePickup),
+    ),
+    pickupRestriction: cleanUndefined({
+      isActive: firstDefined(
+        asBoolean(asRecord(asRecord(commerce.fulfillment).pickupRestriction).isActive),
+        asBoolean(asRecord(legacyFulfillment.pickupRestriction).isActive),
+      ),
+      reason: firstDefined(
+        asString(asRecord(asRecord(commerce.fulfillment).pickupRestriction).reason),
+        asString(asRecord(legacyFulfillment.pickupRestriction).reason),
+      ),
+      message: firstDefined(
+        asString(asRecord(asRecord(commerce.fulfillment).pickupRestriction).message),
+        asString(asRecord(legacyFulfillment.pickupRestriction).message),
+      ),
+      endTime: firstDefined(
+        asNumber(asRecord(asRecord(commerce.fulfillment).pickupRestriction).endTime),
+        asNumber(asRecord(legacyFulfillment.pickupRestriction).endTime),
+      ),
+    }),
+    deliveryRestriction: cleanUndefined({
+      isActive: firstDefined(
+        asBoolean(asRecord(asRecord(commerce.fulfillment).deliveryRestriction).isActive),
+        asBoolean(asRecord(legacyFulfillment.deliveryRestriction).isActive),
+      ),
+      reason: firstDefined(
+        asString(asRecord(asRecord(commerce.fulfillment).deliveryRestriction).reason),
+        asString(asRecord(legacyFulfillment.deliveryRestriction).reason),
+      ),
+      message: firstDefined(
+        asString(asRecord(asRecord(commerce.fulfillment).deliveryRestriction).message),
+        asString(asRecord(legacyFulfillment.deliveryRestriction).message),
+      ),
+      endTime: firstDefined(
+        asNumber(asRecord(asRecord(commerce.fulfillment).deliveryRestriction).endTime),
+        asNumber(asRecord(legacyFulfillment.deliveryRestriction).endTime),
+      ),
+    }),
+  });
+
+  const tax: StoreTaxConfig = cleanUndefined({
+    enabled: firstDefined(
+      asBoolean(asRecord(commerce.tax).enabled),
+      asBoolean(legacyTax.enabled),
+    ),
+    includedInPrice: firstDefined(
+      asBoolean(asRecord(commerce.tax).includedInPrice),
+      asBoolean(legacyTax.includedInPrice),
+    ),
+    name: firstDefined(asString(asRecord(commerce.tax).name), asString(legacyTax.name)),
+    rate: firstDefined(asNumber(asRecord(commerce.tax).rate), asNumber(legacyTax.rate)),
+  });
+
+  const homeHeroConfig: StoreHomeHeroConfig = {
+    displayType:
+      firstDefined(
+        asString(homeHero.displayType),
+        asString(legacyHomeHero.displayType),
+        asString(config.heroDisplayType),
+      ) === "image"
+        ? "image"
+        : "reel",
+    headerImage: firstDefined(
+      asString(homeHero.headerImage),
+      asString(legacyHomeHero.headerImage),
+      asString(config.heroHeaderImage),
+    ),
+    showOverlay:
+      firstDefined(
+        asBoolean(homeHero.showOverlay),
+        asBoolean(legacyHomeHero.showOverlay),
+        asBoolean(config.heroShowOverlay),
+      ) ?? false,
+    showText:
+      firstDefined(
+        asBoolean(homeHero.showText),
+        asBoolean(legacyHomeHero.showText),
+        asBoolean(config.heroShowText),
+      ) ?? false,
+  };
+
+  return {
+    operations: operationsConfig,
+    commerce: {
+      deliveryFees,
+      waiveDeliveryFees: normalizeWaiveDeliveryFees(
+        firstDefined(commerce.waiveDeliveryFees, config.waiveDeliveryFees),
+      ),
+      fulfillment,
+      tax,
+    },
+    media: {
+      homeHero: homeHeroConfig,
+      reels: {
+        activeVersion: firstDefined(
+          asNumber(reels.activeVersion),
+          asNumber(config.activeStreamReel),
+        ),
+        activeHlsUrl: firstDefined(
+          asString(reels.activeHlsUrl),
+          asString(config.activeStreamReelHlsUrl),
+        ),
+        landingPageVersion: firstDefined(
+          asString(reels.landingPageVersion),
+          asString(config.landingPageReelVersion),
+        ),
+        versions:
+          firstDefined(
+            asOptionalArray(reels.versions, (value) => asString(value)),
+            asOptionalArray(config.reelVersions, (value) => asString(value)),
+          ) ?? [],
+        streamReels:
+          firstDefined(
+            asOptionalArray(reels.streamReels, mapStreamReel),
+            asOptionalArray(config.streamReels, mapStreamReel),
+          ) ?? [],
+      },
+      images: cleanUndefined({
+        fallbackImageUrl: firstDefined(
+          asString(images.fallbackImageUrl),
+          asString(legacyUi.fallbackImageUrl),
+        ),
+        shopTheLookImage: firstDefined(
+          asString(images.shopTheLookImage),
+          asString(config.shopTheLookImage),
+        ),
+        showroomImage: firstDefined(
+          asString(images.showroomImage),
+          asString(config.showroomImage),
+        ),
+      }),
+    },
+    promotions: cleanUndefined({
+      homepageDiscountCodeModalPromoCode: firstDefined(
+        mapPromotion(promotions.homepageDiscountCodeModalPromoCode),
+        mapPromotion(config.homepageDiscountCodeModalPromoCode),
+      ),
+      leaveAReviewDiscountCodeModalPromoCode: firstDefined(
+        mapPromotion(promotions.leaveAReviewDiscountCodeModalPromoCode),
+        mapPromotion(config.leaveAReviewDiscountCodeModalPromoCode),
+      ),
+    }),
+    contact: cleanUndefined({
+      phoneNumber: firstDefined(
+        asString(contact.phoneNumber),
+        asString(legacyContactInfo.phoneNumber),
+      ),
+      location: firstDefined(
+        asString(contact.location),
+        asString(legacyContactInfo.location),
+      ),
+    }) as StoreContactConfig,
+  };
+};


### PR DESCRIPTION
## Summary
- add `src/lib/storeConfig.ts` with Athena-side grouped config selectors and legacy fallback support
- switch Athena admin config writes from full-object `updateConfig` payloads to granular `patchConfigV2` patches
- update `useStoreConfigUpdate` to call `patchConfigV2` (with backward-compatible `config` alias during migration)
- migrate homepage/admin config writers to grouped patch paths:
  - hero/reel: `HeroSectionTabs`, `HeroHeaderImageUploader`, `LandingPageReelVersion`
  - maintenance message: `MaintenanceMessageEditor`
  - shop look: `ShopLook`
  - config panels: `ContactView`, `FeesView`, `FulfillmentView`, `MaintenanceView`, `TaxView`
  - promo config updates: `PromoCodeView`
  - asset config actions: `assetsColumns`, `assets/index`

## Behavior Changes
- no UI callsites in migrated Athena config flows spread and send full `activeStore.config` objects anymore
- patches now target grouped V2 keys (for example `media.homeHero`, `commerce.deliveryFees`, `operations.availability`, `promotions.*`, `contact`)
- backend compatibility from PR1 remains active (legacy mirroring still on)

## Testing
- `bun run test -- src/lib/storeConfig.test.ts`
- `bun run test -- convex/inventory/storeConfigV2.test.ts`

## Notes
- full `tsc --noEmit` still reports unrelated pre-existing project issues outside this PR scope; no type errors were reported from the files changed in this PR
