### PR TITLE
ci+symphony: add pr workflow coverage and orchestrator state core

### DIFF
--- a/.github/workflows/athena-pr-tests.yml
+++ b/.github/workflows/athena-pr-tests.yml
@@ -1,4 +1,4 @@
-name: Storefront Webapp Tests
+name: Athena PR Tests
 
 on:
   pull_request:
@@ -28,3 +28,22 @@ jobs:
 
       - name: Run storefront webapp tests
         run: bun run --filter '@athena/storefront-webapp' test
+
+  test-symphony-service:
+    name: Symphony Service Test Suite
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run symphony service tests
+        run: bun run --filter '@athena/symphony-service' test

--- a/packages/symphony-service/src/index.ts
+++ b/packages/symphony-service/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./config";
 export * from "./errors";
 export * from "./issue";
+export * from "./orchestrator";
 export * from "./retry";
 export * from "./scheduler";
 export * from "./template";

--- a/packages/symphony-service/src/orchestrator.ts
+++ b/packages/symphony-service/src/orchestrator.ts
@@ -1,0 +1,285 @@
+import type { NormalizedIssue } from "./issue";
+import { calculateContinuationDelay, calculateFailureRetryDelay } from "./retry";
+import { isIssueDispatchEligible, sortIssuesForDispatch } from "./scheduler";
+
+export interface RetryEntry {
+  issueId: string;
+  identifier: string;
+  attempt: number;
+  dueAtMs: number;
+  error: string;
+}
+
+export interface RunningEntry {
+  issue: NormalizedIssue;
+  startedAtMs: number;
+  lastCodexTimestampMs: number | null;
+  retryAttempt: number;
+  turnCount: number;
+}
+
+export interface OrchestratorState {
+  claimed: Set<string>;
+  running: Map<string, RunningEntry>;
+  retryAttempts: Map<string, RetryEntry>;
+  completed: Set<string>;
+}
+
+export interface RetryScheduleInput {
+  issueId: string;
+  identifier: string;
+  attempt: number;
+  nowMs: number;
+  maxRetryBackoffMs: number;
+  mode: "continuation" | "failure";
+  error: string;
+}
+
+export interface ReconcileAction {
+  issueId: string;
+  identifier: string;
+  action: "terminate_cleanup" | "terminate_keep" | "update_snapshot";
+}
+
+export function createOrchestratorState(): OrchestratorState {
+  return {
+    claimed: new Set(),
+    running: new Map(),
+    retryAttempts: new Map(),
+    completed: new Set(),
+  };
+}
+
+export function markIssueRunning(
+  state: OrchestratorState,
+  issue: NormalizedIssue,
+  nowMs: number,
+  attempt: number | null,
+): void {
+  state.claimed.add(issue.id);
+  state.retryAttempts.delete(issue.id);
+  state.running.set(issue.id, {
+    issue,
+    startedAtMs: nowMs,
+    lastCodexTimestampMs: null,
+    retryAttempt: normalizeRetryAttempt(attempt),
+    turnCount: 0,
+  });
+}
+
+export function getAvailableGlobalSlots(state: OrchestratorState, maxConcurrentAgents: number): number {
+  return Math.max(maxConcurrentAgents - state.running.size, 0);
+}
+
+export function getRunningCountByState(state: OrchestratorState): Record<string, number> {
+  const counts: Record<string, number> = {};
+
+  for (const running of state.running.values()) {
+    const key = running.issue.state.toLowerCase();
+    counts[key] = (counts[key] ?? 0) + 1;
+  }
+
+  return counts;
+}
+
+export function selectDispatchCandidates(input: {
+  candidates: NormalizedIssue[];
+  state: OrchestratorState;
+  activeStates: string[];
+  terminalStates: string[];
+  maxConcurrentAgents: number;
+  maxConcurrentAgentsByState: Record<string, number>;
+}): NormalizedIssue[] {
+  const sorted = sortIssuesForDispatch(input.candidates);
+  const availableGlobalSlots = getAvailableGlobalSlots(input.state, input.maxConcurrentAgents);
+
+  if (availableGlobalSlots <= 0) {
+    return [];
+  }
+
+  const activeStates = new Set(input.activeStates);
+  const terminalStates = new Set(input.terminalStates);
+  const claimed = new Set(input.state.claimed);
+  const running = new Set(input.state.running.keys());
+  const runningByState = getRunningCountByState(input.state);
+
+  const selected: NormalizedIssue[] = [];
+
+  for (const issue of sorted) {
+    if (selected.length >= availableGlobalSlots) {
+      break;
+    }
+
+    const eligible = isIssueDispatchEligible(issue, {
+      activeStates,
+      terminalStates,
+      claimedIssueIds: claimed,
+      runningIssueIds: running,
+    });
+
+    if (!eligible) {
+      continue;
+    }
+
+    const stateKey = issue.state.toLowerCase();
+    const stateLimit = input.maxConcurrentAgentsByState[stateKey];
+    if (typeof stateLimit === "number" && stateLimit > 0) {
+      const used = runningByState[stateKey] ?? 0;
+      if (used >= stateLimit) {
+        continue;
+      }
+    }
+
+    selected.push(issue);
+    claimed.add(issue.id);
+    running.add(issue.id);
+    runningByState[stateKey] = (runningByState[stateKey] ?? 0) + 1;
+  }
+
+  return selected;
+}
+
+export function scheduleRetry(state: OrchestratorState, input: RetryScheduleInput): RetryEntry {
+  const delayMs =
+    input.mode === "continuation"
+      ? calculateContinuationDelay()
+      : calculateFailureRetryDelay(input.attempt, input.maxRetryBackoffMs);
+
+  const entry: RetryEntry = {
+    issueId: input.issueId,
+    identifier: input.identifier,
+    attempt: input.attempt,
+    dueAtMs: input.nowMs + delayMs,
+    error: input.error,
+  };
+
+  state.retryAttempts.set(input.issueId, entry);
+  return entry;
+}
+
+export function onWorkerExit(
+  state: OrchestratorState,
+  input: {
+    issueId: string;
+    nowMs: number;
+    reason: "normal" | "failure";
+    maxRetryBackoffMs: number;
+    error?: string;
+  },
+): RetryEntry | null {
+  const running = state.running.get(input.issueId);
+  if (!running) {
+    return null;
+  }
+
+  state.running.delete(input.issueId);
+
+  if (input.reason === "normal") {
+    state.completed.add(input.issueId);
+    return scheduleRetry(state, {
+      issueId: input.issueId,
+      identifier: running.issue.identifier,
+      attempt: 1,
+      nowMs: input.nowMs,
+      maxRetryBackoffMs: input.maxRetryBackoffMs,
+      mode: "continuation",
+      error: "continuation_retry",
+    });
+  }
+
+  const nextAttempt = running.retryAttempt + 1;
+  return scheduleRetry(state, {
+    issueId: input.issueId,
+    identifier: running.issue.identifier,
+    attempt: nextAttempt,
+    nowMs: input.nowMs,
+    maxRetryBackoffMs: input.maxRetryBackoffMs,
+    mode: "failure",
+    error: input.error ?? "worker_failed",
+  });
+}
+
+export function getStalledIssueIds(
+  state: OrchestratorState,
+  input: {
+    nowMs: number;
+    stallTimeoutMs: number;
+  },
+): string[] {
+  if (input.stallTimeoutMs <= 0) {
+    return [];
+  }
+
+  const stalled: string[] = [];
+
+  for (const [issueId, running] of state.running.entries()) {
+    const baseline = running.lastCodexTimestampMs ?? running.startedAtMs;
+    const elapsedMs = input.nowMs - baseline;
+    if (elapsedMs > input.stallTimeoutMs) {
+      stalled.push(issueId);
+    }
+  }
+
+  return stalled;
+}
+
+export function reconcileRunningIssueStates(
+  state: OrchestratorState,
+  input: {
+    refreshed: NormalizedIssue[];
+    activeStates: string[];
+    terminalStates: string[];
+  },
+): ReconcileAction[] {
+  const active = new Set(input.activeStates);
+  const terminal = new Set(input.terminalStates);
+  const byId = new Map(input.refreshed.map((issue) => [issue.id, issue]));
+
+  const actions: ReconcileAction[] = [];
+
+  for (const [issueId, running] of state.running.entries()) {
+    const refreshed = byId.get(issueId);
+    if (!refreshed) {
+      continue;
+    }
+
+    if (terminal.has(refreshed.state)) {
+      actions.push({
+        issueId,
+        identifier: refreshed.identifier,
+        action: "terminate_cleanup",
+      });
+      continue;
+    }
+
+    if (!active.has(refreshed.state)) {
+      actions.push({
+        issueId,
+        identifier: refreshed.identifier,
+        action: "terminate_keep",
+      });
+      continue;
+    }
+
+    state.running.set(issueId, {
+      ...running,
+      issue: refreshed,
+    });
+
+    actions.push({
+      issueId,
+      identifier: refreshed.identifier,
+      action: "update_snapshot",
+    });
+  }
+
+  return actions;
+}
+
+function normalizeRetryAttempt(value: number | null): number {
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    return Math.trunc(value);
+  }
+
+  return 0;
+}

