### PR TITLE
feat(symphony-service): add optional HTTP status server extension

### DIFF
--- a/packages/symphony-service/CONFORMANCE.md
+++ b/packages/symphony-service/CONFORMANCE.md
@@ -31,10 +31,9 @@ Spec reference: https://github.com/openai/symphony/blob/main/SPEC.md
 
 | Extension | Status | Notes |
 | --- | --- | --- |
-| Optional HTTP server/status surface (`SPEC` §13.7) | In progress | Planned next checkpoint |
+| Optional HTTP server/status surface (`SPEC` §13.7) | Implemented | `src/httpServer.ts`, `src/cli.ts`, `tests/httpServer.test.ts`, `tests/cli.test.ts` |
 | Optional `linear_graphql` client-side tool extension | Not implemented | Out of current scope |
 | Persistent retry/session state across restarts | Not implemented | Future improvement |
 | Workflow-configurable observability settings | Not implemented | Future improvement |
 | First-class tracker write APIs in orchestrator | Not implemented | Current boundary keeps writes in agent tools |
 | Pluggable tracker adapters beyond Linear | Not implemented | Future improvement |
-

--- a/packages/symphony-service/README.md
+++ b/packages/symphony-service/README.md
@@ -14,15 +14,26 @@ Spec-aligned Symphony service foundation for Athena.
 - Worker attempt execution loop (workspace, hooks, prompt, Codex turns)
 - Startup terminal workspace cleanup
 - CLI-hosted service loop with optional workflow watch/reload
+- Optional HTTP status server (`--port` or `server.port`) with dashboard + JSON APIs
 
 ## Specification tracking
 
 - Conformance matrix: [`CONFORMANCE.md`](./CONFORMANCE.md)
+
+## Status server (optional extension)
+
+When enabled (`--port` or `server.port` in `WORKFLOW.md`), the service exposes:
+
+- `GET /` dashboard
+- `GET /api/v1/state`
+- `GET /api/v1/<issue_identifier>`
+- `POST /api/v1/refresh`
 
 ## Commands
 
 ```bash
 bun run --filter '@athena/symphony-service' start
 bun run --filter '@athena/symphony-service' start --watch
+bun run --filter '@athena/symphony-service' start --port 3000
 bun run --filter '@athena/symphony-service' test
 ```

--- a/packages/symphony-service/src/cli.ts
+++ b/packages/symphony-service/src/cli.ts
@@ -1,12 +1,14 @@
 import { resolve } from "node:path";
 import { toErrorMessage } from "./errors";
+import { startStatusServer, type StatusServer } from "./httpServer";
 import { createSymphonyService, type CreateSymphonyServiceOptions, type SymphonyService } from "./service";
