### PR TITLE
feat: migrate storefront config reads to v2 selectors

### DIFF
--- a/packages/storefront-webapp/src/components/HomePage.tsx
+++ b/packages/storefront-webapp/src/components/HomePage.tsx
@@ -28,6 +28,7 @@ import { getRelativeTime } from "@/lib/utils";
 import { ProductActionBar } from "./ProductActionBar";
 import { useShoppingBag } from "@/hooks/useShoppingBag";
 import { LeaveAReviewModal } from "./ui/modals/LeaveAReviewModal";
+import { getStoreConfigV2 } from "@/lib/storeConfig";
 
 const origin = "homepage";
 
@@ -37,6 +38,7 @@ export default function HomePage() {
   const footerRef = useRef<HTMLDivElement>(null);
 
   const { store } = useStoreContext();
+  const storeConfig = getStoreConfigV2(store);
 
   // console.log("store", store);
 
@@ -151,7 +153,7 @@ export default function HomePage() {
       action: "clicked_on_discount_code_trigger",
       origin: "homepage",
       data: {
-        promoCodeId: store?.config?.homepageDiscountCodeModalPromoCode,
+        promoCodeId: storeConfig.promotions.homepageDiscountCodeModalPromoCode,
       },
     });
   };
@@ -163,7 +165,7 @@ export default function HomePage() {
       action: "clicked_on_leave_review_trigger",
       origin: "homepage",
       data: {
-        promoCodeId: store?.config?.leaveAReviewDiscountCodeModalPromoCode,
+        promoCodeId: storeConfig.promotions.leaveAReviewDiscountCodeModalPromoCode,
       },
     });
   };
