### PR TITLE
ci(symphony-service): add gated real integration profile workflow

### DIFF
--- a/.github/workflows/athena-symphony-real-integration.yml
+++ b/.github/workflows/athena-symphony-real-integration.yml
@@ -1,0 +1,76 @@
+name: Athena Symphony Real Integration
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: "Type RUN_REAL_INTEGRATION to execute this workflow"
+        required: true
+        default: ""
+      workflow_path:
+        description: "Path to WORKFLOW.md (relative to repo root)"
+        required: true
+        default: "WORKFLOW.md"
+      run_linear_smoke:
+        description: "Run real Linear tracker smoke"
+        required: true
+        type: choice
+        options:
+          - "true"
+          - "false"
+        default: "true"
+      run_codex_smoke:
+        description: "Run Codex command smoke launch"
+        required: true
+        type: choice
+        options:
+          - "true"
+          - "false"
+        default: "false"
+
+permissions:
+  contents: read
+
+jobs:
+  real-integration-smoke:
+    name: Symphony Real Integration Smoke
+    if: ${{ inputs.confirm == 'RUN_REAL_INTEGRATION' }}
+    runs-on: ubuntu-latest
+    env:
+      LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Validate credentials and tooling
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ inputs.run_linear_smoke }}" == "true" && -z "${LINEAR_API_KEY:-}" ]]; then
+            echo "::error::LINEAR_API_KEY is required when run_linear_smoke=true"
+            exit 1
+          fi
+
+          if [[ "${{ inputs.run_codex_smoke }}" == "true" ]]; then
+            if ! command -v codex >/dev/null 2>&1; then
+              echo "::error::codex command is required when run_codex_smoke=true"
+              exit 1
+            fi
+          fi
+
+      - name: Run real integration smoke
+        run: |
+          bun run --filter '@athena/symphony-service' test:integration:real \
+            "${{ inputs.workflow_path }}" \
+            --linear="${{ inputs.run_linear_smoke }}" \
+            --codex="${{ inputs.run_codex_smoke }}"
+

--- a/packages/symphony-service/CONFORMANCE.md
+++ b/packages/symphony-service/CONFORMANCE.md
@@ -38,3 +38,9 @@ Spec reference: https://github.com/openai/symphony/blob/main/SPEC.md
 | First-class tracker write APIs in orchestrator | Not implemented | Current boundary keeps writes in agent tools |
 | Pluggable tracker adapters beyond Linear | Not implemented | Future improvement |
 
+## Real Integration Profile (`SPEC` §18.3)
+
+| Item | Status | Notes |
+| --- | --- | --- |
+| Real integration smoke can be executed in CI with credentials and optional Codex tooling | Implemented | GitHub Actions workflow: `.github/workflows/athena-symphony-real-integration.yml` |
+| Real integration smoke command is available from package scripts | Implemented | `bun run --filter '@athena/symphony-service' test:integration:real` |

--- a/packages/symphony-service/README.md
+++ b/packages/symphony-service/README.md
@@ -25,4 +25,5 @@ Spec-aligned Symphony service foundation for Athena.
 bun run --filter '@athena/symphony-service' start
 bun run --filter '@athena/symphony-service' start --watch
 bun run --filter '@athena/symphony-service' test
