### PR TITLE
feat: add Athena package-aware Symphony workspace flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,33 @@
 let's go again
 
 ci-check-smoke: storefront workflow validation.
+
+## Running Symphony Against Athena Packages
+
+Symphony can orchestrate real package work in this monorepo using issue-scoped git worktrees.
+
+### Prerequisites
+
+- `LINEAR_API_KEY` exported in your environment.
+- `ATHENA_REPO_ROOT` exported and pointing to this repository root.
+- Linear issues labeled with one or more package labels:
+  - `pkg:athena-webapp`
+  - `pkg:storefront-webapp`
+  - `pkg:symphony-service`
+  - `pkg:valkey-proxy-server`
+
+### Start Symphony
+
+```bash
+export ATHENA_REPO_ROOT="$(pwd)"
+bun run symphony
+```
+
+Watch mode:
+
+```bash
+export ATHENA_REPO_ROOT="$(pwd)"
+bun run symphony:watch
+```
+
+See the detailed runbook in [docs/symphony-athena-packages.md](./docs/symphony-athena-packages.md).

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -7,6 +7,11 @@ polling:
   interval_ms: 30000
 workspace:
   root: $HOME/.athena/symphony-workspaces
+hooks:
+  after_create: bash /Users/kwamina/athena/scripts/symphony/after-create.sh
+  before_run: bash /Users/kwamina/athena/scripts/symphony/before-run.sh
+  before_remove: bash /Users/kwamina/athena/scripts/symphony/before-remove.sh
+  timeout_ms: 120000
 agent:
   max_concurrent_agents: 2
   max_retry_backoff_ms: 300000
@@ -21,4 +26,38 @@ You are working on issue {{ issue.identifier }}: {{ issue.title }}.
 State: {{ issue.state }}
 {% if attempt %}Attempt: {{ attempt }}{% endif %}
 
-Make focused, production-safe changes in this repository and run the narrowest useful validation.
+Repository root: /Users/kwamina/athena
+
+Package routing contract:
+- Use issue labels to determine scope.
+- Label mapping:
+  - pkg:athena-webapp -> packages/athena-webapp
+  - pkg:storefront-webapp -> packages/storefront-webapp
+  - pkg:symphony-service -> packages/symphony-service
+  - pkg:valkey-proxy-server -> packages/valkey-proxy-server
+- If multiple pkg:* labels are present, treat the issue as multi-package scope and validate all mapped packages.
+- If no recognized pkg:* label is present, infer scope from issue text and touched files.
+- Always include either explicit label-based scope or inferred scope in the PR summary.
+
+Validation policy:
+- Run the narrowest package-scoped checks first.
+- Escalate only when changes cross package boundaries or failures indicate broader impact.
+- Required validation matrix:
+  - pkg:athena-webapp:
+    - bun run --filter '@athena/webapp' test
+    - bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json
+  - pkg:storefront-webapp:
+    - bun run --filter '@athena/storefront-webapp' test
+    - bunx tsc --noEmit -p packages/storefront-webapp/tsconfig.json
+  - pkg:symphony-service:
+    - bun run --filter '@athena/symphony-service' test
+    - bunx tsc --noEmit -p packages/symphony-service/tsconfig.json
+  - pkg:valkey-proxy-server:
+    - npm --prefix packages/valkey-proxy-server run test:connection when env prerequisites are available
+    - if prerequisites are unavailable, report skip reason and run: node --check packages/valkey-proxy-server/index.js
+
+Execution requirements:
+- Make focused, production-safe changes in this repository.
+- Follow red-green where practical.
+- Use branch names with codex/ prefix.
+- PR body must include sections: Summary, Why, Validation.