@@ -230,7 +232,7 @@ export default function HomePage() {
 
       {/* Floating leave a review button */}
       {!hasCompletedLeaveReviewModalFlow &&
-        store?.config?.leaveAReviewDiscountCodeModalPromoCode &&
+        storeConfig.promotions.leaveAReviewDiscountCodeModalPromoCode &&
         canShowModal && (
           <motion.button
             initial={{ opacity: 0 }}
@@ -248,7 +250,7 @@ export default function HomePage() {
         isOpen={isLeaveReviewModalOpen && canShowModal}
         onClose={handleCloseLeaveReviewModal}
         onSuccess={handleSuccessLeaveReviewModal}
-        promoCode={store?.config?.leaveAReviewDiscountCodeModalPromoCode}
+        promoCode={storeConfig.promotions.leaveAReviewDiscountCodeModalPromoCode}
       />
 
       <div className="min-h-screen overflow-x-hidden">

--- a/packages/storefront-webapp/src/components/ProductsPage.tsx
+++ b/packages/storefront-webapp/src/components/ProductsPage.tsx
@@ -4,6 +4,7 @@ import { Link, useParams } from "@tanstack/react-router";
 import { Skeleton } from "./ui/skeleton";
 import { ProductCard, ProductSkuCard } from "./ProductCard";
 import { useGetProductFilters } from "@/hooks/useGetProductFilters";
+import { getStoreFallbackImageUrl } from "@/lib/storeConfig";
 
 function ProductCardLoadingSkeleton() {
   return (
@@ -27,6 +28,7 @@ export default function ProductsPage({
   productSkus?: ProductSku[];
 }) {
   const { formatter, store } = useStoreContext();
+  const fallbackImageUrl = getStoreFallbackImageUrl(store);
 
   const { filtersCount } = useGetProductFilters();
 
@@ -103,7 +105,7 @@ export default function ProductsPage({
             className="block mb-4"
           >
             <ProductSkuCard
-              fallbackImageUrl={store?.config?.ui?.fallbackImageUrl}
+              fallbackImageUrl={fallbackImageUrl}
               sku={sku}
               currencyFormatter={formatter}
             />
@@ -123,7 +125,7 @@ export default function ProductsPage({
             className="block mb-4"
           >
             <ProductCard
-              fallbackImageUrl={store?.config?.ui?.fallbackImageUrl}
+              fallbackImageUrl={fallbackImageUrl}
               product={product}
               currencyFormatter={formatter}
             />

--- a/packages/storefront-webapp/src/components/checkout/BagSummary.tsx
+++ b/packages/storefront-webapp/src/components/checkout/BagSummary.tsx
@@ -20,6 +20,7 @@ import { usePromoCodesQueries } from "@/lib/queries/promoCode";
 import { isFeeWaived } from "@/lib/feeUtils";
 import { Badge } from "../ui/badge";
 import { useDiscountCodeAlert } from "@/hooks/useDiscountCodeAlert";
+import { getStoreConfigV2, getStoreFallbackImageUrl } from "@/lib/storeConfig";
 
 function SummaryItem({
   item,
@@ -58,6 +59,7 @@ function SummaryItem({
     (discount.span === "selected-products" || totalItemsInBag === 1);
 
   const hasDiscount = shouldShowDiscount;
+  const fallbackImageUrl = getStoreFallbackImageUrl(store);
 
   return (
     <div className="flex items-center justify-between">
@@ -66,7 +68,7 @@ function SummaryItem({
           <img
             src={
               item.productImage ||
-              store?.config?.ui?.fallbackImageUrl ||
+              fallbackImageUrl ||
               placeholder
             }
             alt={item.productName || "product image"}
@@ -141,7 +143,8 @@ function BagSummary() {
   const { userId, guestId } = useAuth();
   const [code, setCode] = useState("");
   const [invalidMessage, setInvalidMessage] = useState("");
-  const { waiveDeliveryFees } = store?.config || {};
+  const storeConfig = getStoreConfigV2(store);
+  const { waiveDeliveryFees } = storeConfig.commerce;
 
   const queryClient = useQueryClient();
 

--- a/packages/storefront-webapp/src/components/checkout/CheckoutProvider.tsx
+++ b/packages/storefront-webapp/src/components/checkout/CheckoutProvider.tsx
@@ -21,6 +21,7 @@ import {
   CheckoutActions,
   CheckoutContextType,
 } from "./types";
+import { getStoreConfigV2, isStoreReadOnlyMode } from "@/lib/storeConfig";
 
 export const webOrderSchema = z
   .object({
@@ -395,10 +396,11 @@ export const CheckoutProvider = ({
   const { bag } = useShoppingBag();
 
   const { user, store } = useStoreContext();
+  const storeConfig = getStoreConfigV2(store);
 
   const { setNavBarLayout, setAppLocation } = useNavigationBarContext();
 
-  const { waiveDeliveryFees, fulfillment } = store?.config || {};
+  const { waiveDeliveryFees, fulfillment, deliveryFees } = storeConfig.commerce;
   // Default to true if not set (for backward compatibility)
   const isPickupEnabled = fulfillment?.enableStorePickup ?? true;
   const isDeliveryEnabled = fulfillment?.enableDelivery ?? true;
@@ -515,7 +517,7 @@ export const CheckoutProvider = ({
       const shouldWaiveIntlFee = isFeeWaived(waiveDeliveryFees, "intl");
       let deliveryFee = shouldWaiveIntlFee
         ? 0
-        : store?.config?.deliveryFees?.international || 800;
+        : deliveryFees?.international || 800;
 
       if (isGhanaAddress) {
         deliveryOption = isGreaterAccraAddress
@@ -619,7 +621,7 @@ export const CheckoutProvider = ({
         newUpdates.deliveryOption = "intl";
         newUpdates.deliveryFee = shouldWaiveIntlFee
           ? 0
-          : store?.config?.deliveryFees?.international || 800;
+          : deliveryFees?.international || 800;
       }
 
       const isUSOrder =
@@ -760,9 +762,7 @@ export const CheckoutProvider = ({
     }
   }, [data, checkoutState.discount, actionsState.isApplyingDiscount]);
 
-  const { config } = store || {};
-
-  if (config?.visibility?.inReadOnlyMode) {
+  if (isStoreReadOnlyMode(store)) {
     return <CheckoutUnavailable />;
   }
 

--- a/packages/storefront-webapp/src/components/checkout/DeliveryDetails.tsx
+++ b/packages/storefront-webapp/src/components/checkout/DeliveryDetails.tsx
@@ -26,11 +26,13 @@ import { accraNeighborhoods } from "@/lib/ghana";
 import { Plus } from "lucide-react";
 import { CheckoutFormSectionProps } from "./CustomerInfoSection";
 import { useStoreContext } from "@/contexts/StoreContext";
+import { getStoreConfigV2 } from "@/lib/storeConfig";
 
 export const DeliveryDetailsForm = ({ form }: CheckoutFormSectionProps) => {
   const { checkoutState, updateState } = useCheckout();
   const { store } = useStoreContext();
-  const { waiveDeliveryFees, deliveryFees } = store?.config || {};
+  const storeConfig = getStoreConfigV2(store);
+  const { waiveDeliveryFees, deliveryFees } = storeConfig.commerce;
 
   // const onSubmit = (data: z.infer<typeof deliveryDetailsSchema>) => {
   //   console.log("on submit in delivery details ->", data);

--- a/packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryDetails.tsx
+++ b/packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryDetails.tsx
@@ -28,12 +28,14 @@ import { ALL_COUNTRIES } from "@/lib/countries";
 import { useEffect, useRef } from "react";
 import { deliveryDetailsSchema } from "./schema";
 import { useStoreContext } from "@/contexts/StoreContext";
+import { getStoreConfigV2 } from "@/lib/storeConfig";
 
 export const DeliveryDetailsForm = () => {
   const { checkoutState, actionsState, updateActionsState, updateState } =
     useCheckout();
   const { store } = useStoreContext();
-  const { waiveDeliveryFees, deliveryFees } = store?.config || {};
+  const storeConfig = getStoreConfigV2(store);
+  const { waiveDeliveryFees, deliveryFees } = storeConfig.commerce;
 
   const form = useForm({
     resolver: zodResolver(deliveryDetailsSchema),

--- a/packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx
+++ b/packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx
@@ -4,6 +4,7 @@ import { useCheckout } from "@/hooks/useCheckout";
 import { Address } from "../types";
 import { useStoreContext } from "@/contexts/StoreContext";
 import { isFeeWaived } from "@/lib/feeUtils";
+import { getStoreConfigV2 } from "@/lib/storeConfig";
 
 export function StoreSelector() {
   const { updateState, updateActionsState, checkoutState } = useCheckout();
@@ -41,8 +42,9 @@ export function DeliveryOptionsSelector() {
   const { checkoutState, updateState } = useCheckout();
 
   const { store, formatter } = useStoreContext();
+  const storeConfig = getStoreConfigV2(store);
 
-  const { deliveryFees, waiveDeliveryFees } = store?.config || {};
+  const { deliveryFees, waiveDeliveryFees } = storeConfig.commerce;
 
   const { international, withinAccra, otherRegions } = deliveryFees || {};
 

--- a/packages/storefront-webapp/src/components/checkout/DeliveryDetails/PickupOptions.tsx
+++ b/packages/storefront-webapp/src/components/checkout/DeliveryDetails/PickupOptions.tsx
@@ -4,6 +4,7 @@ import { GhostButton } from "@/components/ui/ghost-button";
 import { Truck } from "lucide-react";
 import { StoreIcon } from "lucide-react";
 import { isFeeWaived } from "@/lib/feeUtils";
+import { getStoreConfigV2 } from "@/lib/storeConfig";
 
 // Helper function to check if restriction is within time window
 function isWithinRestrictionTime(restriction: any): boolean {
@@ -25,7 +26,8 @@ function isWithinRestrictionTime(restriction: any): boolean {
 export const PickupOptions = () => {
   const { checkoutState, updateState } = useCheckout();
   const { formatter, store } = useStoreContext();
-  const { waiveDeliveryFees, fulfillment } = store?.config || {};
+  const storeConfig = getStoreConfigV2(store);
+  const { waiveDeliveryFees, fulfillment } = storeConfig.commerce;
 
   const isPickup = checkoutState.deliveryMethod === "pickup";
   const isDelivery = checkoutState.deliveryMethod === "delivery";

--- a/packages/storefront-webapp/src/components/checkout/DeliveryDetailsSection.tsx
+++ b/packages/storefront-webapp/src/components/checkout/DeliveryDetailsSection.tsx
@@ -25,6 +25,7 @@ import { Button } from "../ui/button";
 import { US_STATES } from "@/lib/states";
 import { useStoreContext } from "@/contexts/StoreContext";
 import { isFeeWaived } from "@/lib/feeUtils";
+import { getStoreConfigV2 } from "@/lib/storeConfig";
 
 export const CountryFields = ({ form }: CheckoutFormSectionProps) => {
   const { checkoutState, updateState } = useCheckout();
@@ -116,7 +117,8 @@ export const CountryFields = ({ form }: CheckoutFormSectionProps) => {
 const RegionFields = ({ form }: CheckoutFormSectionProps) => {
   const { checkoutState, updateState } = useCheckout();
   const { store } = useStoreContext();
-  const { waiveDeliveryFees, deliveryFees } = store?.config || {};
+  const storeConfig = getStoreConfigV2(store);
+  const { waiveDeliveryFees, deliveryFees } = storeConfig.commerce;
 
   return (
     <>
@@ -771,8 +773,8 @@ export const DeliveryDetailsSection = ({ form }: CheckoutFormSectionProps) => {
   const { country, region } = deliveryDetails || {};
 
   const { store } = useStoreContext();
-
-  const { deliveryFees, waiveDeliveryFees } = store?.config || {};
+  const storeConfig = getStoreConfigV2(store);
+  const { deliveryFees, waiveDeliveryFees } = storeConfig.commerce;
 
   const previousCountryRef = useRef(
     checkoutState.deliveryDetails?.country || undefined

--- a/packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx
+++ b/packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx
@@ -25,6 +25,7 @@ import { Badge } from "../ui/badge";
 import { motion } from "framer-motion";
 import { toast } from "sonner";
 import { useDiscountCodeAlert } from "@/hooks/useDiscountCodeAlert";
+import { getStoreConfigV2 } from "@/lib/storeConfig";
 
 export default function MobileBagSummary() {
   const { formatter, store } = useStoreContext();
@@ -33,7 +34,8 @@ export default function MobileBagSummary() {
   const [invalidMessage, setInvalidMessage] = useState("");
   const [code, setCode] = useState("");
   const { userId, guestId } = useAuth();
-  const { waiveDeliveryFees } = store?.config || {};
+  const storeConfig = getStoreConfigV2(store);
+  const { waiveDeliveryFees } = storeConfig.commerce;
 
   const queryClient = useQueryClient();
 

--- a/packages/storefront-webapp/src/components/checkout/OrderDetails/OrderSummary.tsx
+++ b/packages/storefront-webapp/src/components/checkout/OrderDetails/OrderSummary.tsx
@@ -12,12 +12,14 @@ import { useState } from "react";
 import { useAuth } from "@/hooks/useAuth";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { redeemPromoCode } from "@/api/promoCodes";
+import { getStoreConfigV2 } from "@/lib/storeConfig";
 
 export default function OrderSummary() {
   const { formatter, store } = useStoreContext();
   const { bagSubtotal } = useShoppingBag();
   const { checkoutState, activeSession, updateState } = useCheckout();
-  const { waiveDeliveryFees } = store?.config || {};
+  const storeConfig = getStoreConfigV2(store);
+  const { waiveDeliveryFees } = storeConfig.commerce;
 
   const [invalidMessage, setInvalidMessage] = useState("");
   const [code, setCode] = useState("");

--- a/packages/storefront-webapp/src/components/footer/Footer.tsx
+++ b/packages/storefront-webapp/src/components/footer/Footer.tsx
@@ -3,6 +3,7 @@ import { Link } from "@tanstack/react-router";
 import { useGetStoreCategories } from "../navigation/hooks";
 import { WIGLUB_HAIR_STUDIO_LOCATION_URL } from "@/lib/constants";
 import { forwardRef } from "react";
+import { getStoreConfigV2 } from "@/lib/storeConfig";
 
 interface FooterLinkGroup {
   header: string;
@@ -26,8 +27,7 @@ function LinkGroup({ group }: { group: FooterLinkGroup }) {
 
 export function FooterInner() {
   const { store } = useStoreContext();
-
-  const { contactInfo } = store?.config || {};
+  const storeConfig = getStoreConfigV2(store);
 
   const { categories } = useGetStoreCategories();
 
@@ -93,13 +93,13 @@ export function FooterInner() {
 
       <div className="space-y-4 text-sm">
         <div className="space-y-2">
-          <p>{contactInfo?.location}</p>
+          <p>{storeConfig.contact.location}</p>
           <div>
             <a
-              href={`tel:${contactInfo?.phoneNumber}`}
+              href={`tel:${storeConfig.contact.phoneNumber}`}
               className="hover:underline font-medium"
             >
-              {contactInfo?.phoneNumber}
+              {storeConfig.contact.phoneNumber}
             </a>
           </div>
         </div>

--- a/packages/storefront-webapp/src/components/home/HomeHero.tsx
+++ b/packages/storefront-webapp/src/components/home/HomeHero.tsx
@@ -5,6 +5,7 @@ import Hls from "hls.js";
 import { useEffect, useRef } from "react";
 import { ScrollDownButton } from "../ui/ScrollDownButton";
 import { VideoPlayer } from "./VideoPlayer";
+import { getStoreConfigV2 } from "@/lib/storeConfig";
 
 interface HomeHeroProps {
   nextSectionRef?: React.RefObject<HTMLDivElement>;
@@ -12,30 +13,32 @@ interface HomeHeroProps {
 
 export const HomeHero = ({ nextSectionRef }: HomeHeroProps) => {
   const { store } = useStoreContext();
+  const storeConfig = getStoreConfigV2(store);
 
   const videoRef = useRef<HTMLVideoElement>(null);
-  const hlsUrl = store?.config?.activeStreamReelHlsUrl;
+  const hlsUrl = storeConfig.media.reels.activeHlsUrl;
 
   // Determine which hero to display (default to "reel" for backward compatibility)
-  const heroDisplayType = store?.config?.homeHero?.displayType || "reel";
+  const heroDisplayType = storeConfig.media.homeHero.displayType || "reel";
 
   const shouldShowImage =
-    heroDisplayType === "image" && store?.config?.homeHero?.headerImage;
+    heroDisplayType === "image" && storeConfig.media.homeHero.headerImage;
 
   const shouldShowVideo =
-    heroDisplayType === "reel" ||
-    (heroDisplayType === "image" &&
-      store?.config?.homeHero?.headerImage === undefined);
+    (heroDisplayType === "reel" ||
+      (heroDisplayType === "image" &&
+        storeConfig.media.homeHero.headerImage === undefined)) &&
+    Boolean(hlsUrl);
 
   // Determine overlay and text visibility (default to true for backward compatibility)
-  const shouldShowOverlay = store?.config?.homeHero?.showOverlay === true;
+  const shouldShowOverlay = storeConfig.media.homeHero.showOverlay === true;
 
-  const shouldShowText = store?.config?.homeHero?.showText === true;
+  const shouldShowText = storeConfig.media.homeHero.showText === true;
 
   return (
     <section className="relative w-full h-screen flex items-center justify-center text-white text-center">
       {/* Background Video - shown when heroDisplayType is "reel" or not set */}
-      {shouldShowVideo && <VideoPlayer hlsUrl={hlsUrl} />}
+      {shouldShowVideo && <VideoPlayer hlsUrl={hlsUrl!} />}
 
       {/* Background Image - shown when heroDisplayType is "image" */}
       {shouldShowImage && (
@@ -49,7 +52,7 @@ export const HomeHero = ({ nextSectionRef }: HomeHeroProps) => {
               ease: [0.6, 0.05, 0.01, 0.9],
             },
           }}
-          src={store?.config?.homeHero?.headerImage}
+          src={storeConfig.media.homeHero.headerImage}
           className="absolute top-0 left-0 w-full h-full object-cover"
           alt="Hero header"
         />

--- a/packages/storefront-webapp/src/components/home/HomeHeroSection.tsx
+++ b/packages/storefront-webapp/src/components/home/HomeHeroSection.tsx
@@ -5,6 +5,7 @@ import { ArrowRight } from "lucide-react";
 import { Button } from "../ui/button";
 import { HomeHero } from "./HomeHero";
 import { useStoreContext } from "@/contexts/StoreContext";
+import { getStoreConfigV2 } from "@/lib/storeConfig";
 
 interface HomeHeroSectionProps {
   shopLookProduct: any;
@@ -24,6 +25,7 @@ export function HomeHeroSection({
   const homeHeroRef = useRef<HTMLDivElement>(null);
   const shopTheLookRef = useRef<HTMLImageElement>(null);
   const { store } = useStoreContext();
+  const storeConfig = getStoreConfigV2(store);
 
   return (
     <div ref={homeHeroRef}>
@@ -42,7 +44,7 @@ export function HomeHeroSection({
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.6, delay: 0.8 }}
-            src={store?.config?.shopTheLookImage}
+            src={storeConfig.media.images.shopTheLookImage}
             className="w-full lg:w-[50%] h-screen object-cover"
           />
         </Link>

--- a/packages/storefront-webapp/src/components/navigation-bar/BagMenu.tsx
+++ b/packages/storefront-webapp/src/components/navigation-bar/BagMenu.tsx
@@ -11,6 +11,7 @@ import { useStoreContext } from "@/contexts/StoreContext";
 import { useLogout } from "@/hooks/useLogout";
 import ImageWithFallback from "../ui/image-with-fallback";
 import { useNavigationBarContext } from "@/contexts/NavigationBarProvider";
+import { getStoreFallbackImageUrl } from "@/lib/storeConfig";
 
 export const BagMenu = ({
   isMobile,
@@ -34,6 +35,7 @@ export const BagMenu = ({
   const handleLogout = useLogout();
 
   const { store } = useStoreContext();
+  const fallbackImageUrl = getStoreFallbackImageUrl(store);
 
   const { navBarLayout, appLocation } = useNavigationBarContext();
 
@@ -75,7 +77,7 @@ export const BagMenu = ({
                   <ImageWithFallback
                     src={
                       item.productImage ||
-                      store?.config?.ui?.fallbackImageUrl ||
+                      fallbackImageUrl ||
                       placeholder
                     }
                     alt={item.productName || "product image"}

--- a/packages/storefront-webapp/src/components/product-page/ProductDetails.tsx
+++ b/packages/storefront-webapp/src/components/product-page/ProductDetails.tsx
@@ -7,6 +7,7 @@ import placeholder from "@/assets/placeholder.png";
 import { WIGLUB_HAIR_STUDIO_LOCATION_URL } from "@/lib/constants";
 import { ShoppingBagAction } from "@/hooks/useShoppingBag";
 import { useStoreContext } from "@/contexts/StoreContext";
+import { getStoreFallbackImageUrl } from "@/lib/storeConfig";
 
 // Product Details Section
 export function PickupDetails({
@@ -56,6 +57,7 @@ export function BagProduct({
   const buttonLink = action == "adding-to-bag" ? "/shop/bag" : "/shop/saved";
 
   const { store } = useStoreContext();
+  const fallbackImageUrl = getStoreFallbackImageUrl(store);
 
   return (
     <div className="flex flex-col gap-12 pt-12">
@@ -67,7 +69,7 @@ export function BagProduct({
             className="w-[140px] h-[180px] aspect-square object-cover rounded"
             src={
               product.images[0] ||
-              store?.config?.ui?.fallbackImageUrl ||
+              fallbackImageUrl ||
               placeholder
             }
           />

--- a/packages/storefront-webapp/src/components/product-page/ProductPage.tsx
+++ b/packages/storefront-webapp/src/components/product-page/ProductPage.tsx
@@ -18,6 +18,8 @@ import { AboutProduct } from "./AboutProduct";
 import { useProductDiscount } from "@/hooks/useProductDiscount";
 import { DiscountBadge } from "./DiscountBadge";
 import { useStoreContext } from "@/contexts/StoreContext";
+import { getStoreFallbackImageUrl } from "@/lib/storeConfig";
+import placeholder from "@/assets/placeholder.png";
 
 // Main Product Page Component
 export default function ProductPage() {
@@ -46,6 +48,7 @@ export default function ProductPage() {
   const pageRef = useRef<HTMLDivElement | null>(null);
 
   const { store } = useStoreContext();
+  const fallbackImageUrl = getStoreFallbackImageUrl(store, placeholder) || placeholder;
 
   useTrackAction({
     action: "viewed_product",
@@ -85,7 +88,7 @@ export default function ProductPage() {
 
   const images = selectedSku.images.length
     ? selectedSku.images
-    : [store?.config?.ui?.fallbackImageUrl];
+    : [fallbackImageUrl];
 
   return (
     <AnimatePresence>

--- a/packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx
+++ b/packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx
@@ -2,6 +2,7 @@ import ImageWithFallback from "../ui/image-with-fallback";
 import { getProductName } from "@/lib/productUtils";
 import placeholder from "@/assets/placeholder.png";
 import { useStoreContext } from "@/contexts/StoreContext";
+import { getStoreFallbackImageUrl } from "@/lib/storeConfig";
 
 interface OrderItemProps {
   item: any;
@@ -14,13 +15,14 @@ export const OrderItem = ({ item, formatter }: OrderItemProps) => {
     : "Free";
 
   const { store } = useStoreContext();
+  const fallbackImageUrl = getStoreFallbackImageUrl(store);
 
   return (
     <div className="flex gap-8 text-sm">
       <ImageWithFallback
         src={
           item.productImage ||
-          store?.config?.ui?.fallbackImageUrl ||
+          fallbackImageUrl ||
           placeholder
         }
         alt={"product image"}

--- a/packages/storefront-webapp/src/components/saved-items/SavedBag.tsx
+++ b/packages/storefront-webapp/src/components/saved-items/SavedBag.tsx
@@ -13,10 +13,12 @@ import { FadeIn } from "../common/FadeIn";
 import ImageWithFallback from "../ui/image-with-fallback";
 import { postAnalytics } from "@/api/analytics";
 import { useTrackEvent } from "@/hooks/useTrackEvent";
+import { getStoreFallbackImageUrl } from "@/lib/storeConfig";
 
 export default function SavedBag() {
   const [bagAction, setBagAction] = useState<ShoppingBagAction>("idle");
   const { formatter, isNavbarShowing, store } = useStoreContext();
+  const fallbackImageUrl = getStoreFallbackImageUrl(store);
   const {
     savedBag,
     deleteItemFromSavedBag,
@@ -101,7 +103,7 @@ export default function SavedBag() {
                       <ImageWithFallback
                         src={
                           (item as any).productImage ||
-                          store?.config?.ui?.fallbackImageUrl ||
+                          fallbackImageUrl ||
                           placeholder
                         }
                         alt={(item as any).productName || "product image"}

--- a/packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx
+++ b/packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx
@@ -48,6 +48,7 @@ import { WelcomeBackModal } from "../ui/modals/WelcomeBackModal";
 import { useProductDiscount } from "@/hooks/useProductDiscount";
 import { DiscountBadge } from "../product-page/DiscountBadge";
 import { useInventoryStatus } from "@/hooks/useInventoryStatus";
+import { getStoreConfigV2 } from "@/lib/storeConfig";
 
 const PendingItem = ({ session, count }: { session: any; count: number }) => {
   return (
@@ -122,6 +123,7 @@ const BagItemWithDiscount = ({
   const discountInfo = useProductDiscount(item.productSkuId, item.price);
 
   const { store } = useStoreContext();
+  const storeConfig = getStoreConfigV2(store);
 
   // Calculate item total with discount
   const itemPrice = discountInfo.hasDiscount
@@ -208,7 +210,7 @@ const BagItemWithDiscount = ({
               <ImageWithFallback
                 src={
                   (item as any)?.productImage ||
-                  store?.config?.ui?.fallbackImageUrl
+                  storeConfig.media.images.fallbackImageUrl
                 }
                 alt={(item as any).productName || "product image"}
                 className="w-full h-full object-cover rounded-lg"
@@ -344,6 +346,7 @@ export default function ShoppingBag() {
   const [updateCounter, forceUpdate] = useReducer((x) => x + 1, 0);
   const itemTotalsRef = useRef<Map<string, number>>(new Map());
   const { formatter, userId, isNavbarShowing, store } = useStoreContext();
+  const storeConfig = getStoreConfigV2(store);
 
   const { setNavBarLayout, setAppLocation } = useNavigationBarContext();
 
@@ -479,7 +482,7 @@ export default function ShoppingBag() {
       action: "clicked_on_discount_code_trigger",
       origin: "shopping_bag",
       data: {
-        promoCodeId: store?.config?.homepageDiscountCodeModalPromoCode,
+        promoCodeId: storeConfig.promotions.homepageDiscountCodeModalPromoCode,
       },
     });
   };
@@ -695,7 +698,7 @@ export default function ShoppingBag() {
         isOpen={isDiscountModalOpen}
         onClose={handleCloseDiscountModal}
         onSuccess={completeDiscountModalFlow}
-        promoCode={store?.config?.homepageDiscountCodeModalPromoCode}
+        promoCode={storeConfig.promotions.homepageDiscountCodeModalPromoCode}
       />
     </FadeIn>
   );

--- a/packages/storefront-webapp/src/components/states/maintenance/Maintenance.tsx
+++ b/packages/storefront-webapp/src/components/states/maintenance/Maintenance.tsx
@@ -1,9 +1,11 @@
 import { useStoreContext } from "@/contexts/StoreContext";
 import { useCountdown } from "@/components/common/hooks";
+import { getStoreConfigV2 } from "@/lib/storeConfig";
 
 export const MaintenanceMode = () => {
   const { store } = useStoreContext();
-  const maintenanceConfig = store?.config?.maintenance;
+  const storeConfig = getStoreConfigV2(store);
+  const maintenanceConfig = storeConfig.operations.maintenance;
 
   const { timeLeft } = useCountdown(maintenanceConfig?.countdownEndsAt);
 

--- a/packages/storefront-webapp/src/components/ui/image-with-fallback.tsx
+++ b/packages/storefront-webapp/src/components/ui/image-with-fallback.tsx
@@ -1,13 +1,14 @@
 import React, { useState, forwardRef, useEffect } from "react";
 import placeholder from "@/assets/placeholder.png";
 import { useStoreContext } from "@/contexts/StoreContext";
+import { getStoreFallbackImageUrl } from "@/lib/storeConfig";
 
 const ImageWithFallback = forwardRef<
   HTMLImageElement,
   React.ImgHTMLAttributes<HTMLImageElement>
 >(({ src, ...props }, ref) => {
   const { store } = useStoreContext();
-  const fallbackImage = store?.config?.ui?.fallbackImageUrl || placeholder;
+  const fallbackImage = getStoreFallbackImageUrl(store, placeholder) || placeholder;
 
   // Use the src prop or fallback, and sync when src changes
   const [imageSrc, setImageSrc] = useState(src || fallbackImage);

--- a/packages/storefront-webapp/src/hooks/useLeaveAReviewModal.tsx
+++ b/packages/storefront-webapp/src/hooks/useLeaveAReviewModal.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useOnlineOrderQueries } from "@/lib/queries/onlineOrder";
 import { useReviewQueries } from "@/lib/queries/reviews";
 import { useStoreContext } from "@/contexts/StoreContext";
+import { getStoreConfigV2 } from "@/lib/storeConfig";
 
 const LEAVE_REVIEW_COOLDOWN_DAYS = 7;
 const LEAVE_REVIEW_LAST_SHOWN_KEY = "leave_review_modal_last_shown";
@@ -15,6 +16,7 @@ const LEAVE_REVIEW_DISMISSED_KEY = "leave_review_modal_dismissed";
  */
 export function useLeaveAReviewModal() {
   const { store } = useStoreContext();
+  const storeConfig = getStoreConfigV2(store);
   const onlineOrderQueries = useOnlineOrderQueries();
   const { data: onlineOrders } = useQuery(onlineOrderQueries.list());
   const { hasUserReviewForOrderItem } = useReviewQueries();
@@ -35,7 +37,7 @@ export function useLeaveAReviewModal() {
 
   // Check if store has promo code configured
   const hasPromoCode = Boolean(
-    store?.config?.leaveAReviewDiscountCodeModalPromoCode
+    storeConfig.promotions.leaveAReviewDiscountCodeModalPromoCode
   );
 
   // Determine if all conditions are met to show modal

--- a/packages/storefront-webapp/src/lib/maintenanceUtils.test.ts
+++ b/packages/storefront-webapp/src/lib/maintenanceUtils.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { isInMaintenanceMode } from "./maintenanceUtils";
+
+describe("maintenanceUtils", () => {
+  it("returns true for active V2 maintenance windows", () => {
+    const config = {
+      operations: {
+        availability: {
+          inMaintenanceMode: true,
+        },
+        maintenance: {
+          countdownEndsAt: Date.now() + 120_000,
+        },
+      },
+    };
+
+    expect(isInMaintenanceMode(config)).toBe(true);
+  });
+
+  it("returns false when V2 maintenance is disabled", () => {
+    const config = {
+      operations: {
+        availability: {
+          inMaintenanceMode: false,
+        },
+        maintenance: {
+          countdownEndsAt: Date.now() + 120_000,
+        },
+      },
+    };
+
+    expect(isInMaintenanceMode(config)).toBe(false);
+  });
+});

--- a/packages/storefront-webapp/src/lib/maintenanceUtils.ts
+++ b/packages/storefront-webapp/src/lib/maintenanceUtils.ts
@@ -1,40 +1,9 @@
-/**
- * Utility functions for maintenance mode logic
- */
-
-type StoreConfig = {
-  availability?: {
-    inMaintenanceMode?: boolean;
-  };
-  maintenance?: {
-    countdownEndsAt?: number;
-  };
-};
+import { isStoreMaintenanceMode } from "@/lib/storeConfig";
 
 /**
- * Determines if the store is in maintenance mode
- * Takes into account both the maintenance mode flag and countdown expiration
+ * Determines if the store is in maintenance mode.
+ * Supports both legacy and grouped V2 config shapes.
  */
-export function isInMaintenanceMode(config?: StoreConfig): boolean {
-  if (!config?.availability?.inMaintenanceMode) {
-    return false;
-  }
-
-  const countdownEndsAt = config?.maintenance?.countdownEndsAt;
-
-  const now = Date.now();
-  const timeLeft = countdownEndsAt ? countdownEndsAt - now : 0;
-
-  // If no countdown is set, use the maintenance mode flag directly
-  if (countdownEndsAt === undefined) {
-    // If countdown expired, not in maintenance mode
-    if (timeLeft <= 0) {
-      return false;
-    }
-
-    return true;
-  }
-
-  // Countdown is active and hasn't expired
-  return true;
+export function isInMaintenanceMode(config?: Record<string, any>): boolean {
+  return isStoreMaintenanceMode(config);
 }

--- a/packages/storefront-webapp/src/lib/storeConfig.test.ts
+++ b/packages/storefront-webapp/src/lib/storeConfig.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getStoreConfigV2,
+  getStoreFallbackImageUrl,
+  isStoreMaintenanceMode,
+  isStoreReadOnlyMode,
+} from "./storeConfig";
+
+const buildV2Config = (overrides: Record<string, any> = {}) => ({
+  operations: {
+    availability: {
+      inMaintenanceMode: true,
+    },
+    visibility: {
+      inReadOnlyMode: true,
+    },
+    maintenance: {
+      heading: "Maintenance",
+      message: "Store is temporarily unavailable",
+      countdownEndsAt: Date.now() + 60_000,
+    },
+  },
+  commerce: {
+    deliveryFees: {
+      withinAccra: 40,
+      otherRegions: 70,
+      international: 800,
+    },
+    waiveDeliveryFees: {
+      all: false,
+      withinAccra: false,
+      otherRegions: true,
+      international: false,
+    },
+    fulfillment: {
+      enableStorePickup: true,
+      enableDelivery: true,
+      disableStorePickup: false,
+      disableDelivery: false,
+      pickupRestriction: {
+        isActive: false,
+      },
+      deliveryRestriction: {
+        isActive: false,
+      },
+    },
+  },
+  media: {
+    homeHero: {
+      displayType: "reel",
+      headerImage: "https://cdn.example.com/home-hero.webp",
+      showOverlay: true,
+      showText: false,
+    },
+    reels: {
+      activeVersion: 2,
+      activeHlsUrl: "https://cdn.example.com/reel-2.m3u8",
+      landingPageVersion: "3",
+      versions: ["1", "2", "3"],
+      streamReels: [
+        {
+          version: 2,
+          hlsUrl: "https://cdn.example.com/reel-2.m3u8",
+          streamUid: "stream-2",
+          thumbnailUrl: "https://cdn.example.com/reel-2.jpg",
+          source: "stream",
+          createdAt: 1700000000000,
+        },
+      ],
+    },
+    images: {
+      fallbackImageUrl: "https://cdn.example.com/fallback.webp",
+      shopTheLookImage: "https://cdn.example.com/shop-look.webp",
+      showroomImage: "https://cdn.example.com/showroom.webp",
+    },
+  },
+  promotions: {
+    homepageDiscountCodeModalPromoCode: {
+      promoCodeId: "promo-home-10",
+      displayText: "10%",
+      value: 10,
+      discountType: "percentage",
+    },
+    leaveAReviewDiscountCodeModalPromoCode: {
+      promoCodeId: "promo-review-20",
+      displayText: "20%",
+      value: 20,
+      discountType: "percentage",
+    },
+  },
+  contact: {
+    location: "2 Jungle Avenue, East Legon, Accra, Ghana",
+    phoneNumber: "+233249771887",
+  },
+  ...overrides,
+});
+
+describe("storeConfig v2 selectors", () => {
+  it("reads grouped V2 media and promotion values", () => {
+    const config = buildV2Config();
+
+    const result = getStoreConfigV2({ config });
+
+    expect(result.media.reels.activeHlsUrl).toBe(
+      "https://cdn.example.com/reel-2.m3u8"
+    );
+    expect(result.media.homeHero.displayType).toBe("reel");
+    expect(result.media.images.shopTheLookImage).toBe(
+      "https://cdn.example.com/shop-look.webp"
+    );
+    expect(result.promotions.homepageDiscountCodeModalPromoCode).toEqual({
+      promoCodeId: "promo-home-10",
+      displayText: "10%",
+      value: 10,
+      discountType: "percentage",
+    });
+  });
+
+  it("reads grouped V2 commerce settings used by checkout", () => {
+    const config = buildV2Config();
+
+    const result = getStoreConfigV2({ config });
+
+    expect(result.commerce.deliveryFees).toEqual({
+      withinAccra: 40,
+      otherRegions: 70,
+      international: 800,
+    });
+    expect(result.commerce.fulfillment.enableDelivery).toBe(true);
+    expect(result.commerce.fulfillment.enableStorePickup).toBe(true);
+    expect(result.commerce.waiveDeliveryFees).toEqual({
+      all: false,
+      withinAccra: false,
+      otherRegions: true,
+      international: false,
+    });
+  });
+
+  it("computes read-only and maintenance modes from grouped V2 operations", () => {
+    const activeMaintenanceConfig = buildV2Config();
+
+    expect(isStoreReadOnlyMode({ config: activeMaintenanceConfig })).toBe(true);
+    expect(isStoreMaintenanceMode({ config: activeMaintenanceConfig })).toBe(
+      true
+    );
+
+    const expiredMaintenanceConfig = buildV2Config({
+      operations: {
+        availability: { inMaintenanceMode: true },
+        visibility: { inReadOnlyMode: false },
+        maintenance: {
+          countdownEndsAt: Date.now() - 60_000,
+        },
+      },
+    });
+
+    expect(isStoreReadOnlyMode({ config: expiredMaintenanceConfig })).toBe(
+      false
+    );
+    expect(isStoreMaintenanceMode({ config: expiredMaintenanceConfig })).toBe(
+      false
+    );
+  });
+
+  it("returns fallback image from grouped V2 media config", () => {
+    const config = buildV2Config();
+
+    expect(getStoreFallbackImageUrl({ config })).toBe(
+      "https://cdn.example.com/fallback.webp"
+    );
+
+    const noFallback = buildV2Config({
+      media: {
+        ...buildV2Config().media,
+        images: {},
+      },
+    });
+
+    expect(getStoreFallbackImageUrl({ config: noFallback }, "default.png")).toBe(
+      "default.png"
+    );
+  });
+});

--- a/packages/storefront-webapp/src/lib/storeConfig.ts
+++ b/packages/storefront-webapp/src/lib/storeConfig.ts
@@ -1,0 +1,460 @@
+import { Store } from "@athena/webapp";
+
+type StoreConfigInput =
+  | Store
+  | { config?: unknown }
+  | Record<string, any>
+  | null
+  | undefined;
+
+type WaiveDeliveryFees =
+  | boolean
+  | {
+      withinAccra?: boolean;
+      otherRegions?: boolean;
+      international?: boolean;
+      all?: boolean;
+    };
+
+type PromoCodeConfig = {
+  promoCodeId: string;
+  value: number;
+  displayText: string;
+  discountType: string;
+};
+
+export type StoreConfigV2View = {
+  operations: {
+    availability: {
+      inMaintenanceMode: boolean;
+    };
+    visibility: {
+      inReadOnlyMode: boolean;
+    };
+    maintenance: {
+      heading?: string;
+      message?: string;
+      countdownEndsAt?: number;
+    };
+  };
+  commerce: {
+    deliveryFees: {
+      withinAccra?: number;
+      otherRegions?: number;
+      international?: number;
+    };
+    waiveDeliveryFees: WaiveDeliveryFees;
+    fulfillment: {
+      enableStorePickup?: boolean;
+      enableDelivery?: boolean;
+      disableStorePickup?: boolean;
+      disableDelivery?: boolean;
+      pickupRestriction?: {
+        isActive?: boolean;
+        message?: string;
+        reason?: string;
+        endTime?: number;
+      };
+      deliveryRestriction?: {
+        isActive?: boolean;
+        message?: string;
+        reason?: string;
+        endTime?: number;
+      };
+    };
+  };
+  media: {
+    homeHero: {
+      displayType: "reel" | "image";
+      headerImage?: string;
+      showOverlay: boolean;
+      showText: boolean;
+    };
+    reels: {
+      activeVersion?: number;
+      activeHlsUrl?: string;
+      landingPageVersion?: string;
+      versions: string[];
+      streamReels: Array<{
+        version: number;
+        hlsUrl?: string;
+        streamUid?: string;
+        thumbnailUrl?: string;
+        source?: string;
+        createdAt?: number;
+      }>;
+    };
+    images: {
+      fallbackImageUrl?: string;
+      shopTheLookImage?: string;
+      showroomImage?: string;
+    };
+  };
+  promotions: {
+    homepageDiscountCodeModalPromoCode?: PromoCodeConfig;
+    leaveAReviewDiscountCodeModalPromoCode?: PromoCodeConfig;
+  };
+  contact: {
+    location?: string;
+    phoneNumber?: string;
+  };
+};
+
+const asRecord = (value: unknown): Record<string, any> => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+
+  return value as Record<string, any>;
+};
+
+const asString = (value: unknown): string | undefined =>
+  typeof value === "string" ? value : undefined;
+
+const asNumber = (value: unknown): number | undefined =>
+  typeof value === "number" ? value : undefined;
+
+const asBoolean = (value: unknown): boolean | undefined =>
+  typeof value === "boolean" ? value : undefined;
+
+const firstDefined = <T>(...values: Array<T | undefined | null>): T | undefined => {
+  for (const value of values) {
+    if (value !== undefined && value !== null) {
+      return value;
+    }
+  }
+
+  return undefined;
+};
+
+const asOptionalArray = <T>(
+  value: unknown,
+  map: (item: unknown) => T | undefined,
+): T[] | undefined => {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  return value
+    .map(map)
+    .filter((item): item is T => item !== undefined);
+};
+
+const cleanUndefined = <T extends Record<string, any>>(value: T): T => {
+  const next = { ...value };
+
+  for (const [key, fieldValue] of Object.entries(next)) {
+    if (fieldValue === undefined) {
+      delete next[key as keyof T];
+    }
+  }
+
+  return next;
+};
+
+const mapStreamReel = (value: unknown) => {
+  const reel = asRecord(value);
+  const version = asNumber(reel.version);
+  if (version === undefined) {
+    return undefined;
+  }
+
+  return {
+    version,
+    hlsUrl: asString(reel.hlsUrl),
+    streamUid: asString(reel.streamUid),
+    thumbnailUrl: asString(reel.thumbnailUrl),
+    source: asString(reel.source),
+    createdAt: asNumber(reel.createdAt),
+  };
+};
+
+const mapPromo = (value: unknown): PromoCodeConfig | undefined => {
+  const record = asRecord(value);
+  const promoCodeId = asString(record.promoCodeId);
+  const promoValue = asNumber(record.value);
+  const displayText = asString(record.displayText);
+  const discountType = asString(record.discountType);
+
+  if (
+    promoCodeId === undefined ||
+    promoValue === undefined ||
+    displayText === undefined ||
+    discountType === undefined
+  ) {
+    return undefined;
+  }
+
+  return {
+    promoCodeId,
+    value: promoValue,
+    displayText,
+    discountType,
+  };
+};
+
+const getRawConfig = (input: StoreConfigInput): Record<string, any> => {
+  if (!input) {
+    return {};
+  }
+
+  if ("config" in (input as Record<string, any>)) {
+    return asRecord((input as { config?: unknown }).config);
+  }
+
+  return asRecord(input);
+};
+
+export const getStoreConfigV2 = (input: StoreConfigInput): StoreConfigV2View => {
+  const config = getRawConfig(input);
+
+  const operations = asRecord(config.operations);
+  const commerce = asRecord(config.commerce);
+  const media = asRecord(config.media);
+  const promotions = asRecord(config.promotions);
+  const contact = asRecord(config.contact);
+
+  const homeHero = asRecord(media.homeHero);
+  const reels = asRecord(media.reels);
+  const images = asRecord(media.images);
+
+  const legacyAvailability = asRecord(config.availability);
+  const legacyVisibility = asRecord(config.visibility);
+  const legacyMaintenance = asRecord(config.maintenance);
+  const legacyDeliveryFees = asRecord(config.deliveryFees);
+  const legacyWaiveFees = config.waiveDeliveryFees;
+  const legacyFulfillment = asRecord(config.fulfillment);
+  const legacyHomeHero = asRecord(config.homeHero);
+  const legacyUi = asRecord(config.ui);
+  const legacyContactInfo = asRecord(config.contactInfo);
+
+  const waiveDeliveryFees: WaiveDeliveryFees = (() => {
+    const value = firstDefined(commerce.waiveDeliveryFees, legacyWaiveFees);
+    if (typeof value === "boolean") {
+      return value;
+    }
+
+    return cleanUndefined({
+      withinAccra: asBoolean(asRecord(value).withinAccra),
+      otherRegions: asBoolean(asRecord(value).otherRegions),
+      international: asBoolean(asRecord(value).international),
+      all: asBoolean(asRecord(value).all),
+    });
+  })();
+
+  return {
+    operations: {
+      availability: {
+        inMaintenanceMode:
+          firstDefined(
+            asBoolean(asRecord(operations.availability).inMaintenanceMode),
+            asBoolean(legacyAvailability.inMaintenanceMode),
+          ) ?? false,
+      },
+      visibility: {
+        inReadOnlyMode:
+          firstDefined(
+            asBoolean(asRecord(operations.visibility).inReadOnlyMode),
+            asBoolean(legacyVisibility.inReadOnlyMode),
+          ) ?? false,
+      },
+      maintenance: cleanUndefined({
+        heading: firstDefined(
+          asString(asRecord(operations.maintenance).heading),
+          asString(legacyMaintenance.heading),
+        ),
+        message: firstDefined(
+          asString(asRecord(operations.maintenance).message),
+          asString(legacyMaintenance.message),
+        ),
+        countdownEndsAt: firstDefined(
+          asNumber(asRecord(operations.maintenance).countdownEndsAt),
+          asNumber(legacyMaintenance.countdownEndsAt),
+        ),
+      }),
+    },
+    commerce: {
+      deliveryFees: cleanUndefined({
+        withinAccra: firstDefined(
+          asNumber(asRecord(commerce.deliveryFees).withinAccra),
+          asNumber(legacyDeliveryFees.withinAccra),
+        ),
+        otherRegions: firstDefined(
+          asNumber(asRecord(commerce.deliveryFees).otherRegions),
+          asNumber(legacyDeliveryFees.otherRegions),
+        ),
+        international: firstDefined(
+          asNumber(asRecord(commerce.deliveryFees).international),
+          asNumber(legacyDeliveryFees.international),
+        ),
+      }),
+      waiveDeliveryFees,
+      fulfillment: cleanUndefined({
+        enableStorePickup: firstDefined(
+          asBoolean(asRecord(commerce.fulfillment).enableStorePickup),
+          asBoolean(legacyFulfillment.enableStorePickup),
+        ),
+        enableDelivery: firstDefined(
+          asBoolean(asRecord(commerce.fulfillment).enableDelivery),
+          asBoolean(legacyFulfillment.enableDelivery),
+        ),
+        disableStorePickup: firstDefined(
+          asBoolean(asRecord(commerce.fulfillment).disableStorePickup),
+          asBoolean(legacyFulfillment.disableStorePickup),
+        ),
+        disableDelivery: firstDefined(
+          asBoolean(asRecord(commerce.fulfillment).disableDelivery),
+          asBoolean(legacyFulfillment.disableDelivery),
+        ),
+        pickupRestriction: cleanUndefined({
+          isActive: firstDefined(
+            asBoolean(asRecord(asRecord(commerce.fulfillment).pickupRestriction).isActive),
+            asBoolean(asRecord(legacyFulfillment.pickupRestriction).isActive),
+          ),
+          message: firstDefined(
+            asString(asRecord(asRecord(commerce.fulfillment).pickupRestriction).message),
+            asString(asRecord(legacyFulfillment.pickupRestriction).message),
+          ),
+          reason: firstDefined(
+            asString(asRecord(asRecord(commerce.fulfillment).pickupRestriction).reason),
+            asString(asRecord(legacyFulfillment.pickupRestriction).reason),
+          ),
+          endTime: firstDefined(
+            asNumber(asRecord(asRecord(commerce.fulfillment).pickupRestriction).endTime),
+            asNumber(asRecord(legacyFulfillment.pickupRestriction).endTime),
+          ),
+        }),
+        deliveryRestriction: cleanUndefined({
+          isActive: firstDefined(
+            asBoolean(asRecord(asRecord(commerce.fulfillment).deliveryRestriction).isActive),
+            asBoolean(asRecord(legacyFulfillment.deliveryRestriction).isActive),
+          ),
+          message: firstDefined(
+            asString(asRecord(asRecord(commerce.fulfillment).deliveryRestriction).message),
+            asString(asRecord(legacyFulfillment.deliveryRestriction).message),
+          ),
+          reason: firstDefined(
+            asString(asRecord(asRecord(commerce.fulfillment).deliveryRestriction).reason),
+            asString(asRecord(legacyFulfillment.deliveryRestriction).reason),
+          ),
+          endTime: firstDefined(
+            asNumber(asRecord(asRecord(commerce.fulfillment).deliveryRestriction).endTime),
+            asNumber(asRecord(legacyFulfillment.deliveryRestriction).endTime),
+          ),
+        }),
+      }),
+    },
+    media: {
+      homeHero: {
+        displayType:
+          firstDefined(
+            asString(homeHero.displayType),
+            asString(legacyHomeHero.displayType),
+            asString(config.heroDisplayType),
+          ) === "image"
+            ? "image"
+            : "reel",
+        headerImage: firstDefined(
+          asString(homeHero.headerImage),
+          asString(legacyHomeHero.headerImage),
+          asString(config.heroHeaderImage),
+        ),
+        showOverlay:
+          firstDefined(
+            asBoolean(homeHero.showOverlay),
+            asBoolean(legacyHomeHero.showOverlay),
+            asBoolean(config.heroShowOverlay),
+          ) ?? false,
+        showText:
+          firstDefined(
+            asBoolean(homeHero.showText),
+            asBoolean(legacyHomeHero.showText),
+            asBoolean(config.heroShowText),
+          ) ?? false,
+      },
+      reels: {
+        activeVersion: firstDefined(
+          asNumber(reels.activeVersion),
+          asNumber(config.activeStreamReel),
+        ),
+        activeHlsUrl: firstDefined(
+          asString(reels.activeHlsUrl),
+          asString(config.activeStreamReelHlsUrl),
+        ),
+        landingPageVersion: firstDefined(
+          asString(reels.landingPageVersion),
+          asString(config.landingPageReelVersion),
+        ),
+        versions:
+          firstDefined(
+            asOptionalArray(reels.versions, (value) => asString(value)),
+            asOptionalArray(config.reelVersions, (value) => asString(value)),
+          ) ?? [],
+        streamReels:
+          firstDefined(
+            asOptionalArray(reels.streamReels, mapStreamReel),
+            asOptionalArray(config.streamReels, mapStreamReel),
+          ) ?? [],
+      },
+      images: cleanUndefined({
+        fallbackImageUrl: firstDefined(
+          asString(images.fallbackImageUrl),
+          asString(legacyUi.fallbackImageUrl),
+        ),
+        shopTheLookImage: firstDefined(
+          asString(images.shopTheLookImage),
+          asString(config.shopTheLookImage),
+        ),
+        showroomImage: firstDefined(
+          asString(images.showroomImage),
+          asString(config.showroomImage),
+        ),
+      }),
+    },
+    promotions: cleanUndefined({
+      homepageDiscountCodeModalPromoCode: firstDefined(
+        mapPromo(promotions.homepageDiscountCodeModalPromoCode),
+        mapPromo(config.homepageDiscountCodeModalPromoCode),
+      ),
+      leaveAReviewDiscountCodeModalPromoCode: firstDefined(
+        mapPromo(promotions.leaveAReviewDiscountCodeModalPromoCode),
+        mapPromo(config.leaveAReviewDiscountCodeModalPromoCode),
+      ),
+    }),
+    contact: cleanUndefined({
+      location: firstDefined(
+        asString(contact.location),
+        asString(legacyContactInfo.location),
+      ),
+      phoneNumber: firstDefined(
+        asString(contact.phoneNumber),
+        asString(legacyContactInfo.phoneNumber),
+      ),
+    }),
+  };
+};
+
+export const isStoreReadOnlyMode = (input: StoreConfigInput): boolean => {
+  return getStoreConfigV2(input).operations.visibility.inReadOnlyMode;
+};
+
+export const isStoreMaintenanceMode = (input: StoreConfigInput): boolean => {
+  const config = getStoreConfigV2(input);
+  if (!config.operations.availability.inMaintenanceMode) {
+    return false;
+  }
+
+  const countdownEndsAt = config.operations.maintenance.countdownEndsAt;
+  if (countdownEndsAt === undefined) {
+    return true;
+  }
+
+  return countdownEndsAt > Date.now();
+};
+
+export const getStoreFallbackImageUrl = (
+  input: StoreConfigInput,
+  defaultValue?: string,
+): string | undefined => {
+  return getStoreConfigV2(input).media.images.fallbackImageUrl || defaultValue;
+};

--- a/packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx
+++ b/packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx
@@ -42,6 +42,7 @@ import { Button } from "@/components/ui/button";
 import { GuestRewardsPrompt } from "@/components/rewards/GuestRewardsPrompt";
 import { useUserQueries } from "@/lib/queries/user";
 import { OrderPointsDisplay } from "@/components/rewards/OrderPointsDisplay";
+import { getStoreFallbackImageUrl } from "@/lib/storeConfig";
 
 export const Route = createFileRoute(
   "/_layout/_ordersLayout/shop/orders/$orderId/"
@@ -198,13 +199,14 @@ const OrderItem = ({
     : "Free";
 
   const { store } = useStoreContext();
+  const fallbackImageUrl = getStoreFallbackImageUrl(store);
 
   return (
     <div className="flex gap-8 text-sm">
       <ImageWithFallback
         src={
           item.productImage ||
-          store?.config?.ui?.fallbackImageUrl ||
+          fallbackImageUrl ||
           placeholder
         }
         alt={"product image"}

--- a/packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx
+++ b/packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx
@@ -35,6 +35,7 @@ import { useOnlineOrderQueries } from "@/lib/queries/onlineOrder";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Input } from "@/components/ui/input";
+import { getStoreFallbackImageUrl } from "@/lib/storeConfig";
 
 export const Route = createFileRoute(
   "/_layout/_ordersLayout/shop/orders/$orderId/review"
@@ -159,12 +160,13 @@ const OrderItem = ({
     : "Free";
 
   const { store } = useStoreContext();
+  const fallbackImageUrl = getStoreFallbackImageUrl(store);
   return (
     <div className="flex gap-8 text-sm">
       <ImageWithFallback
         src={
           item.productImage ||
-          store?.config?.ui?.fallbackImageUrl ||
+          fallbackImageUrl ||
           placeholder
         }
         alt={"product image"}

--- a/packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/index.tsx
+++ b/packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/index.tsx
@@ -13,6 +13,7 @@ import { OnlineOrder } from "@athena/webapp";
 import { FadeIn } from "@/components/common/FadeIn";
 import { Badge } from "@/components/ui/badge";
 import { Banknote, Smartphone, Clock, CircleCheck } from "lucide-react";
+import { getStoreFallbackImageUrl } from "@/lib/storeConfig";
 
 export const Route = createFileRoute("/_layout/_ordersLayout/shop/orders/")({
   component: () => <Purchases />,
@@ -46,6 +47,7 @@ const OrderItem = ({
     order.podPaymentMethod || order.paymentMethod?.podPaymentMethod || "cash";
 
   const { store } = useStoreContext();
+  const fallbackImageUrl = getStoreFallbackImageUrl(store);
 
   return (
     <div className="space-y-8 text-sm">
@@ -113,7 +115,7 @@ const OrderItem = ({
             <ImageWithFallback
               src={
                 item.productImage ||
-                store?.config?.ui?.fallbackImageUrl ||
+                fallbackImageUrl ||
                 placeholder
               }
               alt={"product image"}
@@ -135,7 +137,7 @@ const OrderItem = ({
               <ImageWithFallback
                 src={
                   item.productImage ||
-                  store?.config?.ui?.fallbackImageUrl ||
+                  fallbackImageUrl ||
                   placeholder
                 }
                 alt={"product image"}

--- a/packages/storefront-webapp/src/routes/_layout/contact-us.tsx
+++ b/packages/storefront-webapp/src/routes/_layout/contact-us.tsx
@@ -4,6 +4,7 @@ import { capitalizeWords } from "@/lib/utils";
 import { FadeIn } from "@/components/common/FadeIn";
 import { WIGLUB_HAIR_STUDIO_LOCATION_URL } from "@/lib/constants";
 import ImageWithFallback from "@/components/ui/image-with-fallback";
+import { getStoreConfigV2 } from "@/lib/storeConfig";
 
 export const Route = createFileRoute("/_layout/contact-us")({
   component: () => <ContactUs />,
@@ -11,6 +12,7 @@ export const Route = createFileRoute("/_layout/contact-us")({
 
 const ContactUs = () => {
   const { store } = useStoreContext();
+  const storeConfig = getStoreConfigV2(store);
 
   if (!store) return <div className="h-screen" />;
 
@@ -29,7 +31,7 @@ const ContactUs = () => {
 
         <ImageWithFallback
           className="w-150 h-150 object-cover"
-          src={store.config?.showroomImage}
+          src={storeConfig.media.images.showroomImage}
           alt="showroom"
         />
 
@@ -38,13 +40,13 @@ const ContactUs = () => {
             <p className="font-medium">Address</p>
 
             <div className="space-y-2">
-              <p>{store.config?.contactInfo?.location}</p>
+              <p>{storeConfig.contact.location}</p>
               <div>
                 <a
-                  href={`tel:${store.config?.contactInfo?.phoneNumber}`}
+                  href={`tel:${storeConfig.contact.phoneNumber}`}
                   className="hover:underline font-medium"
                 >
-                  {store.config?.contactInfo?.phoneNumber}
+                  {storeConfig.contact.phoneNumber}
                 </a>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- migrate storefront read paths to `getStoreConfigV2` selectors/helpers
- keep dual-read compatibility by centralizing legacy fallback in `src/lib/storeConfig.ts`
- move checkout, maintenance, promo modal, contact, and fallback image consumers onto V2 selector paths
- add storefront tests for V2 selector behavior and maintenance helper behavior

## Key changes
- added `packages/storefront-webapp/src/lib/storeConfig.ts`
- added tests:
  - `packages/storefront-webapp/src/lib/storeConfig.test.ts`
  - `packages/storefront-webapp/src/lib/maintenanceUtils.test.ts`
- updated read paths across storefront components/routes to use:
  - `getStoreConfigV2`
  - `isStoreMaintenanceMode` / `isStoreReadOnlyMode`
  - `getStoreFallbackImageUrl`

## Test plan
- `bun run test -- src/lib/storeConfig.test.ts src/lib/maintenanceUtils.test.ts src/components/checkout/schemas/checkoutSchemas.test.ts`

## Notes
- tests intentionally focus on the updated V2 behavior paths.
- full storefront `tsc --noEmit` still reports existing unrelated baseline errors outside this PR scope.
