### PR TITLE
feat: add Linear write-back and intake guardrails

### DIFF
--- a/packages/symphony-service/src/errors.ts
+++ b/packages/symphony-service/src/errors.ts
@@ -22,7 +22,8 @@ export type SymphonyErrorCode =
   | "linear_api_status"
   | "linear_graphql_errors"
   | "linear_unknown_payload"
-  | "linear_missing_end_cursor";
+  | "linear_missing_end_cursor"
+  | "guardrail_blocked";
 
 export class SymphonyError extends Error {
   readonly code: SymphonyErrorCode;

--- a/packages/symphony-service/src/issue.ts
+++ b/packages/symphony-service/src/issue.ts
@@ -8,7 +8,9 @@ export interface NormalizedIssue {
   id: string;
   identifier: string;
   title: string;
+  description?: string;
   state: string;
+  team_id?: string;
   priority: number | null;
   created_at: string;
   updated_at: string;
@@ -20,4 +22,6 @@ export interface TrackerClient {
   fetchCandidateIssues(): Promise<NormalizedIssue[]>;
   fetchIssuesByStates(stateNames: string[]): Promise<NormalizedIssue[]>;
   fetchIssueStatesByIds(issueIds: string[]): Promise<NormalizedIssue[]>;
+  createIssueComment?(input: { issueId: string; body: string }): Promise<void>;
+  updateIssueStateByName?(input: { issue: NormalizedIssue; stateName: string }): Promise<boolean>;
 }

--- a/packages/symphony-service/src/runtime.ts
+++ b/packages/symphony-service/src/runtime.ts
@@ -126,6 +126,10 @@ export async function runOrchestratorTick(input: RunOrchestratorTickInput): Prom
         error: message,
       });
 
+      if (isGuardrailBlockedError(error)) {
+        continue;
+      }
+
       scheduleRetry(input.state, {
         issueId: issue.id,
         identifier: issue.identifier,
@@ -146,6 +150,14 @@ export async function runOrchestratorTick(input: RunOrchestratorTickInput): Prom
     reconcileActions,
     stalledIssueIds,
   };
+}
+
+function isGuardrailBlockedError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  return (error as { code?: unknown }).code === "guardrail_blocked";
 }
 
 async function reconcileRunningIssues(input: RunOrchestratorTickInput): Promise<ReconcileAction[]> {

--- a/packages/symphony-service/src/service.ts
+++ b/packages/symphony-service/src/service.ts
@@ -1,8 +1,8 @@
 import type { FSWatcher } from "node:fs";
 import { resolveEffectiveConfig } from "./config";
 import { CodexAppServerClient, type CodexRuntimeEvent } from "./codex/client";
-import { toErrorMessage } from "./errors";
-import type { TrackerClient } from "./issue";
+import { SymphonyError, toErrorMessage } from "./errors";
+import type { NormalizedIssue, TrackerClient } from "./issue";
 import { createOrchestratorState, onWorkerExit, type ReconcileAction } from "./orchestrator";
 import { processDueRetries, runOrchestratorTick, type DispatchInput } from "./runtime";
 import { cleanupTerminalIssueWorkspaces } from "./startup";
@@ -14,6 +14,14 @@ import { loadWorkflowFile, watchWorkflowFile } from "./workflow";
 import { runIssueAttempt, type WorkerCodexClient } from "./worker";
 
 const RELOAD_DEBOUNCE_MS = 100;
+const REQUIRED_PACKAGE_LABELS = new Set([
+  "pkg:athena-webapp",
+  "pkg:storefront-webapp",
+  "pkg:symphony-service",
+  "pkg:valkey-proxy-server",
+]);
+const REQUIRED_PACKAGE_SUFFIXES = new Set(Array.from(REQUIRED_PACKAGE_LABELS).map((label) => label.replace(/^pkg:/, "")));
+const MIN_DESCRIPTION_LENGTH = 24;
 type IntervalHandle = ReturnType<typeof setInterval>;
 type TimeoutHandle = ReturnType<typeof setTimeout>;
 
@@ -147,6 +155,7 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
 
   const activeWorkers = new Map<string, ActiveWorker>();
   const workerTasks = new Set<Promise<void>>();
+  const guardrailNotifiedIssueIds = new Set<string>();
   let completedInputTokens = 0;
   let completedOutputTokens = 0;
   let completedTotalTokens = 0;
@@ -340,6 +349,111 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
     activeWorkers.delete(issueId);
   }
 