-import { DEFAULT_WORKFLOW_FILE } from "./workflow";
+import { DEFAULT_WORKFLOW_FILE, loadWorkflowFile } from "./workflow";
 
 interface CliOptions {
   workflowPath: string;
   watch: boolean;
   printEffectiveConfig: boolean;
+  port?: number;
 }
 
 interface CliDependencies {
@@ -15,7 +17,10 @@ interface CliDependencies {
   onSignal: (signal: "SIGINT" | "SIGTERM", handler: () => void) => void;
   onUncaughtException: (handler: (error: unknown) => void) => void;
   onUnhandledRejection: (handler: (reason: unknown) => void) => void;
+  resolveWorkflowServerPort: (workflowPath: string) => Promise<number | undefined>;
+  startStatusServer: (input: { service: SymphonyService; port: number }) => Promise<StatusServer>;
   writeStderr: (line: string) => void;
+  writeStdout: (line: string) => void;
   exit: (code: number) => void;
 }
 
@@ -31,8 +36,21 @@ const defaultCliDependencies: CliDependencies = {
   onUnhandledRejection: (handler) => {
     process.on("unhandledRejection", handler);
   },
+  resolveWorkflowServerPort: async (workflowPath) => {
+    const workflow = await loadWorkflowFile(workflowPath);
+    return parseWorkflowServerPort(workflow.config);
+  },
+  startStatusServer: async (input) => {
+    return await startStatusServer({
+      service: input.service,
+      port: input.port,
+    });
+  },
   writeStderr: (line) => {
     process.stderr.write(line);
+  },
+  writeStdout: (line) => {
+    process.stdout.write(line);
   },
   exit: (code) => {
     process.exit(code);
@@ -43,8 +61,11 @@ export function parseCliArgs(args: string[], cwd: string): CliOptions {
   let workflowPath = DEFAULT_WORKFLOW_FILE;
   let watch = false;
   let printEffectiveConfig = false;
+  let port: number | undefined;
 
-  for (const arg of args) {
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+
     if (arg === "--watch") {
       watch = true;
       continue;
@@ -52,6 +73,21 @@ export function parseCliArgs(args: string[], cwd: string): CliOptions {
 
     if (arg === "--print-effective-config") {
       printEffectiveConfig = true;
+      continue;
+    }
+
+    if (arg === "--port") {
+      const value = args[i + 1];
+      if (!value) {
+        throw new Error("missing value for --port");
+      }
+      port = parsePortArg(value);
+      i += 1;
+      continue;
+    }
+
+    if (arg.startsWith("--port=")) {
+      port = parsePortArg(arg.slice("--port=".length));
       continue;
     }
 
@@ -64,6 +100,7 @@ export function parseCliArgs(args: string[], cwd: string): CliOptions {
     workflowPath: resolve(cwd, workflowPath),
     watch,
     printEffectiveConfig,
+    port,
   };
 }
 
@@ -80,6 +117,25 @@ export async function runCli(
 
   await service.start();
 
+  let statusServer: StatusServer | null = null;
+  try {
+    const configuredPort = options.port ?? (await dependencies.resolveWorkflowServerPort(options.workflowPath));
+    if (typeof configuredPort === "number") {
+      statusServer = await dependencies.startStatusServer({
+        service,
+        port: configuredPort,
+      });
+      dependencies.writeStdout(`[symphony] status server listening on http://${statusServer.host}:${statusServer.port}\n`);
+    }
+  } catch (error) {
+    try {
+      await service.stop();
+    } catch (stopError) {
+      dependencies.writeStderr(`[symphony] shutdown failed: ${toErrorMessage(stopError)}\n`);
+    }
+    throw error;
+  }
+
   let shuttingDown = false;
 
   const stop = (exitCode: number, error?: unknown) => {
@@ -92,11 +148,21 @@ export async function runCli(
       dependencies.writeStderr(`[symphony] fatal host error: ${toErrorMessage(error)}\n`);
     }
 
-    void service
-      .stop()
-      .catch((error) => {
-        dependencies.writeStderr(`[symphony] shutdown failed: ${toErrorMessage(error)}\n`);
-      })
+    void (async () => {
+      if (statusServer) {
+        try {
+          await statusServer.stop();
+        } catch (statusServerError) {
+          dependencies.writeStderr(`[symphony] status server shutdown failed: ${toErrorMessage(statusServerError)}\n`);
+        }
+      }
+
+      try {
+        await service.stop();
+      } catch (serviceStopError) {
+        dependencies.writeStderr(`[symphony] shutdown failed: ${toErrorMessage(serviceStopError)}\n`);
+      }
+    })()
       .finally(() => {
         dependencies.exit(exitCode);
       });
@@ -122,4 +188,43 @@ export async function runCliEntry(
 
 if (import.meta.main) {
   void runCliEntry(process.argv.slice(2));
+}
+
+function parsePortArg(rawValue: string): number {
+  const parsed = Number.parseInt(rawValue, 10);
+  if (!Number.isFinite(parsed) || String(parsed) !== rawValue.trim()) {
+    throw new Error(`invalid --port value: ${rawValue}`);
+  }
+
+  if (parsed < 0 || parsed > 65535) {
+    throw new Error(`--port out of range: ${rawValue}`);
+  }
+
+  return parsed;
+}
+
+function parseWorkflowServerPort(config: Record<string, unknown>): number | undefined {
+  const server = asObject(config.server);
+  if (!server || !Object.prototype.hasOwnProperty.call(server, "port")) {
+    return undefined;
+  }
+
+  const portValue = server.port;
+  if (typeof portValue === "number" && Number.isInteger(portValue) && portValue >= 0 && portValue <= 65535) {
+    return portValue;
+  }
+
+  if (typeof portValue === "string") {
+    return parsePortArg(portValue);
+  }
+
+  throw new Error("invalid server.port in workflow config");
+}
+
+function asObject(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+
+  return value as Record<string, unknown>;
 }

--- a/packages/symphony-service/src/httpServer.ts
+++ b/packages/symphony-service/src/httpServer.ts
@@ -1,0 +1,336 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { URL } from "node:url";
+import type { SymphonyService } from "./service";
+
+export interface StatusServer {
+  host: string;
+  port: number;
+  stop: () => Promise<void>;
+}
+
+export interface StartStatusServerOptions {
+  service: SymphonyService;
+  port: number;
+  host?: string;
+  onRefreshError?: (error: unknown) => void;
+}
+
+interface RefreshQueueState {
+  queued: boolean;
+  inFlight: boolean;
+}
+
+export async function startStatusServer(options: StartStatusServerOptions): Promise<StatusServer> {
+  const host = options.host ?? "127.0.0.1";
+  const refreshState: RefreshQueueState = {
+    queued: false,
+    inFlight: false,
+  };
+
+  const server = createServer((request, response) => {
+    void handleRequest(options, request, response, refreshState);
+  });
+
+  await listen(server, {
+    host,
+    port: options.port,
+  });
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("status server failed to resolve listening address");
+  }
+
+  return {
+    host,
+    port: address.port,
+    stop: () => closeServer(server),
+  };
+}
+
+async function handleRequest(
+  options: StartStatusServerOptions,
+  request: IncomingMessage,
+  response: ServerResponse,
+  refreshState: RefreshQueueState,
+): Promise<void> {
+  const method = request.method ?? "GET";
+  const url = new URL(request.url ?? "/", "http://localhost");
+  const path = url.pathname;
+
+  if (path === "/") {
+    if (method !== "GET") {
+      sendMethodNotAllowed(response, ["GET"]);
+      return;
+    }
+
+    const runtime = options.service.getRuntimeSnapshot();
+    const html = renderDashboardHtml(runtime);
+    sendText(response, 200, html, "text/html; charset=utf-8");
+    return;
+  }
+
+  if (path === "/api/v1/state") {
+    if (method !== "GET") {
+      sendMethodNotAllowed(response, ["GET"]);
+      return;
+    }
+
+    sendJson(response, 200, toStateResponse(options.service));
+    return;
+  }
+
+  if (path === "/api/v1/refresh") {
+    if (method !== "POST") {
+      sendMethodNotAllowed(response, ["POST"]);
+      return;
+    }
+
+    const coalesced = refreshState.queued || refreshState.inFlight;
+    queueRefresh(options, refreshState);
+
+    sendJson(response, 202, {
+      queued: true,
+      coalesced,
+      requested_at: new Date().toISOString(),
+      operations: ["poll", "reconcile"],
+    });
+    return;
+  }
+
+  if (path.startsWith("/api/v1/")) {
+    const issueIdentifier = decodeURIComponent(path.slice("/api/v1/".length));
+    if (!issueIdentifier || issueIdentifier === "state" || issueIdentifier === "refresh") {
+      sendJsonError(response, 404, "route_not_found", "route not found");
+      return;
+    }
+
+    if (method !== "GET") {
+      sendMethodNotAllowed(response, ["GET"]);
+      return;
+    }
+
+    const issueResponse = toIssueResponse(options.service, issueIdentifier);
+    if (!issueResponse) {
+      sendJsonError(response, 404, "issue_not_found", `issue not found: ${issueIdentifier}`);
+      return;
+    }
+
+    sendJson(response, 200, issueResponse);
+    return;
+  }
+
+  if (path.startsWith("/api/v1")) {
+    sendJsonError(response, 404, "route_not_found", "route not found");
+    return;
+  }
+
+  sendText(response, 404, "Not Found\n");
+}
+
+function queueRefresh(options: StartStatusServerOptions, refreshState: RefreshQueueState): void {
+  refreshState.queued = true;
+  if (refreshState.inFlight) {
+    return;
+  }
+
+  queueMicrotask(() => {
+    void drainRefreshQueue(options, refreshState);
+  });
+}
+
+async function drainRefreshQueue(options: StartStatusServerOptions, refreshState: RefreshQueueState): Promise<void> {
+  if (!refreshState.queued || refreshState.inFlight) {
+    return;
+  }
+
+  refreshState.queued = false;
+  refreshState.inFlight = true;
+
+  try {
+    await options.service.runTickOnce();
+  } catch (error) {
+    options.onRefreshError?.(error);
+  } finally {
+    refreshState.inFlight = false;
+    if (refreshState.queued) {
+      queueMicrotask(() => {
+        void drainRefreshQueue(options, refreshState);
+      });
+    }
+  }
+}
+
+function toStateResponse(service: SymphonyService): Record<string, unknown> {
+  const runtime = service.getRuntimeSnapshot();
+
+  return {
+    generated_at: new Date().toISOString(),
+    counts: {
+      running: runtime.running.length,
+      retrying: runtime.retrying.length,
+    },
+    running: runtime.running.map((row) => ({
+      issue_id: row.issue_id,
+      issue_identifier: row.issue_identifier,
+      state: row.state,
+      session_id: row.session_id,
+      turn_count: row.turn_count,
+      retry_attempt: row.retry_attempt,
+      started_at: toIso(row.started_at_ms),
+      last_event_at: toIsoNullable(row.last_codex_timestamp_ms),
+      tokens: {
+        input_tokens: row.codex_input_tokens,
+        output_tokens: row.codex_output_tokens,
+        total_tokens: row.codex_total_tokens,
+      },
+    })),
+    retrying: runtime.retrying.map((row) => ({
+      issue_id: row.issue_id,
+      issue_identifier: row.issue_identifier,
+      attempt: row.attempt,
+      due_at: toIso(row.due_at_ms),
+      error: row.error,
+    })),
+    codex_totals: runtime.codex_totals,
+    rate_limits: runtime.rate_limits,
+  };
+}
+
+function toIssueResponse(
+  service: SymphonyService,
+  issueIdentifier: string,
+): Record<string, unknown> | null {
+  const runtime = service.getRuntimeSnapshot();
+  const running = runtime.running.find((row) => row.issue_identifier === issueIdentifier);
+  const retry = runtime.retrying.find((row) => row.issue_identifier === issueIdentifier);
+
+  if (!running && !retry) {
+    return null;
+  }
+
+  return {
+    issue_identifier: issueIdentifier,
+    issue_id: running?.issue_id ?? retry?.issue_id ?? "",
+    status: running ? "running" : "retrying",
+    running: running
+      ? {
+          state: running.state,
+          session_id: running.session_id,
+          turn_count: running.turn_count,
+          retry_attempt: running.retry_attempt,
+          started_at: toIso(running.started_at_ms),
+          last_event_at: toIsoNullable(running.last_codex_timestamp_ms),
+          tokens: {
+            input_tokens: running.codex_input_tokens,
+            output_tokens: running.codex_output_tokens,
+            total_tokens: running.codex_total_tokens,
+          },
+        }
+      : null,
+    retry: retry
+      ? {
+          attempt: retry.attempt,
+          due_at: toIso(retry.due_at_ms),
+          error: retry.error,
+        }
+      : null,
+    codex_totals: runtime.codex_totals,
+    rate_limits: runtime.rate_limits,
+  };
+}
+
+function renderDashboardHtml(runtime: ReturnType<SymphonyService["getRuntimeSnapshot"]>): string {
+  const generatedAt = new Date().toISOString();
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Symphony Status</title>
+  <style>
+    body { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; margin: 24px; background: #0b0f14; color: #d8e0ea; }
+    h1 { margin: 0 0 12px; font-size: 20px; }
+    .card { border: 1px solid #263241; border-radius: 8px; padding: 12px; margin-bottom: 12px; background: #121922; }
+    .muted { color: #8aa1ba; }
+    code { color: #8dd3ff; }
+  </style>
+</head>
+<body>
+  <h1>Symphony Runtime Status</h1>
+  <div class="card">
+    <div>Generated: <span class="muted">${generatedAt}</span></div>
+    <div>Running: <code>${runtime.running.length}</code></div>
+    <div>Retrying: <code>${runtime.retrying.length}</code></div>
+  </div>
+  <div class="card">
+    <div>Total tokens: <code>${runtime.codex_totals.total_tokens}</code></div>
+    <div>Runtime seconds: <code>${runtime.codex_totals.seconds_running.toFixed(2)}</code></div>
+    <div>API: <code>/api/v1/state</code></div>
+  </div>
+</body>
+</html>`;
+}
+
+function toIso(epochMs: number): string {
+  return new Date(epochMs).toISOString();
+}
+
+function toIsoNullable(epochMs: number | null): string | null {
+  if (epochMs === null) {
+    return null;
+  }
+  return toIso(epochMs);
+}
+
+function sendJson(response: ServerResponse, status: number, payload: unknown): void {
+  const body = JSON.stringify(payload);
+  response.statusCode = status;
+  response.setHeader("content-type", "application/json; charset=utf-8");
+  response.end(body);
+}
+
+function sendJsonError(response: ServerResponse, status: number, code: string, message: string): void {
+  sendJson(response, status, {
+    error: {
+      code,
+      message,
+    },
+  });
+}
+
+function sendText(response: ServerResponse, status: number, body: string, contentType = "text/plain; charset=utf-8"): void {
+  response.statusCode = status;
+  response.setHeader("content-type", contentType);
+  response.end(body);
+}
+
+function sendMethodNotAllowed(response: ServerResponse, allow: string[]): void {
+  response.statusCode = 405;
+  response.setHeader("allow", allow.join(", "));
+  sendJsonError(response, 405, "method_not_allowed", "method not allowed");
+}
+
+function listen(server: Server, options: { host: string; port: number }): Promise<void> {
+  return new Promise<void>((resolvePromise, rejectPromise) => {
+    server.once("error", rejectPromise);
+    server.listen(options.port, options.host, () => {
+      server.off("error", rejectPromise);
+      resolvePromise();
+    });
+  });
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise<void>((resolvePromise, rejectPromise) => {
+    server.close((error) => {
+      if (error) {
+        rejectPromise(error);
+        return;
+      }
+      resolvePromise();
+    });
+  });
+}
+

--- a/packages/symphony-service/src/index.ts
+++ b/packages/symphony-service/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./config";
 export * from "./errors";
+export * from "./httpServer";
 export * from "./issue";
 export * from "./orchestrator";
 export * from "./retry";

--- a/packages/symphony-service/tests/cli.test.ts
+++ b/packages/symphony-service/tests/cli.test.ts
@@ -42,16 +42,27 @@ describe("parseCliArgs", () => {
       workflowPath: "/repo/WORKFLOW.md",
       watch: false,
       printEffectiveConfig: false,
+      port: undefined,
     });
   });
 
   it("parses watch, print-effective-config, and explicit workflow path", () => {
-    const parsed = parseCliArgs(["./ops/WORKFLOW.md", "--watch", "--print-effective-config"], "/repo");
+    const parsed = parseCliArgs(["./ops/WORKFLOW.md", "--watch", "--print-effective-config", "--port=3131"], "/repo");
     expect(parsed).toEqual({
       workflowPath: "/repo/ops/WORKFLOW.md",
       watch: true,
       printEffectiveConfig: true,
+      port: 3131,
     });
+  });
+
+  it("parses --port value from next arg", () => {
+    const parsed = parseCliArgs(["--port", "8080"], "/repo");
+    expect(parsed.port).toBe(8080);
+  });
+
+  it("throws for invalid --port", () => {
+    expect(() => parseCliArgs(["--port", "foo"], "/repo")).toThrowError("invalid --port value");
   });
 });
 
@@ -68,7 +79,10 @@ describe("runCliEntry", () => {
       onSignal: () => {},
       onUncaughtException: () => {},
       onUnhandledRejection: () => {},
+      resolveWorkflowServerPort: async () => undefined,
+      startStatusServer: async () => ({ host: "127.0.0.1", port: 0, stop: async () => {} }),
       writeStderr: (line) => stderr.push(line),
+      writeStdout: () => {},
       exit: (code) => exits.push(code),
     });
 
@@ -80,6 +94,7 @@ describe("runCliEntry", () => {
     const exits: number[] = [];
     const signals: Partial<Record<"SIGINT" | "SIGTERM", () => void>> = {};
     const stop = vi.fn(async () => {});
+    const statusStop = vi.fn(async () => {});
 
     await runCliEntry([], {
       cwd: () => "/repo",
@@ -89,23 +104,28 @@ describe("runCliEntry", () => {
       },
       onUncaughtException: () => {},
       onUnhandledRejection: () => {},
+      resolveWorkflowServerPort: async () => 4030,
+      startStatusServer: async () => ({ host: "127.0.0.1", port: 4030, stop: statusStop }),
       writeStderr: () => {},
+      writeStdout: () => {},
       exit: (code) => exits.push(code),
     });
 
     expect(stop).not.toHaveBeenCalled();
     signals.SIGINT?.();
-    await Promise.resolve();
-    await Promise.resolve();
+    await vi.waitFor(() => {
+      expect(exits).toEqual([0]);
+    });
 
     expect(stop).toHaveBeenCalledTimes(1);
-    expect(exits).toEqual([0]);
+    expect(statusStop).toHaveBeenCalledTimes(1);
   });
 
   it("still exits zero when shutdown fails", async () => {
     const exits: number[] = [];
     const stderr: string[] = [];
     const signals: Partial<Record<"SIGINT" | "SIGTERM", () => void>> = {};
+    const statusStop = vi.fn(async () => {});
 
     await runCliEntry([], {
       cwd: () => "/repo",
@@ -120,16 +140,20 @@ describe("runCliEntry", () => {
       },
       onUncaughtException: () => {},
       onUnhandledRejection: () => {},
+      resolveWorkflowServerPort: async () => 0,
+      startStatusServer: async () => ({ host: "127.0.0.1", port: 3301, stop: statusStop }),
       writeStderr: (line) => stderr.push(line),
+      writeStdout: () => {},
       exit: (code) => exits.push(code),
     });
 
     signals.SIGTERM?.();
-    await Promise.resolve();
-    await Promise.resolve();
+    await vi.waitFor(() => {
+      expect(exits).toEqual([0]);
+    });
 
     expect(stderr.some((line) => line.includes("shutdown failed"))).toBe(true);
-    expect(exits).toEqual([0]);
+    expect(statusStop).toHaveBeenCalledTimes(1);
   });
 
   it("stops service and exits nonzero on uncaught exception", async () => {
@@ -146,7 +170,10 @@ describe("runCliEntry", () => {
         uncaughtHandler = handler;
       },
       onUnhandledRejection: () => {},
+      resolveWorkflowServerPort: async () => undefined,
+      startStatusServer: async () => ({ host: "127.0.0.1", port: 0, stop: async () => {} }),
       writeStderr: (line) => stderr.push(line),
+      writeStdout: () => {},
       exit: (code) => exits.push(code),
     });
 
@@ -176,7 +203,10 @@ describe("runCliEntry", () => {
       onUnhandledRejection: (handler) => {
         rejectionHandler = handler;
       },
+      resolveWorkflowServerPort: async () => undefined,
+      startStatusServer: async () => ({ host: "127.0.0.1", port: 0, stop: async () => {} }),
       writeStderr: (line) => stderr.push(line),
+      writeStdout: () => {},
       exit: (code) => exits.push(code),
     });
 
@@ -189,6 +219,77 @@ describe("runCliEntry", () => {
 
     expect(stop).toHaveBeenCalledTimes(1);
     expect(stderr.some((line) => line.includes("fatal host error"))).toBe(true);
+    expect(exits).toEqual([1]);
+  });
+
+  it("starts status server when --port is provided", async () => {
+    const startedPorts: number[] = [];
+    const stdout: string[] = [];
+
+    await runCliEntry(["--port", "4321"], {
+      cwd: () => "/repo",
+      createService: () => makeService(),
+      onSignal: () => {},
+      onUncaughtException: () => {},
+      onUnhandledRejection: () => {},
+      resolveWorkflowServerPort: async () => 7000,
+      startStatusServer: async ({ port }) => {
+        startedPorts.push(port);
+        return { host: "127.0.0.1", port, stop: async () => {} };
+      },
+      writeStderr: () => {},
+      writeStdout: (line) => stdout.push(line),
+      exit: () => {},
+    });
+
+    expect(startedPorts).toEqual([4321]);
+    expect(stdout.some((line) => line.includes("4321"))).toBe(true);
+  });
+
+  it("uses workflow server port when --port is not provided", async () => {
+    const startedPorts: number[] = [];
+
+    await runCliEntry([], {
+      cwd: () => "/repo",
+      createService: () => makeService(),
+      onSignal: () => {},
+      onUncaughtException: () => {},
+      onUnhandledRejection: () => {},
+      resolveWorkflowServerPort: async () => 5050,
+      startStatusServer: async ({ port }) => {
+        startedPorts.push(port);
+        return { host: "127.0.0.1", port, stop: async () => {} };
+      },
+      writeStderr: () => {},
+      writeStdout: () => {},
+      exit: () => {},
+    });
+
+    expect(startedPorts).toEqual([5050]);
+  });
+
+  it("stops service and exits nonzero when status server startup fails", async () => {
+    const exits: number[] = [];
+    const stderr: string[] = [];
+    const stop = vi.fn(async () => {});
+
+    await runCliEntry(["--port", "4200"], {
+      cwd: () => "/repo",
+      createService: () => makeService({ stop }),
+      onSignal: () => {},
+      onUncaughtException: () => {},
+      onUnhandledRejection: () => {},
+      resolveWorkflowServerPort: async () => undefined,
+      startStatusServer: async () => {
+        throw new Error("port in use");
+      },
+      writeStderr: (line) => stderr.push(line),
+      writeStdout: () => {},
+      exit: (code) => exits.push(code),
+    });
+
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(stderr.some((line) => line.includes("startup failed"))).toBe(true);
     expect(exits).toEqual([1]);
   });
 });

--- a/packages/symphony-service/tests/httpServer.test.ts
+++ b/packages/symphony-service/tests/httpServer.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SymphonyService } from "../src/service";
+import { startStatusServer } from "../src/httpServer";
+
+function makeService(overrides?: Partial<SymphonyService>): SymphonyService {
+  return {
+    async start() {},
+    async stop() {},
+    async reloadWorkflow() {
+      return true;
+    },
+    async runTickOnce() {},
+    getSnapshot() {
+      return {
+        workflowPath: "/tmp/WORKFLOW.md",
+        pollIntervalMs: 1000,
+        runningCount: 1,
+        retryCount: 1,
+      };
+    },
+    getRuntimeSnapshot() {
+      return {
+        running: [
+          {
+            issue_id: "issue-1",
+            issue_identifier: "ATH-100",
+            state: "In Progress",
+            session_id: "thread-1-turn-1",
+            turn_count: 3,
+            retry_attempt: 1,
+            started_at_ms: 1_700_000_000_000,
+            last_codex_timestamp_ms: 1_700_000_000_500,
+            codex_input_tokens: 10,
+            codex_output_tokens: 4,
+            codex_total_tokens: 14,
+          },
+        ],
+        retrying: [
+          {
+            issue_id: "issue-2",
+            issue_identifier: "ATH-101",
+            attempt: 2,
+            due_at_ms: 1_700_000_010_000,
+            error: "no available orchestrator slots",
+          },
+        ],
+        codex_totals: {
+          input_tokens: 30,
+          output_tokens: 12,
+          total_tokens: 42,
+          seconds_running: 180,
+        },
+        rate_limits: {
+          rpm: {
+            remaining: 900,
+          },
+        },
+      };
+    },
+    ...overrides,
+  };
+}
+
+describe("status server", () => {
+  it("serves dashboard and state API", async () => {
+    const statusServer = await startStatusServer({
+      service: makeService(),
+      port: 0,
+    });
+
+    try {
+      const rootResponse = await fetch(`http://${statusServer.host}:${statusServer.port}/`);
+      expect(rootResponse.status).toBe(200);
+      const rootBody = await rootResponse.text();
+      expect(rootBody).toContain("Symphony Runtime Status");
+
+      const stateResponse = await fetch(`http://${statusServer.host}:${statusServer.port}/api/v1/state`);
+      expect(stateResponse.status).toBe(200);
+      const stateBody = (await stateResponse.json()) as Record<string, any>;
+      expect(stateBody.counts).toEqual({
+        running: 1,
+        retrying: 1,
+      });
+      expect(stateBody.running[0].issue_identifier).toBe("ATH-100");
+      expect(stateBody.retrying[0].issue_identifier).toBe("ATH-101");
+    } finally {
+      await statusServer.stop();
+    }
+  });
+
+  it("serves per-issue API and returns 404 for unknown issue", async () => {
+    const statusServer = await startStatusServer({
+      service: makeService(),
+      port: 0,
+    });
+
+    try {
+      const runningResponse = await fetch(`http://${statusServer.host}:${statusServer.port}/api/v1/ATH-100`);
+      expect(runningResponse.status).toBe(200);
+      const runningBody = (await runningResponse.json()) as Record<string, any>;
+      expect(runningBody.status).toBe("running");
+      expect(runningBody.issue_id).toBe("issue-1");
+
+      const retryResponse = await fetch(`http://${statusServer.host}:${statusServer.port}/api/v1/ATH-101`);
+      expect(retryResponse.status).toBe(200);
+      const retryBody = (await retryResponse.json()) as Record<string, any>;
+      expect(retryBody.status).toBe("retrying");
+      expect(retryBody.retry.attempt).toBe(2);
+
+      const missingResponse = await fetch(`http://${statusServer.host}:${statusServer.port}/api/v1/ATH-999`);
+      expect(missingResponse.status).toBe(404);
+      const missingBody = (await missingResponse.json()) as Record<string, any>;
+      expect(missingBody.error.code).toBe("issue_not_found");
+    } finally {
+      await statusServer.stop();
+    }
+  });
+
+  it("handles refresh trigger and method checks", async () => {
+    const runTickOnce = vi.fn(async () => {
+      await Promise.resolve();
+    });
+    const onRefreshError = vi.fn();
+
+    const statusServer = await startStatusServer({
+      service: makeService({ runTickOnce }),
+      port: 0,
+      onRefreshError,
+    });
+
+    try {
+      const refreshResponse = await fetch(`http://${statusServer.host}:${statusServer.port}/api/v1/refresh`, {
+        method: "POST",
+      });
+      expect(refreshResponse.status).toBe(202);
+      const refreshBody = (await refreshResponse.json()) as Record<string, any>;
+      expect(refreshBody.queued).toBe(true);
+      expect(refreshBody.operations).toEqual(["poll", "reconcile"]);
+
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(runTickOnce).toHaveBeenCalledTimes(1);
+      expect(onRefreshError).not.toHaveBeenCalled();
+
+      const methodResponse = await fetch(`http://${statusServer.host}:${statusServer.port}/api/v1/refresh`, {
+        method: "GET",
+      });
+      expect(methodResponse.status).toBe(405);
+      const methodBody = (await methodResponse.json()) as Record<string, any>;
+      expect(methodBody.error.code).toBe("method_not_allowed");
+    } finally {
+      await statusServer.stop();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add optional HTTP status server extension with dashboard/API endpoints:
  - `GET /`
  - `GET /api/v1/state`
  - `GET /api/v1/<issue_identifier>`
  - `POST /api/v1/refresh`
- add CLI enablement for status server via `--port` (CLI override) or `server.port` from `WORKFLOW.md`
- extend CLI lifecycle handling so status-server startup failure performs best-effort service shutdown before surfacing startup failure
- add full unit/integration tests for status server routing and new CLI port/lifecycle behavior
- update docs (`README`, `CONFORMANCE.md`) to reflect HTTP extension support

## Why
- this closes the primary remaining extension gap from the Symphony spec by providing an operator-facing observability surface without coupling correctness to UI
- CLI `--port` override plus workflow-based `server.port` matches extension enablement semantics while preserving existing startup behavior
- explicit API endpoints and method/error handling make operational debugging and manual poll triggering reliable

## Validation
- `bun run --filter '@athena/symphony-service' test -- tests/cli.test.ts tests/httpServer.test.ts`
- `bunx tsc --noEmit -p packages/symphony-service/tsconfig.json`
- `bun run --filter '@athena/symphony-service' test`
- `bun run --filter '@athena/storefront-webapp' test`
