### PR TITLE
feat: enrich Symphony dashboard with live runtime state

### DIFF
--- a/packages/symphony-service/src/httpServer.ts
+++ b/packages/symphony-service/src/httpServer.ts
@@ -20,6 +20,43 @@ interface RefreshQueueState {
   inFlight: boolean;
 }
 
+interface StateApiResponse {
+  generated_at: string;
+  counts: {
+    running: number;
+    retrying: number;
+  };
+  running: Array<{
+    issue_id: string;
+    issue_identifier: string;
+    state: string;
+    session_id: string | null;
+    turn_count: number;
+    retry_attempt: number;
+    started_at: string;
+    last_event_at: string | null;
+    tokens: {
+      input_tokens: number;
+      output_tokens: number;
+      total_tokens: number;
+    };
+  }>;
+  retrying: Array<{
+    issue_id: string;
+    issue_identifier: string;
+    attempt: number;
+    due_at: string;
+    error: string;
+  }>;
+  codex_totals: {
+    input_tokens: number;
+    output_tokens: number;
+    total_tokens: number;
+    seconds_running: number;
+  };
+  rate_limits: Record<string, unknown> | null;
+}
+
 export async function startStatusServer(options: StartStatusServerOptions): Promise<StatusServer> {
   const host = options.host ?? "127.0.0.1";
   const refreshState: RefreshQueueState = {
@@ -64,8 +101,8 @@ async function handleRequest(
       return;
     }
 
-    const runtime = options.service.getRuntimeSnapshot();
-    const html = renderDashboardHtml(runtime);
+    const state = toStateResponse(options.service);
+    const html = renderDashboardHtml(state);
     sendText(response, 200, html, "text/html; charset=utf-8");
     return;
   }
@@ -161,7 +198,7 @@ async function drainRefreshQueue(options: StartStatusServerOptions, refreshState
   }
 }
 