--- a/packages/symphony-service/tests/orchestrator.test.ts
+++ b/packages/symphony-service/tests/orchestrator.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from "vitest";
+import type { NormalizedIssue } from "../src/issue";
+import {
+  createOrchestratorState,
+  getAvailableGlobalSlots,
+  getStalledIssueIds,
+  markIssueRunning,
+  onWorkerExit,
+  reconcileRunningIssueStates,
+  scheduleRetry,
+  selectDispatchCandidates,
+} from "../src/orchestrator";
+
+function issue(partial: Partial<NormalizedIssue>): NormalizedIssue {
+  return {
+    id: partial.id ?? "1",
+    identifier: partial.identifier ?? "ATH-1",
+    title: partial.title ?? "Issue",
+    state: partial.state ?? "Todo",
+    priority: partial.priority ?? 1,
+    created_at: partial.created_at ?? "2026-01-01T00:00:00.000Z",
+    updated_at: partial.updated_at ?? "2026-01-01T00:00:00.000Z",
+    labels: partial.labels ?? [],
+    blocked_by: partial.blocked_by ?? [],
+  };
+}
+
+describe("orchestrator state", () => {
+  it("creates empty state", () => {
+    const state = createOrchestratorState();
+    expect(state.running.size).toBe(0);
+    expect(state.claimed.size).toBe(0);
+    expect(state.retryAttempts.size).toBe(0);
+  });
+
+  it("marks issue running and calculates global slots", () => {
+    const state = createOrchestratorState();
+    markIssueRunning(state, issue({ id: "a" }), 1000, null);
+
+    expect(state.running.has("a")).toBe(true);
+    expect(state.claimed.has("a")).toBe(true);
+    expect(getAvailableGlobalSlots(state, 2)).toBe(1);
+  });
+});
+
+describe("dispatch selection", () => {
+  it("respects global and per-state concurrency limits", () => {
+    const state = createOrchestratorState();
+    markIssueRunning(state, issue({ id: "inprog-1", identifier: "ATH-10", state: "In Progress" }), 0, null);
+
+    const selected = selectDispatchCandidates({
+      candidates: [
+        issue({ id: "todo-1", identifier: "ATH-1", state: "Todo", priority: 1 }),
+        issue({ id: "inprog-2", identifier: "ATH-2", state: "In Progress", priority: 1 }),
+        issue({ id: "todo-2", identifier: "ATH-3", state: "Todo", priority: 2 }),
+      ],
+      state,
+      activeStates: ["Todo", "In Progress"],
+      terminalStates: ["Done", "Closed"],
+      maxConcurrentAgents: 3,
+      maxConcurrentAgentsByState: {
+        "in progress": 1,
+      },
+    });
+
+    expect(selected.map((item) => item.id)).toEqual(["todo-1", "todo-2"]);
+  });
+
+  it("skips blocked Todo issues when blockers are non-terminal", () => {
+    const state = createOrchestratorState();
+
+    const selected = selectDispatchCandidates({
+      candidates: [
+        issue({
+          id: "todo-blocked",
+          blocked_by: [{ id: "x", identifier: "ATH-X", state: "In Progress" }],
+        }),
+      ],
+      state,
+      activeStates: ["Todo", "In Progress"],
+      terminalStates: ["Done", "Closed"],
+      maxConcurrentAgents: 2,
+      maxConcurrentAgentsByState: {},
+    });
+
+    expect(selected).toHaveLength(0);
+  });
+});
+
+describe("retry scheduling", () => {
+  it("schedules continuation retry after normal worker exit", () => {
+    const state = createOrchestratorState();
+    markIssueRunning(state, issue({ id: "a", identifier: "ATH-1" }), 0, 3);
+
+    const retry = onWorkerExit(state, {
+      issueId: "a",
+      nowMs: 2000,
+      reason: "normal",
+      maxRetryBackoffMs: 300000,
+    });
+
+    expect(retry?.attempt).toBe(1);
+    expect(retry?.dueAtMs).toBe(3000);
+    expect(state.completed.has("a")).toBe(true);
+  });
+
+  it("schedules exponential backoff retry after failure", () => {
+    const state = createOrchestratorState();
+    markIssueRunning(state, issue({ id: "b", identifier: "ATH-2" }), 0, 2);
+
+    const retry = onWorkerExit(state, {
+      issueId: "b",
+      nowMs: 1000,
+      reason: "failure",
+      maxRetryBackoffMs: 300000,
+      error: "turn_failed",
+    });
+
+    expect(retry?.attempt).toBe(3);
+    expect(retry?.dueAtMs).toBe(41000);
+    expect(retry?.error).toBe("turn_failed");
+  });
+
+  it("replaces existing retry entry for same issue", () => {
+    const state = createOrchestratorState();
+
+    scheduleRetry(state, {
+      issueId: "x",
+      identifier: "ATH-X",
+      attempt: 1,
+      nowMs: 0,
+      maxRetryBackoffMs: 300000,
+      mode: "failure",
+      error: "old",
+    });
+
+    scheduleRetry(state, {
+      issueId: "x",
+      identifier: "ATH-X",
+      attempt: 2,
+      nowMs: 0,
+      maxRetryBackoffMs: 300000,
+      mode: "failure",
+      error: "new",
+    });
+
+    expect(state.retryAttempts.get("x")?.attempt).toBe(2);
+    expect(state.retryAttempts.get("x")?.error).toBe("new");
+  });
+});
+
+describe("reconciliation", () => {
+  it("flags terminal and non-active issues for termination and updates active snapshots", () => {
+    const state = createOrchestratorState();
+    markIssueRunning(state, issue({ id: "a", identifier: "ATH-1", state: "In Progress" }), 0, null);
+    markIssueRunning(state, issue({ id: "b", identifier: "ATH-2", state: "In Progress" }), 0, null);
+    markIssueRunning(state, issue({ id: "c", identifier: "ATH-3", state: "In Progress" }), 0, null);
+
+    const actions = reconcileRunningIssueStates(state, {
+      refreshed: [
+        issue({ id: "a", identifier: "ATH-1", state: "Done" }),
+        issue({ id: "b", identifier: "ATH-2", state: "Backlog" }),
+        issue({ id: "c", identifier: "ATH-3", state: "In Progress", title: "Updated" }),
+      ],
+      activeStates: ["Todo", "In Progress"],
+      terminalStates: ["Done", "Closed"],
+    });
+
+    expect(actions).toEqual([
+      { issueId: "a", identifier: "ATH-1", action: "terminate_cleanup" },
+      { issueId: "b", identifier: "ATH-2", action: "terminate_keep" },
+      { issueId: "c", identifier: "ATH-3", action: "update_snapshot" },
+    ]);
+
+    expect(state.running.get("c")?.issue.title).toBe("Updated");
+  });
+
+  it("detects stalled sessions based on last codex activity", () => {
+    const state = createOrchestratorState();
+    markIssueRunning(state, issue({ id: "a" }), 1000, null);
+    markIssueRunning(state, issue({ id: "b" }), 1000, null);
+
+    const b = state.running.get("b");
+    if (b) {
+      b.lastCodexTimestampMs = 4900;
+      state.running.set("b", b);
+    }
+
+    const stalled = getStalledIssueIds(state, {
+      nowMs: 7000,
+      stallTimeoutMs: 3000,
+    });
+
+    expect(stalled).toEqual(["a"]);
+    expect(getStalledIssueIds(state, { nowMs: 7000, stallTimeoutMs: 0 })).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- rename the PR workflow to `Athena PR Tests`
- add a PR job to run `@athena/symphony-service` tests alongside storefront tests
- add Symphony orchestrator state core (claimed/running/retry/completed state, dispatch candidate selection, stall detection, reconciliation actions, worker-exit retry scheduling)
- add orchestrator unit tests covering concurrency, eligibility, retries, reconciliation, and stall timeout behavior

## Validation
- `bun run --filter '@athena/symphony-service' test` (37 passing)

## Notes
- branch: `codex/symphony-orchestrator`
- unrelated untracked local path `packages/.claude/worktrees/` left untouched