--- a/docs/symphony-athena-packages.md
+++ b/docs/symphony-athena-packages.md
@@ -1,0 +1,115 @@
+# Symphony Athena Package Runbook
+
+This runbook explains how to operate Symphony against real Athena package code.
+
+## Required Environment
+
+- `LINEAR_API_KEY`: Linear API token used by tracker integration.
+- `ATHENA_REPO_ROOT`: absolute path to this repository root.
+
+Recommended setup from repo root:
+
+```bash
+export ATHENA_REPO_ROOT="$(pwd)"
+```
+
+## Label Taxonomy
+
+Use `pkg:*` labels on Linear issues:
+
+- `pkg:athena-webapp`
+- `pkg:storefront-webapp`
+- `pkg:symphony-service`
+- `pkg:valkey-proxy-server`
+
+If multiple `pkg:*` labels are present, Symphony treats scope as multi-package.
+
+If no recognized package label is present, scope is inferred from issue content and touched paths.
+
+## Local Commands
+
+Start service:
+
+```bash
+bun run symphony
+```
+
+Start with workflow reload watch:
+
+```bash
+bun run symphony:watch
+```
+
+## Validation Expectations
+
+Validation is package-scoped by label and defined in root `WORKFLOW.md`.
+
+- Webapp: `@athena/webapp` tests + TypeScript check.
+- Storefront: `@athena/storefront-webapp` tests + TypeScript check.
+- Symphony: `@athena/symphony-service` tests + TypeScript check.
+- Valkey proxy: connection test when env prerequisites are present; fallback to `node --check` with explicit skip reason when unavailable.
+
+## Hook Behavior Overview
+
+Hooks configured in `WORKFLOW.md`:
+
+- `after_create`: create/reuse git worktree from `origin/main` and ensure issue branch `codex/<issue-id>` exists.
+- `before_run`: verify git-backed workspace, enforce issue branch checkout, run `bun install` when `node_modules` is missing.
+- `before_remove`: remove/prune worktree metadata best effort.
+
+## Troubleshooting
+
+### Missing `ATHENA_REPO_ROOT`
+
+Symptoms:
+
+- `after_create` or `before_run` fails early with explicit hook error.
+
+Fix:
+
+```bash
+export ATHENA_REPO_ROOT="/absolute/path/to/athena"
+```
+
+### Invalid repo root
+
+Symptoms:
+
+- hook logs indicate `ATHENA_REPO_ROOT is not a git repository`.
+
+Fix:
+
+- point `ATHENA_REPO_ROOT` to the actual repo root.
+
+### Worktree add conflict
+
+Symptoms:
+
+- `git worktree add` fails (path already attached or stale metadata).
+
+Fix:
+
+```bash
+git -C "$ATHENA_REPO_ROOT" worktree list
+git -C "$ATHENA_REPO_ROOT" worktree prune
+```
+
+If needed, remove stale entry manually:
+
+```bash
+git -C "$ATHENA_REPO_ROOT" worktree remove --force <workspace-path>
+```
+
+### Valkey connection test unavailable
+
+Symptoms:
+
+- valkey connection test cannot run due to missing runtime prerequisites.
+
+Expected behavior:
+
+- Symphony should report skip reason and run fallback syntax check:
+
+```bash
+node --check packages/valkey-proxy-server/index.js
+```

--- a/packages/symphony-service/README.md
+++ b/packages/symphony-service/README.md
@@ -15,6 +15,7 @@ Spec-aligned Symphony service foundation for Athena.
 - Startup terminal workspace cleanup
 - CLI-hosted service loop with optional workflow watch/reload
 - Optional HTTP status server (`--port` or `server.port`) with dashboard + JSON APIs
+- Hook-driven git worktree provisioning for issue workspaces (`after_create`, `before_run`, `before_remove`)
 
 ## Specification tracking
 