+  function evaluateGuardrails(issue: NormalizedIssue): string[] {
+    const problems: string[] = [];
+
+    if (!hasRecognizedPackageLabel(issue.labels)) {
+      problems.push(
+        "Missing package routing label. Add one of: pkg:athena-webapp, pkg:storefront-webapp, pkg:symphony-service, pkg:valkey-proxy-server.",
+      );
+    }
+
+    const trimmedDescription = (issue.description ?? "").trim();
+    if (trimmedDescription.length < MIN_DESCRIPTION_LENGTH) {
+      problems.push(
+        `Issue description is too short (${trimmedDescription.length} chars). Add concrete scope and acceptance criteria.`,
+      );
+    }
+
+    return problems;
+  }
+
+  async function publishGuardrailComment(trackerClient: TrackerClient, issue: NormalizedIssue, reasons: string[]): Promise<void> {
+    if (!trackerClient.createIssueComment) {
+      return;
+    }
+
+    const reasonLines = reasons.map((reason) => `- ${reason}`).join("\n");
+    const body = [
+      "Symphony paused automatic execution for this issue because intake guardrails are not met.",
+      "",
+      reasonLines,
+      "",
+      "After updating the issue details, trigger a refresh to resume scheduling.",
+    ].join("\n");
+
+    await safeTrackerWrite("guardrail_comment", issue, async () => {
+      await trackerClient.createIssueComment?.({
+        issueId: issue.id,
+        body,
+      });
+    });
+  }
+
+  async function moveIssueToInProgress(trackerClient: TrackerClient, issue: NormalizedIssue): Promise<void> {
+    if (!trackerClient.updateIssueStateByName) {
+      return;
+    }
+
+    await safeTrackerWrite("state_transition", issue, async () => {
+      const changed = await trackerClient.updateIssueStateByName?.({
+        issue,
+        stateName: "In Progress",
+      });
+
+      if (changed) {
+        emitLog({
+          level: "info",
+          message: "action=tracker_write outcome=completed kind=state_transition",
+          details: {
+            issue_id: issue.id,
+            issue_identifier: issue.identifier,
+            next_state: "In Progress",
+          },
+        });
+      }
+    });
+  }
+
+  async function publishRunComment(
+    trackerClient: TrackerClient,
+    issue: NormalizedIssue,
+    input: {
+      kind: "started" | "completed" | "failed";
+      attempt: number;
+      error?: string;
+    },
+  ): Promise<void> {
+    if (!trackerClient.createIssueComment) {
+      return;
+    }
+
+    const body = buildRunCommentBody(input);
+    await safeTrackerWrite(`run_${input.kind}`, issue, async () => {
+      await trackerClient.createIssueComment?.({
+        issueId: issue.id,
+        body,
+      });
+    });
+  }
+
+  async function safeTrackerWrite(kind: string, issue: NormalizedIssue, writer: () => Promise<void>): Promise<void> {
+    try {
+      await writer();
+    } catch (error) {
+      emitLog({
+        level: "warn",
+        message: "action=tracker_write outcome=failed",
+        details: {
+          kind,
+          issue_id: issue.id,
+          issue_identifier: issue.identifier,
+          error: toErrorMessage(error),
+        },
+      });
+    }
+  }
+
   async function dispatchIssue(input: DispatchInput): Promise<void> {
     if (!config || !tracker || !workflow) {
       throw new Error("service runtime is not initialized");
@@ -352,6 +466,23 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
     const runtimeConfig = config;
     const runtimeTracker = tracker;
     const runtimeWorkflow = workflow;
+    const guardrailProblems = evaluateGuardrails(input.issue);
+
+    if (guardrailProblems.length > 0) {
+      if (!guardrailNotifiedIssueIds.has(input.issue.id)) {
+        await publishGuardrailComment(runtimeTracker, input.issue, guardrailProblems);
+        guardrailNotifiedIssueIds.add(input.issue.id);
+      }
+
+      throw new SymphonyError("guardrail_blocked", `issue failed intake guardrails: ${guardrailProblems.join(" | ")}`);
+    }
+
+    guardrailNotifiedIssueIds.delete(input.issue.id);
+    await moveIssueToInProgress(runtimeTracker, input.issue);
+    await publishRunComment(runtimeTracker, input.issue, {
+      kind: "started",
+      attempt: input.attempt,
+    });
 
     const startedAtMs = deps.nowMs();
     const worker: ActiveWorker = {
@@ -395,20 +526,31 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
           });
         },
       })
