### PR TITLE
chore: update deploy script to target DigitalOcean

### DIFF
--- a/deploy-athena.sh
+++ b/deploy-athena.sh
@@ -15,23 +15,19 @@ function deploy-athena {
   echo "building and deploying Athena..."
   TIMESTAMP=$(date +%Y%m%d%H%M%S)
   FUN_NAME=$(random_fun_name)
-  VERSION_PATH="/home/ec2-user/athena/athena-webapp/versions/$TIMESTAMP"
-  SYMLINK_PATH="/home/ec2-user/athena/athena-webapp/current"
+  VERSION_PATH="/root/athena/athena-webapp/versions/$TIMESTAMP"
+  SYMLINK_PATH="/root/athena/athena-webapp/current"
 
   VITE_CONVEX_URL=https://colorless-cardinal-870.convex.cloud \
   VITE_API_GATEWAY_URL='https://colorless-cardinal-870.convex.site' \
   VITE_STOREFRONT_URL='https://wigclub.store' \
-  VITE_HLS_URL='https://d37wmi4mfpeer9.cloudfront.net' \
   bun run build &&
 
-  ssh -i /Users/kwamina/Desktop/athena-webserver/athena-eu-west-key.pem \
-  ec2-user@ec2-34-244-249-177.eu-west-1.compute.amazonaws.com "mkdir -p $VERSION_PATH && echo '$FUN_NAME' > $VERSION_PATH/fun-name.txt" &&
+  ssh root@178.128.161.200 "mkdir -p $VERSION_PATH && echo '$FUN_NAME' > $VERSION_PATH/fun-name.txt" &&
 
-  scp -i /Users/kwamina/Desktop/athena-webserver/athena-eu-west-key.pem \
-  -r dist/* ec2-user@ec2-34-244-249-177.eu-west-1.compute.amazonaws.com:$VERSION_PATH &&
+  scp -r dist/* root@178.128.161.200:$VERSION_PATH &&
 
-  ssh -i /Users/kwamina/Desktop/athena-webserver/athena-eu-west-key.pem \
-  ec2-user@ec2-34-244-249-177.eu-west-1.compute.amazonaws.com "ln -sfn $VERSION_PATH $SYMLINK_PATH" &&
+  ssh root@178.128.161.200 "ln -sfn $VERSION_PATH $SYMLINK_PATH" &&
 
   echo "✅ Deployed version: $FUN_NAME ($TIMESTAMP)"
 }
@@ -40,21 +36,17 @@ function deploy-storefront {
   echo "building and deploying store..."
   TIMESTAMP=$(date +%Y%m%d%H%M%S)
   FUN_NAME=$(random_fun_name)
-  VERSION_PATH="/home/ec2-user/athena/storefront/versions/$TIMESTAMP"
-  SYMLINK_PATH="/home/ec2-user/athena/storefront/current"
+  VERSION_PATH="/root/athena/storefront/versions/$TIMESTAMP"
+  SYMLINK_PATH="/root/athena/storefront/current"
 
   VITE_API_URL='https://api.wigclub.store' \
-  VITE_HLS_URL='https://d37wmi4mfpeer9.cloudfront.net' \
   bun run build &&
 
-  ssh -i /Users/kwamina/Desktop/athena-webserver/athena-eu-west-key.pem \
-  ec2-user@ec2-34-244-249-177.eu-west-1.compute.amazonaws.com "mkdir -p $VERSION_PATH && echo '$FUN_NAME' > $VERSION_PATH/fun-name.txt" &&
+  ssh root@178.128.161.200 "mkdir -p $VERSION_PATH && echo '$FUN_NAME' > $VERSION_PATH/fun-name.txt" &&
 
-  scp -i /Users/kwamina/Desktop/athena-webserver/athena-eu-west-key.pem \
-  -r dist/* ec2-user@ec2-34-244-249-177.eu-west-1.compute.amazonaws.com:$VERSION_PATH &&
+  scp -r dist/* root@178.128.161.200:$VERSION_PATH &&
 
-  ssh -i /Users/kwamina/Desktop/athena-webserver/athena-eu-west-key.pem \
-  ec2-user@ec2-34-244-249-177.eu-west-1.compute.amazonaws.com "ln -sfn $VERSION_PATH $SYMLINK_PATH" &&
+  ssh root@178.128.161.200 "ln -sfn $VERSION_PATH $SYMLINK_PATH" &&
 
   echo "✅ Deployed version: $FUN_NAME ($TIMESTAMP)"
 }


### PR DESCRIPTION
## Summary
- Switch deploy target from AWS EC2 to DigitalOcean droplet (178.128.161.200)
- Remove CloudFront HLS URL (`VITE_HLS_URL`) from both build commands (replaced by Cloudflare Stream)
- Use default SSH key (`~/.ssh/id_rsa`) instead of explicit PEM file

## Test plan
- [ ] Run `source deploy-athena.sh && deploy-athena` and verify it deploys to the DO droplet
- [ ] Run `source deploy-athena.sh && deploy-storefront` and verify storefront deploys correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)