### PR TITLE
fix: rehydrate stale Symphony issue workspaces

### DIFF
--- a/packages/symphony-service/src/workspace.ts
+++ b/packages/symphony-service/src/workspace.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { mkdir, rm, stat } from "node:fs/promises";
-import { resolve, sep } from "node:path";
+import { join, resolve, sep } from "node:path";
 import { SymphonyError, toErrorMessage } from "./errors";
 
 export interface WorkspaceHooksConfig {
@@ -33,7 +33,8 @@ export async function ensureWorkspaceForIssue(
   await mkdir(location.path, { recursive: true });
 
   const createdNow = !existed;
-  if (createdNow && config.hooks.afterCreate?.trim()) {
+  const missingGitMetadata = !(await pathExists(join(location.path, ".git")));
+  if ((createdNow || missingGitMetadata) && config.hooks.afterCreate?.trim()) {
     await runRequiredHook(config, location.path, "after_create", config.hooks.afterCreate);
   }
 

--- a/packages/symphony-service/tests/workspace.test.ts
+++ b/packages/symphony-service/tests/workspace.test.ts
@@ -51,7 +51,7 @@ describe("workspace lifecycle", () => {
     const root = await mkdtemp(join(tmpdir(), "symphony-workspace-hook-"));
     const marker = join(root, "marker.txt");
 
-    const hook = `echo created > ${JSON.stringify(marker)}`;
+    const hook = `echo created > ${JSON.stringify(marker)} && touch .git`;
     await ensureWorkspaceForIssue(
       {
         root,
@@ -78,6 +78,28 @@ describe("workspace lifecycle", () => {
 
     const current = await readFile(marker, "utf8");
     expect(current.trim()).toBe("mutated");
+  });
+
+  it("rehydrates existing non-git workspaces by rerunning after_create", async () => {
+    const root = await mkdtemp(join(tmpdir(), "symphony-workspace-rehydrate-"));
+    const marker = join(root, "rehydrated.txt");
+    const workspace = resolve(root, "ATH-106");
+    await mkdir(workspace, { recursive: true });
+
+    const result = await ensureWorkspaceForIssue(
+      {
+        root,
+        hooks: {
+          timeoutMs: 2000,
+          afterCreate: `echo rehydrated > ${JSON.stringify(marker)}`,
+        },
+      },
+      "ATH-106",
+    );
+
+    expect(result.createdNow).toBe(false);
+    const current = await readFile(marker, "utf8");
+    expect(current.trim()).toBe("rehydrated");
   });
 
   it("treats after_create failure as fatal", async () => {


### PR DESCRIPTION
## Summary
- make workspace hydration resilient by rerunning `after_create` when an issue workspace exists but is not git-backed
- preserve normal idempotent behavior for healthy git-backed workspaces
- add a regression test covering stale/non-git workspace recovery in `workspace.test.ts`

## Why
- Symphony can fall into retry loops when a workspace directory exists without a proper git worktree checkout
- automatic rehydration removes the need for manual workspace deletion to recover
- this turns a brittle startup condition into a self-healing path

## Validation
- `bun run --filter '@athena/symphony-service' test tests/workspace.test.ts`
- `bun run --filter '@athena/symphony-service' test`
- `bunx tsc --noEmit -p packages/symphony-service/tsconfig.json`
