### PR TITLE
Checkout: add coverage and extract schema/state/fee/storage utilities

### DIFF
--- a/packages/storefront-webapp/src/components/checkout/CheckoutForm.tsx
+++ b/packages/storefront-webapp/src/components/checkout/CheckoutForm.tsx
@@ -36,13 +36,6 @@ export const CheckoutForm = () => {
       neighborhood: "",
       landmark: "",
     },
-    // billingDetails: checkoutState.billingDetails || {
-    //   address: "",
-    //   city: "",
-    //   state: "",
-    //   country: "",
-    //   zip: "",
-    // },
   };
 
   const form = useForm({
@@ -68,13 +61,6 @@ export const CheckoutForm = () => {
         neighborhood: "",
         landmark: "",
       },
-      // billingDetails: {
-      //   address: "",
-      //   city: "",
-      //   state: "",
-      //   country: "",
-      //   zip: "",
-      // },
     },
   });
 

--- a/packages/storefront-webapp/src/components/checkout/CheckoutProvider.tsx
+++ b/packages/storefront-webapp/src/components/checkout/CheckoutProvider.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useEffect, useState } from "react";
-import { z, ZodError } from "zod";
+import { ZodError } from "zod";
 import { useGetActiveCheckoutSession } from "@/hooks/useGetActiveCheckoutSession";
 import {
   CheckoutExpired,
@@ -7,316 +7,19 @@ import {
 } from "../states/checkout-expired/CheckoutExpired";
 import { useShoppingBag } from "@/hooks/useShoppingBag";
 import { useStoreContext } from "@/contexts/StoreContext";
-import { SESSION_STORAGE_KEY } from "@/lib/constants";
-import { customerDetailsSchema } from "./schemas/customerDetailsSchema";
-import { baseDeliveryDetailsSchema } from "./schemas/deliveryDetailsSchema";
 import { CheckoutUnavailable } from "../states/checkout unavailable/CheckoutUnavailable";
 import { useNavigationBarContext } from "@/contexts/NavigationBarProvider";
 import { isFeeWaived, isAnyFeeWaived } from "@/lib/feeUtils";
 import { useOnlineOrderQueries } from "@/lib/queries/onlineOrder";
 import { useQuery } from "@tanstack/react-query";
-import {
-  DeliveryOption,
-  CheckoutState,
-  CheckoutActions,
-  CheckoutContextType,
-} from "./types";
+import { CheckoutState, CheckoutActions, CheckoutContextType } from "./types";
 import { getStoreConfigV2, isStoreReadOnlyMode } from "@/lib/storeConfig";
+import { webOrderSchema } from "./schemas/webOrderSchema";
+import { calculateDeliveryFee } from "./deliveryFees";
+import { deriveCheckoutState } from "./deriveCheckoutState";
+import { loadCheckoutState, saveCheckoutState } from "./checkoutStorage";
 
-export const webOrderSchema = z
-  .object({
-    // billingDetails: baseBillingDetailsSchema,
-    customerDetails: customerDetailsSchema,
-    deliveryMethod: z
-      .enum(["pickup", "delivery"])
-      .refine((value) => !!value, { message: "Delivery method is required" }),
-    deliveryOption: z
-      .enum(["within-accra", "outside-accra", "intl"])
-      .refine((value) => !!value, { message: "Delivery option is required" })
-      .nullable(),
-    deliveryFee: z.number().nullable(),
-    pickupLocation: z.string().min(1).nullable(),
-    deliveryDetails: baseDeliveryDetailsSchema.optional().nullable(),
-    deliveryInstructions: z.string().optional(),
-    discount: z.record(z.string(), z.any()).nullable(),
-  })
-  .superRefine((data, ctx) => {
-    const { deliveryFee, deliveryMethod, deliveryDetails, pickupLocation } =
-      data;
-
-    if (deliveryMethod == "delivery") {
-      // if (!billingDetails) {
-      //   ctx.addIssue({
-      //     code: z.ZodIssueCode.custom,
-      //     path: ["billingDetails"],
-      //     message: "Billing details are required",
-      //   });
-      // }
-
-      // const {
-      //   address: billingAddress,
-      //   billingAddressSameAsDelivery,
-      //   city: billingCity,
-      //   state: billingState,
-      //   zip: billingZip,
-      //   country: billingCountry,
-      // } = billingDetails || {};
-
-      // const isUSBillingAddress = billingCountry == "US";
-
-      // if (!billingAddressSameAsDelivery) {
-      //   if (!billingAddress) {
-      //     ctx.addIssue({
-      //       code: z.ZodIssueCode.custom,
-      //       path: ["billingDetails", "address"],
-      //       message: "Address is required",
-      //     });
-      //   }
-
-      //   if (billingAddress?.trim().length == 0) {
-      //     ctx.addIssue({
-      //       code: z.ZodIssueCode.custom,
-      //       path: ["billingDetails", "address"],
-      //       message: "Address cannot be empty or whitespace",
-      //     });
-      //   }
-
-      //   if (!billingCity) {
-      //     ctx.addIssue({
-      //       code: z.ZodIssueCode.custom,
-      //       path: ["billingDetails", "city"],
-      //       message: "City is required",
-      //     });
-      //   }
-
-      //   if (billingCity?.trim().length == 0) {
-      //     ctx.addIssue({
-      //       code: z.ZodIssueCode.custom,
-      //       path: ["billingDetails", "city"],
-      //       message: "City cannot be empty or whitespace",
-      //     });
-      //   }
-
-      //   if (!billingCountry) {
-      //     ctx.addIssue({
-      //       code: z.ZodIssueCode.custom,
-      //       path: ["billingDetails", "country"],
-      //       message: "Country is required",
-      //     });
-      //   }
-      // }
-
-      // if (billingCountry?.trim().length == 0) {
-      //   ctx.addIssue({
-      //     code: z.ZodIssueCode.custom,
-      //     path: ["billingDetails", "country"],
-      //     message: "Country cannot be empty or whitespace",
-      //   });
-      // }
-
-      // if (isUSBillingAddress) {
-      //   if (!billingState) {
-      //     ctx.addIssue({
-      //       code: z.ZodIssueCode.custom,
-      //       path: ["billingDetails", "state"],
-      //       message: "State is required",
-      //     });
-
-      //     if (billingState?.trim().length == 0) {
-      //       ctx.addIssue({
-      //         code: z.ZodIssueCode.custom,
-      //         path: ["billingDetails", "state"],
-      //         message: "State cannot be empty or whitespace",
-      //       });
-      //     }
-      //   }
-
-      //   if (!billingZip) {
-      //     ctx.addIssue({
-      //       code: z.ZodIssueCode.custom,
-      //       path: ["billingDetails", "zip"],
-      //       message: "Zip is required",
-      //     });
-      //   }
-
-      //   if (billingZip?.trim().length == 0) {
-      //     ctx.addIssue({
-      //       code: z.ZodIssueCode.custom,
-      //       path: ["billingDetails", "zip"],
-      //       message: "Zip code cannot be empty or whitespace",
-      //     });
-      //   }
-
-      //   if (billingZip && !/^\d{5}$/.test(billingZip)) {
-      //     ctx.addIssue({
-      //       code: z.ZodIssueCode.custom,
-      //       path: ["billingDetails", "zip"],
-      //       message: "Zip code must be a 5-digit number",
-      //     });
-      //   }
-      // }
-
-      if (deliveryFee == null) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ["deliveryFee"],
-          message: "Delivery fee is required",
-        });
-      }
-
-      if (!deliveryDetails) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ["deliveryDetails"],
-          message: "Delivery details are required",
-        });
-      }
-
-      const {
-        address,
-        city,
-        street,
-        neighborhood,
-        state,
-        zip,
-        region,
-        country,
-      } = deliveryDetails || {};
-
-      const isGhanaAddress = country == "GH";
-
-      const isUSAddress = country == "US";
-
-      // validate the address fields for US and ROW orders
-      if (!isGhanaAddress) {
-        if (!address) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: ["deliveryDetails", "address"],
-            message: "Address is required",
-          });
-        }
-
-        if (address?.trim().length == 0) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: ["deliveryDetails", "address"],
-            message: "Address cannot be empty or whitespace",
-          });
-        }
-
-        if (!city) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: ["deliveryDetails", "city"],
-            message: "City is required",
-          });
-        }
-
-        if (city?.trim().length == 0) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: ["deliveryDetails", "city"],
-            message: "City cannot be empty or whitespace",
-          });
-        }
-      }
-
-      if (!country) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ["deliveryDetails", "country"],
-          message: "Country is required",
-        });
-      }
-
-      if (isUSAddress) {
-        if (!state) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: ["deliveryDetails", "state"],
-            message: "State is required",
-          });
-        }
-
-        if (!zip) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: ["deliveryDetails", "zip"],
-            message: "Zip is required",
-          });
-        }
-
-        if (zip?.trim().length == 0) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: ["deliveryDetails", "zip"],
-            message: "Zip code cannot be empty or whitespace",
-          });
-        }
-
-        if (zip && !/^\d{5}$/.test(zip)) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: ["deliveryDetails", "zip"],
-            message: "Zip code must be a 5-digit number",
-          });
-        }
-      }
-
-      if (isGhanaAddress) {
-        if (!region) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: ["deliveryDetails", "region"],
-            message: "Region is required",
-          });
-        }
-
-        if (!street) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: ["deliveryDetails", "street"],
-            message: "Street is required",
-          });
-        }
-
-        // if (!houseNumber) {
-        //   ctx.addIssue({
-        //     code: z.ZodIssueCode.custom,
-        //     path: ["deliveryDetails", "houseNumber"],
-        //     message: "Apt/House number is required",
-        //   });
-        // }
-
-        if (!neighborhood) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: ["deliveryDetails", "neighborhood"],
-            message: "Neighborhood is required",
-          });
-        }
-      }
-    }
-
-    if (deliveryMethod == "pickup") {
-      if (!pickupLocation) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ["pickupLocation"],
-          message: "Pickup location is required",
-        });
-      }
-
-      if (pickupLocation?.trim().length == 0) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ["pickupLocation"],
-          message: "Pickup location cannot be empty or whitespace",
-        });
-      }
-    }
-  });
+export { webOrderSchema } from "./schemas/webOrderSchema";
 
 const initialActionsState: CheckoutActions = {
   isEditingCustomerDetails: false,
@@ -369,26 +72,9 @@ export const CheckoutProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const [checkoutState, setCheckoutState] = useState<CheckoutState>(() => {
-    if (typeof window === "undefined") return initialState;
-
-    try {
-      const savedState = sessionStorage.getItem(SESSION_STORAGE_KEY);
-      if (savedState) {
-        const parsed = JSON.parse(savedState);
-        return {
-          ...initialState,
-          ...parsed,
-          // Ensure new fields have defaults
-          paymentMethod: parsed.paymentMethod || "online_payment",
-          podPaymentMethod: parsed.podPaymentMethod || null,
-        };
-      }
-      return initialState;
-    } catch {
-      return initialState;
-    }
-  });
+  const [checkoutState, setCheckoutState] = useState<CheckoutState>(() =>
+    loadCheckoutState(initialState)
+  );
 
   const [actionsState, setActionsState] =
     useState<CheckoutActions>(initialActionsState);
@@ -472,10 +158,7 @@ export const CheckoutProvider = ({
 
   useEffect(() => {
     if (bag?.items?.length && bag?.items?.length > 0) {
-      sessionStorage.setItem(
-        SESSION_STORAGE_KEY,
-        JSON.stringify({ ...checkoutState, discount: null, bag })
-      );
+      saveCheckoutState({ ...checkoutState, bag });
     }
   }, [checkoutState, bag]);
 
@@ -509,38 +192,13 @@ export const CheckoutProvider = ({
 
       const { email, firstName, lastName, phoneNumber } = user;
 
-      const isGhanaAddress = country == "GH";
-
-      const isGreaterAccraAddress = region == "GA";
-
-      let deliveryOption: DeliveryOption = "intl";
-      const shouldWaiveIntlFee = isFeeWaived(waiveDeliveryFees, "intl");
-      let deliveryFee = shouldWaiveIntlFee
-        ? 0
-        : deliveryFees?.international || 800;
-
-      if (isGhanaAddress) {
-        deliveryOption = isGreaterAccraAddress
-          ? "within-accra"
-          : "outside-accra";
-
-        const shouldWaiveRegionFee =
-          typeof waiveDeliveryFees === "boolean"
-            ? waiveDeliveryFees
-            : isGreaterAccraAddress
-              ? waiveDeliveryFees?.withinAccra ||
-                waiveDeliveryFees?.all ||
-                false
-              : waiveDeliveryFees?.otherRegions ||
-                waiveDeliveryFees?.all ||
-                false;
-
-        deliveryFee = shouldWaiveRegionFee
-          ? 0
-          : isGreaterAccraAddress
-            ? 30
-            : 70;
-      }
+      const { deliveryFee, deliveryOption } = calculateDeliveryFee({
+        deliveryMethod: "delivery",
+        country: country || "",
+        region: region || null,
+        waiveDeliveryFees,
+        deliveryFees,
+      });
 
       updateState({
         customerDetails: {
@@ -603,11 +261,6 @@ export const CheckoutProvider = ({
       const newUpdates = { ...prev, ...updates };
 
       const isDeliveryOrder = newUpdates.deliveryMethod == "delivery";
-      const isPickupOrder = newUpdates.deliveryMethod == "pickup";
-
-      const isGhanaOrder =
-        isPickupOrder ||
-        (isDeliveryOrder && newUpdates.deliveryDetails?.country == "GH");
 
       // Always set international delivery for non-Ghana countries
       if (
@@ -624,73 +277,7 @@ export const CheckoutProvider = ({
           : deliveryFees?.international || 800;
       }
 
-      const isUSOrder =
-        isDeliveryOrder && newUpdates.deliveryDetails?.country == "US";
-
-      const isROWOrder = isDeliveryOrder && !isUSOrder && !isGhanaOrder;
-
-      const didSelectPickupLocation = Boolean(
-        isPickupOrder && newUpdates.pickupLocation
-      );
-
-      const didProvideAllUSAddressFields = Boolean(
-        newUpdates.deliveryDetails?.address &&
-          newUpdates.deliveryDetails?.city &&
-          newUpdates.deliveryDetails?.state &&
-          newUpdates.deliveryDetails?.zip
-      );
-
-      const didProvideAllRestOfWorldFields = Boolean(
-        newUpdates.deliveryDetails?.address && newUpdates.deliveryDetails?.city
-      );
-
-      const didProvideAllGhanaAddressFields = Boolean(
-        newUpdates.deliveryDetails?.street && newUpdates.deliveryDetails?.region
-      );
-
-      const didEnterDeliveryDetails =
-        (isUSOrder
-          ? didProvideAllUSAddressFields
-          : isGhanaOrder && isDeliveryOrder
-            ? didProvideAllGhanaAddressFields
-            : didProvideAllRestOfWorldFields) &&
-        Boolean(newUpdates.deliveryOption);
-
-      const didProvideAllUSBillingAddressFields = Boolean(
-        newUpdates.billingDetails?.address &&
-          newUpdates.billingDetails?.city &&
-          newUpdates.billingDetails?.state &&
-          newUpdates.billingDetails?.zip
-      );
-
-      const didProvideAllRestOfWorldBillingFields = Boolean(
-        newUpdates.billingDetails?.address && newUpdates.billingDetails?.city
-      );
-
-      const didProvideAllGhanaBillingAddressFields = Boolean(
-        newUpdates.billingDetails?.address && newUpdates.billingDetails?.city
-      );
-
-      const isGhanaBillingAddrss = newUpdates.billingDetails?.country == "GH";
-      const isUSBillingAddrss = newUpdates.billingDetails?.country == "US";
-
-      const didEnterBillingDetails = isGhanaBillingAddrss
-        ? didProvideAllGhanaBillingAddressFields
-        : isUSBillingAddrss
-          ? didProvideAllUSBillingAddressFields
-          : didProvideAllRestOfWorldBillingFields;
-
-      return {
-        ...newUpdates,
-        didEnterDeliveryDetails,
-        didEnterBillingDetails,
-        didSelectPickupLocation,
-        isGhanaOrder,
-        isUSOrder,
-        isROWOrder,
-        isPickupOrder,
-        isDeliveryOrder,
-      };
+      return deriveCheckoutState(newUpdates);
     });
   };
 

--- a/packages/storefront-webapp/src/components/checkout/DeliveryDetailsSection.tsx
+++ b/packages/storefront-webapp/src/components/checkout/DeliveryDetailsSection.tsx
@@ -674,35 +674,6 @@ const USAddressFields = ({ form }: CheckoutFormSectionProps) => {
   const { checkoutState, updateState } = useCheckout();
   return (
     <>
-      {/* <div className="w-full">
-        <FormField
-          control={form.control}
-          name="deliveryDetails.state"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel className="text-muted-foreground text-xs">
-                State
-              </FormLabel>
-              <FormControl>
-                <Input
-                  {...field}
-                  onChange={(e) => {
-                    updateState({
-                      deliveryDetails: {
-                        ...checkoutState.deliveryDetails,
-                        state: e.target.value,
-                      } as Address,
-                    });
-                    field.onChange(e);
-                  }}
-                />
-              </FormControl>
-              <FormMessage className="text-xs" />
-            </FormItem>
-          )}
-        />
-      </div> */}
-
       <StateFields form={form} />
 
       <div className="w-full">

--- a/packages/storefront-webapp/src/components/checkout/PaymentMethodSection.tsx
+++ b/packages/storefront-webapp/src/components/checkout/PaymentMethodSection.tsx
@@ -1,16 +1,13 @@
 import { useEffect } from "react";
 import { useCheckout } from "@/hooks/useCheckout";
-import { PaymentMethodType, PODPaymentMethod } from "./types";
-
+import { PaymentMethodType } from "./types";
 import { motion } from "framer-motion";
-import { CreditCard, Smartphone, Banknote, Info } from "lucide-react";
+import { CreditCard, Smartphone } from "lucide-react";
 import { GhostButton } from "../ui/ghost-button";
-import { Alert, AlertDescription } from "@/components/ui/alert";
 
 export const PaymentMethodSection = () => {
   const { checkoutState, updateState } = useCheckout();
 
-  // Ensure checkout state has a default payment method on mount
   useEffect(() => {
     if (!checkoutState.paymentMethod) {
       updateState({
@@ -21,7 +18,6 @@ export const PaymentMethodSection = () => {
   }, []);
 
   const handlePaymentMethodChange = (method: PaymentMethodType) => {
-    console.log("PaymentMethodSection - Changing payment method to:", method);
     updateState({
       paymentMethod: method,
       podPaymentMethod:
@@ -30,14 +26,6 @@ export const PaymentMethodSection = () => {
           : undefined,
     });
   };
-
-  const handlePODMethodChange = (method: PODPaymentMethod) => {
-    updateState({
-      podPaymentMethod: method,
-    });
-  };
-
-  const isDeliveryOrder = checkoutState.deliveryMethod === "delivery";
 
   const onlineTagline = checkoutState.isGhanaOrder
     ? "Secure mobile money or credit/debit card"
@@ -79,118 +67,7 @@ export const PaymentMethodSection = () => {
               </div>
             </div>
           </GhostButton>
-
-          {/* {isDeliveryOrder &&
-            checkoutState.deliveryOption === "within-accra" && (
-              <GhostButton
-                type="button"
-                onClick={() => handlePaymentMethodChange("payment_on_delivery")}
-                selected={checkoutState.paymentMethod === "payment_on_delivery"}
-                className="w-full h-auto p-5 sm:p-6 text-left"
-              >
-                <div className="flex items-start space-x-4 w-full">
-                  <div className="flex-shrink-0 w-5 h-5 flex items-center justify-start">
-                    <Banknote className="w-5 h-5" />
-                  </div>
-                  <div className="flex-1 min-w-0 space-y-2 text-left">
-                    <p className="font-medium text-sm sm:text-base leading-tight text-left">
-                      Pay on delivery
-                    </p>
-                    <p className="text-sm text-muted-foreground leading-relaxed text-left text-wrap">
-                      Pay with cash or mobile money when your order arrives
-                    </p>
-                  </div>
-                </div>
-              </GhostButton>
-            )} */}
         </div>
-
-        {/* POD Payment Method Selection */}
-        {/* {checkoutState.paymentMethod === "payment_on_delivery" &&
-          checkoutState.deliveryOption === "within-accra" && (
-            <motion.div
-              initial={{ opacity: 0, height: 0 }}
-              animate={{ opacity: 1, height: "auto" }}
-              exit={{ opacity: 0, height: 0 }}
-              transition={{ duration: 0.3 }}
-              className="space-y-4 sm:space-y-6 mt-8 sm:mt-6 pt-8"
-            >
-              <p className="font-medium text-muted-foreground">
-                How would you like to pay on delivery?
-              </p>
-
-              <div className="space-y-3">
-                <GhostButton
-                  type="button"
-                  onClick={() => handlePODMethodChange("cash")}
-                  selected={checkoutState.podPaymentMethod === "cash"}
-                  className="w-full h-auto p-4 sm:p-5 text-left"
-                >
-                  <div className="flex items-start space-x-3 w-full">
-                    <div className="flex-shrink-0 w-4 h-4 flex items-center justify-start">
-                      <Banknote className="w-4 h-4" />
-                    </div>
-                    <div className="flex-1 min-w-0 space-y-1.5 text-left">
-                      <p className="text-sm sm:text-base font-medium leading-tight text-left">
-                        Cash
-                      </p>
-                      <p className="text-sm text-muted-foreground leading-relaxed text-left">
-                        Pay with cash to the delivery courier
-                      </p>
-                    </div>
-                  </div>
-                </GhostButton>
-
-                <GhostButton
-                  type="button"
-                  onClick={() => handlePODMethodChange("mobile_money")}
-                  selected={checkoutState.podPaymentMethod === "mobile_money"}
-                  className="w-full h-auto p-4 sm:p-5 text-left"
-                >
-                  <div className="flex items-start space-x-3 w-full">
-                    <div className="flex-shrink-0 w-4 h-4 flex items-center justify-start">
-                      <Smartphone className="w-4 h-4" />
-                    </div>
-                    <div className="flex-1 min-w-0 space-y-1.5 text-left">
-                      <p className="text-sm sm:text-base font-medium leading-tight text-left">
-                        Mobile Money
-                      </p>
-                      <p className="text-sm text-muted-foreground leading-relaxed text-left">
-                        Pay via MTN, Telecel, or AirtelTigo mobile money
-                      </p>
-                    </div>
-                  </div>
-                </GhostButton>
-              </div>
-
-              <Alert className="p-4 sm:p-5 mt-4 bg-accent5/40 border border-accent5/40">
-                <div className="flex items-start space-x-3">
-                  <div className="flex-shrink-0 w-4 h-4 flex items-center justify-start">
-                    <Info className="h-3.5 w-3.5" />
-                  </div>
-                  <AlertDescription className="text-xs sm:text-sm leading-relaxed flex-1 text-left">
-                    {checkoutState.podPaymentMethod === "cash"
-                      ? "Please have the exact amount ready when the delivery arrives."
-                      : "Our delivery courier will help you complete the mobile money payment when your order arrives."}
-                  </AlertDescription>
-                </div>
-              </Alert>
-            </motion.div>
-          )} */}
-
-        {/* Pickup Order Notice */}
-        {/* {!isDeliveryOrder && (
-          <Alert className="p-4 sm:p-5 w-fit">
-            <div className="flex items-start space-x-3">
-              <div className="flex-shrink-0 w-4 h-4 flex items-center justify-start">
-                <Info className="h-4 w-4" />
-              </div>
-              <AlertDescription className="text-xs sm:text-sm leading-relaxed flex-1 text-left">
-                Payment on delivery is only available for delivery orders.
-              </AlertDescription>
-            </div>
-          </Alert>
-        )} */}
       </div>
     </motion.div>
   );

--- a/packages/storefront-webapp/src/components/checkout/PaymentSection.tsx
+++ b/packages/storefront-webapp/src/components/checkout/PaymentSection.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { webOrderSchema } from "./CheckoutProvider";
+import { webOrderSchema } from "./schemas/webOrderSchema";
 import { useCheckout } from "@/hooks/useCheckout";
 import { CheckedState } from "@radix-ui/react-checkbox";
 import { Separator } from "../ui/separator";
@@ -228,8 +228,6 @@ export const PaymentSection = ({ form }: CheckoutFormSectionProps) => {
 
   const didAcceptTerms = didAcceptStoreTerms && didAcceptCommsTerms;
 
-  const showPayment = true;
-
   const showProceedSection = true;
 
   return (
@@ -239,25 +237,6 @@ export const PaymentSection = ({ form }: CheckoutFormSectionProps) => {
       className="w-full flex flex-col space-y-12"
     >
       <div className="space-y-12">
-        {/* <motion.div
-          initial={{ opacity: 0 }}
-          animate={{
-            opacity: 1,
-            y: 0,
-            transition: { duration: 0.3, ease: "easeOut" },
-          }}
-          exit={{
-            opacity: 0,
-            transition: { duration: 0.3, ease: "easeOut" },
-          }}
-          className="flex items-center"
-        >
-          <p>Payment</p>
-        </motion.div> */}
-
-        {/* {showPayment && <BillingDetailsForm />} */}
-        {/* {showPayment && <BillingDetailsSection form={form} />} */}
-
         {showProceedSection && (
           <motion.div
             initial={{ opacity: 0 }}

--- a/packages/storefront-webapp/src/components/checkout/checkoutStorage.test.ts
+++ b/packages/storefront-webapp/src/components/checkout/checkoutStorage.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { SESSION_STORAGE_KEY } from "@/lib/constants";
+import { loadCheckoutState, saveCheckoutState } from "./checkoutStorage";
+
+const initialState = {
+  deliveryMethod: "pickup" as const,
+  paymentMethod: "online_payment" as const,
+  podPaymentMethod: null,
+};
+
+describe("loadCheckoutState", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("returns initial state when no saved state exists", () => {
+    const result = loadCheckoutState(initialState as any);
+    expect(result).toEqual(initialState);
+  });
+
+  it("merges saved state with initial state", () => {
+    sessionStorage.setItem(
+      SESSION_STORAGE_KEY,
+      JSON.stringify({ deliveryMethod: "delivery" })
+    );
+
+    const result = loadCheckoutState(initialState as any);
+    expect(result.deliveryMethod).toBe("delivery");
+    expect(result.paymentMethod).toBe("online_payment");
+  });
+
+  it("returns initial state when saved state is invalid JSON", () => {
+    sessionStorage.setItem(SESSION_STORAGE_KEY, "not-json");
+    const result = loadCheckoutState(initialState as any);
+    expect(result).toEqual(initialState);
+  });
+});
+
+describe("saveCheckoutState", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("saves state to session storage without discount", () => {
+    saveCheckoutState({
+      deliveryMethod: "pickup",
+      discount: {
+        id: "1",
+        code: "TEST",
+        type: "percentage",
+        value: 10,
+        span: "entire-order",
+        isMultipleUses: false,
+      },
+      bag: { items: [{ id: "1" }] },
+    } as any);
+
+    const saved = JSON.parse(sessionStorage.getItem(SESSION_STORAGE_KEY)!);
+    expect(saved.deliveryMethod).toBe("pickup");
+    expect(saved.discount).toBeNull();
+    expect(saved.bag).toEqual({ items: [{ id: "1" }] });
+  });
+});

--- a/packages/storefront-webapp/src/components/checkout/checkoutStorage.ts
+++ b/packages/storefront-webapp/src/components/checkout/checkoutStorage.ts
@@ -1,0 +1,29 @@
+import { SESSION_STORAGE_KEY } from "@/lib/constants";
+import { CheckoutState } from "./types";
+
+export function loadCheckoutState(initialState: CheckoutState): CheckoutState {
+  if (typeof window === "undefined") return initialState;
+
+  try {
+    const savedState = sessionStorage.getItem(SESSION_STORAGE_KEY);
+    if (savedState) {
+      const parsed = JSON.parse(savedState);
+      return {
+        ...initialState,
+        ...parsed,
+        paymentMethod: parsed.paymentMethod || "online_payment",
+        podPaymentMethod: parsed.podPaymentMethod || null,
+      };
+    }
+    return initialState;
+  } catch {
+    return initialState;
+  }
+}
+
+export function saveCheckoutState(state: CheckoutState): void {
+  sessionStorage.setItem(
+    SESSION_STORAGE_KEY,
+    JSON.stringify({ ...state, discount: null })
+  );
+}

--- a/packages/storefront-webapp/src/components/checkout/deliveryFees.test.ts
+++ b/packages/storefront-webapp/src/components/checkout/deliveryFees.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+import { calculateDeliveryFee } from "./deliveryFees";
+
+describe("calculateDeliveryFee", () => {
+  it("returns 0 for pickup orders", () => {
+    const result = calculateDeliveryFee({
+      deliveryMethod: "pickup",
+      country: "GH",
+      region: "GA",
+      waiveDeliveryFees: null,
+      deliveryFees: null,
+    });
+
+    expect(result).toEqual({
+      deliveryFee: 0,
+      deliveryOption: null,
+    });
+  });
+
+  it("calculates within-accra fee for Greater Accra region", () => {
+    const result = calculateDeliveryFee({
+      deliveryMethod: "delivery",
+      country: "GH",
+      region: "GA",
+      waiveDeliveryFees: null,
+      deliveryFees: { withinAccra: 30, otherRegions: 70, international: 800 },
+    });
+
+    expect(result).toEqual({
+      deliveryFee: 30,
+      deliveryOption: "within-accra",
+    });
+  });
+
+  it("calculates outside-accra fee for non-GA Ghana regions", () => {
+    const result = calculateDeliveryFee({
+      deliveryMethod: "delivery",
+      country: "GH",
+      region: "AS",
+      waiveDeliveryFees: null,
+      deliveryFees: { withinAccra: 30, otherRegions: 70, international: 800 },
+    });
+
+    expect(result).toEqual({
+      deliveryFee: 70,
+      deliveryOption: "outside-accra",
+    });
+  });
+
+  it("calculates international fee for non-GH countries", () => {
+    const result = calculateDeliveryFee({
+      deliveryMethod: "delivery",
+      country: "US",
+      region: null,
+      waiveDeliveryFees: null,
+      deliveryFees: { withinAccra: 30, otherRegions: 70, international: 800 },
+    });
+
+    expect(result).toEqual({
+      deliveryFee: 800,
+      deliveryOption: "intl",
+    });
+  });
+
+  it("waives fee when all fees are waived", () => {
+    const result = calculateDeliveryFee({
+      deliveryMethod: "delivery",
+      country: "GH",
+      region: "GA",
+      waiveDeliveryFees: { all: true },
+      deliveryFees: { withinAccra: 30, otherRegions: 70, international: 800 },
+    });
+
+    expect(result).toEqual({
+      deliveryFee: 0,
+      deliveryOption: "within-accra",
+    });
+  });
+
+  it("waives fee when specific region fee is waived", () => {
+    const result = calculateDeliveryFee({
+      deliveryMethod: "delivery",
+      country: "GH",
+      region: "GA",
+      waiveDeliveryFees: { withinAccra: true },
+      deliveryFees: { withinAccra: 30, otherRegions: 70, international: 800 },
+    });
+
+    expect(result).toEqual({
+      deliveryFee: 0,
+      deliveryOption: "within-accra",
+    });
+  });
+
+  it("uses legacy boolean waiveDeliveryFees format", () => {
+    const result = calculateDeliveryFee({
+      deliveryMethod: "delivery",
+      country: "US",
+      region: null,
+      waiveDeliveryFees: true,
+      deliveryFees: { withinAccra: 30, otherRegions: 70, international: 800 },
+    });
+
+    expect(result).toEqual({
+      deliveryFee: 0,
+      deliveryOption: "intl",
+    });
+  });
+
+  it("uses hardcoded Ghana fees regardless of deliveryFees config", () => {
+    const result = calculateDeliveryFee({
+      deliveryMethod: "delivery",
+      country: "GH",
+      region: "GA",
+      waiveDeliveryFees: null,
+      deliveryFees: { withinAccra: 50, otherRegions: 100, international: 800 },
+    });
+
+    expect(result).toEqual({
+      deliveryFee: 30,
+      deliveryOption: "within-accra",
+    });
+  });
+
+  it("uses default fees when deliveryFees config is null", () => {
+    const result = calculateDeliveryFee({
+      deliveryMethod: "delivery",
+      country: "GH",
+      region: "GA",
+      waiveDeliveryFees: null,
+      deliveryFees: null,
+    });
+
+    expect(result).toEqual({
+      deliveryFee: 30,
+      deliveryOption: "within-accra",
+    });
+  });
+
+  it("uses default international fee when not configured", () => {
+    const result = calculateDeliveryFee({
+      deliveryMethod: "delivery",
+      country: "US",
+      region: null,
+      waiveDeliveryFees: null,
+      deliveryFees: null,
+    });
+
+    expect(result).toEqual({
+      deliveryFee: 800,
+      deliveryOption: "intl",
+    });
+  });
+
+  it("ignores country for pickup orders", () => {
+    const result = calculateDeliveryFee({
+      deliveryMethod: "pickup",
+      country: "US",
+      region: null,
+      waiveDeliveryFees: null,
+      deliveryFees: null,
+    });
+
+    expect(result).toEqual({
+      deliveryFee: 0,
+      deliveryOption: null,
+    });
+  });
+});

--- a/packages/storefront-webapp/src/components/checkout/deliveryFees.ts
+++ b/packages/storefront-webapp/src/components/checkout/deliveryFees.ts
@@ -1,0 +1,77 @@
+import { isFeeWaived } from "@/lib/feeUtils";
+import { DeliveryMethod, DeliveryOption } from "./types";
+
+type DeliveryFeeConfig = {
+  withinAccra?: number;
+  otherRegions?: number;
+  international?: number;
+} | null;
+
+type WaiveDeliveryFees =
+  | boolean
+  | {
+      withinAccra?: boolean;
+      otherRegions?: boolean;
+      international?: boolean;
+      all?: boolean;
+    }
+  | null
+  | undefined;
+
+type CalculateDeliveryFeeInput = {
+  deliveryMethod: DeliveryMethod;
+  country: string;
+  region: string | null;
+  waiveDeliveryFees: WaiveDeliveryFees;
+  deliveryFees: DeliveryFeeConfig;
+};
+
+type CalculateDeliveryFeeResult = {
+  deliveryFee: number;
+  deliveryOption: DeliveryOption | null;
+};
+
+const DEFAULT_WITHIN_ACCRA_FEE = 30;
+const DEFAULT_OTHER_REGIONS_FEE = 70;
+const DEFAULT_INTERNATIONAL_FEE = 800;
+
+export function calculateDeliveryFee({
+  deliveryMethod,
+  country,
+  region,
+  waiveDeliveryFees,
+  deliveryFees,
+}: CalculateDeliveryFeeInput): CalculateDeliveryFeeResult {
+  if (deliveryMethod === "pickup") {
+    return { deliveryFee: 0, deliveryOption: null };
+  }
+
+  const isGhana = country === "GH";
+  const isGreaterAccra = region === "GA";
+
+  let deliveryOption: DeliveryOption;
+  let baseFee: number;
+
+  if (isGhana) {
+    deliveryOption = isGreaterAccra ? "within-accra" : "outside-accra";
+    baseFee = isGreaterAccra
+      ? DEFAULT_WITHIN_ACCRA_FEE
+      : DEFAULT_OTHER_REGIONS_FEE;
+  } else {
+    deliveryOption = "intl";
+    baseFee = deliveryFees?.international || DEFAULT_INTERNATIONAL_FEE;
+  }
+
+  const shouldWaive = isGhana
+    ? typeof waiveDeliveryFees === "boolean"
+      ? waiveDeliveryFees
+      : isGreaterAccra
+        ? waiveDeliveryFees?.withinAccra || waiveDeliveryFees?.all || false
+        : waiveDeliveryFees?.otherRegions || waiveDeliveryFees?.all || false
+    : isFeeWaived(waiveDeliveryFees, "intl");
+
+  return {
+    deliveryFee: shouldWaive ? 0 : baseFee,
+    deliveryOption,
+  };
+}

--- a/packages/storefront-webapp/src/components/checkout/deriveCheckoutState.test.ts
+++ b/packages/storefront-webapp/src/components/checkout/deriveCheckoutState.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from "vitest";
+import { deriveCheckoutState } from "./deriveCheckoutState";
+import { CheckoutState } from "./types";
+
+const baseState: CheckoutState = {
+  billingDetails: null,
+  deliveryFee: null,
+  deliveryMethod: "pickup",
+  deliveryOption: null,
+  deliveryDetails: null,
+  deliveryInstructions: "",
+  customerDetails: null,
+  pickupLocation: "wigclub-hair-studio",
+  didEnterDeliveryDetails: false,
+  didEnterBillingDetails: false,
+  didSelectPickupLocation: false,
+  isUSOrder: false,
+  isROWOrder: false,
+  isGhanaOrder: true,
+  isPickupOrder: true,
+  isDeliveryOrder: false,
+  failedFinalValidation: false,
+  bag: null,
+  discount: null,
+  onlineOrder: null,
+  paymentMethod: "online_payment",
+  podPaymentMethod: null,
+};
+
+describe("deriveCheckoutState", () => {
+  it("marks pickup orders correctly", () => {
+    const result = deriveCheckoutState({
+      ...baseState,
+      deliveryMethod: "pickup",
+      pickupLocation: "wigclub-hair-studio",
+    });
+
+    expect(result.isPickupOrder).toBe(true);
+    expect(result.isDeliveryOrder).toBe(false);
+    expect(result.isGhanaOrder).toBe(true);
+    expect(result.didSelectPickupLocation).toBe(true);
+  });
+
+  it("marks delivery orders correctly", () => {
+    const result = deriveCheckoutState({
+      ...baseState,
+      deliveryMethod: "delivery",
+      deliveryDetails: {
+        country: "US",
+        address: "123 Main",
+        city: "Austin",
+        state: "TX",
+        zip: "78701",
+      },
+    });
+
+    expect(result.isPickupOrder).toBe(false);
+    expect(result.isDeliveryOrder).toBe(true);
+    expect(result.isUSOrder).toBe(true);
+    expect(result.isGhanaOrder).toBe(false);
+    expect(result.isROWOrder).toBe(false);
+  });
+
+  it("identifies Ghana delivery orders", () => {
+    const result = deriveCheckoutState({
+      ...baseState,
+      deliveryMethod: "delivery",
+      deliveryDetails: {
+        country: "GH",
+        region: "GA",
+        street: "Oxford St",
+        neighborhood: "osu",
+      },
+      deliveryOption: "within-accra",
+    });
+
+    expect(result.isGhanaOrder).toBe(true);
+    expect(result.isUSOrder).toBe(false);
+    expect(result.isROWOrder).toBe(false);
+  });
+
+  it("identifies rest-of-world delivery orders", () => {
+    const result = deriveCheckoutState({
+      ...baseState,
+      deliveryMethod: "delivery",
+      deliveryDetails: { country: "GB", address: "10 Downing", city: "London" },
+    });
+
+    expect(result.isROWOrder).toBe(true);
+    expect(result.isUSOrder).toBe(false);
+    expect(result.isGhanaOrder).toBe(false);
+  });
+
+  it("computes didEnterDeliveryDetails for US addresses", () => {
+    const result = deriveCheckoutState({
+      ...baseState,
+      deliveryMethod: "delivery",
+      deliveryOption: "intl",
+      deliveryDetails: {
+        country: "US",
+        address: "123 Main",
+        city: "Austin",
+        state: "TX",
+        zip: "78701",
+      },
+    });
+
+    expect(result.didEnterDeliveryDetails).toBe(true);
+  });
+
+  it("computes didEnterDeliveryDetails as false when US fields are incomplete", () => {
+    const result = deriveCheckoutState({
+      ...baseState,
+      deliveryMethod: "delivery",
+      deliveryOption: "intl",
+      deliveryDetails: {
+        country: "US",
+        address: "123 Main",
+        city: "Austin",
+      },
+    });
+
+    expect(result.didEnterDeliveryDetails).toBe(false);
+  });
+
+  it("computes didEnterDeliveryDetails for Ghana addresses", () => {
+    const result = deriveCheckoutState({
+      ...baseState,
+      deliveryMethod: "delivery",
+      deliveryOption: "within-accra",
+      deliveryDetails: {
+        country: "GH",
+        region: "GA",
+        street: "Oxford St",
+      },
+    });
+
+    expect(result.didEnterDeliveryDetails).toBe(true);
+  });
+
+  it("computes didEnterDeliveryDetails for ROW addresses", () => {
+    const result = deriveCheckoutState({
+      ...baseState,
+      deliveryMethod: "delivery",
+      deliveryOption: "intl",
+      deliveryDetails: {
+        country: "GB",
+        address: "10 Downing St",
+        city: "London",
+      },
+    });
+
+    expect(result.didEnterDeliveryDetails).toBe(true);
+  });
+
+  it("requires deliveryOption for didEnterDeliveryDetails", () => {
+    const result = deriveCheckoutState({
+      ...baseState,
+      deliveryMethod: "delivery",
+      deliveryOption: null,
+      deliveryDetails: {
+        country: "GB",
+        address: "10 Downing St",
+        city: "London",
+      },
+    });
+
+    expect(result.didEnterDeliveryDetails).toBe(false);
+  });
+
+  it("computes didEnterBillingDetails for US billing address", () => {
+    const result = deriveCheckoutState({
+      ...baseState,
+      billingDetails: {
+        country: "US",
+        address: "123 Main",
+        city: "Austin",
+        state: "TX",
+        zip: "78701",
+      },
+    });
+
+    expect(result.didEnterBillingDetails).toBe(true);
+  });
+
+  it("computes didEnterBillingDetails as false when US billing fields incomplete", () => {
+    const result = deriveCheckoutState({
+      ...baseState,
+      billingDetails: {
+        country: "US",
+        address: "123 Main",
+        city: "Austin",
+      },
+    });
+
+    expect(result.didEnterBillingDetails).toBe(false);
+  });
+});

--- a/packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts
+++ b/packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts
@@ -1,0 +1,77 @@
+import { CheckoutState } from "./types";
+
+export function deriveCheckoutState(state: CheckoutState): CheckoutState {
+  const isDeliveryOrder = state.deliveryMethod === "delivery";
+  const isPickupOrder = state.deliveryMethod === "pickup";
+
+  const isGhanaOrder =
+    isPickupOrder ||
+    (isDeliveryOrder && state.deliveryDetails?.country === "GH");
+
+  const isUSOrder = isDeliveryOrder && state.deliveryDetails?.country === "US";
+
+  const isROWOrder = isDeliveryOrder && !isUSOrder && !isGhanaOrder;
+
+  const didSelectPickupLocation = Boolean(
+    isPickupOrder && state.pickupLocation
+  );
+
+  const didProvideAllUSAddressFields = Boolean(
+    state.deliveryDetails?.address &&
+      state.deliveryDetails?.city &&
+      state.deliveryDetails?.state &&
+      state.deliveryDetails?.zip
+  );
+
+  const didProvideAllRestOfWorldFields = Boolean(
+    state.deliveryDetails?.address && state.deliveryDetails?.city
+  );
+
+  const didProvideAllGhanaAddressFields = Boolean(
+    state.deliveryDetails?.street && state.deliveryDetails?.region
+  );
+
+  const didEnterDeliveryDetails =
+    (isUSOrder
+      ? didProvideAllUSAddressFields
+      : isGhanaOrder && isDeliveryOrder
+        ? didProvideAllGhanaAddressFields
+        : didProvideAllRestOfWorldFields) &&
+    Boolean(state.deliveryOption);
+
+  const didProvideAllUSBillingAddressFields = Boolean(
+    state.billingDetails?.address &&
+      state.billingDetails?.city &&
+      state.billingDetails?.state &&
+      state.billingDetails?.zip
+  );
+
+  const didProvideAllRestOfWorldBillingFields = Boolean(
+    state.billingDetails?.address && state.billingDetails?.city
+  );
+
+  const didProvideAllGhanaBillingAddressFields = Boolean(
+    state.billingDetails?.address && state.billingDetails?.city
+  );
+
+  const isGhanaBillingAddress = state.billingDetails?.country === "GH";
+  const isUSBillingAddress = state.billingDetails?.country === "US";
+
+  const didEnterBillingDetails = isGhanaBillingAddress
+    ? didProvideAllGhanaBillingAddressFields
+    : isUSBillingAddress
+      ? didProvideAllUSBillingAddressFields
+      : didProvideAllRestOfWorldBillingFields;
+
+  return {
+    ...state,
+    isPickupOrder,
+    isDeliveryOrder,
+    isGhanaOrder,
+    isUSOrder,
+    isROWOrder,
+    didSelectPickupLocation,
+    didEnterDeliveryDetails,
+    didEnterBillingDetails,
+  };
+}

--- a/packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.test.ts
+++ b/packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.test.ts
@@ -1,0 +1,470 @@
+import { describe, expect, it } from "vitest";
+
+import { webOrderSchema } from "./webOrderSchema";
+
+const validCustomerDetails = {
+  firstName: "Ada",
+  lastName: "Lovelace",
+  email: "ada@example.com",
+  phoneNumber: "5555551234",
+};
+
+const getIssueMap = (issues: { path: (string | number)[]; message: string }[]) =>
+  new Map(issues.map((issue) => [issue.path.join("."), issue.message]));
+
+describe("webOrderSchema", () => {
+  describe("pickup orders", () => {
+    it("accepts a valid pickup order with a pickup location", () => {
+      const result = webOrderSchema.safeParse({
+        customerDetails: validCustomerDetails,
+        deliveryMethod: "pickup",
+        deliveryOption: null,
+        deliveryFee: null,
+        pickupLocation: "wigclub-hair-studio",
+        deliveryDetails: null,
+        discount: null,
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects a pickup order without a pickup location", () => {
+      const result = webOrderSchema.safeParse({
+        customerDetails: validCustomerDetails,
+        deliveryMethod: "pickup",
+        deliveryOption: null,
+        deliveryFee: null,
+        pickupLocation: null,
+        deliveryDetails: null,
+        discount: null,
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issues = getIssueMap(result.error.issues);
+        expect(issues.get("pickupLocation")).toBe("Pickup location is required");
+      }
+    });
+
+    it("rejects a pickup order with whitespace-only pickup location", () => {
+      const result = webOrderSchema.safeParse({
+        customerDetails: validCustomerDetails,
+        deliveryMethod: "pickup",
+        deliveryOption: null,
+        deliveryFee: null,
+        pickupLocation: "   ",
+        deliveryDetails: null,
+        discount: null,
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issues = getIssueMap(result.error.issues);
+        expect(issues.get("pickupLocation")).toBe(
+          "Pickup location cannot be empty or whitespace"
+        );
+      }
+    });
+
+    it("does not require delivery details for pickup orders", () => {
+      const result = webOrderSchema.safeParse({
+        customerDetails: validCustomerDetails,
+        deliveryMethod: "pickup",
+        deliveryOption: null,
+        deliveryFee: null,
+        pickupLocation: "wigclub-hair-studio",
+        deliveryDetails: null,
+        discount: null,
+      });
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  it("rejects an unknown delivery method", () => {
+    const result = webOrderSchema.safeParse({
+      customerDetails: validCustomerDetails,
+      deliveryMethod: "shipping",
+      deliveryOption: null,
+      deliveryFee: null,
+      pickupLocation: null,
+      deliveryDetails: null,
+      discount: null,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects orders with invalid customer details", () => {
+    const result = webOrderSchema.safeParse({
+      customerDetails: {
+        firstName: "",
+        lastName: "",
+        email: "not-an-email",
+        phoneNumber: "123",
+      },
+      deliveryMethod: "pickup",
+      deliveryOption: null,
+      deliveryFee: null,
+      pickupLocation: "wigclub-hair-studio",
+      deliveryDetails: null,
+      discount: null,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  describe("Ghana delivery orders", () => {
+    const ghanaDeliveryBase = {
+      customerDetails: validCustomerDetails,
+      deliveryMethod: "delivery" as const,
+      deliveryOption: "within-accra",
+      deliveryFee: 30,
+      pickupLocation: null,
+      discount: null,
+    };
+
+    it("accepts a valid Ghana delivery order with all required fields", () => {
+      const result = webOrderSchema.safeParse({
+        ...ghanaDeliveryBase,
+        deliveryDetails: {
+          country: "GH",
+          region: "GA",
+          street: "Oxford Street",
+          neighborhood: "osu",
+        },
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("requires region for Ghana addresses", () => {
+      const result = webOrderSchema.safeParse({
+        ...ghanaDeliveryBase,
+        deliveryDetails: {
+          country: "GH",
+          street: "Oxford Street",
+          neighborhood: "osu",
+        },
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issues = getIssueMap(result.error.issues);
+        expect(issues.get("deliveryDetails.region")).toBe("Region is required");
+      }
+    });
+
+    it("requires street for Ghana addresses", () => {
+      const result = webOrderSchema.safeParse({
+        ...ghanaDeliveryBase,
+        deliveryDetails: {
+          country: "GH",
+          region: "GA",
+          neighborhood: "osu",
+        },
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issues = getIssueMap(result.error.issues);
+        expect(issues.get("deliveryDetails.street")).toBe("Street is required");
+      }
+    });
+
+    it("requires neighborhood for Ghana addresses", () => {
+      const result = webOrderSchema.safeParse({
+        ...ghanaDeliveryBase,
+        deliveryDetails: {
+          country: "GH",
+          region: "GA",
+          street: "Oxford Street",
+        },
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issues = getIssueMap(result.error.issues);
+        expect(issues.get("deliveryDetails.neighborhood")).toBe(
+          "Neighborhood is required"
+        );
+      }
+    });
+
+    it("does not require address or city for Ghana addresses", () => {
+      const result = webOrderSchema.safeParse({
+        ...ghanaDeliveryBase,
+        deliveryDetails: {
+          country: "GH",
+          region: "GA",
+          street: "Oxford Street",
+          neighborhood: "osu",
+        },
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("requires delivery fee for delivery orders", () => {
+      const result = webOrderSchema.safeParse({
+        ...ghanaDeliveryBase,
+        deliveryFee: null,
+        deliveryDetails: {
+          country: "GH",
+          region: "GA",
+          street: "Oxford Street",
+          neighborhood: "osu",
+        },
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issues = getIssueMap(result.error.issues);
+        expect(issues.get("deliveryFee")).toBe("Delivery fee is required");
+      }
+    });
+
+    it("requires delivery details object for delivery orders", () => {
+      const result = webOrderSchema.safeParse({
+        ...ghanaDeliveryBase,
+        deliveryDetails: null,
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issues = getIssueMap(result.error.issues);
+        expect(issues.get("deliveryDetails")).toBe(
+          "Delivery details are required"
+        );
+      }
+    });
+  });
+
+  describe("US delivery orders", () => {
+    const usDeliveryBase = {
+      customerDetails: validCustomerDetails,
+      deliveryMethod: "delivery" as const,
+      deliveryOption: "intl",
+      deliveryFee: 800,
+      pickupLocation: null,
+      discount: null,
+    };
+
+    it("accepts a valid US delivery order", () => {
+      const result = webOrderSchema.safeParse({
+        ...usDeliveryBase,
+        deliveryDetails: {
+          country: "US",
+          address: "123 Main St",
+          city: "Austin",
+          state: "TX",
+          zip: "78701",
+        },
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("requires state for US addresses", () => {
+      const result = webOrderSchema.safeParse({
+        ...usDeliveryBase,
+        deliveryDetails: {
+          country: "US",
+          address: "123 Main St",
+          city: "Austin",
+          zip: "78701",
+        },
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issues = getIssueMap(result.error.issues);
+        expect(issues.get("deliveryDetails.state")).toBe("State is required");
+      }
+    });
+
+    it("requires zip for US addresses", () => {
+      const result = webOrderSchema.safeParse({
+        ...usDeliveryBase,
+        deliveryDetails: {
+          country: "US",
+          address: "123 Main St",
+          city: "Austin",
+          state: "TX",
+        },
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issues = getIssueMap(result.error.issues);
+        expect(issues.get("deliveryDetails.zip")).toBe("Zip is required");
+      }
+    });
+
+    it("rejects non-5-digit zip codes for US addresses", () => {
+      const result = webOrderSchema.safeParse({
+        ...usDeliveryBase,
+        deliveryDetails: {
+          country: "US",
+          address: "123 Main St",
+          city: "Austin",
+          state: "TX",
+          zip: "9410",
+        },
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issues = getIssueMap(result.error.issues);
+        expect(issues.get("deliveryDetails.zip")).toBe(
+          "Zip code must be a 5-digit number"
+        );
+      }
+    });
+
+    it("rejects whitespace-only zip codes for US addresses", () => {
+      const result = webOrderSchema.safeParse({
+        ...usDeliveryBase,
+        deliveryDetails: {
+          country: "US",
+          address: "123 Main St",
+          city: "Austin",
+          state: "TX",
+          zip: "   ",
+        },
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(
+          result.error.issues.some(
+            (issue) =>
+              issue.path.join(".") === "deliveryDetails.zip" &&
+              issue.message === "Zip code cannot be empty or whitespace"
+          )
+        ).toBe(true);
+      }
+    });
+
+    it("requires address for US orders", () => {
+      const result = webOrderSchema.safeParse({
+        ...usDeliveryBase,
+        deliveryDetails: {
+          country: "US",
+          city: "Austin",
+          state: "TX",
+          zip: "78701",
+        },
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issues = getIssueMap(result.error.issues);
+        expect(issues.get("deliveryDetails.address")).toBe(
+          "Address is required"
+        );
+      }
+    });
+
+    it("requires city for US orders", () => {
+      const result = webOrderSchema.safeParse({
+        ...usDeliveryBase,
+        deliveryDetails: {
+          country: "US",
+          address: "123 Main St",
+          state: "TX",
+          zip: "78701",
+        },
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issues = getIssueMap(result.error.issues);
+        expect(issues.get("deliveryDetails.city")).toBe("City is required");
+      }
+    });
+  });
+
+  describe("international (non-US, non-GH) delivery orders", () => {
+    const intlDeliveryBase = {
+      customerDetails: validCustomerDetails,
+      deliveryMethod: "delivery" as const,
+      deliveryOption: "intl",
+      deliveryFee: 800,
+      pickupLocation: null,
+      discount: null,
+    };
+
+    it("accepts a valid international delivery order", () => {
+      const result = webOrderSchema.safeParse({
+        ...intlDeliveryBase,
+        deliveryDetails: {
+          country: "GB",
+          address: "10 Downing St",
+          city: "London",
+        },
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("requires address for international orders", () => {
+      const result = webOrderSchema.safeParse({
+        ...intlDeliveryBase,
+        deliveryDetails: {
+          country: "GB",
+          city: "London",
+        },
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issues = getIssueMap(result.error.issues);
+        expect(issues.get("deliveryDetails.address")).toBe(
+          "Address is required"
+        );
+      }
+    });
+
+    it("requires city for international orders", () => {
+      const result = webOrderSchema.safeParse({
+        ...intlDeliveryBase,
+        deliveryDetails: {
+          country: "GB",
+          address: "10 Downing St",
+        },
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issues = getIssueMap(result.error.issues);
+        expect(issues.get("deliveryDetails.city")).toBe("City is required");
+      }
+    });
+
+    it("requires country for all delivery orders", () => {
+      const result = webOrderSchema.safeParse({
+        ...intlDeliveryBase,
+        deliveryDetails: {
+          address: "10 Downing St",
+          city: "London",
+        },
+      });
+
+      expect(result.success).toBe(false);
+    });
+
+    it("does not require state or zip for non-US international orders", () => {
+      const result = webOrderSchema.safeParse({
+        ...intlDeliveryBase,
+        deliveryDetails: {
+          country: "GB",
+          address: "10 Downing St",
+          city: "London",
+        },
+      });
+
+      expect(result.success).toBe(true);
+    });
+  });
+});

--- a/packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.ts
+++ b/packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.ts
@@ -2,18 +2,35 @@ import { z } from "zod";
 import { customerDetailsSchema } from "./customerDetailsSchema";
 import { baseDeliveryDetailsSchema } from "./deliveryDetailsSchema";
 
-export const checkoutFormSchema = z
+export const webOrderSchema = z
   .object({
+    customerDetails: customerDetailsSchema,
     deliveryMethod: z
       .enum(["pickup", "delivery"])
       .refine((value) => !!value, { message: "Delivery method is required" }),
-    customerDetails: z.object({ ...customerDetailsSchema.shape }),
-    deliveryDetails: z.object({ ...baseDeliveryDetailsSchema.shape }),
+    deliveryOption: z
+      .enum(["within-accra", "outside-accra", "intl"])
+      .refine((value) => !!value, { message: "Delivery option is required" })
+      .nullable(),
+    deliveryFee: z.number().nullable(),
+    pickupLocation: z.string().min(1).nullable(),
+    deliveryDetails: baseDeliveryDetailsSchema.optional().nullable(),
+    deliveryInstructions: z.string().optional(),
+    discount: z.record(z.string(), z.any()).nullable(),
   })
   .superRefine((data, ctx) => {
-    const { deliveryMethod, deliveryDetails } = data;
+    const { deliveryFee, deliveryMethod, deliveryDetails, pickupLocation } =
+      data;
 
     if (deliveryMethod == "delivery") {
+      if (deliveryFee == null) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["deliveryFee"],
+          message: "Delivery fee is required",
+        });
+      }
+
       if (!deliveryDetails) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
@@ -138,6 +155,22 @@ export const checkoutFormSchema = z
         }
       }
     }
-  });
 
-export type CheckoutFormData = z.infer<typeof checkoutFormSchema>;
+    if (deliveryMethod == "pickup") {
+      if (!pickupLocation) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["pickupLocation"],
+          message: "Pickup location is required",
+        });
+      }
+
+      if (pickupLocation?.trim().length == 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["pickupLocation"],
+          message: "Pickup location cannot be empty or whitespace",
+        });
+      }
+    }
+  });

--- a/packages/storefront-webapp/src/components/checkout/utils.test.ts
+++ b/packages/storefront-webapp/src/components/checkout/utils.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatDeliveryAddress,
+  getDiscountValue,
+  getOrderAmount,
+  BagItem,
+} from "./utils";
+import { Discount } from "./types";
+
+const sampleItems: BagItem[] = [
+  { productSkuId: "sku-1", quantity: 2, price: 50 },
+  { productSkuId: "sku-2", quantity: 1, price: 100 },
+];
+
+describe("getDiscountValue", () => {
+  it("returns 0 when no discount is provided", () => {
+    expect(getDiscountValue(sampleItems, null)).toBe(0);
+    expect(getDiscountValue(sampleItems, undefined)).toBe(0);
+  });
+
+  describe("entire-order percentage discounts", () => {
+    it("calculates percentage discount on the full subtotal", () => {
+      const discount: Discount = {
+        id: "d1",
+        code: "SAVE10",
+        type: "percentage",
+        value: 10,
+        span: "entire-order",
+        isMultipleUses: false,
+      };
+
+      expect(getDiscountValue(sampleItems, discount)).toBe(20);
+    });
+
+    it("applies isInCents multiplier for percentage discounts", () => {
+      const discount: Discount = {
+        id: "d1",
+        code: "SAVE10",
+        type: "percentage",
+        value: 10,
+        span: "entire-order",
+        isMultipleUses: false,
+      };
+
+      expect(getDiscountValue(sampleItems, discount, true)).toBe(2000);
+    });
+  });
+
+  describe("entire-order amount discounts", () => {
+    it("applies fixed amount discount directly", () => {
+      const discount: Discount = {
+        id: "d2",
+        code: "FLAT25",
+        type: "amount",
+        value: 25,
+        span: "entire-order",
+        isMultipleUses: false,
+      };
+
+      expect(getDiscountValue(sampleItems, discount)).toBe(25);
+    });
+
+    it("applies isInCents multiplier for amount discounts", () => {
+      const discount: Discount = {
+        id: "d2",
+        code: "FLAT25",
+        type: "amount",
+        value: 25,
+        span: "entire-order",
+        isMultipleUses: false,
+      };
+
+      expect(getDiscountValue(sampleItems, discount, true)).toBe(2500);
+    });
+  });
+
+  describe("selected-products percentage discounts", () => {
+    it("applies percentage only to eligible items", () => {
+      const discount: Discount = {
+        id: "d3",
+        code: "SKU1SAVE",
+        type: "percentage",
+        value: 50,
+        span: "selected-products",
+        isMultipleUses: false,
+        productSkus: ["sku-1"],
+      };
+
+      expect(getDiscountValue(sampleItems, discount)).toBe(50);
+    });
+  });
+
+  describe("selected-products amount discounts", () => {
+    it("caps amount discount at eligible items subtotal", () => {
+      const discount: Discount = {
+        id: "d4",
+        code: "BIGDISCOUNT",
+        type: "amount",
+        value: 500,
+        span: "selected-products",
+        isMultipleUses: false,
+        productSkus: ["sku-1"],
+      };
+
+      expect(getDiscountValue(sampleItems, discount)).toBe(100);
+    });
+
+    it("applies full amount when less than eligible subtotal", () => {
+      const discount: Discount = {
+        id: "d5",
+        code: "SMALL",
+        type: "amount",
+        value: 10,
+        span: "selected-products",
+        isMultipleUses: false,
+        productSkus: ["sku-1"],
+      };
+
+      expect(getDiscountValue(sampleItems, discount)).toBe(10);
+    });
+  });
+
+  it("returns 0 for selected-products discount with no productSkus", () => {
+    const discount: Discount = {
+      id: "d6",
+      code: "NOSKUS",
+      type: "percentage",
+      value: 10,
+      span: "selected-products",
+      isMultipleUses: false,
+    };
+
+    expect(getDiscountValue(sampleItems, discount)).toBe(0);
+  });
+});
+
+describe("getOrderAmount", () => {
+  it("calculates order amount with no discount and no delivery fee", () => {
+    const result = getOrderAmount({
+      items: sampleItems,
+      discount: null,
+      deliveryFee: null,
+      subtotal: 200,
+    });
+
+    expect(result.amountCharged).toBe(200);
+    expect(result.amountPaid).toBe(200);
+    expect(result.discountValue).toBe(0);
+  });
+
+  it("includes delivery fee in amountCharged but not amountPaid", () => {
+    const result = getOrderAmount({
+      items: sampleItems,
+      discount: null,
+      deliveryFee: 30,
+      subtotal: 200,
+    });
+
+    expect(result.amountCharged).toBe(230);
+    expect(result.amountPaid).toBe(200);
+  });
+
+  it("subtracts discount from both amountCharged and amountPaid", () => {
+    const discount: Discount = {
+      id: "d1",
+      code: "SAVE10",
+      type: "percentage",
+      value: 10,
+      span: "entire-order",
+      isMultipleUses: false,
+    };
+
+    const result = getOrderAmount({
+      items: sampleItems,
+      discount,
+      deliveryFee: 30,
+      subtotal: 200,
+    });
+
+    expect(result.discountValue).toBe(20);
+    expect(result.amountCharged).toBe(210);
+    expect(result.amountPaid).toBe(180);
+  });
+});
+
+describe("formatDeliveryAddress", () => {
+  it("formats US addresses with address, city, state, zip", () => {
+    const result = formatDeliveryAddress({
+      country: "US",
+      address: "123 Main St",
+      city: "Austin",
+      state: "TX",
+      zip: "78701",
+    });
+
+    expect(result.addressLine).toBe("123 Main St, Austin, TX, 78701");
+    expect(result.country).toBe("United States");
+  });
+
+  it("formats international addresses with address and city", () => {
+    const result = formatDeliveryAddress({
+      country: "GB",
+      address: "10 Downing St",
+      city: "London",
+    });
+
+    expect(result.addressLine).toBe("10 Downing St, London");
+    expect(result.country).toBe("United Kingdom");
+  });
+
+  it("formats Ghana addresses with house number, street, neighborhood and region", () => {
+    const result = formatDeliveryAddress({
+      country: "GH",
+      houseNumber: "15",
+      street: "Oxford Street",
+      neighborhood: "osu",
+      region: "GA",
+    });
+
+    expect(result.addressLine).toContain("15");
+    expect(result.addressLine).toContain("Oxford Street");
+  });
+
+  it("handles Ghana address without house number", () => {
+    const result = formatDeliveryAddress({
+      country: "GH",
+      street: "Oxford Street",
+      neighborhood: "osu",
+      region: "GA",
+    });
+
+    expect(result.addressLine).toContain("Oxford Street");
+    expect(result.addressLine).not.toMatch(/^\s/);
+  });
+});

--- a/packages/storefront-webapp/src/lib/feeUtils.test.ts
+++ b/packages/storefront-webapp/src/lib/feeUtils.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { isFeeWaived, isAnyFeeWaived } from "./feeUtils";
+
+describe("isFeeWaived", () => {
+  it("returns false for undefined/null waiveDeliveryFees", () => {
+    expect(isFeeWaived(undefined, "within-accra")).toBe(false);
+    expect(isFeeWaived(null, "within-accra")).toBe(false);
+  });
+
+  it("returns the boolean value for legacy boolean format", () => {
+    expect(isFeeWaived(true, "within-accra")).toBe(true);
+    expect(isFeeWaived(true, "intl")).toBe(true);
+    expect(isFeeWaived(false, "within-accra")).toBe(false);
+  });
+
+  it("returns true when all fees are waived", () => {
+    expect(isFeeWaived({ all: true }, "within-accra")).toBe(true);
+    expect(isFeeWaived({ all: true }, "outside-accra")).toBe(true);
+    expect(isFeeWaived({ all: true }, "intl")).toBe(true);
+  });
+
+  it("returns false when no delivery option is selected", () => {
+    expect(isFeeWaived({ withinAccra: true }, null)).toBe(false);
+  });
+
+  it("checks specific delivery option flags", () => {
+    const config = {
+      withinAccra: true,
+      otherRegions: false,
+      international: true,
+    };
+
+    expect(isFeeWaived(config, "within-accra")).toBe(true);
+    expect(isFeeWaived(config, "outside-accra")).toBe(false);
+    expect(isFeeWaived(config, "intl")).toBe(true);
+  });
+});
+
+describe("isAnyFeeWaived", () => {
+  it("returns false for undefined/null", () => {
+    expect(isAnyFeeWaived(undefined)).toBe(false);
+    expect(isAnyFeeWaived(null)).toBe(false);
+  });
+
+  it("returns the boolean value for legacy format", () => {
+    expect(isAnyFeeWaived(true)).toBe(true);
+    expect(isAnyFeeWaived(false)).toBe(false);
+  });
+
+  it("returns true if any fee type is waived", () => {
+    expect(isAnyFeeWaived({ withinAccra: true })).toBe(true);
+    expect(isAnyFeeWaived({ otherRegions: true })).toBe(true);
+    expect(isAnyFeeWaived({ international: true })).toBe(true);
+    expect(isAnyFeeWaived({ all: true })).toBe(true);
+  });
+
+  it("returns false when no fees are waived", () => {
+    expect(isAnyFeeWaived({})).toBe(false);
+    expect(
+      isAnyFeeWaived({
+        withinAccra: false,
+        otherRegions: false,
+        international: false,
+      })
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add comprehensive checkout tests for `webOrderSchema` (pickup, Ghana delivery, US/international delivery)
- add checkout utility test coverage for `getDiscountValue`, `getOrderAmount`, `formatDeliveryAddress`, and fee utility helpers
- extract `webOrderSchema` into `schemas/webOrderSchema.ts` and update imports/re-export
- extract pure helpers: `calculateDeliveryFee`, `deriveCheckoutState`, and checkout session storage helpers
- wire `CheckoutProvider` to use extracted helpers and remove large commented-out checkout dead code

## Validation
- `npx vitest run src/components/checkout/**/*.test.ts src/lib/feeUtils.test.ts`
- `npx vite build`
- `npx tsc --noEmit --incremental false` (validated after pointing worktree to project dependency set)

## Notes
- `npx vitest run` still picks up `tests/e2e/checkout.spec.ts` (Playwright test) and fails under Vitest; checkout/unit tests pass.