+bun run --filter '@athena/symphony-service' test:integration:real WORKFLOW.md --linear=true --codex=false
 ```

--- a/packages/symphony-service/package.json
+++ b/packages/symphony-service/package.json
@@ -7,7 +7,8 @@
     "start": "bun run src/cli.ts",
     "dev": "bun run src/cli.ts",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:integration:real": "bun run scripts/realIntegrationSmoke.ts"
   },
   "dependencies": {
     "liquidjs": "^10.24.0",

--- a/packages/symphony-service/scripts/realIntegrationSmoke.ts
+++ b/packages/symphony-service/scripts/realIntegrationSmoke.ts
@@ -1,0 +1,172 @@
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { resolveEffectiveConfig } from "../src/config";
+import { LinearTrackerClient } from "../src/tracker/linear";
+import { validateDispatchPreflight } from "../src/validate";
+import { loadWorkflowFile } from "../src/workflow";
+
+async function main(): Promise<void> {
+  const { workflowPath, runLinearSmoke, runCodexSmoke } = parseArgs(process.argv.slice(2));
+
+  const workflow = await loadWorkflowFile(workflowPath);
+  const config = resolveEffectiveConfig(workflow.config);
+  validateDispatchPreflight(config);
+
+  console.log(`[integration] workflow=${workflow.path}`);
+  console.log(`[integration] tracker_kind=${config.tracker.kind}`);
+  console.log(`[integration] linear_smoke=${String(runLinearSmoke)} codex_smoke=${String(runCodexSmoke)}`);
+
+  if (runLinearSmoke) {
+    if (config.tracker.kind !== "linear") {
+      throw new Error(`real integration smoke only supports tracker.kind=linear (received: ${config.tracker.kind})`);
+    }
+
+    const tracker = new LinearTrackerClient({
+      endpoint: config.tracker.endpoint,
+      apiKey: config.tracker.apiKey ?? "",
+      projectSlug: config.tracker.projectSlug ?? "",
+      activeStates: config.tracker.activeStates,
+    });
+
+    const candidates = await tracker.fetchCandidateIssues();
+    console.log(`[integration] linear_candidate_count=${candidates.length}`);
+  }
+
+  if (runCodexSmoke) {
+    await smokeLaunchCodex(config.codex.command, dirname(workflow.path));
+    console.log("[integration] codex_launch=ok");
+  }
+
+  console.log("[integration] status=ok");
+}
+
+function parseArgs(args: string[]): {
+  workflowPath: string;
+  runLinearSmoke: boolean;
+  runCodexSmoke: boolean;
+} {
+  let workflowPath: string | null = null;
+  let runLinearSmoke = true;
+  let runCodexSmoke = true;
+
+  for (const arg of args) {
+    if (arg.startsWith("--linear=")) {
+      runLinearSmoke = parseBooleanFlag("linear", arg.slice("--linear=".length));
+      continue;
+    }
+
+    if (arg.startsWith("--codex=")) {
+      runCodexSmoke = parseBooleanFlag("codex", arg.slice("--codex=".length));
+      continue;
+    }
+
+    if (!arg.startsWith("-")) {
+      workflowPath = arg;
+    }
+  }
+
+  return {
+    workflowPath: resolveWorkflowPath(workflowPath),
+    runLinearSmoke,
+    runCodexSmoke,
+  };
+}
+
+function resolveWorkflowPath(rawPath: string | null): string {
+  const candidates = rawPath
+    ? [resolve(process.cwd(), rawPath), resolve(process.cwd(), "../../", rawPath)]
+    : [resolve(process.cwd(), "../../WORKFLOW.md"), resolve(process.cwd(), "WORKFLOW.md")];
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return candidates[0];
+}
+
+function parseBooleanFlag(name: string, value: string): boolean {
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "true" || normalized === "1" || normalized === "yes") {
+    return true;
+  }
+
+  if (normalized === "false" || normalized === "0" || normalized === "no") {
+    return false;
+  }
+
+  throw new Error(`invalid --${name} value: ${value}`);
+}
+
+async function smokeLaunchCodex(command: string, cwd: string): Promise<void> {
+  await new Promise<void>((resolvePromise, rejectPromise) => {
+    const processHandle = spawn("bash", ["-lc", command], {
+      cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let settled = false;
+    let stderr = "";
+    const killTimer = setTimeout(() => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      processHandle.kill("SIGTERM");
+      setTimeout(() => {
+        processHandle.kill("SIGKILL");
+      }, 500).unref();
+      resolvePromise();
+    }, 1500);
+
+    processHandle.stderr.on("data", (chunk: Buffer | string) => {
+      stderr += chunk.toString();
+      if (stderr.length > 8_000) {
+        stderr = stderr.slice(-8_000);
+      }
+    });
+
+    processHandle.on("error", (error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(killTimer);
+      rejectPromise(new Error(`failed to launch codex command: ${error.message}`));
+    });
+
+    processHandle.on("exit", (code, signal) => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      clearTimeout(killTimer);
+
+      if (signal === "SIGTERM" || signal === "SIGKILL") {
+        resolvePromise();
+        return;
+      }
+
+      if (code === 0) {
+        resolvePromise();
+        return;
+      }
+
+      rejectPromise(
+        new Error(
+          `codex command exited before smoke timeout (code=${String(code)} signal=${String(signal)} stderr=${stderr.trim()})`,
+        ),
+      );
+    });
+  });
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`[integration] status=failed error=${message}\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a new manual, gated GitHub Actions workflow: `.github/workflows/athena-symphony-real-integration.yml`
- add `@athena/symphony-service` real integration smoke command: `test:integration:real`
- add `scripts/realIntegrationSmoke.ts` to execute real tracker/Codex smoke checks against a selected `WORKFLOW.md`
- add workflow-level credential/tooling preflight checks so runs fail fast with explicit errors when required inputs are missing
- update package docs and conformance tracking to include the real integration profile

## Why
- the Symphony spec recommends a real integration profile before production, but this should be opt-in and credential-gated so regular PR CI remains deterministic
- a dedicated manual workflow allows operational validation against real services without forcing external dependencies into unit-test pipelines
- scripting the smoke profile keeps validation reproducible locally and in CI using the same command surface

## Validation
- `LINEAR_API_KEY=dummy bun run --filter '@athena/symphony-service' test:integration:real WORKFLOW.md --linear=false --codex=false`
- `bunx tsc --noEmit -p packages/symphony-service/tsconfig.json`
- `bun run --filter '@athena/symphony-service' test`
- `bun run --filter '@athena/storefront-webapp' test`
