### PR TITLE
chore: ignore local claude worktree metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,6 @@ dist
 
 # Finder (MacOS) folder config
 .DS_Store
+
+# Local Claude/Codex worktree tracking metadata
+packages/.claude/worktrees/


### PR DESCRIPTION
## Summary
- Add `packages/.claude/worktrees/` to root `.gitignore`.
- Prevent local Claude/Codex worktree tracking artifacts from appearing as unrelated untracked changes.

## Why
- Keeps `git status` focused on real code changes.
- Reduces noise during PR development and review.

## Validation
- `git status -sb` no longer shows `packages/.claude/worktrees/` as untracked.
