### PR TITLE
feat: add Symphony orchestrator poll tick runtime

### DIFF
--- a/packages/symphony-service/src/errors.ts
+++ b/packages/symphony-service/src/errors.ts
@@ -16,6 +16,8 @@ export type SymphonyErrorCode =
   | "invalid_workspace_path"
   | "hook_failed"
   | "hook_timeout"
+  | "worker_turn_failed"
+  | "worker_attempt_failed"
   | "linear_api_request"
   | "linear_api_status"
   | "linear_graphql_errors"

--- a/packages/symphony-service/src/index.ts
+++ b/packages/symphony-service/src/index.ts
@@ -3,6 +3,7 @@ export * from "./errors";
 export * from "./issue";
 export * from "./orchestrator";
 export * from "./retry";
+export * from "./runtime";
 export * from "./scheduler";
 export * from "./startup";
 export * from "./template";

--- a/packages/symphony-service/src/index.ts
+++ b/packages/symphony-service/src/index.ts
@@ -12,3 +12,4 @@ export * from "./types";
 export * from "./validate";
 export * from "./workspace";
 export * from "./workflow";
+export * from "./worker";

--- a/packages/symphony-service/src/runtime.ts
+++ b/packages/symphony-service/src/runtime.ts
@@ -4,6 +4,7 @@ import {
   getStalledIssueIds,
   markIssueRunning,
   onWorkerExit,
+  type RetryEntry,
   reconcileRunningIssueStates,
   selectDispatchCandidates,
   type OrchestratorState,
@@ -37,6 +38,21 @@ export interface RunOrchestratorTickResult {
   reconcileActions: ReconcileAction[];
   stalledIssueIds: string[];
   preflightError?: string;
+}
+
+export interface ProcessDueRetriesInput {
+  state: OrchestratorState;
+  tracker: TrackerClient;
+  config: EffectiveConfig;
+  nowMs: number;
+  dispatchIssue: (input: DispatchInput) => Promise<void>;
+}
+
+export interface ProcessDueRetriesResult {
+  processedIssueIds: string[];
+  dispatchedIssueIds: string[];
+  requeuedIssueIds: string[];
+  releasedIssueIds: string[];
 }
 
 export async function runOrchestratorTick(input: RunOrchestratorTickInput): Promise<RunOrchestratorTickResult> {
@@ -171,4 +187,146 @@ function nextRetryAttempt(retryAttempt: number | null): number {
   }
 
   return 1;
+}
+
+export async function processDueRetries(input: ProcessDueRetriesInput): Promise<ProcessDueRetriesResult> {
+  const dueEntries = Array.from(input.state.retryAttempts.values())
+    .filter((entry) => entry.dueAtMs <= input.nowMs)
+    .sort((a, b) => a.dueAtMs - b.dueAtMs);
+
+  if (dueEntries.length === 0) {
+    return {
+      processedIssueIds: [],
+      dispatchedIssueIds: [],
+      requeuedIssueIds: [],
+      releasedIssueIds: [],
+    };
+  }
+
+  const processedIssueIds: string[] = [];
+  const dispatchedIssueIds: string[] = [];
+  const requeuedIssueIds: string[] = [];
+  const releasedIssueIds: string[] = [];
+
+  for (const entry of dueEntries) {
+    input.state.retryAttempts.delete(entry.issueId);
+    processedIssueIds.push(entry.issueId);
+  }
+
+  let candidates: NormalizedIssue[];
+  try {
+    candidates = await input.tracker.fetchCandidateIssues();
+  } catch (error) {
+    const message = `retry poll failed: ${toErrorMessage(error)}`;
+    for (const entry of dueEntries) {
+      requeueRetryEntry(input, entry, {
+        attempt: entry.attempt + 1,
+        mode: "failure",
+        error: message,
+      });
+      requeuedIssueIds.push(entry.issueId);
+    }
+
+    return {
+      processedIssueIds,
+      dispatchedIssueIds,
+      requeuedIssueIds,
+      releasedIssueIds,
+    };
+  }
+
+  const activeStates = new Set(input.config.tracker.activeStates);
+  const terminalStates = new Set(input.config.tracker.terminalStates);
+  const candidatesById = new Map(candidates.map((issue) => [issue.id, issue]));
+
+  for (const entry of dueEntries) {
+    const issue = candidatesById.get(entry.issueId);
+    if (!issue) {
+      input.state.claimed.delete(entry.issueId);
+      releasedIssueIds.push(entry.issueId);
+      continue;
+    }
+
+    if (!activeStates.has(issue.state) || terminalStates.has(issue.state)) {
+      input.state.claimed.delete(entry.issueId);
+      releasedIssueIds.push(entry.issueId);
+      continue;
+    }
+
+    if (!canDispatchRetryIssue(issue, input.state, input.config)) {
+      requeueRetryEntry(input, entry, {
+        attempt: entry.attempt,
+        mode: "continuation",
+        error: "no available orchestrator slots",
+      });
+      requeuedIssueIds.push(entry.issueId);
+      continue;
+    }
+
+    try {
+      await input.dispatchIssue({
+        issue,
+        attempt: normalizeDispatchAttempt(entry.attempt),
+      });
+
+      markIssueRunning(input.state, issue, input.nowMs, entry.attempt);
+      dispatchedIssueIds.push(entry.issueId);
+    } catch (error) {
+      requeueRetryEntry(input, entry, {
+        attempt: entry.attempt + 1,
+        mode: "failure",
+        error: toErrorMessage(error),
+      });
+      requeuedIssueIds.push(entry.issueId);
+    }
+  }
+
+  return {
+    processedIssueIds,
+    dispatchedIssueIds,
+    requeuedIssueIds,
+    releasedIssueIds,
+  };
+}
+
+function canDispatchRetryIssue(issue: NormalizedIssue, state: OrchestratorState, config: EffectiveConfig): boolean {
+  const tempState: OrchestratorState = {
+    claimed: new Set(state.claimed),
+    running: state.running,
+    retryAttempts: state.retryAttempts,
+    completed: state.completed,
+  };
+
+  tempState.claimed.delete(issue.id);
+
+  const selected = selectDispatchCandidates({
+    candidates: [issue],
+    state: tempState,
+    activeStates: config.tracker.activeStates,
+    terminalStates: config.tracker.terminalStates,
+    maxConcurrentAgents: config.agent.maxConcurrentAgents,
+    maxConcurrentAgentsByState: config.agent.maxConcurrentAgentsByState,
+  });
+
+  return selected.length > 0;
+}
+
+function requeueRetryEntry(
+  input: ProcessDueRetriesInput,
+  entry: RetryEntry,
+  options: {
+    attempt: number;
+    mode: "continuation" | "failure";
+    error: string;
+  },
+): void {
+  scheduleRetry(input.state, {
+    issueId: entry.issueId,
+    identifier: entry.identifier,
+    attempt: options.attempt,
+    nowMs: input.nowMs,
+    maxRetryBackoffMs: input.config.agent.maxRetryBackoffMs,
+    mode: options.mode,
+    error: options.error,
+  });
 }

--- a/packages/symphony-service/src/runtime.ts
+++ b/packages/symphony-service/src/runtime.ts
@@ -1,0 +1,174 @@
+import { toErrorMessage } from "./errors";
+import type { NormalizedIssue, TrackerClient } from "./issue";
+import {
+  getStalledIssueIds,
+  markIssueRunning,
+  onWorkerExit,
+  reconcileRunningIssueStates,
+  selectDispatchCandidates,
+  type OrchestratorState,
+  type ReconcileAction,
+  scheduleRetry,
+} from "./orchestrator";
+import type { EffectiveConfig } from "./types";
+import { validateDispatchPreflight } from "./validate";
+
+export interface DispatchInput {
+  issue: NormalizedIssue;
+  attempt: number;
+}
+
+export interface RunOrchestratorTickInput {
+  state: OrchestratorState;
+  tracker: TrackerClient;
+  config: EffectiveConfig;
+  nowMs: number;
+  dispatchIssue: (input: DispatchInput) => Promise<void>;
+  validatePreflight?: () => void;
+  onReconcileAction?: (action: ReconcileAction) => void | Promise<void>;
+  onStalledIssue?: (issueId: string) => void | Promise<void>;
+}
+
+export interface RunOrchestratorTickResult {
+  skippedDispatch: boolean;
+  selectedIssueIds: string[];
+  dispatchedIssueIds: string[];
+  dispatchErrors: Array<{ issueId: string; error: string }>;
+  reconcileActions: ReconcileAction[];
+  stalledIssueIds: string[];
+  preflightError?: string;
+}
+
+export async function runOrchestratorTick(input: RunOrchestratorTickInput): Promise<RunOrchestratorTickResult> {
+  const stalledIssueIds = getStalledIssueIds(input.state, {
+    nowMs: input.nowMs,
+    stallTimeoutMs: input.config.codex.stallTimeoutMs,
+  });
+
+  for (const issueId of stalledIssueIds) {
+    await input.onStalledIssue?.(issueId);
+    onWorkerExit(input.state, {
+      issueId,
+      nowMs: input.nowMs,
+      reason: "failure",
+      maxRetryBackoffMs: input.config.agent.maxRetryBackoffMs,
+      error: "stall_timeout",
+    });
+  }
+
+  const reconcileActions = await reconcileRunningIssues(input);
+
+  try {
+    if (input.validatePreflight) {
+      input.validatePreflight();
+    } else {
+      validateDispatchPreflight(input.config);
+    }
+  } catch (error) {
+    return {
+      skippedDispatch: true,
+      selectedIssueIds: [],
+      dispatchedIssueIds: [],
+      dispatchErrors: [],
+      reconcileActions,
+      stalledIssueIds,
+      preflightError: toErrorMessage(error),
+    };
+  }
+
+  const candidates = await input.tracker.fetchCandidateIssues();
+
+  const selected = selectDispatchCandidates({
+    candidates,
+    state: input.state,
+    activeStates: input.config.tracker.activeStates,
+    terminalStates: input.config.tracker.terminalStates,
+    maxConcurrentAgents: input.config.agent.maxConcurrentAgents,
+    maxConcurrentAgentsByState: input.config.agent.maxConcurrentAgentsByState,
+  });
+
+  const selectedIssueIds = selected.map((issue) => issue.id);
+  const dispatchedIssueIds: string[] = [];
+  const dispatchErrors: Array<{ issueId: string; error: string }> = [];
+
+  for (const issue of selected) {
+    const existingRetryAttempt = input.state.retryAttempts.get(issue.id)?.attempt ?? null;
+    const dispatchAttempt = normalizeDispatchAttempt(existingRetryAttempt);
+
+    try {
+      await input.dispatchIssue({
+        issue,
+        attempt: dispatchAttempt,
+      });
+
+      markIssueRunning(input.state, issue, input.nowMs, existingRetryAttempt);
+      dispatchedIssueIds.push(issue.id);
+    } catch (error) {
+      const message = toErrorMessage(error);
+      dispatchErrors.push({
+        issueId: issue.id,
+        error: message,
+      });
+
+      scheduleRetry(input.state, {
+        issueId: issue.id,
+        identifier: issue.identifier,
+        attempt: nextRetryAttempt(existingRetryAttempt),
+        nowMs: input.nowMs,
+        maxRetryBackoffMs: input.config.agent.maxRetryBackoffMs,
+        mode: "failure",
+        error: message,
+      });
+    }
+  }
+
+  return {
+    skippedDispatch: false,
+    selectedIssueIds,
+    dispatchedIssueIds,
+    dispatchErrors,
+    reconcileActions,
+    stalledIssueIds,
+  };
+}
+
+async function reconcileRunningIssues(input: RunOrchestratorTickInput): Promise<ReconcileAction[]> {
+  if (input.state.running.size === 0) {
+    return [];
+  }
+
+  const runningIds = Array.from(input.state.running.keys());
+
+  try {
+    const refreshed = await input.tracker.fetchIssueStatesByIds(runningIds);
+    const actions = reconcileRunningIssueStates(input.state, {
+      refreshed,
+      activeStates: input.config.tracker.activeStates,
+      terminalStates: input.config.tracker.terminalStates,
+    });
+
+    for (const action of actions) {
+      await input.onReconcileAction?.(action);
+    }
+
+    return actions;
+  } catch {
+    return [];
+  }
+}
+
+function normalizeDispatchAttempt(retryAttempt: number | null): number {
+  if (typeof retryAttempt === "number" && Number.isFinite(retryAttempt) && retryAttempt > 0) {
+    return Math.trunc(retryAttempt);
+  }
+
+  return 1;
+}
+
+function nextRetryAttempt(retryAttempt: number | null): number {
+  if (typeof retryAttempt === "number" && Number.isFinite(retryAttempt) && retryAttempt > 0) {
+    return Math.trunc(retryAttempt) + 1;
+  }
+
+  return 1;
+}

--- a/packages/symphony-service/src/worker.ts
+++ b/packages/symphony-service/src/worker.ts
@@ -1,0 +1,140 @@
+import type { TurnOutcome } from "./codex/client";
+import { SymphonyError, toErrorMessage } from "./errors";
+import type { NormalizedIssue, TrackerClient } from "./issue";
+import { buildIssuePrompt } from "./template";
+import type { EffectiveConfig, IssueTemplateInput } from "./types";
+import { ensureWorkspaceForIssue, runAfterRunHook, runBeforeRunHook, type WorkspaceConfig } from "./workspace";
+
+export interface WorkerCodexClient {
+  startSession(input: { cwd: string }): Promise<{ threadId: string }>;
+  runTurn(input: {
+    threadId: string;
+    cwd: string;
+    title: string;
+    prompt: string;
+  }): Promise<{ turnId: string; sessionId: string; outcome: TurnOutcome }>;
+  stop(): void;
+}
+
+export interface RunIssueAttemptInput {
+  issue: NormalizedIssue;
+  attempt: number;
+  workflowTemplate: string;
+  config: EffectiveConfig;
+  tracker: TrackerClient;
+  createCodexClient: () => WorkerCodexClient;
+}
+
+export interface RunIssueAttemptResult {
+  exit: "normal";
+  turnCount: number;
+  workspacePath: string;
+  issue: NormalizedIssue;
+}
+
+export async function runIssueAttempt(input: RunIssueAttemptInput): Promise<RunIssueAttemptResult> {
+  const workspaceConfig = toWorkspaceConfig(input.config);
+  const workspace = await ensureWorkspaceForIssue(workspaceConfig, input.issue.identifier);
+  await runBeforeRunHook(workspaceConfig, workspace.path);
+
+  const codex = input.createCodexClient();
+  let shouldStopClient = true;
+  let turnCount = 0;
+  let currentIssue = input.issue;
+
+  try {
+    const session = await codex.startSession({
+      cwd: workspace.path,
+    });
+
+    while (shouldContinueTurns(currentIssue, turnCount, input.config)) {
+      const prompt = await buildIssuePrompt(input.workflowTemplate, {
+        issue: toTemplateIssue(currentIssue),
+        attempt: input.attempt,
+      });
+
+      const turn = await codex.runTurn({
+        threadId: session.threadId,
+        cwd: workspace.path,
+        title: `${currentIssue.identifier}: ${currentIssue.title}`,
+        prompt,
+      });
+      turnCount += 1;
+
+      if (turn.outcome !== "completed") {
+        throw new SymphonyError("worker_turn_failed", `codex turn ended with non-completed outcome: ${turn.outcome}`, {
+          details: {
+            issue_id: currentIssue.id,
+            issue_identifier: currentIssue.identifier,
+            outcome: turn.outcome,
+          },
+        });
+      }
+
+      const refreshed = await input.tracker.fetchIssueStatesByIds([currentIssue.id]);
+      if (Array.isArray(refreshed) && refreshed[0]) {
+        currentIssue = refreshed[0];
+      }
+    }
+
+    return {
+      exit: "normal",
+      turnCount,
+      workspacePath: workspace.path,
+      issue: currentIssue,
+    };
+  } catch (error) {
+    if (error instanceof SymphonyError) {
+      throw error;
+    }
+
+    throw new SymphonyError("worker_attempt_failed", `worker attempt failed: ${toErrorMessage(error)}`, {
+      cause: error,
+      details: {
+        issue_id: currentIssue.id,
+        issue_identifier: currentIssue.identifier,
+      },
+    });
+  } finally {
+    if (shouldStopClient) {
+      codex.stop();
+    }
+
+    await runAfterRunHook(workspaceConfig, workspace.path);
+  }
+}
+
+function shouldContinueTurns(issue: NormalizedIssue, turnCount: number, config: EffectiveConfig): boolean {
+  if (turnCount >= config.agent.maxTurns) {
+    return false;
+  }
+
+  return config.tracker.activeStates.includes(issue.state);
+}
+
+function toWorkspaceConfig(config: EffectiveConfig): WorkspaceConfig {
+  return {
+    root: config.workspace.root,
+    hooks: {
+      afterCreate: config.hooks.afterCreate,
+      beforeRun: config.hooks.beforeRun,
+      afterRun: config.hooks.afterRun,
+      beforeRemove: config.hooks.beforeRemove,
+      timeoutMs: config.hooks.timeoutMs,
+    },
+  };
+}
+
+function toTemplateIssue(issue: NormalizedIssue): IssueTemplateInput {
+  return {
+    id: issue.id,
+    identifier: issue.identifier,
+    title: issue.title,
+    state: issue.state,
+    priority: issue.priority,
+    labels: issue.labels,
+    blocked_by: issue.blocked_by.map((blocker) => blocker.identifier),
+    created_at: issue.created_at,
+    updated_at: issue.updated_at,
+  };
+}

--- a/packages/symphony-service/tests/runtime.test.ts
+++ b/packages/symphony-service/tests/runtime.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "vitest";
+import type { EffectiveConfig } from "../src/types";
+import type { NormalizedIssue, TrackerClient } from "../src/issue";
+import { createOrchestratorState, markIssueRunning } from "../src/orchestrator";
+import { runOrchestratorTick } from "../src/runtime";
+
+function issue(partial: Partial<NormalizedIssue>): NormalizedIssue {
+  return {
+    id: partial.id ?? "1",
+    identifier: partial.identifier ?? "ATH-1",
+    title: partial.title ?? "Issue",
+    state: partial.state ?? "Todo",
+    priority: partial.priority ?? 1,
+    created_at: partial.created_at ?? "2026-01-01T00:00:00.000Z",
+    updated_at: partial.updated_at ?? "2026-01-01T00:00:00.000Z",
+    labels: partial.labels ?? [],
+    blocked_by: partial.blocked_by ?? [],
+  };
+}
+
+class FakeTracker implements TrackerClient {
+  constructor(
+    private readonly candidates: NormalizedIssue[],
+    private readonly refreshed: NormalizedIssue[] = [],
+  ) {}
+
+  async fetchCandidateIssues(): Promise<NormalizedIssue[]> {
+    return this.candidates;
+  }
+
+  async fetchIssuesByStates(): Promise<NormalizedIssue[]> {
+    return [];
+  }
+
+  async fetchIssueStatesByIds(): Promise<NormalizedIssue[]> {
+    return this.refreshed;
+  }
+}
+
+function config(partial?: Partial<EffectiveConfig>): EffectiveConfig {
+  return {
+    tracker: {
+      kind: partial?.tracker?.kind ?? "linear",
+      endpoint: partial?.tracker?.endpoint ?? "https://api.linear.app/graphql",
+      apiKey: partial?.tracker?.apiKey ?? "key",
+      projectSlug: partial?.tracker?.projectSlug ?? "ATH",
+      activeStates: partial?.tracker?.activeStates ?? ["Todo", "In Progress"],
+      terminalStates: partial?.tracker?.terminalStates ?? ["Done", "Closed"],
+    },
+    polling: {
+      intervalMs: partial?.polling?.intervalMs ?? 30_000,
+    },
+    workspace: {
+      root: partial?.workspace?.root ?? "/tmp/symphony",
+    },
+    hooks: {
+      afterCreate: partial?.hooks?.afterCreate,
+      beforeRun: partial?.hooks?.beforeRun,
+      afterRun: partial?.hooks?.afterRun,
+      beforeRemove: partial?.hooks?.beforeRemove,
+      timeoutMs: partial?.hooks?.timeoutMs ?? 60_000,
+    },
+    agent: {
+      maxConcurrentAgents: partial?.agent?.maxConcurrentAgents ?? 2,
+      maxRetryBackoffMs: partial?.agent?.maxRetryBackoffMs ?? 300_000,
+      maxTurns: partial?.agent?.maxTurns ?? 20,
+      maxConcurrentAgentsByState: partial?.agent?.maxConcurrentAgentsByState ?? {},
+    },
+    codex: {
+      command: partial?.codex?.command ?? "codex app-server",
+      clientName: partial?.codex?.clientName ?? "symphony",
+      clientVersion: partial?.codex?.clientVersion ?? "test",
+      clientCapabilities: partial?.codex?.clientCapabilities ?? {},
+      approvalPolicy: partial?.codex?.approvalPolicy,
+      threadSandbox: partial?.codex?.threadSandbox,
+      turnSandboxPolicy: partial?.codex?.turnSandboxPolicy,
+      turnTimeoutMs: partial?.codex?.turnTimeoutMs ?? 3_600_000,
+      readTimeoutMs: partial?.codex?.readTimeoutMs ?? 5_000,
+      stallTimeoutMs: partial?.codex?.stallTimeoutMs ?? 300_000,
+    },
+  };
+}
+
+describe("runOrchestratorTick", () => {
+  it("reconciles before dispatch preflight and skips dispatch on validation failure", async () => {
+    const state = createOrchestratorState();
+    markIssueRunning(
+      state,
+      issue({
+        id: "running-1",
+        identifier: "ATH-11",
+        state: "In Progress",
+      }),
+      1000,
+      null,
+    );
+
+    const actions: string[] = [];
+    const result = await runOrchestratorTick({
+      state,
+      tracker: new FakeTracker(
+        [issue({ id: "todo-1", identifier: "ATH-1", state: "Todo" })],
+        [issue({ id: "running-1", identifier: "ATH-11", state: "Done" })],
+      ),
+      config: config(),
+      nowMs: 2000,
+      validatePreflight: () => {
+        throw new Error("invalid config");
+      },
+      onReconcileAction: (action) => {
+        actions.push(action.action);
+      },
+      dispatchIssue: async () => {
+        throw new Error("dispatch should not run");
+      },
+    });
+
+    expect(actions).toEqual(["terminate_cleanup"]);
+    expect(result.skippedDispatch).toBe(true);
+    expect(result.selectedIssueIds).toEqual([]);
+    expect(result.dispatchedIssueIds).toEqual([]);
+  });
+
+  it("dispatches selected issues and marks them running", async () => {
+    const state = createOrchestratorState();
+    const dispatched: string[] = [];
+
+    const result = await runOrchestratorTick({
+      state,
+      tracker: new FakeTracker([
+        issue({ id: "todo-1", identifier: "ATH-1", state: "Todo", priority: 1 }),
+        issue({ id: "todo-2", identifier: "ATH-2", state: "Todo", priority: 2 }),
+      ]),
+      config: config(),
+      nowMs: 100,
+      dispatchIssue: async (input) => {
+        dispatched.push(input.issue.id);
+      },
+    });
+
+    expect(result.selectedIssueIds).toEqual(["todo-1", "todo-2"]);
+    expect(result.dispatchedIssueIds).toEqual(["todo-1", "todo-2"]);
+    expect(dispatched).toEqual(["todo-1", "todo-2"]);
+    expect(state.running.has("todo-1")).toBe(true);
+    expect(state.running.has("todo-2")).toBe(true);
+    expect(state.retryAttempts.size).toBe(0);
+  });
+
+  it("schedules retry when dispatch fails", async () => {
+    const state = createOrchestratorState();
+
+    await runOrchestratorTick({
+      state,
+      tracker: new FakeTracker([issue({ id: "todo-1", identifier: "ATH-1", state: "Todo" })]),
+      config: config(),
+      nowMs: 500,
+      dispatchIssue: async () => {
+        throw new Error("spawn failed");
+      },
+    });
+
+    const retry = state.retryAttempts.get("todo-1");
+    expect(retry?.attempt).toBe(1);
+    expect(retry?.error).toContain("spawn failed");
+    expect(state.running.has("todo-1")).toBe(false);
+  });
+
+  it("queues failure retry for stalled running issues", async () => {
+    const state = createOrchestratorState();
+    markIssueRunning(
+      state,
+      issue({
+        id: "running-stalled",
+        identifier: "ATH-20",
+        state: "In Progress",
+      }),
+      1000,
+      null,
+    );
+
+    const terminated: string[] = [];
+
+    await runOrchestratorTick({
+      state,
+      tracker: new FakeTracker([]),
+      config: config({
+        codex: {
+          command: "codex app-server",
+          clientName: "symphony",
+          clientVersion: "test",
+          clientCapabilities: {},
+          turnTimeoutMs: 3_600_000,
+          readTimeoutMs: 5_000,
+          stallTimeoutMs: 2000,
+        },
+      }),
+      nowMs: 6000,
+      dispatchIssue: async () => {},
+      onStalledIssue: (issueId) => {
+        terminated.push(issueId);
+      },
+    });
+
+    expect(terminated).toEqual(["running-stalled"]);
+    expect(state.running.has("running-stalled")).toBe(false);
+    expect(state.retryAttempts.get("running-stalled")?.attempt).toBe(1);
+    expect(state.retryAttempts.get("running-stalled")?.error).toBe("stall_timeout");
+  });
+});

--- a/packages/symphony-service/tests/runtime.test.ts
+++ b/packages/symphony-service/tests/runtime.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import type { EffectiveConfig } from "../src/types";
 import type { NormalizedIssue, TrackerClient } from "../src/issue";
-import { createOrchestratorState, markIssueRunning } from "../src/orchestrator";
-import { runOrchestratorTick } from "../src/runtime";
+import { createOrchestratorState, markIssueRunning, scheduleRetry } from "../src/orchestrator";
+import { processDueRetries, runOrchestratorTick } from "../src/runtime";
 
 function issue(partial: Partial<NormalizedIssue>): NormalizedIssue {
   return {
@@ -205,5 +205,98 @@ describe("runOrchestratorTick", () => {
     expect(state.running.has("running-stalled")).toBe(false);
     expect(state.retryAttempts.get("running-stalled")?.attempt).toBe(1);
     expect(state.retryAttempts.get("running-stalled")?.error).toBe("stall_timeout");
+  });
+});
+
+describe("processDueRetries", () => {
+  it("dispatches due retry when issue is found and slot is available", async () => {
+    const state = createOrchestratorState();
+
+    scheduleRetry(state, {
+      issueId: "todo-1",
+      identifier: "ATH-1",
+      attempt: 2,
+      nowMs: 0,
+      maxRetryBackoffMs: 300_000,
+      mode: "continuation",
+      error: "retry",
+    });
+
+    const dispatched: string[] = [];
+
+    const result = await processDueRetries({
+      state,
+      tracker: new FakeTracker([issue({ id: "todo-1", identifier: "ATH-1", state: "Todo" })]),
+      config: config(),
+      nowMs: 1000,
+      dispatchIssue: async (input) => {
+        dispatched.push(`${input.issue.id}:${input.attempt}`);
+      },
+    });
+
+    expect(result.processedIssueIds).toEqual(["todo-1"]);
+    expect(result.dispatchedIssueIds).toEqual(["todo-1"]);
+    expect(dispatched).toEqual(["todo-1:2"]);
+    expect(state.running.has("todo-1")).toBe(true);
+    expect(state.retryAttempts.has("todo-1")).toBe(false);
+  });
+
+  it("releases claim when due retry issue is no longer active", async () => {
+    const state = createOrchestratorState();
+    state.claimed.add("todo-2");
+    scheduleRetry(state, {
+      issueId: "todo-2",
+      identifier: "ATH-2",
+      attempt: 1,
+      nowMs: 0,
+      maxRetryBackoffMs: 300_000,
+      mode: "continuation",
+      error: "retry",
+    });
+
+    const result = await processDueRetries({
+      state,
+      tracker: new FakeTracker([]),
+      config: config(),
+      nowMs: 1000,
+      dispatchIssue: async () => {},
+    });
+
+    expect(result.releasedIssueIds).toEqual(["todo-2"]);
+    expect(state.claimed.has("todo-2")).toBe(false);
+    expect(state.retryAttempts.has("todo-2")).toBe(false);
+  });
+
+  it("requeues due retry when no slots are available", async () => {
+    const state = createOrchestratorState();
+    markIssueRunning(state, issue({ id: "running", state: "In Progress" }), 0, null);
+    scheduleRetry(state, {
+      issueId: "todo-3",
+      identifier: "ATH-3",
+      attempt: 1,
+      nowMs: 0,
+      maxRetryBackoffMs: 300_000,
+      mode: "continuation",
+      error: "retry",
+    });
+
+    const result = await processDueRetries({
+      state,
+      tracker: new FakeTracker([issue({ id: "todo-3", identifier: "ATH-3", state: "Todo" })]),
+      config: config({
+        agent: {
+          maxConcurrentAgents: 1,
+          maxRetryBackoffMs: 300_000,
+          maxTurns: 20,
+          maxConcurrentAgentsByState: {},
+        },
+      }),
+      nowMs: 1000,
+      dispatchIssue: async () => {},
+    });
+
+    expect(result.requeuedIssueIds).toEqual(["todo-3"]);
+    expect(state.retryAttempts.get("todo-3")?.attempt).toBe(1);
+    expect(state.retryAttempts.get("todo-3")?.error).toBe("no available orchestrator slots");
   });
 });

--- a/packages/symphony-service/tests/worker.test.ts
+++ b/packages/symphony-service/tests/worker.test.ts
@@ -1,0 +1,198 @@
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import type { CodexAppServerClient } from "../src/codex/client";
+import type { NormalizedIssue, TrackerClient } from "../src/issue";
+import type { EffectiveConfig } from "../src/types";
+import { runIssueAttempt } from "../src/worker";
+
+function issue(partial: Partial<NormalizedIssue>): NormalizedIssue {
+  return {
+    id: partial.id ?? "1",
+    identifier: partial.identifier ?? "ATH-1",
+    title: partial.title ?? "Issue",
+    state: partial.state ?? "Todo",
+    priority: partial.priority ?? 1,
+    created_at: partial.created_at ?? "2026-01-01T00:00:00.000Z",
+    updated_at: partial.updated_at ?? "2026-01-01T00:00:00.000Z",
+    labels: partial.labels ?? [],
+    blocked_by: partial.blocked_by ?? [],
+  };
+}
+
+class FakeTracker implements TrackerClient {
+  constructor(
+    private readonly refreshed: NormalizedIssue[],
+  ) {}
+
+  async fetchCandidateIssues(): Promise<NormalizedIssue[]> {
+    return [];
+  }
+
+  async fetchIssuesByStates(): Promise<NormalizedIssue[]> {
+    return [];
+  }
+
+  async fetchIssueStatesByIds(): Promise<NormalizedIssue[]> {
+    return this.refreshed;
+  }
+}
+
+class FakeCodex {
+  readonly startedCwds: string[] = [];
+  readonly prompts: string[] = [];
+  readonly stops: number[] = [];
+
+  constructor(
+    private readonly runTurnOutcome: "completed" | "failed" | "cancelled" | "turn_timeout" | "port_exit" | "turn_input_required" = "completed",
+  ) {}
+
+  async startSession(input: { cwd: string }): Promise<{ threadId: string }> {
+    this.startedCwds.push(input.cwd);
+    return { threadId: "thread-1" };
+  }
+
+  async runTurn(input: {
+    threadId: string;
+    cwd: string;
+    title: string;
+    prompt: string;
+  }): Promise<{ turnId: string; sessionId: string; outcome: "completed" | "failed" | "cancelled" | "turn_timeout" | "port_exit" | "turn_input_required" }> {
+    this.prompts.push(input.prompt);
+    return {
+      turnId: "turn-1",
+      sessionId: "thread-1-turn-1",
+      outcome: this.runTurnOutcome,
+    };
+  }
+
+  stop(): void {
+    this.stops.push(Date.now());
+  }
+}
+
+function config(root: string, overrides?: Partial<EffectiveConfig>): EffectiveConfig {
+  return {
+    tracker: {
+      kind: "linear",
+      endpoint: "https://api.linear.app/graphql",
+      apiKey: "key",
+      projectSlug: "ATH",
+      activeStates: ["Todo", "In Progress"],
+      terminalStates: ["Done", "Closed"],
+      ...overrides?.tracker,
+    },
+    polling: {
+      intervalMs: 30_000,
+      ...overrides?.polling,
+    },
+    workspace: {
+      root,
+      ...overrides?.workspace,
+    },
+    hooks: {
+      timeoutMs: 2000,
+      ...overrides?.hooks,
+    },
+    agent: {
+      maxConcurrentAgents: 2,
+      maxRetryBackoffMs: 300_000,
+      maxTurns: 3,
+      maxConcurrentAgentsByState: {},
+      ...overrides?.agent,
+    },
+    codex: {
+      command: "codex app-server",
+      clientName: "symphony",
+      clientVersion: "test",
+      clientCapabilities: {},
+      turnTimeoutMs: 60_000,
+      readTimeoutMs: 5000,
+      stallTimeoutMs: 300_000,
+      ...overrides?.codex,
+    },
+  };
+}
+
+describe("runIssueAttempt", () => {
+  it("creates workspace, runs hooks, executes turn loop, and exits when issue becomes terminal", async () => {
+    const root = await mkdtemp(join(tmpdir(), "symphony-worker-success-"));
+    const codex = new FakeCodex("completed");
+    const tracker = new FakeTracker([
+      issue({ id: "1", identifier: "ATH-1", state: "Done" }),
+    ]);
+
+    const result = await runIssueAttempt({
+      issue: issue({ id: "1", identifier: "ATH-1", state: "Todo" }),
+      attempt: 1,
+      workflowTemplate: "Issue {{ issue.identifier }} attempt {{ attempt }}",
+      config: config(root, {
+        hooks: {
+          timeoutMs: 2000,
+          beforeRun: "echo before > before.txt",
+          afterRun: "echo after > after.txt",
+        },
+      }),
+      tracker,
+      createCodexClient: () => codex as unknown as CodexAppServerClient,
+    });
+
+    expect(result.exit).toBe("normal");
+    expect(result.turnCount).toBe(1);
+    expect(codex.startedCwds.length).toBe(1);
+    expect(codex.prompts[0]).toContain("ATH-1");
+    expect(codex.stops.length).toBe(1);
+    expect((await readFile(join(result.workspacePath, "before.txt"), "utf8")).trim()).toBe("before");
+    expect((await readFile(join(result.workspacePath, "after.txt"), "utf8")).trim()).toBe("after");
+  });
+
+  it("fails fast when before_run hook fails", async () => {
+    const root = await mkdtemp(join(tmpdir(), "symphony-worker-before-run-fail-"));
+
+    await expect(
+      runIssueAttempt({
+        issue: issue({ id: "2", identifier: "ATH-2", state: "Todo" }),
+        attempt: 1,
+        workflowTemplate: "Issue {{ issue.identifier }}",
+        config: config(root, {
+          hooks: {
+            timeoutMs: 2000,
+            beforeRun: "exit 7",
+          },
+        }),
+        tracker: new FakeTracker([]),
+        createCodexClient: () => new FakeCodex() as unknown as CodexAppServerClient,
+      }),
+    ).rejects.toMatchObject({
+      code: "hook_failed",
+    });
+  });
+
+  it("runs after_run hook even when turn fails", async () => {
+    const root = await mkdtemp(join(tmpdir(), "symphony-worker-turn-fail-"));
+
+    await expect(
+      runIssueAttempt({
+        issue: issue({ id: "3", identifier: "ATH-3", state: "Todo" }),
+        attempt: 1,
+        workflowTemplate: "Issue {{ issue.identifier }}",
+        config: config(root, {
+          hooks: {
+            timeoutMs: 2000,
+            afterRun: "echo after > after.txt",
+          },
+        }),
+        tracker: new FakeTracker([
+          issue({ id: "3", identifier: "ATH-3", state: "Todo" }),
+        ]),
+        createCodexClient: () => new FakeCodex("failed") as unknown as CodexAppServerClient,
+      }),
+    ).rejects.toMatchObject({
+      code: "worker_turn_failed",
+    });
+
+    const workspacePath = join(root, "ATH-3");
+    expect((await readFile(join(workspacePath, "after.txt"), "utf8")).trim()).toBe("after");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `symphony-service` runtime orchestration in [`src/runtime.ts`](packages/symphony-service/src/runtime.ts):
  - stall detection handling
  - running-state reconciliation before dispatch
  - dispatch preflight gating
  - candidate selection and dispatch
  - due-retry processing (dispatch/requeue/release-claim)
- Add worker attempt execution in [`src/worker.ts`](packages/symphony-service/src/worker.ts):
  - workspace creation/reuse
  - `before_run` / `after_run` hooks
  - strict prompt rendering and Codex session/turn execution loop
  - issue-state refresh between turns
  - failure mapping for non-completed turn outcomes
- Add targeted unit coverage:
  - [`tests/runtime.test.ts`](packages/symphony-service/tests/runtime.test.ts)
  - [`tests/worker.test.ts`](packages/symphony-service/tests/worker.test.ts)

## Why
- Moves implementation from isolated state helpers to executable orchestration behavior.
- Aligns service behavior with Symphony spec requirements for tick sequencing, retry handling, and worker attempt lifecycle.

## Validation
- `bunx tsc --noEmit -p packages/symphony-service/tsconfig.json`
- `bun run --filter '@athena/symphony-service' test`

## Follow-up
- Wire `runtime` + `worker` into the CLI-hosted long-running service loop with workflow reload re-apply.