### PR TITLE
fix: extract mutation handlers to fix Convex build errors

### DIFF
--- a/packages/athena-webapp/convex/inventory/cashier.ts
+++ b/packages/athena-webapp/convex/inventory/cashier.ts
@@ -1,4 +1,4 @@
-import { query, mutation } from "../_generated/server";
+import { query, mutation, MutationCtx } from "../_generated/server";
 import { v } from "convex/values";
 import { Id } from "../_generated/dataModel";
 
@@ -236,10 +236,81 @@ export const remove = mutation({
   },
 });
 
+export async function authenticateHandler(
+  ctx: MutationCtx,
+  args: {
+    username: string;
+    pin: string;
+    storeId: Id<"store">;
+    terminalId: Id<"posTerminal">;
+  }
+) {
+  console.log("Authenticating cashier", args);
+  // Validate required fields
+  if (!args.username.trim()) {
+    return {
+      success: false as const,
+      error: "Username is required",
+    };
+  }
+
+  if (!args.pin) {
+    return {
+      success: false as const,
+      error: "PIN is required",
+    };
+  }
+
+  // Find cashier by username and storeId using the index
+  const cashiers = await ctx.db
+    .query(entity)
+    .withIndex("by_store_and_username", (q) =>
+      q.eq("storeId", args.storeId).eq("username", args.username.trim())
+    )
+    .collect();
+
+  if (cashiers.length === 0) {
+    return {
+      success: false as const,
+      error: "Invalid username or PIN",
+    };
+  }
+
+  const cashier = cashiers[0];
+
+  // Verify the cashier is active
+  if (!cashier.active) {
+    return {
+      success: false as const,
+      error: "This cashier account is inactive",
+    };
+  }
+
+  // Compare the hashed PIN with stored PIN
+  // Both PINs are hashed, so we do a direct comparison
+  if (cashier.pin !== args.pin) {
+    return {
+      success: false as const,
+      error: "Invalid username or PIN",
+    };
+  }
+
+  // Return cashier data without PIN
+  return {
+    success: true as const,
+    cashier: {
+      _id: cashier._id,
+      firstName: cashier.firstName,
+      lastName: cashier.lastName,
+      username: cashier.username,
+    },
+  };
+}
+
 export const authenticate = mutation({
   args: {
     username: v.string(),
-    pin: v.string(), // Hashed PIN from client
+    pin: v.string(),
     storeId: v.id("store"),
     terminalId: v.id("posTerminal"),
   },
@@ -255,68 +326,7 @@ export const authenticate = mutation({
       })
     ),
   }),
-  handler: async (ctx, args) => {
-    console.log("Authenticating cashier", args);
-    // Validate required fields
-    if (!args.username.trim()) {
-      return {
-        success: false,
-        error: "Username is required",
-      };
-    }
-
-    if (!args.pin) {
-      return {
-        success: false,
-        error: "PIN is required",
-      };
-    }
-
-    // Find cashier by username and storeId using the index
-    const cashiers = await ctx.db
-      .query(entity)
-      .withIndex("by_store_and_username", (q) =>
-        q.eq("storeId", args.storeId).eq("username", args.username.trim())
-      )
-      .collect();
-
-    if (cashiers.length === 0) {
-      return {
-        success: false,
-        error: "Invalid username or PIN",
-      };
-    }
-
-    const cashier = cashiers[0];
-
-    // Verify the cashier is active
-    if (!cashier.active) {
-      return {
-        success: false,
-        error: "This cashier account is inactive",
-      };
-    }
-
-    // Compare the hashed PIN with stored PIN
-    // Both PINs are hashed, so we do a direct comparison
-    if (cashier.pin !== args.pin) {
-      return {
-        success: false,
-        error: "Invalid username or PIN",
-      };
-    }
-
-    // Return cashier data without PIN
-    return {
-      success: true,
-      cashier: {
-        _id: cashier._id,
-        firstName: cashier.firstName,
-        lastName: cashier.lastName,
-        username: cashier.username,
-      },
-    };
-  },
+  handler: async (ctx, args) => authenticateHandler(ctx, args),
 });
 
 export const checkUsernameAvailable = query({
@@ -358,7 +368,7 @@ export const signIn = mutation({
     ),
   }),
   handler: async (ctx, args) => {
-    const result = await authenticate(ctx, args);
+    const result = await authenticateHandler(ctx, args);
 
     if (!result.success) {
       return result;

--- a/packages/athena-webapp/convex/inventory/pos.ts
+++ b/packages/athena-webapp/convex/inventory/pos.ts
@@ -1,4 +1,4 @@
-import { query, mutation } from "../_generated/server";
+import { query, mutation, MutationCtx } from "../_generated/server";
 import { v } from "convex/values";
 import type { Id } from "../_generated/dataModel";
 import { capitalizeWords, generateTransactionNumber } from "../utils";
@@ -810,19 +810,14 @@ export const voidTransaction = mutation({
 });
 
 // Create transaction from session (used by session completion)
-export const createTransactionFromSession = mutation({
+export async function createTransactionFromSessionHandler(
+  ctx: MutationCtx,
   args: {
-    sessionId: v.id("posSession"),
-    payments: v.array(
-      v.object({
-        method: v.string(), // "cash", "card", "mobile_money"
-        amount: v.number(),
-        timestamp: v.number(),
-      })
-    ),
-    notes: v.optional(v.string()),
-  },
-  handler: async (ctx, args) => {
+    sessionId: Id<"posSession">;
+    payments: { method: string; amount: number; timestamp: number }[];
+    notes?: string;
+  }
+) {
     const session = await ctx.db.get(args.sessionId);
     if (!session) {
       throw new Error("Session not found");
@@ -989,7 +984,21 @@ export const createTransactionFromSession = mutation({
       transactionNumber,
       transactionItems: transactionItems.filter((item) => item !== null),
     };
+}
+
+export const createTransactionFromSession = mutation({
+  args: {
+    sessionId: v.id("posSession"),
+    payments: v.array(
+      v.object({
+        method: v.string(),
+        amount: v.number(),
+        timestamp: v.number(),
+      })
+    ),
+    notes: v.optional(v.string()),
   },
+  handler: async (ctx, args) => createTransactionFromSessionHandler(ctx, args),
 });
 
 // Debug query to check recent transactions and their customer links

--- a/packages/athena-webapp/convex/inventory/posSessions.ts
+++ b/packages/athena-webapp/convex/inventory/posSessions.ts
@@ -19,7 +19,7 @@ import {
   createSessionResultValidator,
 } from "./helpers/resultTypes";
 import { calculateSessionExpiration } from "./helpers/sessionExpiration";
-import { createTransactionFromSession } from "./pos";
+import { createTransactionFromSessionHandler } from "./pos";
 
 // Get sessions for a store (with filtering)
 export const getStoreSessions = query({
@@ -451,7 +451,7 @@ export const completeSession = mutation({
       total: args.total,
     });
 
-    const { transactionNumber } = await createTransactionFromSession(ctx, {
+    const { transactionNumber } = await createTransactionFromSessionHandler(ctx, {
       sessionId: args.sessionId,
       payments: args.payments,
       notes: args.notes,


### PR DESCRIPTION
## Summary
- Extract `authenticateHandler` from `authenticate` mutation in `cashier.ts` so it can be called directly from other mutations
- Extract `createTransactionFromSessionHandler` from `createTransactionFromSession` mutation in `pos.ts` for the same reason
- Update `posSessions.ts` to import and call the handler function instead of the registered mutation

## Test plan
- [x] `npx tsc --noEmit` passes with no errors
- [ ] Verify POS authentication and transaction completion work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)