### PR TITLE
fix: keep symphony service running when log sink fails

### DIFF
--- a/packages/symphony-service/src/service.ts
+++ b/packages/symphony-service/src/service.ts
@@ -101,6 +101,29 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
   const activeWorkers = new Map<string, ActiveWorker>();
   const workerTasks = new Set<Promise<void>>();
 
+  function emitLog(entry: ServiceLogEntry): void {
+    try {
+      deps.onLog(entry);
+      return;
+    } catch (error) {
+      const fallback: ServiceLogEntry = {
+        level: "warn",
+        message: "action=log_sink outcome=failed",
+        details: {
+          sink_error: toErrorMessage(error),
+          original_level: entry.level,
+          original_message: entry.message,
+        },
+      };
+
+      try {
+        process.stderr.write(`[symphony] ${formatServiceLogLine(fallback)}\n`);
+      } catch {
+        // Last-resort logging path failed; continue orchestration without throwing.
+      }
+    }
+  }
+
   async function start(): Promise<void> {
     if (started) {
       return;
@@ -126,7 +149,7 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
           timeoutMs: config.hooks.timeoutMs,
         },
       },
-      onLog: deps.onLog,
+      onLog: emitLog,
     });
 
     await runTickOnce();
@@ -143,7 +166,7 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
         }, RELOAD_DEBOUNCE_MS);
       });
 
-      deps.onLog({
+      emitLog({
         level: "info",
         message: "action=watch outcome=started",
         details: {
@@ -293,7 +316,7 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
         tracker: runtimeTracker,
         createCodexClient: () => codexClient,
         onLog: (entry) => {
-          deps.onLog({
+          emitLog({
             level: entry.message.includes("outcome=failed") ? "warn" : "info",
             message: entry.message,
             details: entry.details,
@@ -336,7 +359,7 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
       config = nextConfig;
       tracker = nextTracker;
 
-      deps.onLog({
+      emitLog({
         level: "info",
         message: "action=config_validate outcome=completed",
         details: {
@@ -347,7 +370,7 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
       });
 
       if (options.printEffectiveConfig) {
-        deps.onLog({
+        emitLog({
           level: "info",
           message: JSON.stringify(config, null, 2),
         });
@@ -359,7 +382,7 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
         throw error;
       }
 
-      deps.onLog({
+      emitLog({
         level: "warn",
         message: "action=config_reload outcome=failed reason=reload_failed",
         details: {
@@ -382,7 +405,7 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
 
     pollTimer = deps.setIntervalFn(() => {
       void runTickOnce().catch((error) => {
-        deps.onLog({
+        emitLog({
           level: "warn",
           message: "action=tick outcome=failed",
           details: {

--- a/packages/symphony-service/tests/service.test.ts
+++ b/packages/symphony-service/tests/service.test.ts
@@ -303,6 +303,50 @@ describe("createSymphonyService", () => {
       ),
     ).toBe(true);
   });
+
+  it("continues running when configured log sink throws", async () => {
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    let logCalls = 0;
+
+    const service = createSymphonyService({
+      workflowPath: "/tmp/WORKFLOW.md",
+      deps: {
+        loadWorkflowFile: async () => workflow(1000),
+        createTracker: () => new FakeTracker(),
+        cleanupTerminalIssueWorkspaces: async () => ({ removed: 0, failed: 0, warnings: [] }),
+        processDueRetries: async () => ({
+          processedIssueIds: [],
+          dispatchedIssueIds: [],
+          requeuedIssueIds: [],
+          releasedIssueIds: [],
+        }),
+        runOrchestratorTick: async () => ({
+          skippedDispatch: false,
+          selectedIssueIds: [],
+          dispatchedIssueIds: [],
+          dispatchErrors: [],
+          reconcileActions: [],
+          stalledIssueIds: [],
+        }),
+        onLog: () => {
+          logCalls += 1;
+          throw new Error("sink broke");
+        },
+      },
+    });
+
+    await service.start();
+    await service.stop();
+
+    expect(logCalls).toBeGreaterThan(0);
+    expect(
+      stderrSpy.mock.calls.some(
+        (call) => String(call[0]).includes("action=log_sink outcome=failed"),
+      ),
+    ).toBe(true);
+
+    stderrSpy.mockRestore();
+  });
 });
 
 describe("formatServiceLogLine", () => {


### PR DESCRIPTION
## Summary
- Port the missed post-merge change onto a fresh branch from current `main`.
- Make service log sink failures non-fatal in [`packages/symphony-service/src/service.ts`](packages/symphony-service/src/service.ts):
  - catch sink exceptions
  - emit fallback warning `action=log_sink outcome=failed` to stderr
  - continue orchestration without crashing
- Keep coverage in [`packages/symphony-service/tests/service.test.ts`](packages/symphony-service/tests/service.test.ts).

## Validation
- `bunx tsc --noEmit -p packages/symphony-service/tsconfig.json`
- `bun run --filter '@athena/symphony-service' test -- tests/service.test.ts`