-function toStateResponse(service: SymphonyService): Record<string, unknown> {
+function toStateResponse(service: SymphonyService): StateApiResponse {
   const runtime = service.getRuntimeSnapshot();
 
   return {
@@ -240,8 +277,8 @@ function toIssueResponse(
   };
 }
 
-function renderDashboardHtml(runtime: ReturnType<SymphonyService["getRuntimeSnapshot"]>): string {
-  const generatedAt = new Date().toISOString();
+function renderDashboardHtml(state: StateApiResponse): string {
+  const initialStateJson = safeJsonForScript(state);
 
   return `<!doctype html>
 <html lang="en">
@@ -250,27 +287,298 @@ function renderDashboardHtml(runtime: ReturnType<SymphonyService["getRuntimeSnap
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Symphony Status</title>
   <style>
-    body { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; margin: 24px; background: #0b0f14; color: #d8e0ea; }
-    h1 { margin: 0 0 12px; font-size: 20px; }
-    .card { border: 1px solid #263241; border-radius: 8px; padding: 12px; margin-bottom: 12px; background: #121922; }
-    .muted { color: #8aa1ba; }
-    code { color: #8dd3ff; }
+    :root {
+      color-scheme: dark;
+    }
+    body {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      margin: 24px;
+      background: #0b0f14;
+      color: #d8e0ea;
+    }
+    h1 {
+      margin: 0;
+      font-size: 20px;
+    }
+    h2 {
+      margin: 0 0 8px;
+      font-size: 15px;
+      color: #a9bfd8;
+    }
+    .topbar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      margin-bottom: 12px;
+    }
+    .controls {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+    button {
+      border: 1px solid #305075;
+      background: #12233a;
+      color: #d8e0ea;
+      border-radius: 6px;
+      padding: 6px 10px;
+      cursor: pointer;
+    }
+    button[disabled] {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+    .card {
+      border: 1px solid #263241;
+      border-radius: 8px;
+      padding: 12px;
+      margin-bottom: 12px;
+      background: #121922;
+    }
+    .stats {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(180px, 1fr));
+      gap: 8px;
+    }
+    .muted {
+      color: #8aa1ba;
+    }
+    code {
+      color: #8dd3ff;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 13px;
+    }
+    th, td {
+      border-bottom: 1px solid #233244;
+      text-align: left;
+      padding: 7px 6px;
+      vertical-align: top;
+    }
+    th {
+      color: #99b3cd;
+      font-weight: 600;
+    }
+    .empty {
+      color: #8aa1ba;
+      font-style: italic;
+    }
+    .split {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr);
+      gap: 12px;
+    }
+    pre {
+      margin: 0;
+      white-space: pre-wrap;
+      word-break: break-word;
+      font-size: 12px;
+      color: #b7cce1;
+    }
+    a {
+      color: #8dd3ff;
+      text-decoration: none;
+    }
+    a:hover {
+      text-decoration: underline;
+    }
+    @media (max-width: 860px) {
+      .stats {
+        grid-template-columns: 1fr;
+      }
+      .topbar {
+        flex-direction: column;
+        align-items: flex-start;
+      }
+    }
   </style>
 </head>
 <body>
-  <h1>Symphony Runtime Status</h1>
-  <div class="card">
-    <div>Generated: <span class="muted">${generatedAt}</span></div>
-    <div>Running: <code>${runtime.running.length}</code></div>
-    <div>Retrying: <code>${runtime.retrying.length}</code></div>
+  <div class="topbar">
+    <h1>Symphony Runtime Status</h1>
+    <div class="controls">
+      <button id="refresh-btn" type="button">Refresh Now</button>
+      <span class="muted" id="refresh-status"></span>
+    </div>
   </div>
   <div class="card">
-    <div>Total tokens: <code>${runtime.codex_totals.total_tokens}</code></div>
-    <div>Runtime seconds: <code>${runtime.codex_totals.seconds_running.toFixed(2)}</code></div>
-    <div>API: <code>/api/v1/state</code></div>
+    <div>Generated: <span class="muted" id="generated-at"></span></div>
+    <div class="stats">
+      <div>Running: <code id="count-running"></code></div>
+      <div>Retrying: <code id="count-retrying"></code></div>
+      <div>Total tokens: <code id="total-tokens"></code></div>
+      <div>Input tokens: <code id="input-tokens"></code></div>
+      <div>Output tokens: <code id="output-tokens"></code></div>
+      <div>Runtime seconds: <code id="runtime-seconds"></code></div>
+    </div>
   </div>
+  <div class="split">
+    <div class="card">
+      <h2>Running Issues</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Issue</th>
+            <th>State</th>
+            <th>Turns</th>
+            <th>Retry</th>
+            <th>Started</th>
+            <th>Last event</th>
+            <th>Tokens</th>
+            <th>Session</th>
+          </tr>
+        </thead>
+        <tbody id="running-body"></tbody>
+      </table>
+      <div id="running-empty" class="empty" style="display:none;">No running issues.</div>
+    </div>
+
+    <div class="card">
+      <h2>Retry Queue</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Issue</th>
+            <th>Attempt</th>
+            <th>Due at</th>
+            <th>Error</th>
+          </tr>
+        </thead>
+        <tbody id="retrying-body"></tbody>
+      </table>
+      <div id="retrying-empty" class="empty" style="display:none;">No retrying issues.</div>
+    </div>
+
+    <div class="card">
+      <h2>Rate Limits</h2>
+      <pre id="rate-limits"></pre>
+      <div class="muted">API endpoints: <code>/api/v1/state</code>, <code>/api/v1/refresh</code></div>
+    </div>
+  </div>
+  <script>
+    const initialState = ${initialStateJson};
+    const refreshBtn = document.getElementById("refresh-btn");
+    const refreshStatus = document.getElementById("refresh-status");
+
+    function esc(value) {
+      return String(value)
+        .replaceAll("&", "&amp;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;")
+        .replaceAll('"', "&quot;")
+        .replaceAll("'", "&#39;");
+    }
+
+    function formatDate(value) {
+      if (!value) return "—";
+      const date = new Date(value);
+      if (Number.isNaN(date.valueOf())) return esc(value);
+      return esc(date.toLocaleString());
+    }
+
+    function formatNumber(value) {
+      if (typeof value !== "number" || !Number.isFinite(value)) return "0";
+      return value.toLocaleString();
+    }
+
+    function renderRows(state) {
+      document.getElementById("generated-at").textContent = state.generated_at || "";
+      document.getElementById("count-running").textContent = formatNumber(state.counts?.running ?? 0);
+      document.getElementById("count-retrying").textContent = formatNumber(state.counts?.retrying ?? 0);
+      document.getElementById("total-tokens").textContent = formatNumber(state.codex_totals?.total_tokens ?? 0);
+      document.getElementById("input-tokens").textContent = formatNumber(state.codex_totals?.input_tokens ?? 0);
+      document.getElementById("output-tokens").textContent = formatNumber(state.codex_totals?.output_tokens ?? 0);
+      document.getElementById("runtime-seconds").textContent = Number(state.codex_totals?.seconds_running ?? 0).toFixed(2);
+
+      const running = Array.isArray(state.running) ? state.running : [];
+      const retrying = Array.isArray(state.retrying) ? state.retrying : [];
+
+      const runningBody = document.getElementById("running-body");
+      runningBody.innerHTML = running
+        .map((row) => \`<tr>
+          <td><a href="/api/v1/\${encodeURIComponent(row.issue_identifier)}">\${esc(row.issue_identifier)}</a></td>
+          <td>\${esc(row.state)}</td>
+          <td>\${formatNumber(row.turn_count)}</td>
+          <td>\${formatNumber(row.retry_attempt)}</td>
+          <td>\${formatDate(row.started_at)}</td>
+          <td>\${formatDate(row.last_event_at)}</td>
+          <td>\${formatNumber(row.tokens?.total_tokens ?? 0)}</td>
+          <td>\${esc(row.session_id ?? "—")}</td>
+        </tr>\`)
+        .join("");
+      document.getElementById("running-empty").style.display = running.length > 0 ? "none" : "block";
+
+      const retryingBody = document.getElementById("retrying-body");
+      retryingBody.innerHTML = retrying
+        .map((row) => \`<tr>
+          <td><a href="/api/v1/\${encodeURIComponent(row.issue_identifier)}">\${esc(row.issue_identifier)}</a></td>
+          <td>\${formatNumber(row.attempt)}</td>
+          <td>\${formatDate(row.due_at)}</td>
+          <td>\${esc(row.error)}</td>
+        </tr>\`)
+        .join("");
+      document.getElementById("retrying-empty").style.display = retrying.length > 0 ? "none" : "block";
+
+      const rateLimits = state.rate_limits == null ? "null" : JSON.stringify(state.rate_limits, null, 2);
+      document.getElementById("rate-limits").textContent = rateLimits;
+    }
+
+    async function fetchState() {
+      const response = await fetch("/api/v1/state");
+      if (!response.ok) {
+        throw new Error(\`state request failed: \${response.status}\`);
+      }
+      return await response.json();
+    }
+
+    async function refreshNow() {
+      refreshBtn.disabled = true;
+      refreshStatus.textContent = "refreshing...";
+      try {
+        const response = await fetch("/api/v1/refresh", { method: "POST" });
+        if (!response.ok) {
+          throw new Error(\`refresh request failed: \${response.status}\`);
+        }
+        const state = await fetchState();
+        renderRows(state);
+        refreshStatus.textContent = "updated";
+      } catch (error) {
+        refreshStatus.textContent = String(error instanceof Error ? error.message : error);
+      } finally {
+        refreshBtn.disabled = false;
+      }
+    }
+
+    async function pollState() {
+      try {
+        const state = await fetchState();
+        renderRows(state);
+      } catch (error) {
+        refreshStatus.textContent = String(error instanceof Error ? error.message : error);
+      }
+    }
+
+    refreshBtn.addEventListener("click", () => {
+      void refreshNow();
+    });
+
+    renderRows(initialState);
+    setInterval(() => {
+      void pollState();
+    }, 2000);
+  </script>
 </body>
 </html>`;
+}
+
+function safeJsonForScript(value: unknown): string {
+  return JSON.stringify(value)
+    .replace(/</g, "\\u003c")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
 }
 
 function toIso(epochMs: number): string {
@@ -333,4 +641,3 @@ function closeServer(server: Server): Promise<void> {
     });
   });
 }
-


### PR DESCRIPTION
## Summary
- upgrade the Symphony status dashboard (`GET /`) to surface the same runtime details exposed by `/api/v1/state`
- add rich dashboard sections for:
  - running/retrying counts and codex token/runtime totals
  - running issues table (state, turn count, retry attempt, start/last event timestamps, tokens, session id)
  - retry queue table (attempt, due time, error)
  - rate limits panel
- add in-dashboard controls:
  - `Refresh Now` button wired to `POST /api/v1/refresh`
  - periodic auto-poll every 2s from `GET /api/v1/state`
- keep existing API routes unchanged

## Why
- operators currently have to use curl + jq to inspect runtime state
- exposing the same data on `/` reduces friction for local and remote monitoring
- explicit refresh controls and automatic polling make issue progress/debugging faster during active runs

## Validation
- `bun run --filter '@athena/symphony-service' test`
- `bunx tsc --noEmit -p packages/symphony-service/tsconfig.json`
- manual behavior check:
  - open `/` and verify live running/retrying/tokens/rate-limit data
  - click `Refresh Now` and verify it triggers state update without curl
