### PR TITLE
fix: use configured checkout delivery fees

### DIFF
--- a/packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx
+++ b/packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx
@@ -45,8 +45,9 @@ export function DeliveryOptionsSelector() {
   const storeConfig = getStoreConfigV2(store);
 
   const { deliveryFees, waiveDeliveryFees } = storeConfig.commerce;
-
-  const { international, withinAccra, otherRegions } = deliveryFees || {};
+  const withinAccraFee = deliveryFees?.withinAccra ?? 30;
+  const otherRegionsFee = deliveryFees?.otherRegions ?? 70;
+  const internationalFee = deliveryFees?.international ?? 800;
 
   // Replace the waived fee checks with the shared utility function
   const shouldWaiveWithinAccraFee = isFeeWaived(
@@ -69,17 +70,13 @@ export function DeliveryOptionsSelector() {
     if (value == "intl") {
       updateState({
         ...base,
-        deliveryFee: shouldWaiveIntlFee
-          ? 0
-          : deliveryFees?.international || 800,
+        deliveryFee: shouldWaiveIntlFee ? 0 : internationalFee,
         deliveryOption: "intl",
       });
     } else if (value == "within-accra") {
       updateState({
         ...base,
-        deliveryFee: shouldWaiveWithinAccraFee
-          ? 0
-          : deliveryFees?.withinAccra || 30,
+        deliveryFee: shouldWaiveWithinAccraFee ? 0 : withinAccraFee,
         deliveryOption: "within-accra",
         deliveryDetails: {
           ...checkoutState.deliveryDetails,
@@ -89,9 +86,7 @@ export function DeliveryOptionsSelector() {
     } else {
       updateState({
         ...base,
-        deliveryFee: shouldWaiveOtherRegionsFee
-          ? 0
-          : deliveryFees?.otherRegions || 70,
+        deliveryFee: shouldWaiveOtherRegionsFee ? 0 : otherRegionsFee,
         deliveryOption: "outside-accra",
         deliveryDetails: {
           ...checkoutState.deliveryDetails,
@@ -124,9 +119,7 @@ export function DeliveryOptionsSelector() {
         // Always force update for non-Ghana (international) destinations
         // to ensure the fee waiving settings are applied correctly
         updateState({
-          deliveryFee: shouldWaiveIntlFee
-            ? 0
-            : deliveryFees?.international || 800,
+          deliveryFee: shouldWaiveIntlFee ? 0 : internationalFee,
           deliveryOption: "intl",
         });
       }
@@ -135,7 +128,7 @@ export function DeliveryOptionsSelector() {
     checkoutState.deliveryDetails,
     updateState,
     shouldWaiveIntlFee,
-    deliveryFees,
+    internationalFee,
   ]);
 
   useEffect(() => {
@@ -146,9 +139,7 @@ export function DeliveryOptionsSelector() {
     ) {
       updateState({
         deliveryOption: "within-accra",
-        deliveryFee: shouldWaiveWithinAccraFee
-          ? 0
-          : deliveryFees?.withinAccra || 30,
+        deliveryFee: shouldWaiveWithinAccraFee ? 0 : withinAccraFee,
       });
     }
   }, [checkoutState.deliveryDetails?.region]);
@@ -169,7 +160,7 @@ export function DeliveryOptionsSelector() {
               {shouldWaiveWithinAccraFee && (
                 <div className="flex items-center gap-2 text-muted-foreground">
                   <p className="text-start line-through">
-                    {formatter.format(withinAccra || 30)}
+                    {formatter.format(withinAccraFee)}
                   </p>
                   <p className="text-start">Free</p>
                 </div>
@@ -177,7 +168,7 @@ export function DeliveryOptionsSelector() {
 
               {!shouldWaiveWithinAccraFee && (
                 <p className="text-muted-foreground">
-                  {formatter.format(withinAccra || 30)}
+                  {formatter.format(withinAccraFee)}
                 </p>
               )}
             </div>
@@ -191,7 +182,7 @@ export function DeliveryOptionsSelector() {
               {shouldWaiveOtherRegionsFee && (
                 <div className="flex items-center gap-2 text-muted-foreground">
                   <p className="text-start line-through">
-                    {formatter.format(otherRegions || 70)}
+                    {formatter.format(otherRegionsFee)}
                   </p>
                   <p className="text-start">Free</p>
                 </div>
@@ -199,7 +190,7 @@ export function DeliveryOptionsSelector() {
 
               {!shouldWaiveOtherRegionsFee && (
                 <p className="text-muted-foreground">
-                  {formatter.format(otherRegions || 70)}
+                  {formatter.format(otherRegionsFee)}
                 </p>
               )}
             </div>
@@ -217,7 +208,7 @@ export function DeliveryOptionsSelector() {
               {shouldWaiveIntlFee && (
                 <div className="flex items-center gap-2 text-muted-foreground">
                   <p className="text-start line-through">
-                    {formatter.format(international || 800)}
+                    {formatter.format(internationalFee)}
                   </p>
                   <p className="text-start">Free</p>
                 </div>
@@ -225,7 +216,7 @@ export function DeliveryOptionsSelector() {
 
               {!shouldWaiveIntlFee && (
                 <p className="text-muted-foreground">
-                  {formatter.format(international || 800)}
+                  {formatter.format(internationalFee)}
                 </p>
               )}
             </div>

--- a/packages/storefront-webapp/src/components/checkout/deliveryFees.test.ts
+++ b/packages/storefront-webapp/src/components/checkout/deliveryFees.test.ts
@@ -107,7 +107,7 @@ describe("calculateDeliveryFee", () => {
     });
   });
 
-  it("uses hardcoded Ghana fees regardless of deliveryFees config", () => {
+  it("uses configured Ghana fees when provided", () => {
     const result = calculateDeliveryFee({
       deliveryMethod: "delivery",
       country: "GH",
@@ -117,8 +117,23 @@ describe("calculateDeliveryFee", () => {
     });
 
     expect(result).toEqual({
-      deliveryFee: 30,
+      deliveryFee: 50,
       deliveryOption: "within-accra",
+    });
+  });
+
+  it("uses configured other-regions Ghana fee when provided", () => {
+    const result = calculateDeliveryFee({
+      deliveryMethod: "delivery",
+      country: "GH",
+      region: "AS",
+      waiveDeliveryFees: null,
+      deliveryFees: { withinAccra: 50, otherRegions: 100, international: 800 },
+    });
+
+    expect(result).toEqual({
+      deliveryFee: 100,
+      deliveryOption: "outside-accra",
     });
   });
 

--- a/packages/storefront-webapp/src/components/checkout/deliveryFees.ts
+++ b/packages/storefront-webapp/src/components/checkout/deliveryFees.ts
@@ -54,12 +54,16 @@ export function calculateDeliveryFee({
 
   if (isGhana) {
     deliveryOption = isGreaterAccra ? "within-accra" : "outside-accra";
+    const withinAccraFee =
+      deliveryFees?.withinAccra ?? DEFAULT_WITHIN_ACCRA_FEE;
+    const otherRegionsFee =
+      deliveryFees?.otherRegions ?? DEFAULT_OTHER_REGIONS_FEE;
     baseFee = isGreaterAccra
-      ? DEFAULT_WITHIN_ACCRA_FEE
-      : DEFAULT_OTHER_REGIONS_FEE;
+      ? withinAccraFee
+      : otherRegionsFee;
   } else {
     deliveryOption = "intl";
-    baseFee = deliveryFees?.international || DEFAULT_INTERNATIONAL_FEE;
+    baseFee = deliveryFees?.international ?? DEFAULT_INTERNATIONAL_FEE;
   }
 
   const shouldWaive = isGhana


### PR DESCRIPTION
## Summary
- use `storeConfig.commerce.deliveryFees` for Ghana checkout fees instead of hardcoded values
- keep defaults (30/70/800) as fallback when config values are missing
- update `DeliveryOptionsSelector` display and selection logic to use config-driven fees
- update delivery fee tests to assert configured Ghana fee behavior

## Validation
- `npx vitest run src/components/checkout/**/*.test.ts src/lib/feeUtils.test.ts`
- `npx vite build`
- `bun run build` currently fails due existing unrelated TypeScript errors in checkout/auth route files