### PR TITLE
test(symphony-service): harden codex app-server client edge handling

### DIFF
--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -1,0 +1,15 @@
+# Athena Packages Agent Rules
+
+## Git Branching
+- After each merged checkpoint, start the next task from a new branch created from the latest `main`.
+- Branch names must use the `codex/` prefix.
+
+## PR Preparation
+- Before opening or updating a PR, sync the working branch with the latest `origin/main` (merge or rebase).
+- Run PR-equivalent test checks after syncing with `origin/main`.
+
+## PR Body Format
+- Every PR body must include these sections:
+  - `## Summary`
+  - `## Why`
+  - `## Validation`

--- a/packages/symphony-service/src/codex/client.ts
+++ b/packages/symphony-service/src/codex/client.ts
@@ -75,6 +75,8 @@ export class CodexAppServerClient {
   private nextRequestId = 1;
   private initialized = false;
   private pendingTurn: PendingTurn | null = null;
+  private queuedTurnOutcome: TurnOutcome | null = null;
+  private readonly recentStderr: string[] = [];
 
   constructor(
     private readonly config: CodexAppServerConfig,
@@ -174,19 +176,16 @@ export class CodexAppServerClient {
       proc.stderr.on("data", (chunk: Buffer | string) => {
         const message = chunk.toString().trim();
         if (message) {
+          this.recordStderr(message);
           this.emit({ event: "other_message", message });
         }
       });
 
       proc.on("exit", (code, signal) => {
         const exitMessage = `codex app-server exited (code=${String(code)} signal=${String(signal)})`;
-        this.rejectAllPending(new SymphonyError("port_exit", exitMessage));
+        this.rejectAllPending(this.mapExitError(code, signal, exitMessage));
 
-        if (this.pendingTurn) {
-          this.pendingTurn.resolve("port_exit");
-          clearTimeout(this.pendingTurn.timer);
-          this.pendingTurn = null;
-        }
+        this.resolveTurnOutcome("port_exit");
 
         this.emit({ event: "turn_ended_with_error", message: exitMessage });
         this.teardown();
@@ -315,6 +314,8 @@ export class CodexAppServerClient {
 
   private handleIncomingMessage(message: JsonRpcMessage): void {
     const method = getMethodName(message);
+    const usage = extractUsage(message) ?? undefined;
+    const rateLimits = extractRateLimits(message) ?? undefined;
 
     if (isApprovalRequest(message)) {
       this.sendRequestResult(message.id, { approved: true });
@@ -329,26 +330,26 @@ export class CodexAppServerClient {
     }
 
     if (isUserInputRequired(message)) {
-      this.emit({ event: "turn_input_required", payload: { method } });
+      this.emit({ event: "turn_input_required", payload: { method }, usage, rate_limits: rateLimits });
       this.resolveTurnOutcome("turn_input_required");
       return;
     }
 
     const terminal = getTurnTerminalState(method);
     if (terminal === "completed") {
-      this.emit({ event: "turn_completed", payload: { method } });
+      this.emit({ event: "turn_completed", payload: { method }, usage, rate_limits: rateLimits });
       this.resolveTurnOutcome("completed");
       return;
     }
 
     if (terminal === "failed") {
-      this.emit({ event: "turn_failed", payload: { method } });
+      this.emit({ event: "turn_failed", payload: { method }, usage, rate_limits: rateLimits });
       this.resolveTurnOutcome("failed");
       return;
     }
 
     if (terminal === "cancelled") {
-      this.emit({ event: "turn_cancelled", payload: { method } });
+      this.emit({ event: "turn_cancelled", payload: { method }, usage, rate_limits: rateLimits });
       this.resolveTurnOutcome("cancelled");
       return;
     }
@@ -356,8 +357,8 @@ export class CodexAppServerClient {
     this.emit({
       event: "notification",
       payload: message,
-      usage: extractUsage(message) ?? undefined,
-      rate_limits: extractRateLimits(message) ?? undefined,
+      usage,
+      rate_limits: rateLimits,
     });
   }
 
@@ -379,6 +380,12 @@ export class CodexAppServerClient {
       throw new SymphonyError("response_error", "a turn is already in progress");
     }
 
+    if (this.queuedTurnOutcome) {
+      const queued = this.queuedTurnOutcome;
+      this.queuedTurnOutcome = null;
+      return Promise.resolve(queued);
+    }
+
     return new Promise<TurnOutcome>((resolve) => {
       const timer = setTimeout(() => {
         this.pendingTurn = null;
@@ -391,6 +398,7 @@ export class CodexAppServerClient {
 
   private resolveTurnOutcome(outcome: TurnOutcome): void {
     if (!this.pendingTurn) {
+      this.queuedTurnOutcome = outcome;
       return;
     }
 
@@ -411,6 +419,7 @@ export class CodexAppServerClient {
   private teardown(): void {
     this.process = null;
     this.initialized = false;
+    this.queuedTurnOutcome = null;
 
     if (this.stdoutLineReader) {
       this.stdoutLineReader.removeAllListeners();
@@ -438,5 +447,35 @@ export class CodexAppServerClient {
     if (absolute !== cwd) {
       throw new SymphonyError("invalid_workspace_cwd", `workspace cwd must be absolute: ${cwd}`);
     }
+  }
+
+  private recordStderr(message: string): void {
+    this.recentStderr.push(message);
+    if (this.recentStderr.length > 6) {
+      this.recentStderr.shift();
+    }
+  }
+
+  private mapExitError(code: number | null, signal: NodeJS.Signals | null, fallback: string): SymphonyError {
+    if (!this.initialized && this.looksLikeCommandNotFound(code)) {
+      return new SymphonyError("codex_not_found", `failed to launch codex command: ${this.config.command}`, {
+        details: {
+          exit_code: code,
+          signal: signal ?? undefined,
+          stderr: this.recentStderr[this.recentStderr.length - 1],
+        },
+      });
+    }
+
+    return new SymphonyError("port_exit", fallback);
+  }
+
+  private looksLikeCommandNotFound(code: number | null): boolean {
+    if (code !== 127) {
+      return false;
+    }
+
+    const joined = this.recentStderr.join("\n").toLowerCase();
+    return joined.includes("command not found") || joined.includes("not recognized") || joined.includes("no such file");
   }
 }

--- a/packages/symphony-service/tests/codexClient.test.ts
+++ b/packages/symphony-service/tests/codexClient.test.ts
@@ -23,7 +23,7 @@ describe("CodexAppServerClient", () => {
   it("maps missing codex command to codex_not_found", async () => {
     const client = new CodexAppServerClient({
       command: "bash -lc \"echo command not found >&2; exit 127\"",
-      readTimeoutMs: TEST_READ_TIMEOUT_MS,
+      readTimeoutMs: 1000,
       turnTimeoutMs: TEST_TURN_TIMEOUT_MS,
     });
 

--- a/packages/symphony-service/tests/codexClient.test.ts
+++ b/packages/symphony-service/tests/codexClient.test.ts
@@ -22,7 +22,7 @@ describe("CodexAppServerClient", () => {
 
   it("maps missing codex command to codex_not_found", async () => {
     const client = new CodexAppServerClient({
-      command: "__missing_codex_binary_for_test__ app-server",
+      command: "bash -lc \"echo command not found >&2; exit 127\"",
       readTimeoutMs: TEST_READ_TIMEOUT_MS,
       turnTimeoutMs: TEST_TURN_TIMEOUT_MS,
     });

--- a/packages/symphony-service/tests/codexClient.test.ts
+++ b/packages/symphony-service/tests/codexClient.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { SymphonyError } from "../src/errors";
 import { CodexAppServerClient } from "../src/codex/client";
+
+const TEST_READ_TIMEOUT_MS = 75;
+const TEST_TURN_TIMEOUT_MS = 75;
 
 describe("CodexAppServerClient", () => {
   it("fails fast when cwd is not absolute", async () => {
@@ -18,31 +20,76 @@ describe("CodexAppServerClient", () => {
     });
   });
 
-  it("returns turn_input_required when protocol signals user input requirement", async () => {
-    const events: unknown[] = [];
-    const client = new CodexAppServerClient(
-      {
-        command: "node -e \"console.log(JSON.stringify({id:1,result:{}}));\"",
-        readTimeoutMs: 100,
-        turnTimeoutMs: 100,
-      },
-      (event) => events.push(event),
-    );
+  it("maps missing codex command to codex_not_found", async () => {
+    const client = new CodexAppServerClient({
+      command: "__missing_codex_binary_for_test__ app-server",
+      readTimeoutMs: TEST_READ_TIMEOUT_MS,
+      turnTimeoutMs: TEST_TURN_TIMEOUT_MS,
+    });
 
-    // This test is a placeholder for the injectable transport harness.
-    // For now we validate construction/event callback shape only.
-    expect(events).toEqual([]);
+    await expect(client.startSession({ cwd: process.cwd() })).rejects.toMatchObject({
+      code: "codex_not_found",
+    });
     client.stop();
   });
 
-  it("completes initialize + thread/start handshake and returns thread id", async () => {
-    const dir = await mkdtemp(join(tmpdir(), "symphony-codex-mock-"));
-    const serverPath = join(dir, "mock-app-server.mjs");
+  it("enforces request/response read timeout", async () => {
+    const client = new CodexAppServerClient({
+      command: "node -e \"setInterval(() => {}, 10_000)\"",
+      readTimeoutMs: TEST_READ_TIMEOUT_MS,
+      turnTimeoutMs: TEST_TURN_TIMEOUT_MS,
+    });
 
-    await writeFile(
-      serverPath,
+    try {
+      await expect(client.startSession({ cwd: process.cwd() })).rejects.toMatchObject({
+        code: "response_timeout",
+      });
+    } finally {
+      client.stop();
+    }
+  });
+
+  it("completes initialize + thread/start handshake and returns thread id", async () => {
+    const serverPath = await writeMockServer(
+      "basic",
       `
 import readline from "node:readline";
+
+const rl = readline.createInterface({ input: process.stdin });
+for await (const line of rl) {
+  const msg = JSON.parse(line);
+  if (msg.method === "initialize") {
+    console.log(JSON.stringify({ id: msg.id, result: { protocolVersion: "test" } }));
+    continue;
+  }
+
+  if (msg.method === "thread/start") {
+    console.log(JSON.stringify({ id: msg.id, result: { thread: { id: "thread-abc" } } }));
+  }
+}
+`,
+    );
+
+    const client = new CodexAppServerClient({
+      command: `node ${serverPath}`,
+      readTimeoutMs: 1000,
+      turnTimeoutMs: 1000,
+    });
+
+    try {
+      const session = await client.startSession({ cwd: process.cwd() });
+      expect(session.threadId).toBe("thread-abc");
+    } finally {
+      client.stop();
+    }
+  });
+
+  it("returns turn_input_required when protocol signals user input requirement", async () => {
+    const serverPath = await writeMockServer(
+      "input-required",
+      `
+import readline from "node:readline";
+
 const rl = readline.createInterface({ input: process.stdin });
 for await (const line of rl) {
   const msg = JSON.parse(line);
@@ -54,30 +101,139 @@ for await (const line of rl) {
     console.log(JSON.stringify({ id: msg.id, result: { thread: { id: "thread-abc" } } }));
     continue;
   }
+
+  if (msg.method === "turn/start") {
+    console.log(JSON.stringify({ id: msg.id, result: { turn: { id: "turn-1" } } }));
+    console.log(JSON.stringify({ method: "item/tool/requestUserInput", params: { reason: "confirm" } }));
+  }
 }
 `,
-      "utf8",
     );
 
+    const events: unknown[] = [];
     const client = new CodexAppServerClient({
       command: `node ${serverPath}`,
       readTimeoutMs: 1000,
       turnTimeoutMs: 1000,
-    });
+    }, (event) => events.push(event));
 
-    const session = await client.startSession({ cwd: process.cwd() });
-    expect(session.threadId).toBe("thread-abc");
-    client.stop();
+    try {
+      const session = await client.startSession({ cwd: process.cwd() });
+      const result = await client.runTurn({
+        threadId: session.threadId,
+        cwd: process.cwd(),
+        title: "ATH-1",
+        prompt: "hello",
+      });
+
+      expect(result.outcome).toBe("turn_input_required");
+      expect(events).toContainEqual(expect.objectContaining({ event: "turn_input_required" }));
+    } finally {
+      client.stop();
+    }
+  });
+
+  it("auto-approves approval requests, rejects unsupported tools, and completes turn", async () => {
+    const serverPath = await writeMockServer(
+      "approval-and-tool-call",
+      `
+import readline from "node:readline";
+
+let approvalHandled = false;
+let toolHandled = false;
+const rl = readline.createInterface({ input: process.stdin });
+for await (const line of rl) {
+  const msg = JSON.parse(line);
+
+  if (msg.method === "initialize") {
+    console.error("mock server stderr line");
+    console.log(JSON.stringify({ id: msg.id, result: { protocolVersion: "test" } }));
+    continue;
+  }
+
+  if (msg.method === "thread/start") {
+    console.log(JSON.stringify({ id: msg.id, result: { thread: { id: "thread-tool" } } }));
+    continue;
+  }
+
+  if (msg.method === "turn/start") {
+    console.log(JSON.stringify({ id: msg.id, result: { turnId: "turn-tool-1" } }));
+    console.log(JSON.stringify({ id: "approval-1", method: "approval/request", params: { action: "shell" } }));
+    continue;
+  }
+
+  if (msg.id === "approval-1") {
+    if (!msg.result || msg.result.approved !== true) {
+      process.exitCode = 1;
+      break;
+    }
+    approvalHandled = true;
+    console.log(JSON.stringify({ id: "tool-1", method: "item/tool/call", params: { name: "unsupported" } }));
+    continue;
+  }
+
+  if (msg.id === "tool-1") {
+    if (!msg.result || msg.result.success !== false || msg.result.error !== "unsupported_tool_call") {
+      process.exitCode = 1;
+      break;
+    }
+    toolHandled = true;
+  }
+
+  if (approvalHandled && toolHandled) {
+    console.log(JSON.stringify({
+      method: "turn/completed",
+      params: {
+        usage: { input_tokens: 7, output_tokens: 4, total_tokens: 11 },
+        rate_limits: { rpm: { remaining: 900 } }
+      }
+    }));
+  }
+}
+`,
+    );
+
+    const events: unknown[] = [];
+    const client = new CodexAppServerClient(
+      {
+        command: `node ${serverPath}`,
+        readTimeoutMs: 1000,
+        turnTimeoutMs: 1000,
+      },
+      (event) => events.push(event),
+    );
+
+    try {
+      const session = await client.startSession({ cwd: process.cwd() });
+      const turn = await client.runTurn({
+        threadId: session.threadId,
+        cwd: process.cwd(),
+        title: "ATH-7",
+        prompt: "run",
+      });
+
+      expect(turn.outcome).toBe("completed");
+      expect(events).toContainEqual(expect.objectContaining({ event: "approval_auto_approved" }));
+      expect(events).toContainEqual(expect.objectContaining({ event: "unsupported_tool_call" }));
+      expect(events).toContainEqual(expect.objectContaining({ event: "other_message", message: "mock server stderr line" }));
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          event: "turn_completed",
+          usage: { input_tokens: 7, output_tokens: 4, total_tokens: 11 },
+          rate_limits: { rpm: { remaining: 900 } },
+        }),
+      );
+    } finally {
+      client.stop();
+    }
   });
 
   it("uses configurable initialize client metadata", async () => {
-    const dir = await mkdtemp(join(tmpdir(), "symphony-codex-mock-meta-"));
-    const serverPath = join(dir, "mock-app-server-meta.mjs");
-
-    await writeFile(
-      serverPath,
+    const serverPath = await writeMockServer(
+      "metadata",
       `
 import readline from "node:readline";
+
 const rl = readline.createInterface({ input: process.stdin });
 for await (const line of rl) {
   const msg = JSON.parse(line);
@@ -99,7 +255,6 @@ for await (const line of rl) {
   }
 }
 `,
-      "utf8",
     );
 
     const client = new CodexAppServerClient({
@@ -113,8 +268,18 @@ for await (const line of rl) {
       turnTimeoutMs: 1000,
     });
 
-    const session = await client.startSession({ cwd: process.cwd() });
-    expect(session.threadId).toBe("thread-meta");
-    client.stop();
+    try {
+      const session = await client.startSession({ cwd: process.cwd() });
+      expect(session.threadId).toBe("thread-meta");
+    } finally {
+      client.stop();
+    }
   });
 });
+
+async function writeMockServer(name: string, source: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), `symphony-codex-mock-${name}-`));
+  const serverPath = join(dir, "mock-app-server.mjs");
+  await writeFile(serverPath, source, "utf8");
+  return serverPath;
+}


### PR DESCRIPTION
## Summary
- expand `codexClient` coverage to include missing-command handling, request read-timeout enforcement, user-input-required turn handling, and approval/tool-call policy behavior
- fix a turn outcome race by queuing terminal/user-input outcomes that arrive before `waitForTurnOutcome` is attached
- emit usage/rate-limit telemetry on terminal turn events (`turn_completed`, `turn_failed`, `turn_cancelled`, `turn_input_required`) so final-turn usage is not dropped
- map early exit code `127` with command-not-found stderr to `codex_not_found` instead of generic `port_exit`

## Why
- Section 17.5 of the Symphony spec requires robust app-server lifecycle semantics across timeouts, policy-controlled requests, and command launch failures
- the previous implementation could miss fast turn terminal signals and incorrectly time out, creating false retries and inconsistent worker behavior
- terminal-event telemetry propagation is needed for accurate token/rate-limit accounting in orchestrator snapshots

## Validation
- `bun run --filter '@athena/symphony-service' test -- tests/codexClient.test.ts`
- `bunx tsc --noEmit -p packages/symphony-service/tsconfig.json`
- `bun run --filter '@athena/symphony-service' test`
