### PR TITLE
test(symphony-service): cover fatal CLI host lifecycle paths

### DIFF
--- a/packages/symphony-service/src/cli.ts
+++ b/packages/symphony-service/src/cli.ts
@@ -13,6 +13,8 @@ interface CliDependencies {
   cwd: () => string;
   createService: (options: CreateSymphonyServiceOptions) => SymphonyService;
   onSignal: (signal: "SIGINT" | "SIGTERM", handler: () => void) => void;
+  onUncaughtException: (handler: (error: unknown) => void) => void;
+  onUnhandledRejection: (handler: (reason: unknown) => void) => void;
   writeStderr: (line: string) => void;
   exit: (code: number) => void;
 }
@@ -22,6 +24,12 @@ const defaultCliDependencies: CliDependencies = {
   createService: (options) => createSymphonyService(options),
   onSignal: (signal, handler) => {
     process.on(signal, handler);
+  },
+  onUncaughtException: (handler) => {
+    process.on("uncaughtException", handler);
+  },
+  onUnhandledRejection: (handler) => {
+    process.on("unhandledRejection", handler);
   },
   writeStderr: (line) => {
     process.stderr.write(line);
@@ -72,19 +80,32 @@ export async function runCli(
 
   await service.start();
 
-  const stop = () => {
+  let shuttingDown = false;
+
+  const stop = (exitCode: number, error?: unknown) => {
+    if (shuttingDown) {
+      return;
+    }
+    shuttingDown = true;
+
+    if (error !== undefined) {
+      dependencies.writeStderr(`[symphony] fatal host error: ${toErrorMessage(error)}\n`);
+    }
+
     void service
       .stop()
       .catch((error) => {
         dependencies.writeStderr(`[symphony] shutdown failed: ${toErrorMessage(error)}\n`);
       })
       .finally(() => {
-        dependencies.exit(0);
+        dependencies.exit(exitCode);
       });
   };
 
-  dependencies.onSignal("SIGINT", stop);
-  dependencies.onSignal("SIGTERM", stop);
+  dependencies.onSignal("SIGINT", () => stop(0));
+  dependencies.onSignal("SIGTERM", () => stop(0));
+  dependencies.onUncaughtException((error) => stop(1, error));
+  dependencies.onUnhandledRejection((reason) => stop(1, reason));
 }
 
 export async function runCliEntry(

--- a/packages/symphony-service/tests/cli.test.ts
+++ b/packages/symphony-service/tests/cli.test.ts
@@ -66,6 +66,8 @@ describe("runCliEntry", () => {
         throw new Error("startup failed");
       },
       onSignal: () => {},
+      onUncaughtException: () => {},
+      onUnhandledRejection: () => {},
       writeStderr: (line) => stderr.push(line),
       exit: (code) => exits.push(code),
     });
@@ -85,6 +87,8 @@ describe("runCliEntry", () => {
       onSignal: (signal, handler) => {
         signals[signal] = handler;
       },
+      onUncaughtException: () => {},
+      onUnhandledRejection: () => {},
       writeStderr: () => {},
       exit: (code) => exits.push(code),
     });
@@ -114,6 +118,8 @@ describe("runCliEntry", () => {
       onSignal: (signal, handler) => {
         signals[signal] = handler;
       },
+      onUncaughtException: () => {},
+      onUnhandledRejection: () => {},
       writeStderr: (line) => stderr.push(line),
       exit: (code) => exits.push(code),
     });
@@ -124,5 +130,65 @@ describe("runCliEntry", () => {
 
     expect(stderr.some((line) => line.includes("shutdown failed"))).toBe(true);
     expect(exits).toEqual([0]);
+  });
+
+  it("stops service and exits nonzero on uncaught exception", async () => {
+    const exits: number[] = [];
+    const stderr: string[] = [];
+    let uncaughtHandler: ((error: unknown) => void) | null = null;
+    const stop = vi.fn(async () => {});
+
+    await runCliEntry([], {
+      cwd: () => "/repo",
+      createService: () => makeService({ stop }),
+      onSignal: () => {},
+      onUncaughtException: (handler) => {
+        uncaughtHandler = handler;
+      },
+      onUnhandledRejection: () => {},
+      writeStderr: (line) => stderr.push(line),
+      exit: (code) => exits.push(code),
+    });
+
+    if (!uncaughtHandler) {
+      throw new Error("uncaught exception handler was not registered");
+    }
+    (uncaughtHandler as (error: unknown) => void)(new Error("boom"));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(stderr.some((line) => line.includes("fatal host error"))).toBe(true);
+    expect(exits).toEqual([1]);
+  });
+
+  it("stops service and exits nonzero on unhandled rejection", async () => {
+    const exits: number[] = [];
+    const stderr: string[] = [];
+    let rejectionHandler: ((reason: unknown) => void) | null = null;
+    const stop = vi.fn(async () => {});
+
+    await runCliEntry([], {
+      cwd: () => "/repo",
+      createService: () => makeService({ stop }),
+      onSignal: () => {},
+      onUncaughtException: () => {},
+      onUnhandledRejection: (handler) => {
+        rejectionHandler = handler;
+      },
+      writeStderr: (line) => stderr.push(line),
+      exit: (code) => exits.push(code),
+    });
+
+    if (!rejectionHandler) {
+      throw new Error("unhandled rejection handler was not registered");
+    }
+    (rejectionHandler as (reason: unknown) => void)(new Error("rejected"));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(stderr.some((line) => line.includes("fatal host error"))).toBe(true);
+    expect(exits).toEqual([1]);
   });
 });


### PR DESCRIPTION
## Summary
- extend CLI host lifecycle handling to register `uncaughtException` and `unhandledRejection` handlers after startup
- make shutdown one-shot so concurrent signal/fatal paths cannot race multiple `service.stop()` calls
- add CLI tests that assert fatal host events trigger best-effort shutdown and non-zero exit

## Why
- Symphony SPEC §17.7 requires non-zero process exit on abnormal host termination paths
- previously the CLI only handled `SIGINT`/`SIGTERM`, so fatal runtime events could bypass orchestrated shutdown semantics
- explicit fatal handlers reduce ambiguity and keep service lifecycle behavior deterministic

## Validation
- `bun run --filter '@athena/symphony-service' test -- tests/cli.test.ts`
- `bunx tsc --noEmit -p packages/symphony-service/tsconfig.json`
- `bun run --filter '@athena/symphony-service' test`
