### PR TITLE
fix: restore Linear issue state write-back

### DIFF
--- a/packages/symphony-service/src/tracker/linear.ts
+++ b/packages/symphony-service/src/tracker/linear.ts
@@ -81,7 +81,7 @@ ${ISSUE_NODE_FIELDS}
 `;
 
 const FIND_WORKFLOW_STATE_ID_QUERY = `
-query FindWorkflowStateId($teamId: String!, $stateName: String!) {
+query FindWorkflowStateId($teamId: ID!, $stateName: String!) {
   workflowStates(
     filter: {
       team: { id: { eq: $teamId } }
@@ -98,7 +98,7 @@ query FindWorkflowStateId($teamId: String!, $stateName: String!) {
 `;
 
 const UPDATE_ISSUE_STATE_MUTATION = `
-mutation UpdateIssueState($issueId: String!, $stateId: String!) {
+mutation UpdateIssueState($issueId: String!, $stateId: String) {
   issueUpdate(id: $issueId, input: { stateId: $stateId }) {
     success
   }

--- a/packages/symphony-service/tests/linearTracker.test.ts
+++ b/packages/symphony-service/tests/linearTracker.test.ts
@@ -236,7 +236,10 @@ describe("LinearTrackerClient", () => {
     expect(changed).toBe(true);
     expect(calls).toHaveLength(2);
     expect(calls[0]?.body?.query).toContain("workflowStates");
+    expect(calls[0]?.body?.query).toContain("$teamId: ID!");
     expect(calls[1]?.body?.query).toContain("issueUpdate");
+    expect(calls[1]?.body?.query).toContain("$issueId: String!");
+    expect(calls[1]?.body?.query).toContain("$stateId: String");
   });
 
   it("skips issue state update when team id is missing", async () => {


### PR DESCRIPTION
## Summary
- fix Linear workflow-state lookup to use `ID!` for `teamId` in the `workflowStates` query
- keep `issueUpdate` mutation variable types aligned with Linear schema (`issueId: String!`, `stateId: String`)
- add regression assertions in `linearTracker.test.ts` to lock query variable contracts for state write-back

## Why
- Symphony was failing to move active issues from `Todo` to `In Progress` because GraphQL variable types in the Linear adapter did not match Linear’s schema
- the failure was silently swallowed by `safeTrackerWrite`, so runs continued while issue state stayed stale
- this restores deterministic tracker write-back behavior for active runs

## Validation
- `bun run --filter '@athena/symphony-service' test tests/linearTracker.test.ts`
- `bun run --filter '@athena/symphony-service' test`
- `bunx tsc --noEmit -p packages/symphony-service/tsconfig.json`
- real API verification: `updateIssueStateByName` changed `V26-162` from `Todo` to `In Progress`
