### PR TITLE
test(symphony-service): harden CLI lifecycle lifecycle tests

### DIFF
--- a/packages/symphony-service/src/cli.ts
+++ b/packages/symphony-service/src/cli.ts
@@ -1,6 +1,6 @@
 import { resolve } from "node:path";
 import { toErrorMessage } from "./errors";
-import { createSymphonyService } from "./service";
+import { createSymphonyService, type CreateSymphonyServiceOptions, type SymphonyService } from "./service";
 import { DEFAULT_WORKFLOW_FILE } from "./workflow";
 
 interface CliOptions {
@@ -9,32 +9,29 @@ interface CliOptions {
   printEffectiveConfig: boolean;
 }
 
-async function main(): Promise<void> {
-  const options = parseArgs(process.argv.slice(2));
-  const service = createSymphonyService({
-    workflowPath: options.workflowPath,
-    watch: options.watch,
-    printEffectiveConfig: options.printEffectiveConfig,
-  });
-
-  await service.start();
-
-  const stop = () => {
-    void service
-      .stop()
-      .catch((error) => {
-        process.stderr.write(`[symphony] shutdown failed: ${toErrorMessage(error)}\n`);
-      })
-      .finally(() => {
-        process.exit(0);
-      });
-  };
-
-  process.on("SIGINT", stop);
-  process.on("SIGTERM", stop);
+interface CliDependencies {
+  cwd: () => string;
+  createService: (options: CreateSymphonyServiceOptions) => SymphonyService;
+  onSignal: (signal: "SIGINT" | "SIGTERM", handler: () => void) => void;
+  writeStderr: (line: string) => void;
+  exit: (code: number) => void;
 }
 
-function parseArgs(args: string[]): CliOptions {
+const defaultCliDependencies: CliDependencies = {
+  cwd: () => process.cwd(),
+  createService: (options) => createSymphonyService(options),
+  onSignal: (signal, handler) => {
+    process.on(signal, handler);
+  },
+  writeStderr: (line) => {
+    process.stderr.write(line);
+  },
+  exit: (code) => {
+    process.exit(code);
+  },
+};
+
+export function parseCliArgs(args: string[], cwd: string): CliOptions {
   let workflowPath = DEFAULT_WORKFLOW_FILE;
   let watch = false;
   let printEffectiveConfig = false;
@@ -56,13 +53,52 @@ function parseArgs(args: string[]): CliOptions {
   }
 
   return {
-    workflowPath: resolve(process.cwd(), workflowPath),
+    workflowPath: resolve(cwd, workflowPath),
     watch,
     printEffectiveConfig,
   };
 }
 
-main().catch((error) => {
-  process.stderr.write(`[symphony] startup failed: ${toErrorMessage(error)}\n`);
-  process.exit(1);
-});
+export async function runCli(
+  args: string[],
+  dependencies: CliDependencies = defaultCliDependencies,
+): Promise<void> {
+  const options = parseCliArgs(args, dependencies.cwd());
+  const service = dependencies.createService({
+    workflowPath: options.workflowPath,
+    watch: options.watch,
+    printEffectiveConfig: options.printEffectiveConfig,
+  });
+
+  await service.start();
+
+  const stop = () => {
+    void service
+      .stop()
+      .catch((error) => {
+        dependencies.writeStderr(`[symphony] shutdown failed: ${toErrorMessage(error)}\n`);
+      })
+      .finally(() => {
+        dependencies.exit(0);
+      });
+  };
+
+  dependencies.onSignal("SIGINT", stop);
+  dependencies.onSignal("SIGTERM", stop);
+}
+
+export async function runCliEntry(
+  args: string[],
+  dependencies: CliDependencies = defaultCliDependencies,
+): Promise<void> {
+  try {
+    await runCli(args, dependencies);
+  } catch (error) {
+    dependencies.writeStderr(`[symphony] startup failed: ${toErrorMessage(error)}\n`);
+    dependencies.exit(1);
+  }
+}
+
+if (import.meta.main) {
+  void runCliEntry(process.argv.slice(2));
+}

--- a/packages/symphony-service/tests/cli.test.ts
+++ b/packages/symphony-service/tests/cli.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SymphonyService } from "../src/service";
+import { parseCliArgs, runCliEntry } from "../src/cli";
+
+function makeService(overrides?: Partial<SymphonyService>): SymphonyService {
+  return {
+    async start() {},
+    async stop() {},
+    async reloadWorkflow() {
+      return true;
+    },
+    async runTickOnce() {},
+    getSnapshot() {
+      return {
+        workflowPath: "/tmp/WORKFLOW.md",
+        pollIntervalMs: 1000,
+        runningCount: 0,
+        retryCount: 0,
+      };
+    },
+    getRuntimeSnapshot() {
+      return {
+        running: [],
+        retrying: [],
+        codex_totals: {
+          input_tokens: 0,
+          output_tokens: 0,
+          total_tokens: 0,
+          seconds_running: 0,
+        },
+        rate_limits: null,
+      };
+    },
+    ...overrides,
+  };
+}
+
+describe("parseCliArgs", () => {
+  it("uses cwd + WORKFLOW.md by default", () => {
+    const parsed = parseCliArgs([], "/repo");
+    expect(parsed).toEqual({
+      workflowPath: "/repo/WORKFLOW.md",
+      watch: false,
+      printEffectiveConfig: false,
+    });
+  });
+
+  it("parses watch, print-effective-config, and explicit workflow path", () => {
+    const parsed = parseCliArgs(["./ops/WORKFLOW.md", "--watch", "--print-effective-config"], "/repo");
+    expect(parsed).toEqual({
+      workflowPath: "/repo/ops/WORKFLOW.md",
+      watch: true,
+      printEffectiveConfig: true,
+    });
+  });
+});
+
+describe("runCliEntry", () => {
+  it("exits nonzero when startup fails", async () => {
+    const exits: number[] = [];
+    const stderr: string[] = [];
+
+    await runCliEntry(["./WORKFLOW.md"], {
+      cwd: () => "/repo",
+      createService: () => {
+        throw new Error("startup failed");
+      },
+      onSignal: () => {},
+      writeStderr: (line) => stderr.push(line),
+      exit: (code) => exits.push(code),
+    });
+
+    expect(exits).toEqual([1]);
+    expect(stderr.some((line) => line.includes("startup failed"))).toBe(true);
+  });
+
+  it("stops service and exits zero on SIGINT", async () => {
+    const exits: number[] = [];
+    const signals: Partial<Record<"SIGINT" | "SIGTERM", () => void>> = {};
+    const stop = vi.fn(async () => {});
+
+    await runCliEntry([], {
+      cwd: () => "/repo",
+      createService: () => makeService({ stop }),
+      onSignal: (signal, handler) => {
+        signals[signal] = handler;
+      },
+      writeStderr: () => {},
+      exit: (code) => exits.push(code),
+    });
+
+    expect(stop).not.toHaveBeenCalled();
+    signals.SIGINT?.();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(exits).toEqual([0]);
+  });
+
+  it("still exits zero when shutdown fails", async () => {
+    const exits: number[] = [];
+    const stderr: string[] = [];
+    const signals: Partial<Record<"SIGINT" | "SIGTERM", () => void>> = {};
+
+    await runCliEntry([], {
+      cwd: () => "/repo",
+      createService: () =>
+        makeService({
+          stop: async () => {
+            throw new Error("stop failed");
+          },
+        }),
+      onSignal: (signal, handler) => {
+        signals[signal] = handler;
+      },
+      writeStderr: (line) => stderr.push(line),
+      exit: (code) => exits.push(code),
+    });
+
+    signals.SIGTERM?.();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(stderr.some((line) => line.includes("shutdown failed"))).toBe(true);
+    expect(exits).toEqual([0]);
+  });
+});


### PR DESCRIPTION
## Summary
- refactor the symphony CLI entrypoint into testable exports (`parseCliArgs`, `runCli`, `runCliEntry`) with injected process hooks
- add focused lifecycle tests for argument parsing, startup failure handling, SIGINT shutdown, and shutdown-failure fallback behavior
- keep production behavior unchanged by preserving the `import.meta.main` execution path while avoiding side effects on import during tests

## Why
- CLI lifecycle behavior is high-risk for regressions because it depends on process signals and exit handling
- previous structure made it difficult to verify failure and shutdown paths without executing real process effects
- this coverage closes a gap in Symphony runtime reliability expectations by asserting deterministic host lifecycle semantics

## Validation
- `bunx tsc --noEmit -p packages/symphony-service/tsconfig.json`
- `bun run --filter '@athena/symphony-service' test`