-      .then(() => {
+      .then(async () => {
         onWorkerExit(state, {
           issueId: input.issue.id,
           nowMs: deps.nowMs(),
           reason: "normal",
           maxRetryBackoffMs: runtimeConfig.agent.maxRetryBackoffMs,
         });
+
+        await publishRunComment(runtimeTracker, input.issue, {
+          kind: "completed",
+          attempt: input.attempt,
+        });
       })
-      .catch((error) => {
+      .catch(async (error) => {
         onWorkerExit(state, {
           issueId: input.issue.id,
           nowMs: deps.nowMs(),
           reason: "failure",
           maxRetryBackoffMs: runtimeConfig.agent.maxRetryBackoffMs,
+          error: toErrorMessage(error),
+        });
+
+        await publishRunComment(runtimeTracker, input.issue, {
+          kind: "failed",
+          attempt: input.attempt,
           error: toErrorMessage(error),
         });
       })
@@ -711,6 +853,53 @@ function resolveDependencies(overrides: Partial<ServiceDependencies> | undefined
     },
     ...overrides,
   };
+}
+
+function hasRecognizedPackageLabel(labels: string[]): boolean {
+  for (const label of labels) {
+    const normalized = label.trim().toLowerCase();
+    if (!normalized) {
+      continue;
+    }
+
+    if (REQUIRED_PACKAGE_LABELS.has(normalized)) {
+      return true;
+    }
+
+    if (REQUIRED_PACKAGE_SUFFIXES.has(normalized)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function buildRunCommentBody(input: { kind: "started" | "completed" | "failed"; attempt: number; error?: string }): string {
+  const timestamp = new Date().toISOString();
+  const attemptText = `attempt ${input.attempt}`;
+
+  if (input.kind === "started") {
+    return [
+      `Symphony started work on this issue (${attemptText}).`,
+      "",
+      `Timestamp: ${timestamp}`,
+    ].join("\n");
+  }
+
+  if (input.kind === "completed") {
+    return [
+      `Symphony finished a run for this issue (${attemptText}).`,
+      "",
+      `Timestamp: ${timestamp}`,
+    ].join("\n");
+  }
+
+  return [
+    `Symphony run failed for this issue (${attemptText}).`,
+    "",
+    `Error: ${input.error ?? "unknown failure"}`,
+    `Timestamp: ${timestamp}`,
+  ].join("\n");
 }
 
 function formatLogValue(value: unknown): string {

--- a/packages/symphony-service/src/tracker/linear.ts
+++ b/packages/symphony-service/src/tracker/linear.ts
@@ -1,23 +1,15 @@
 import { SymphonyError } from "../errors";
 import type { NormalizedIssue, TrackerClient } from "../issue";
 
-const CANDIDATE_QUERY = `
-query FetchCandidateIssues($projectSlug: String!, $activeStates: [String!], $after: String, $first: Int!) {
-  issues(
-    filter: {
-      project: { slugId: { eq: $projectSlug } }
-      state: { name: { in: $activeStates } }
-    }
-    first: $first
-    after: $after
-  ) {
-    nodes {
+const ISSUE_NODE_FIELDS = `
       id
       identifier
       title
+      description
       priority
       createdAt
       updatedAt
+      team { id }
       state { name }
       labels { nodes { name } }
       relations {
@@ -30,6 +22,20 @@ query FetchCandidateIssues($projectSlug: String!, $activeStates: [String!], $aft
           }
         }
       }
+`;
+
+const CANDIDATE_QUERY = `
+query FetchCandidateIssues($projectSlug: String!, $activeStates: [String!], $after: String, $first: Int!) {
+  issues(
+    filter: {
+      project: { slugId: { eq: $projectSlug } }
+      state: { name: { in: $activeStates } }
+    }
+    first: $first
+    after: $after
+  ) {
+    nodes {
+${ISSUE_NODE_FIELDS}
     }
     pageInfo {
       hasNextPage
@@ -50,24 +56,7 @@ query FetchIssuesByStates($projectSlug: String!, $states: [String!], $after: Str
     after: $after
   ) {
     nodes {
-      id
-      identifier
-      title
-      priority
-      createdAt
-      updatedAt
-      state { name }
-      labels { nodes { name } }
-      relations {
-        nodes {
-          type
-          relatedIssue {
-            id
-            identifier
-            state { name }
-          }
-        }
-      }
+${ISSUE_NODE_FIELDS}
     }
     pageInfo {
       hasNextPage
@@ -81,29 +70,45 @@ const BY_IDS_QUERY = `
 query FetchIssueStatesByIds($issueIds: [ID!]!) {
   issues(filter: { id: { in: $issueIds } }, first: 250) {
     nodes {
-      id
-      identifier
-      title
-      priority
-      createdAt
-      updatedAt
-      state { name }
-      labels { nodes { name } }
-      relations {
-        nodes {
-          type
-          relatedIssue {
-            id
-            identifier
-            state { name }
-          }
-        }
-      }
+${ISSUE_NODE_FIELDS}
     }
     pageInfo {
       hasNextPage
       endCursor
     }
+  }
+}
+`;
+
+const FIND_WORKFLOW_STATE_ID_QUERY = `
+query FindWorkflowStateId($teamId: String!, $stateName: String!) {
+  workflowStates(
+    filter: {
+      team: { id: { eq: $teamId } }
+      name: { eq: $stateName }
+    }
+    first: 1
+  ) {
+    nodes {
+      id
+      name
+    }
+  }
+}
+`;
+
+const UPDATE_ISSUE_STATE_MUTATION = `
+mutation UpdateIssueState($issueId: String!, $stateId: String!) {
+  issueUpdate(id: $issueId, input: { stateId: $stateId }) {
+    success
+  }
+}
+`;
+
+const CREATE_COMMENT_MUTATION = `
+mutation CreateIssueComment($issueId: String!, $body: String!) {
+  commentCreate(input: { issueId: $issueId, body: $body }) {
+    success
   }
 }
 `;
@@ -133,6 +138,24 @@ interface IssueConnection {
   };
 }
 
+interface WorkflowStateConnection {
+  workflowStates?: {
+    nodes?: unknown[];
+  };
+}
+
+interface IssueUpdatePayload {
+  issueUpdate?: {
+    success?: boolean;
+  };
+}
+
+interface CommentCreatePayload {
+  commentCreate?: {
+    success?: boolean;
+  };
+}
+
 export class LinearTrackerClient implements TrackerClient {
   private readonly endpoint: string;
   private readonly apiKey: string;
@@ -141,6 +164,7 @@ export class LinearTrackerClient implements TrackerClient {
   private readonly timeoutMs: number;
   private readonly pageSize: number;
   private readonly fetchImpl: typeof fetch;
+  private readonly stateNameIdCache = new Map<string, string>();
 
   constructor(options: LinearClientOptions) {
     this.endpoint = options.endpoint;
@@ -187,6 +211,40 @@ export class LinearTrackerClient implements TrackerClient {
     return nodes.map(normalizeIssue).filter((issue): issue is NormalizedIssue => issue !== null);
   }
 
+  async createIssueComment(input: { issueId: string; body: string }): Promise<void> {
+    const response = await this.graphqlRequest<CommentCreatePayload>(CREATE_COMMENT_MUTATION, {
+      issueId: input.issueId,
+      body: input.body,
+    });
+
+    if (!response.commentCreate?.success) {
+      throw new SymphonyError("linear_unknown_payload", "Linear commentCreate returned unsuccessful response");
+    }
+  }
+
+  async updateIssueStateByName(input: { issue: NormalizedIssue; stateName: string }): Promise<boolean> {
+    const teamId = (input.issue.team_id ?? "").trim();
+    if (!teamId) {
+      return false;
+    }
+
+    if (input.issue.state.trim().toLowerCase() === input.stateName.trim().toLowerCase()) {
+      return false;
+    }
+
+    const stateId = await this.resolveWorkflowStateIdByName(teamId, input.stateName);
+    if (!stateId) {
+      return false;
+    }
+
+    const response = await this.graphqlRequest<IssueUpdatePayload>(UPDATE_ISSUE_STATE_MUTATION, {
+      issueId: input.issue.id,
+      stateId,
+    });
+
+    return Boolean(response.issueUpdate?.success);
+  }
+
   private async fetchPaginatedIssues(
     query: string,
     baseVariables: Record<string, unknown>,
@@ -225,6 +283,32 @@ export class LinearTrackerClient implements TrackerClient {
 
       after = endCursor;
     }
+  }
+
+  private async resolveWorkflowStateIdByName(teamId: string, stateName: string): Promise<string | null> {
+    const cacheKey = `${teamId}:${stateName.toLowerCase()}`;
+    const cached = this.stateNameIdCache.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    const response = await this.graphqlRequest<WorkflowStateConnection>(FIND_WORKFLOW_STATE_ID_QUERY, {
+      teamId,
+      stateName,
+    });
+
+    const firstNode = response.workflowStates?.nodes?.[0];
+    if (!firstNode || typeof firstNode !== "object") {
+      return null;
+    }
+
+    const id = asString((firstNode as { id?: unknown }).id);
+    if (!id) {
+      return null;
+    }
+
+    this.stateNameIdCache.set(cacheKey, id);
+    return id;
   }
 
   private async graphqlRequest<T>(query: string, variables: Record<string, unknown>): Promise<T> {
@@ -282,7 +366,9 @@ function normalizeIssue(raw: unknown): NormalizedIssue | null {
   const id = asString(node.id);
   const identifier = asString(node.identifier);
   const title = asString(node.title);
+  const description = asString(node.description);
   const state = asString((node.state as { name?: unknown } | undefined)?.name);
+  const teamId = asString((node.team as { id?: unknown } | undefined)?.id);
 
   if (!id || !identifier || !title || !state) {
     return null;
@@ -292,7 +378,9 @@ function normalizeIssue(raw: unknown): NormalizedIssue | null {
     id,
     identifier,
     title,
+    description,
     state,
+    team_id: teamId || undefined,
     priority: normalizePriority(node.priority),
     created_at: normalizeIso(node.createdAt),
     updated_at: normalizeIso(node.updatedAt),

--- a/packages/symphony-service/tests/linearTracker.test.ts
+++ b/packages/symphony-service/tests/linearTracker.test.ts
@@ -171,4 +171,94 @@ describe("LinearTrackerClient", () => {
       expect((error as SymphonyError).code).toBe("linear_unknown_payload");
     }
   });
+
+  it("creates issue comments through commentCreate mutation", async () => {
+    const { fetchMock, calls } = makeFetch([
+      {
+        data: {
+          commentCreate: {
+            success: true,
+          },
+        },
+      },
+    ]);
+
+    const client = clientWith(fetchMock);
+    await client.createIssueComment?.({
+      issueId: "issue-1",
+      body: "hello",
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.body?.query).toContain("commentCreate");
+    expect(calls[0]?.body?.variables).toMatchObject({
+      issueId: "issue-1",
+      body: "hello",
+    });
+  });
+
+  it("updates issue state by name when team id is present", async () => {
+    const { fetchMock, calls } = makeFetch([
+      {
+        data: {
+          workflowStates: {
+            nodes: [{ id: "state-in-progress", name: "In Progress" }],
+          },
+        },
+      },
+      {
+        data: {
+          issueUpdate: {
+            success: true,
+          },
+        },
+      },
+    ]);
+
+    const client = clientWith(fetchMock);
+    const changed = await client.updateIssueStateByName?.({
+      issue: {
+        id: "issue-2",
+        identifier: "ATH-2",
+        title: "state move",
+        description: "desc",
+        state: "Todo",
+        team_id: "team-1",
+        priority: 1,
+        created_at: "2026-01-01T00:00:00.000Z",
+        updated_at: "2026-01-01T00:00:00.000Z",
+        labels: [],
+        blocked_by: [],
+      },
+      stateName: "In Progress",
+    });
+
+    expect(changed).toBe(true);
+    expect(calls).toHaveLength(2);
+    expect(calls[0]?.body?.query).toContain("workflowStates");
+    expect(calls[1]?.body?.query).toContain("issueUpdate");
+  });
+
+  it("skips issue state update when team id is missing", async () => {
+    const { fetchMock, calls } = makeFetch([]);
+    const client = clientWith(fetchMock);
+
+    const changed = await client.updateIssueStateByName?.({
+      issue: {
+        id: "issue-3",
+        identifier: "ATH-3",
+        title: "no team",
+        state: "Todo",
+        priority: 1,
+        created_at: "2026-01-01T00:00:00.000Z",
+        updated_at: "2026-01-01T00:00:00.000Z",
+        labels: [],
+        blocked_by: [],
+      },
+      stateName: "In Progress",
+    });
+
+    expect(changed).toBe(false);
+    expect(calls).toHaveLength(0);
+  });
 });

--- a/packages/symphony-service/tests/runtime.test.ts
+++ b/packages/symphony-service/tests/runtime.test.ts
@@ -165,6 +165,31 @@ describe("runOrchestratorTick", () => {
     expect(state.running.has("todo-1")).toBe(false);
   });
 
+  it("does not schedule retry when dispatch is blocked by guardrail", async () => {
+    const state = createOrchestratorState();
+
+    const result = await runOrchestratorTick({
+      state,
+      tracker: new FakeTracker([issue({ id: "todo-guardrail", identifier: "ATH-99", state: "Todo" })]),
+      config: config(),
+      nowMs: 500,
+      dispatchIssue: async () => {
+        const error = new Error("guardrail");
+        (error as Error & { code?: string }).code = "guardrail_blocked";
+        throw error;
+      },
+    });
+
+    expect(result.dispatchErrors).toEqual([
+      {
+        issueId: "todo-guardrail",
+        error: "guardrail",
+      },
+    ]);
+    expect(state.retryAttempts.size).toBe(0);
+    expect(state.running.size).toBe(0);
+  });
+
   it("queues failure retry for stalled running issues", async () => {
     const state = createOrchestratorState();
     markIssueRunning(

--- a/packages/symphony-service/tests/service.test.ts
+++ b/packages/symphony-service/tests/service.test.ts
@@ -23,11 +23,14 @@ function issue(partial: Partial<NormalizedIssue>): NormalizedIssue {
     id: partial.id ?? "1",
     identifier: partial.identifier ?? "ATH-1",
     title: partial.title ?? "Issue",
+    description:
+      partial.description ?? "Implement the requested change with clear acceptance criteria and validation details.",
     state: partial.state ?? "Todo",
+    team_id: partial.team_id,
     priority: partial.priority ?? 1,
     created_at: partial.created_at ?? "2026-01-01T00:00:00.000Z",
     updated_at: partial.updated_at ?? "2026-01-01T00:00:00.000Z",
-    labels: partial.labels ?? [],
+    labels: partial.labels ?? ["pkg:symphony-service"],
     blocked_by: partial.blocked_by ?? [],
   };
 }
@@ -510,6 +513,130 @@ describe("createSymphonyService", () => {
       error: "boom",
     });
     expect(snapshot.retrying[0]!.due_at_ms).toBe(nowMs + 10_000);
+
+    await service.stop();
+  });
+
+  it("writes back tracker comments and moves issue to In Progress on dispatch", async () => {
+    const comments: string[] = [];
+    const transitioned: string[] = [];
+    const candidates = [
+      issue({
+        id: "writeback-1",
+        identifier: "ATH-777",
+        state: "Todo",
+        labels: ["pkg:storefront-webapp"],
+        description: "Implement product search with clear acceptance criteria and validation steps.",
+        team_id: "team-1",
+      }),
+    ];
+
+    const service = createSymphonyService({
+      workflowPath: "/tmp/WORKFLOW.md",
+      deps: {
+        loadWorkflowFile: async () => workflow(1000),
+        createTracker: () => ({
+          async fetchCandidateIssues() {
+            return candidates.splice(0, candidates.length);
+          },
+          async fetchIssuesByStates() {
+            return [];
+          },
+          async fetchIssueStatesByIds() {
+            return [];
+          },
+          async createIssueComment(input) {
+            comments.push(input.body);
+          },
+          async updateIssueStateByName(input) {
+            transitioned.push(`${input.issue.identifier}:${input.stateName}`);
+            return true;
+          },
+        }),
+        cleanupTerminalIssueWorkspaces: async () => ({ removed: 0, failed: 0, warnings: [] }),
+        processDueRetries: async () => ({
+          processedIssueIds: [],
+          dispatchedIssueIds: [],
+          requeuedIssueIds: [],
+          releasedIssueIds: [],
+        }),
+        setIntervalFn: () => 1 as unknown as ReturnType<typeof setInterval>,
+        clearIntervalFn: () => {},
+        runIssueAttempt: async (input) => ({
+          exit: "normal" as const,
+          turnCount: 1,
+          workspacePath: "/tmp/fake",
+          issue: input.issue,
+        }),
+      },
+    });
+
+    await service.start();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(transitioned).toEqual(["ATH-777:In Progress"]);
+    expect(comments.some((entry) => entry.includes("started work"))).toBe(true);
+    expect(comments.some((entry) => entry.includes("finished a run"))).toBe(true);
+
+    await service.stop();
+  });
+
+  it("blocks issues that fail intake guardrails and comments once", async () => {
+    const comments: string[] = [];
+    const runIssueAttempt = vi.fn(async (input: any) => ({
+      exit: "normal" as const,
+      turnCount: 0,
+      workspacePath: "/tmp/fake",
+      issue: input.issue,
+    }));
+
+    const candidateIssue = issue({
+      id: "guardrail-1",
+      identifier: "ATH-778",
+      state: "Todo",
+      labels: [],
+      description: "short",
+    });
+
+    const service = createSymphonyService({
+      workflowPath: "/tmp/WORKFLOW.md",
+      deps: {
+        loadWorkflowFile: async () => workflow(1000),
+        createTracker: () => ({
+          async fetchCandidateIssues() {
+            return [candidateIssue];
+          },
+          async fetchIssuesByStates() {
+            return [];
+          },
+          async fetchIssueStatesByIds() {
+            return [];
+          },
+          async createIssueComment(input) {
+            comments.push(input.body);
+          },
+        }),
+        cleanupTerminalIssueWorkspaces: async () => ({ removed: 0, failed: 0, warnings: [] }),
+        processDueRetries: async () => ({
+          processedIssueIds: [],
+          dispatchedIssueIds: [],
+          requeuedIssueIds: [],
+          releasedIssueIds: [],
+        }),
+        setIntervalFn: () => 1 as unknown as ReturnType<typeof setInterval>,
+        clearIntervalFn: () => {},
+        runIssueAttempt: runIssueAttempt as any,
+      },
+    });
+
+    await service.start();
+    await service.runTickOnce();
+
+    expect(runIssueAttempt).not.toHaveBeenCalled();
+    expect(comments).toHaveLength(1);
+    expect(comments[0]).toContain("guardrails");
+    expect(service.getRuntimeSnapshot().retrying).toHaveLength(0);
 
     await service.stop();
   });


### PR DESCRIPTION
## Summary
- extend Symphony tracker contract with optional write-back methods:
  - `createIssueComment`
  - `updateIssueStateByName`
- implement Linear write-back in `LinearTrackerClient`:
  - `commentCreate` mutation for run/guardrail comments
  - `issueUpdate` mutation (via workflow state lookup by team + state name) to move selected issues to `In Progress`
- add intake guardrails before dispatch in service runtime:
  - require recognized package label (`pkg:*` contract, with tolerance for display-normalized label suffixes)
  - require non-trivial issue description length
  - on guardrail failure: post one Linear comment, block execution, and avoid retry churn
- update orchestrator runtime behavior to treat `guardrail_blocked` as non-retryable
- extend tests across service/runtime/tracker for write-back and guardrail behavior

## Why
- operators need visible issue-level activity in Linear when Symphony starts, finishes, or fails a run
- automation should not execute on underspecified tickets; vague/no-scope issues should be explicitly paused with actionable feedback
- repeated retries for intake problems add noise and hide true runtime failures, so guardrail blocks must be non-retryable

## Validation
- `bun run --filter '@athena/symphony-service' test`
- `bunx tsc --noEmit -p packages/symphony-service/tsconfig.json`
- new/updated assertions cover:
  - tracker write-back mutations (`commentCreate`, `issueUpdate`)
  - non-retryable guardrail dispatch behavior
  - service-level write-back sequencing + one-time guardrail commenting