@@ -38,3 +39,26 @@ bun run --filter '@athena/symphony-service' start --port 3000
 bun run --filter '@athena/symphony-service' test
 bun run --filter '@athena/symphony-service' test:integration:real WORKFLOW.md --linear=true --codex=false
 ```
+
+## Athena Package Routing Contract
+
+Package routing is driven by Linear labels and configured in the root `WORKFLOW.md` prompt:
+
+- `pkg:athena-webapp` -> `packages/athena-webapp`
+- `pkg:storefront-webapp` -> `packages/storefront-webapp`
+- `pkg:symphony-service` -> `packages/symphony-service`
+- `pkg:valkey-proxy-server` -> `packages/valkey-proxy-server`
+
+If labels are missing, scope is inferred from issue text and touched files, and must be documented in PR summary.
+
+## Workspace Hook Notes
+
+Root `WORKFLOW.md` uses:
+
+- `hooks.after_create: bash /Users/kwamina/athena/scripts/symphony/after-create.sh`
+- `hooks.before_run: bash /Users/kwamina/athena/scripts/symphony/before-run.sh`
+- `hooks.before_remove: bash /Users/kwamina/athena/scripts/symphony/before-remove.sh`
+
+These hooks require:
+
+- `ATHENA_REPO_ROOT` set to the athena repository root.

--- a/scripts/symphony/after-create.sh
+++ b/scripts/symphony/after-create.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+  printf '[symphony-hook after_create] %s\n' "$*" >&2
+}
+
+if [[ -z "${ATHENA_REPO_ROOT:-}" ]]; then
+  log 'ATHENA_REPO_ROOT is required'
+  exit 1
+fi
+
+REPO_ROOT="$(cd "$ATHENA_REPO_ROOT" && pwd)"
+WORKSPACE_PATH="$(pwd)"
+
+if ! git -C "$REPO_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  log "ATHENA_REPO_ROOT is not a git repository: $REPO_ROOT"
+  exit 1
+fi
+
+if git -C "$WORKSPACE_PATH" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  log "workspace already git-backed: $WORKSPACE_PATH"
+else
+  log "fetching origin/main in $REPO_ROOT"
+  git -C "$REPO_ROOT" fetch origin main --prune
+
+  log "adding git worktree at $WORKSPACE_PATH from origin/main"
+  git -C "$REPO_ROOT" worktree add --detach "$WORKSPACE_PATH" origin/main
+fi
+
+ISSUE_KEY="$(basename "$WORKSPACE_PATH")"
+BRANCH_SUFFIX="$(printf '%s' "$ISSUE_KEY" | sed -E 's/[^A-Za-z0-9._-]+/-/g')"
+BRANCH_SUFFIX="${BRANCH_SUFFIX#-}"
+BRANCH_SUFFIX="${BRANCH_SUFFIX%-}"
+if [[ -z "$BRANCH_SUFFIX" ]]; then
+  BRANCH_SUFFIX='issue'
+fi
+BRANCH_NAME="codex/$BRANCH_SUFFIX"
+
+if git -C "$WORKSPACE_PATH" show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
+  log "checking out existing local branch $BRANCH_NAME"
+  git -C "$WORKSPACE_PATH" checkout "$BRANCH_NAME"
+  exit 0
+fi
+
+if git -C "$REPO_ROOT" show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
+  log "checking out existing repo branch $BRANCH_NAME"
+  git -C "$WORKSPACE_PATH" checkout "$BRANCH_NAME"
+  exit 0
+fi
+
+log "creating branch $BRANCH_NAME"
+git -C "$WORKSPACE_PATH" checkout -b "$BRANCH_NAME"

--- a/scripts/symphony/before-remove.sh
+++ b/scripts/symphony/before-remove.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+  printf '[symphony-hook before_remove] %s\n' "$*" >&2
+}
+
+if [[ -z "${ATHENA_REPO_ROOT:-}" ]]; then
+  log 'ATHENA_REPO_ROOT is not set; skipping worktree cleanup'
+  exit 0
+fi
+
+REPO_ROOT="$(cd "$ATHENA_REPO_ROOT" && pwd)"
+WORKSPACE_PATH="$(pwd)"
+
+if ! git -C "$REPO_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  log "ATHENA_REPO_ROOT is not a git repository; skipping cleanup: $REPO_ROOT"
+  exit 0
+fi
+
+log "removing worktree metadata for $WORKSPACE_PATH"
+git -C "$REPO_ROOT" worktree remove --force "$WORKSPACE_PATH" >/dev/null 2>&1 || true
+
+log 'pruning stale worktree metadata'
+git -C "$REPO_ROOT" worktree prune >/dev/null 2>&1 || true

--- a/scripts/symphony/before-run.sh
+++ b/scripts/symphony/before-run.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+  printf '[symphony-hook before_run] %s\n' "$*" >&2
+}
+
+if [[ -z "${ATHENA_REPO_ROOT:-}" ]]; then
+  log 'ATHENA_REPO_ROOT is required'
+  exit 1
+fi
+
+REPO_ROOT="$(cd "$ATHENA_REPO_ROOT" && pwd)"
+WORKSPACE_PATH="$(pwd)"
+
+if ! git -C "$REPO_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  log "ATHENA_REPO_ROOT is not a git repository: $REPO_ROOT"
+  exit 1
+fi
+
+if ! git -C "$WORKSPACE_PATH" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  log "workspace is not git-backed: $WORKSPACE_PATH"
+  exit 1
+fi
+
+ISSUE_KEY="$(basename "$WORKSPACE_PATH")"
+BRANCH_SUFFIX="$(printf '%s' "$ISSUE_KEY" | sed -E 's/[^A-Za-z0-9._-]+/-/g')"
+BRANCH_SUFFIX="${BRANCH_SUFFIX#-}"
+BRANCH_SUFFIX="${BRANCH_SUFFIX%-}"
+if [[ -z "$BRANCH_SUFFIX" ]]; then
+  BRANCH_SUFFIX='issue'
+fi
+BRANCH_NAME="codex/$BRANCH_SUFFIX"
+
+CURRENT_BRANCH="$(git -C "$WORKSPACE_PATH" rev-parse --abbrev-ref HEAD || echo '')"
+if [[ "$CURRENT_BRANCH" != "$BRANCH_NAME" ]]; then
+  if git -C "$WORKSPACE_PATH" show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
+    log "switching to existing branch $BRANCH_NAME"
+    git -C "$WORKSPACE_PATH" checkout "$BRANCH_NAME"
+  else
+    log "creating missing branch $BRANCH_NAME"
+    git -C "$WORKSPACE_PATH" checkout -b "$BRANCH_NAME"
+  fi
+fi
+
+if [[ ! -d "$WORKSPACE_PATH/node_modules" ]]; then
+  log 'node_modules missing; running bun install'
+  (cd "$WORKSPACE_PATH" && bun install)
+else
+  log 'node_modules present; skipping bun install'
+fi


### PR DESCRIPTION
## Summary
- add Symphony workspace lifecycle hooks to provision and clean git worktrees:
  - `scripts/symphony/after-create.sh`
  - `scripts/symphony/before-run.sh`
  - `scripts/symphony/before-remove.sh`
- update root `WORKFLOW.md` front matter to wire hook commands and set `hooks.timeout_ms: 120000`
- replace workflow prompt contract with package-aware routing and scoped validation:
  - label mapping for `pkg:athena-webapp`, `pkg:storefront-webapp`, `pkg:symphony-service`, `pkg:valkey-proxy-server`
  - fallback inference policy when labels are missing
  - multi-package behavior for multiple labels
  - validation matrix per package including valkey fallback behavior
- document operation/runbook updates:
  - `README.md` section: **Running Symphony Against Athena Packages**
  - `packages/symphony-service/README.md` package routing + hook notes
  - new `docs/symphony-athena-packages.md` runbook (env, labels, commands, troubleshooting)

## Why
- issue execution should run against real Athena code instead of empty per-issue directories
- package-scoped routing and validations reduce over-testing while preserving safety
- standardized operator docs reduce setup drift and make hook/worktree failures diagnosable
- codifies existing team conventions (branch naming, PR quality expectations, scoped checks)

## Validation
- hook smoke (real local worktree lifecycle):
  - `after_create` created a worktree from `origin/main`
  - second `after_create` run was idempotent and reused the existing branch
  - `before_run` enforced branch and respected install guard (`node_modules` present => skip install)
  - `before_remove` removed worktree metadata and pruned stale entries
- script syntax check:
  - `bash -n scripts/symphony/after-create.sh scripts/symphony/before-run.sh scripts/symphony/before-remove.sh`
- regression checks:
  - `bun run --filter '@athena/symphony-service' test`
  - `bunx tsc --noEmit -p packages/symphony-service/tsconfig.json`
  - `bun run --filter '@athena/storefront-webapp' test`
