### PR TITLE
feat: add Symphony CLI-hosted service loop

### DIFF
--- a/packages/symphony-service/README.md
+++ b/packages/symphony-service/README.md
@@ -8,7 +8,12 @@ Spec-aligned Symphony service foundation for Athena.
 - Config resolution with defaults and env indirection
 - Dispatch preflight validation (`tracker` + `codex` required fields)
 - Strict prompt rendering (`strictVariables` + `strictFilters`)
-- Startup CLI with optional workflow watch/reload
+- Workspace manager with safety checks and hook execution semantics
+- Codex app-server protocol + client integration
+- Runtime tick orchestration (reconciliation, dispatch, retry handling)
+- Worker attempt execution loop (workspace, hooks, prompt, Codex turns)
+- Startup terminal workspace cleanup
+- CLI-hosted service loop with optional workflow watch/reload
 
 ## Commands
 

--- a/packages/symphony-service/src/cli.ts
+++ b/packages/symphony-service/src/cli.ts
@@ -1,8 +1,7 @@
 import { resolve } from "node:path";
-import { resolveEffectiveConfig } from "./config";
 import { toErrorMessage } from "./errors";
-import { validateDispatchPreflight } from "./validate";
-import { DEFAULT_WORKFLOW_FILE, loadWorkflowFile, watchWorkflowFile } from "./workflow";
+import { createSymphonyService } from "./service";
+import { DEFAULT_WORKFLOW_FILE } from "./workflow";
 
 interface CliOptions {
   workflowPath: string;
@@ -12,52 +11,27 @@ interface CliOptions {
 
 async function main(): Promise<void> {
   const options = parseArgs(process.argv.slice(2));
-
-  let lastGood = await loadAndValidate(options.workflowPath, options.printEffectiveConfig);
-
-  if (!options.watch) {
-    return;
-  }
-
-  process.stdout.write(`[symphony] watching ${lastGood.workflow.path}\n`);
-
-  let timer: ReturnType<typeof setTimeout> | null = null;
-  const watcher = watchWorkflowFile(lastGood.workflow.path, () => {
-    if (timer) {
-      clearTimeout(timer);
-    }
-
-    timer = setTimeout(async () => {
-      try {
-        lastGood = await loadAndValidate(options.workflowPath, options.printEffectiveConfig);
-        process.stdout.write(`[symphony] reloaded ${lastGood.workflow.path}\n`);
-      } catch (error) {
-        process.stderr.write(`[symphony] reload failed (keeping last-known-good): ${toErrorMessage(error)}\n`);
-      }
-    }, 100);
+  const service = createSymphonyService({
+    workflowPath: options.workflowPath,
+    watch: options.watch,
+    printEffectiveConfig: options.printEffectiveConfig,
   });
 
+  await service.start();
+
   const stop = () => {
-    watcher.close();
-    process.exit(0);
+    void service
+      .stop()
+      .catch((error) => {
+        process.stderr.write(`[symphony] shutdown failed: ${toErrorMessage(error)}\n`);
+      })
+      .finally(() => {
+        process.exit(0);
+      });
   };
 
   process.on("SIGINT", stop);
   process.on("SIGTERM", stop);
-}
-
-async function loadAndValidate(workflowPath: string, printConfig: boolean) {
-  const workflow = await loadWorkflowFile(workflowPath);
-  const config = resolveEffectiveConfig(workflow.config);
-  validateDispatchPreflight(config);
-
-  process.stdout.write(`[symphony] config valid: tracker=${config.tracker.kind} project=${config.tracker.projectSlug} poll=${config.polling.intervalMs}ms\n`);
-
-  if (printConfig) {
-    process.stdout.write(`${JSON.stringify(config, null, 2)}\n`);
-  }
-
-  return { workflow, config };
 }
 
 function parseArgs(args: string[]): CliOptions {

--- a/packages/symphony-service/src/index.ts
+++ b/packages/symphony-service/src/index.ts
@@ -5,6 +5,7 @@ export * from "./orchestrator";
 export * from "./retry";
 export * from "./runtime";
 export * from "./scheduler";
+export * from "./service";
 export * from "./startup";
 export * from "./template";
 export * from "./tracker/linear";

--- a/packages/symphony-service/src/service.ts
+++ b/packages/symphony-service/src/service.ts
@@ -1,0 +1,428 @@
+import type { FSWatcher } from "node:fs";
+import { resolveEffectiveConfig } from "./config";
+import { CodexAppServerClient } from "./codex/client";
+import { toErrorMessage } from "./errors";
+import type { TrackerClient } from "./issue";
+import { createOrchestratorState, onWorkerExit, type ReconcileAction } from "./orchestrator";
+import { processDueRetries, runOrchestratorTick, type DispatchInput } from "./runtime";
+import { cleanupTerminalIssueWorkspaces } from "./startup";
+import { LinearTrackerClient } from "./tracker/linear";
+import type { EffectiveConfig, WorkflowDocument } from "./types";
+import { validateDispatchPreflight } from "./validate";
+import { removeWorkspace, resolveWorkspaceLocation } from "./workspace";
+import { loadWorkflowFile, watchWorkflowFile } from "./workflow";
+import { runIssueAttempt, type WorkerCodexClient } from "./worker";
+
+const RELOAD_DEBOUNCE_MS = 100;
+type IntervalHandle = ReturnType<typeof setInterval>;
+type TimeoutHandle = ReturnType<typeof setTimeout>;
+
+export interface ServiceLogEntry {
+  level: "info" | "warn" | "error";
+  message: string;
+  details?: Record<string, unknown>;
+}
+
+interface ActiveWorker {
+  identifier: string;
+  stop: () => void;
+}
+
+interface ServiceDependencies {
+  loadWorkflowFile: (path: string) => Promise<WorkflowDocument>;
+  watchWorkflowFile: (path: string, onReloadRequested: () => void) => FSWatcher;
+  resolveEffectiveConfig: (config: WorkflowDocument["config"]) => EffectiveConfig;
+  validateDispatchPreflight: (config: EffectiveConfig) => void;
+  createTracker: (config: EffectiveConfig) => TrackerClient;
+  createCodexClient: (config: EffectiveConfig) => WorkerCodexClient;
+  runIssueAttempt: typeof runIssueAttempt;
+  processDueRetries: typeof processDueRetries;
+  runOrchestratorTick: typeof runOrchestratorTick;
+  cleanupTerminalIssueWorkspaces: typeof cleanupTerminalIssueWorkspaces;
+  nowMs: () => number;
+  setIntervalFn: (callback: () => void, intervalMs: number) => IntervalHandle;
+  clearIntervalFn: (handle: IntervalHandle) => void;
+  setTimeoutFn: (callback: () => void, timeoutMs: number) => TimeoutHandle;
+  clearTimeoutFn: (handle: TimeoutHandle) => void;
+  onLog: (entry: ServiceLogEntry) => void;
+}
+
+export interface CreateSymphonyServiceOptions {
+  workflowPath: string;
+  watch?: boolean;
+  printEffectiveConfig?: boolean;
+  deps?: Partial<ServiceDependencies>;
+}
+
+export interface SymphonyServiceSnapshot {
+  workflowPath: string | null;
+  pollIntervalMs: number | null;
+  runningCount: number;
+  retryCount: number;
+}
+
+export interface SymphonyService {
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  reloadWorkflow(): Promise<boolean>;
+  runTickOnce(): Promise<void>;
+  getSnapshot(): SymphonyServiceSnapshot;
+}
+
+export function createSymphonyService(options: CreateSymphonyServiceOptions): SymphonyService {
+  const deps = resolveDependencies(options.deps);
+
+  const state = createOrchestratorState();
+
+  let workflow: WorkflowDocument | null = null;
+  let config: EffectiveConfig | null = null;
+  let tracker: TrackerClient | null = null;
+  let pollTimer: IntervalHandle | null = null;
+  let reloadTimer: TimeoutHandle | null = null;
+  let watcher: FSWatcher | null = null;
+  let tickInFlight: Promise<void> | null = null;
+  let started = false;
+
+  const activeWorkers = new Map<string, ActiveWorker>();
+  const workerTasks = new Set<Promise<void>>();
+
+  async function start(): Promise<void> {
+    if (started) {
+      return;
+    }
+
+    await applyWorkflow({ mode: "startup" });
+    started = true;
+
+    if (!config || !tracker) {
+      throw new Error("service missing runtime config after startup");
+    }
+
+    await deps.cleanupTerminalIssueWorkspaces({
+      tracker,
+      terminalStates: config.tracker.terminalStates,
+      workspace: {
+        root: config.workspace.root,
+        hooks: {
+          afterCreate: config.hooks.afterCreate,
+          beforeRun: config.hooks.beforeRun,
+          afterRun: config.hooks.afterRun,
+          beforeRemove: config.hooks.beforeRemove,
+          timeoutMs: config.hooks.timeoutMs,
+        },
+      },
+      onLog: deps.onLog,
+    });
+
+    await runTickOnce();
+    schedulePolling();
+
+    if (options.watch && workflow) {
+      watcher = deps.watchWorkflowFile(workflow.path, () => {
+        if (reloadTimer) {
+          deps.clearTimeoutFn(reloadTimer);
+        }
+
+        reloadTimer = deps.setTimeoutFn(() => {
+          void reloadWorkflow();
+        }, RELOAD_DEBOUNCE_MS);
+      });
+
+      deps.onLog({
+        level: "info",
+        message: `watching ${workflow.path}`,
+      });
+    }
+  }
+
+  async function stop(): Promise<void> {
+    if (pollTimer) {
+      deps.clearIntervalFn(pollTimer);
+      pollTimer = null;
+    }
+
+    if (reloadTimer) {
+      deps.clearTimeoutFn(reloadTimer);
+      reloadTimer = null;
+    }
+
+    if (watcher) {
+      watcher.close();
+      watcher = null;
+    }
+
+    for (const worker of activeWorkers.values()) {
+      worker.stop();
+    }
+
+    await Promise.allSettled(Array.from(workerTasks));
+    started = false;
+  }
+
+  async function reloadWorkflow(): Promise<boolean> {
+    const loaded = await applyWorkflow({ mode: "reload" });
+    if (loaded && started) {
+      schedulePolling();
+    }
+
+    return loaded;
+  }
+
+  async function runTickOnce(): Promise<void> {
+    if (!config || !tracker) {
+      return;
+    }
+
+    if (tickInFlight) {
+      return await tickInFlight;
+    }
+
+    tickInFlight = (async () => {
+      const nowMs = deps.nowMs();
+
+      await deps.processDueRetries({
+        state,
+        tracker,
+        config,
+        nowMs,
+        dispatchIssue: (input) => dispatchIssue(input),
+      });
+
+      await deps.runOrchestratorTick({
+        state,
+        tracker,
+        config,
+        nowMs,
+        dispatchIssue: (input) => dispatchIssue(input),
+        onStalledIssue: async (issueId) => {
+          terminateRunningIssue(issueId);
+        },
+        onReconcileAction: async (action) => {
+          await onReconcileAction(action);
+        },
+      });
+    })().finally(() => {
+      tickInFlight = null;
+    });
+
+    return await tickInFlight;
+  }
+
+  async function onReconcileAction(action: ReconcileAction): Promise<void> {
+    if (action.action === "update_snapshot") {
+      return;
+    }
+
+    terminateRunningIssue(action.issueId);
+
+    state.running.delete(action.issueId);
+    state.claimed.delete(action.issueId);
+    state.retryAttempts.delete(action.issueId);
+
+    if (action.action === "terminate_cleanup" && config) {
+      const workspace = resolveWorkspaceLocation(config.workspace.root, action.identifier);
+      await removeWorkspace(
+        {
+          root: config.workspace.root,
+          hooks: {
+            afterCreate: config.hooks.afterCreate,
+            beforeRun: config.hooks.beforeRun,
+            afterRun: config.hooks.afterRun,
+            beforeRemove: config.hooks.beforeRemove,
+            timeoutMs: config.hooks.timeoutMs,
+          },
+        },
+        workspace.path,
+      );
+    }
+  }
+
+  function terminateRunningIssue(issueId: string): void {
+    const worker = activeWorkers.get(issueId);
+    if (!worker) {
+      return;
+    }
+
+    worker.stop();
+    activeWorkers.delete(issueId);
+  }
+
+  async function dispatchIssue(input: DispatchInput): Promise<void> {
+    if (!config || !tracker || !workflow) {
+      throw new Error("service runtime is not initialized");
+    }
+
+    if (activeWorkers.has(input.issue.id)) {
+      throw new Error(`worker already active for issue: ${input.issue.id}`);
+    }
+
+    const runtimeConfig = config;
+    const runtimeTracker = tracker;
+    const runtimeWorkflow = workflow;
+
+    const codexClient = deps.createCodexClient(runtimeConfig);
+    activeWorkers.set(input.issue.id, {
+      identifier: input.issue.identifier,
+      stop: () => codexClient.stop(),
+    });
+
+    const task = deps
+      .runIssueAttempt({
+        issue: input.issue,
+        attempt: input.attempt,
+        workflowTemplate: runtimeWorkflow.promptTemplate,
+        config: runtimeConfig,
+        tracker: runtimeTracker,
+        createCodexClient: () => codexClient,
+      })
+      .then(() => {
+        onWorkerExit(state, {
+          issueId: input.issue.id,
+          nowMs: deps.nowMs(),
+          reason: "normal",
+          maxRetryBackoffMs: runtimeConfig.agent.maxRetryBackoffMs,
+        });
+      })
+      .catch((error) => {
+        onWorkerExit(state, {
+          issueId: input.issue.id,
+          nowMs: deps.nowMs(),
+          reason: "failure",
+          maxRetryBackoffMs: runtimeConfig.agent.maxRetryBackoffMs,
+          error: toErrorMessage(error),
+        });
+      })
+      .finally(() => {
+        activeWorkers.delete(input.issue.id);
+        workerTasks.delete(task);
+      });
+
+    workerTasks.add(task);
+  }
+
+  async function applyWorkflow(input: { mode: "startup" | "reload" }): Promise<boolean> {
+    try {
+      const loaded = await deps.loadWorkflowFile(options.workflowPath);
+      const nextConfig = deps.resolveEffectiveConfig(loaded.config);
+      deps.validateDispatchPreflight(nextConfig);
+      const nextTracker = deps.createTracker(nextConfig);
+
+      workflow = loaded;
+      config = nextConfig;
+      tracker = nextTracker;
+
+      deps.onLog({
+        level: "info",
+        message: `config valid: tracker=${config.tracker.kind} project=${config.tracker.projectSlug} poll=${config.polling.intervalMs}ms`,
+      });
+
+      if (options.printEffectiveConfig) {
+        deps.onLog({
+          level: "info",
+          message: JSON.stringify(config, null, 2),
+        });
+      }
+
+      return true;
+    } catch (error) {
+      if (input.mode === "startup") {
+        throw error;
+      }
+
+      deps.onLog({
+        level: "warn",
+        message: `reload failed (keeping last-known-good): ${toErrorMessage(error)}`,
+      });
+      return false;
+    }
+  }
+
+  function schedulePolling(): void {
+    if (!config) {
+      return;
+    }
+
+    if (pollTimer) {
+      deps.clearIntervalFn(pollTimer);
+      pollTimer = null;
+    }
+
+    pollTimer = deps.setIntervalFn(() => {
+      void runTickOnce().catch((error) => {
+        deps.onLog({
+          level: "warn",
+          message: `tick failed: ${toErrorMessage(error)}`,
+        });
+      });
+    }, config.polling.intervalMs);
+  }
+
+  function getSnapshot(): SymphonyServiceSnapshot {
+    return {
+      workflowPath: workflow?.path ?? null,
+      pollIntervalMs: config?.polling.intervalMs ?? null,
+      runningCount: state.running.size,
+      retryCount: state.retryAttempts.size,
+    };
+  }
+
+  return {
+    start,
+    stop,
+    reloadWorkflow,
+    runTickOnce,
+    getSnapshot,
+  };
+}
+
+function resolveDependencies(overrides: Partial<ServiceDependencies> | undefined): ServiceDependencies {
+  return {
+    loadWorkflowFile,
+    watchWorkflowFile,
+    resolveEffectiveConfig,
+    validateDispatchPreflight,
+    createTracker: (config) => {
+      if (config.tracker.kind !== "linear" || !config.tracker.apiKey || !config.tracker.projectSlug) {
+        throw new Error("unsupported or invalid tracker config");
+      }
+
+      return new LinearTrackerClient({
+        endpoint: config.tracker.endpoint,
+        apiKey: config.tracker.apiKey,
+        projectSlug: config.tracker.projectSlug,
+        activeStates: config.tracker.activeStates,
+      });
+    },
+    createCodexClient: (config) => {
+      return new CodexAppServerClient({
+        command: config.codex.command,
+        clientName: config.codex.clientName,
+        clientVersion: config.codex.clientVersion,
+        clientCapabilities: config.codex.clientCapabilities,
+        approvalPolicy: config.codex.approvalPolicy,
+        threadSandbox: config.codex.threadSandbox,
+        turnSandboxPolicy: config.codex.turnSandboxPolicy,
+        readTimeoutMs: config.codex.readTimeoutMs,
+        turnTimeoutMs: config.codex.turnTimeoutMs,
+      });
+    },
+    runIssueAttempt,
+    processDueRetries,
+    runOrchestratorTick,
+    cleanupTerminalIssueWorkspaces,
+    nowMs: () => Date.now(),
+    setIntervalFn: setInterval,
+    clearIntervalFn: clearInterval,
+    setTimeoutFn: setTimeout,
+    clearTimeoutFn: clearTimeout,
+    onLog: (entry) => {
+      const line = `[symphony] ${entry.message}\n`;
+      if (entry.level === "warn" || entry.level === "error") {
+        process.stderr.write(line);
+      } else {
+        process.stdout.write(line);
+      }
+    },
+    ...overrides,
+  };
+}

--- a/packages/symphony-service/tests/service.test.ts
+++ b/packages/symphony-service/tests/service.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it, vi } from "vitest";
+import type { FSWatcher } from "node:fs";
+import type { WorkflowDocument } from "../src/types";
+import type { TrackerClient } from "../src/issue";
+import { createSymphonyService } from "../src/service";
+
+class FakeTracker implements TrackerClient {
+  async fetchCandidateIssues() {
+    return [];
+  }
+
+  async fetchIssuesByStates() {
+    return [];
+  }
+
+  async fetchIssueStatesByIds() {
+    return [];
+  }
+}
+
+function workflow(pollMs: number): WorkflowDocument {
+  return {
+    path: "/tmp/WORKFLOW.md",
+    config: {
+      tracker: {
+        kind: "linear",
+        api_key: "key",
+        project_slug: "ATH",
+      },
+      polling: {
+        interval_ms: pollMs,
+      },
+      codex: {
+        command: "codex app-server",
+      },
+    },
+    promptTemplate: "Issue {{ issue.identifier }}",
+  };
+}
+
+describe("createSymphonyService", () => {
+  it("runs startup cleanup, immediate tick, and schedules polling", async () => {
+    const intervalCalls: number[] = [];
+    const clearCalls: unknown[] = [];
+    let intervalId = 0;
+    const runTickCalls: number[] = [];
+    const dueRetryCalls: number[] = [];
+    const cleanupCalls: number[] = [];
+
+    const service = createSymphonyService({
+      workflowPath: "/tmp/WORKFLOW.md",
+      deps: {
+        loadWorkflowFile: async () => workflow(1234),
+        createTracker: () => new FakeTracker(),
+        cleanupTerminalIssueWorkspaces: async () => {
+          cleanupCalls.push(1);
+          return { removed: 0, failed: 0, warnings: [] };
+        },
+        processDueRetries: async () => {
+          dueRetryCalls.push(1);
+          return {
+            processedIssueIds: [],
+            dispatchedIssueIds: [],
+            requeuedIssueIds: [],
+            releasedIssueIds: [],
+          };
+        },
+        runOrchestratorTick: async () => {
+          runTickCalls.push(1);
+          return {
+            skippedDispatch: false,
+            selectedIssueIds: [],
+            dispatchedIssueIds: [],
+            dispatchErrors: [],
+            reconcileActions: [],
+            stalledIssueIds: [],
+          };
+        },
+        setIntervalFn: (fn: () => void, ms: number) => {
+          intervalCalls.push(ms);
+          void fn;
+          intervalId += 1;
+          return intervalId as unknown as ReturnType<typeof setInterval>;
+        },
+        clearIntervalFn: (id: ReturnType<typeof setInterval>) => {
+          clearCalls.push(id);
+        },
+      },
+    });
+
+    await service.start();
+
+    expect(cleanupCalls).toHaveLength(1);
+    expect(dueRetryCalls).toHaveLength(1);
+    expect(runTickCalls).toHaveLength(1);
+    expect(intervalCalls).toEqual([1234]);
+    expect(service.getSnapshot().pollIntervalMs).toBe(1234);
+
+    await service.stop();
+    expect(clearCalls).toHaveLength(1);
+  });
+
+  it("reloads workflow and updates poll interval while keeping last-known-good on reload failure", async () => {
+    const workflows = [workflow(1000), workflow(2500)];
+    const intervalCalls: number[] = [];
+    const clearCalls: number[] = [];
+    const warnings: string[] = [];
+    let intervalId = 0;
+
+    const service = createSymphonyService({
+      workflowPath: "/tmp/WORKFLOW.md",
+      deps: {
+        loadWorkflowFile: async () => {
+          const next = workflows.shift();
+          if (!next) {
+            throw new Error("reload parse failed");
+          }
+          return next;
+        },
+        createTracker: () => new FakeTracker(),
+        cleanupTerminalIssueWorkspaces: async () => ({ removed: 0, failed: 0, warnings: [] }),
+        processDueRetries: async () => ({
+          processedIssueIds: [],
+          dispatchedIssueIds: [],
+          requeuedIssueIds: [],
+          releasedIssueIds: [],
+        }),
+        runOrchestratorTick: async () => ({
+          skippedDispatch: false,
+          selectedIssueIds: [],
+          dispatchedIssueIds: [],
+          dispatchErrors: [],
+          reconcileActions: [],
+          stalledIssueIds: [],
+        }),
+        setIntervalFn: (_fn: () => void, ms: number) => {
+          intervalCalls.push(ms);
+          intervalId += 1;
+          return intervalId as unknown as ReturnType<typeof setInterval>;
+        },
+        clearIntervalFn: (_id: ReturnType<typeof setInterval>) => {
+          clearCalls.push(1);
+        },
+        onLog: (entry) => {
+          if (entry.level === "warn") {
+            warnings.push(entry.message);
+          }
+        },
+      },
+    });
+
+    await service.start();
+    expect(service.getSnapshot().pollIntervalMs).toBe(1000);
+
+    await service.reloadWorkflow();
+    expect(service.getSnapshot().pollIntervalMs).toBe(2500);
+    expect(intervalCalls).toEqual([1000, 2500]);
+    expect(clearCalls.length).toBeGreaterThanOrEqual(1);
+
+    await service.reloadWorkflow();
+    expect(service.getSnapshot().pollIntervalMs).toBe(2500);
+    expect(warnings.some((msg) => msg.includes("reload failed"))).toBe(true);
+
+    await service.stop();
+  });
+
+  it("debounces watch-triggered reloads", async () => {
+    vi.useFakeTimers();
+
+    const watchCallbacks: Array<() => void> = [];
+    let loadCount = 0;
+
+    const service = createSymphonyService({
+      workflowPath: "/tmp/WORKFLOW.md",
+      watch: true,
+      deps: {
+        loadWorkflowFile: async () => {
+          loadCount += 1;
+          return workflow(1000);
+        },
+        createTracker: () => new FakeTracker(),
+        cleanupTerminalIssueWorkspaces: async () => ({ removed: 0, failed: 0, warnings: [] }),
+        processDueRetries: async () => ({
+          processedIssueIds: [],
+          dispatchedIssueIds: [],
+          requeuedIssueIds: [],
+          releasedIssueIds: [],
+        }),
+        runOrchestratorTick: async () => ({
+          skippedDispatch: false,
+          selectedIssueIds: [],
+          dispatchedIssueIds: [],
+          dispatchErrors: [],
+          reconcileActions: [],
+          stalledIssueIds: [],
+        }),
+        watchWorkflowFile: (_path: string, cb: () => void) => {
+          watchCallbacks.push(cb);
+          return {
+            close: () => {},
+          } as FSWatcher;
+        },
+      },
+    });
+
+    await service.start();
+    expect(loadCount).toBe(1);
+
+    const triggerWatchReload = watchCallbacks[0];
+    if (!triggerWatchReload) {
+      throw new Error("expected watch callback to be registered");
+    }
+
+    triggerWatchReload();
+    triggerWatchReload();
+    triggerWatchReload();
+    await vi.advanceTimersByTimeAsync(99);
+    expect(loadCount).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(loadCount).toBe(2);
+
+    await service.stop();
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- Add a long-running Symphony host in [`packages/symphony-service/src/service.ts`](packages/symphony-service/src/service.ts) that:
  - loads and validates workflow/config
  - performs startup terminal workspace cleanup
  - runs an immediate tick, then polls on `polling.interval_ms`
  - processes due retries and normal tick dispatch paths
  - handles reconcile/stall terminations and worker tracking
- Rewire CLI to run the service host instead of only validating config:
  - [`packages/symphony-service/src/cli.ts`](packages/symphony-service/src/cli.ts)
- Support dynamic watch/reload with debounce and last-known-good behavior.
- Add service-level unit coverage:
  - [`packages/symphony-service/tests/service.test.ts`](packages/symphony-service/tests/service.test.ts)
- Update package scope docs in [`packages/symphony-service/README.md`](packages/symphony-service/README.md).

## Why
- Completes the next conformance checkpoint by wiring runtime + worker logic into an executable host lifecycle.
- Makes `symphony-service` behave as an actual orchestrator process rather than a set of isolated modules.

## Validation
- `bunx tsc --noEmit -p packages/symphony-service/tsconfig.json`
- `bun run --filter '@athena/symphony-service' test`
