### PR TITLE
feat: add operator done-signal contract to Symphony runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,5 @@ bun run symphony:watch
 ```
 
 See the detailed runbook in [docs/symphony-athena-packages.md](./docs/symphony-athena-packages.md).
+
+Symphony runtime status includes running/retrying plus delivery-complete issue signals via the status dashboard/API.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -3,6 +3,7 @@ tracker:
   kind: linear
   api_key: $LINEAR_API_KEY
   project_slug: 22769268c360
+  handoff_state: Human Review
 polling:
   interval_ms: 30000
 workspace:
@@ -65,3 +66,5 @@ Execution requirements:
 - Follow red-green where practical.
 - Use branch names with codex/ prefix.
 - PR body must include sections: Summary, Why, Validation.
+- When implementation is complete, move the issue to the handoff state (`Human Review`) or `Done` if handoff is unavailable.
+- Add a completion update that includes: PR link, package scope, validation commands/results, and any unresolved risks.

--- a/docs/symphony-athena-packages.md
+++ b/docs/symphony-athena-packages.md
@@ -49,6 +49,15 @@ Validation is package-scoped by label and defined in root `WORKFLOW.md`.
 - Symphony: `@athena/symphony-service` tests + TypeScript check.
 - Valkey proxy: connection test when env prerequisites are present; fallback to `node --check` with explicit skip reason when unavailable.
 
+## Done Signal and Operator Readiness
+
+- Configure `tracker.handoff_state` in `WORKFLOW.md` (default: `Human Review`).
+- Symphony records a delivery-complete signal when issue state is handoff or terminal.
+- Operator-facing checks:
+  - Dashboard/API: `GET /api/v1/state` shows `completed` entries.
+  - Per-issue API: `GET /api/v1/<issue_identifier>` may return `status: "completed"`.
+  - Tracker comment includes completion details and operator checklist.
+
 ## Hook Behavior Overview
 
 Hooks configured in `WORKFLOW.md`:

--- a/packages/symphony-service/README.md
+++ b/packages/symphony-service/README.md
@@ -30,6 +30,9 @@ When enabled (`--port` or `server.port` in `WORKFLOW.md`), the service exposes:
 - `GET /api/v1/<issue_identifier>`
 - `POST /api/v1/refresh`
 
+`/api/v1/state` now includes `completed` delivery signals (issue, final state, attempt, observed timestamp), and
+`/api/v1/<issue_identifier>` can return `status: "completed"` when a done signal is present in runtime state.
+
 ## Commands
 
 ```bash
@@ -50,6 +53,13 @@ Package routing is driven by Linear labels and configured in the root `WORKFLOW.
 - `pkg:valkey-proxy-server` -> `packages/valkey-proxy-server`
 
 If labels are missing, scope is inferred from issue text and touched files, and must be documented in PR summary.
+
+## Done Signal Contract
+
+- Configure tracker handoff state via `tracker.handoff_state` in `WORKFLOW.md` (default: `Human Review`).
+- Symphony records a delivery-complete signal when a run exits with issue state equal to handoff state
+  or any terminal state.
+- On signal, Symphony writes a structured tracker comment so operators can quickly verify delivery status.
 
 ## Workspace Hook Notes
 

--- a/packages/symphony-service/src/config.ts
+++ b/packages/symphony-service/src/config.ts
@@ -20,6 +20,7 @@ export function resolveEffectiveConfig(config: WorkflowConfigMap): EffectiveConf
 
   const trackerApiKey = resolveEnvReference(asString(tracker.api_key));
   const trackerProjectSlug = asString(tracker.project_slug);
+  const trackerHandoffState = asString(tracker.handoff_state)?.trim() || "Human Review";
 
   return {
     tracker: {
@@ -27,6 +28,7 @@ export function resolveEffectiveConfig(config: WorkflowConfigMap): EffectiveConf
       endpoint: trackerEndpoint,
       apiKey: trackerApiKey || undefined,
       projectSlug: trackerProjectSlug || undefined,
+      handoffState: trackerHandoffState,
       activeStates: asStringArray(tracker.active_states) ?? defaultActiveStates,
       terminalStates: asStringArray(tracker.terminal_states) ?? defaultTerminalStates,
     },

--- a/packages/symphony-service/src/httpServer.ts
+++ b/packages/symphony-service/src/httpServer.ts
@@ -25,6 +25,7 @@ interface StateApiResponse {
   counts: {
     running: number;
     retrying: number;
+    completed: number;
   };
   running: Array<{
     issue_id: string;
@@ -47,6 +48,14 @@ interface StateApiResponse {
     attempt: number;
     due_at: string;
     error: string;
+  }>;
+  completed: Array<{
+    issue_id: string;
+    issue_identifier: string;
+    state: string;
+    attempt: number;
+    observed_at: string;
+    done: boolean;
   }>;
   codex_totals: {
     input_tokens: number;
@@ -206,6 +215,7 @@ function toStateResponse(service: SymphonyService): StateApiResponse {
     counts: {
       running: runtime.running.length,
       retrying: runtime.retrying.length,
+      completed: runtime.completed.length,
     },
     running: runtime.running.map((row) => ({
       issue_id: row.issue_id,
@@ -229,6 +239,14 @@ function toStateResponse(service: SymphonyService): StateApiResponse {
       due_at: toIso(row.due_at_ms),
       error: row.error,
     })),
+    completed: runtime.completed.map((row) => ({
+      issue_id: row.issue_id,
+      issue_identifier: row.issue_identifier,
+      state: row.state,
+      attempt: row.attempt,
+      observed_at: toIso(row.observed_at_ms),
+      done: row.done,
+    })),
     codex_totals: runtime.codex_totals,
     rate_limits: runtime.rate_limits,
   };
@@ -241,15 +259,16 @@ function toIssueResponse(
   const runtime = service.getRuntimeSnapshot();
   const running = runtime.running.find((row) => row.issue_identifier === issueIdentifier);
   const retry = runtime.retrying.find((row) => row.issue_identifier === issueIdentifier);
+  const completed = runtime.completed.find((row) => row.issue_identifier === issueIdentifier);
 
-  if (!running && !retry) {
+  if (!running && !retry && !completed) {
     return null;
   }
 
   return {
     issue_identifier: issueIdentifier,
-    issue_id: running?.issue_id ?? retry?.issue_id ?? "",
-    status: running ? "running" : "retrying",
+    issue_id: running?.issue_id ?? retry?.issue_id ?? completed?.issue_id ?? "",
+    status: running ? "running" : retry ? "retrying" : "completed",
     running: running
       ? {
           state: running.state,
@@ -270,6 +289,14 @@ function toIssueResponse(
           attempt: retry.attempt,
           due_at: toIso(retry.due_at_ms),
           error: retry.error,
+        }
+      : null,
+    completed: completed
+      ? {
+          state: completed.state,
+          attempt: completed.attempt,
+          observed_at: toIso(completed.observed_at_ms),
+          done: completed.done,
         }
       : null,
     codex_totals: runtime.codex_totals,
@@ -409,6 +436,7 @@ function renderDashboardHtml(state: StateApiResponse): string {
     <div class="stats">
       <div>Running: <code id="count-running"></code></div>
       <div>Retrying: <code id="count-retrying"></code></div>
+      <div>Completed: <code id="count-completed"></code></div>
       <div>Total tokens: <code id="total-tokens"></code></div>
       <div>Input tokens: <code id="input-tokens"></code></div>
       <div>Output tokens: <code id="output-tokens"></code></div>
@@ -453,6 +481,23 @@ function renderDashboardHtml(state: StateApiResponse): string {
     </div>
 
     <div class="card">
+      <h2>Completed Signals</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Issue</th>
+            <th>State</th>
+            <th>Attempt</th>
+            <th>Observed at</th>
+            <th>Done</th>
+          </tr>
+        </thead>
+        <tbody id="completed-body"></tbody>
+      </table>
+      <div id="completed-empty" class="empty" style="display:none;">No completed signals yet.</div>
+    </div>
+
+    <div class="card">
       <h2>Rate Limits</h2>
       <pre id="rate-limits"></pre>
       <div class="muted">API endpoints: <code>/api/v1/state</code>, <code>/api/v1/refresh</code></div>
@@ -488,6 +533,7 @@ function renderDashboardHtml(state: StateApiResponse): string {
       document.getElementById("generated-at").textContent = state.generated_at || "";
       document.getElementById("count-running").textContent = formatNumber(state.counts?.running ?? 0);
       document.getElementById("count-retrying").textContent = formatNumber(state.counts?.retrying ?? 0);
+      document.getElementById("count-completed").textContent = formatNumber(state.counts?.completed ?? 0);
       document.getElementById("total-tokens").textContent = formatNumber(state.codex_totals?.total_tokens ?? 0);
       document.getElementById("input-tokens").textContent = formatNumber(state.codex_totals?.input_tokens ?? 0);
       document.getElementById("output-tokens").textContent = formatNumber(state.codex_totals?.output_tokens ?? 0);
@@ -495,6 +541,7 @@ function renderDashboardHtml(state: StateApiResponse): string {
 
       const running = Array.isArray(state.running) ? state.running : [];
       const retrying = Array.isArray(state.retrying) ? state.retrying : [];
+      const completed = Array.isArray(state.completed) ? state.completed : [];
 
       const runningBody = document.getElementById("running-body");
       runningBody.innerHTML = running
@@ -521,6 +568,18 @@ function renderDashboardHtml(state: StateApiResponse): string {
         </tr>\`)
         .join("");
       document.getElementById("retrying-empty").style.display = retrying.length > 0 ? "none" : "block";
+
+      const completedBody = document.getElementById("completed-body");
+      completedBody.innerHTML = completed
+        .map((row) => \`<tr>
+          <td><a href="/api/v1/\${encodeURIComponent(row.issue_identifier)}">\${esc(row.issue_identifier)}</a></td>
+          <td>\${esc(row.state)}</td>
+          <td>\${formatNumber(row.attempt)}</td>
+          <td>\${formatDate(row.observed_at)}</td>
+          <td>\${esc(String(row.done))}</td>
+        </tr>\`)
+        .join("");
+      document.getElementById("completed-empty").style.display = completed.length > 0 ? "none" : "block";
 
       const rateLimits = state.rate_limits == null ? "null" : JSON.stringify(state.rate_limits, null, 2);
       document.getElementById("rate-limits").textContent = rateLimits;

--- a/packages/symphony-service/src/service.ts
+++ b/packages/symphony-service/src/service.ts
@@ -103,9 +103,19 @@ export interface RuntimeSnapshotRetryRow {
   error: string;
 }
 
+export interface RuntimeSnapshotCompletedRow {
+  issue_id: string;
+  issue_identifier: string;
+  state: string;
+  attempt: number;
+  observed_at_ms: number;
+  done: boolean;
+}
+
 export interface RuntimeSnapshot {
   running: RuntimeSnapshotRunningRow[];
   retrying: RuntimeSnapshotRetryRow[];
+  completed: RuntimeSnapshotCompletedRow[];
   codex_totals: {
     input_tokens: number;
     output_tokens: number;
@@ -154,6 +164,7 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
   let started = false;
 
   const activeWorkers = new Map<string, ActiveWorker>();
+  const completionSignals = new Map<string, RuntimeSnapshotCompletedRow>();
   const workerTasks = new Set<Promise<void>>();
   const guardrailNotifiedIssueIds = new Set<string>();
   let completedInputTokens = 0;
@@ -437,6 +448,52 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
     });
   }
 
+  async function publishCompletionSignalComment(
+    trackerClient: TrackerClient,
+    issue: NormalizedIssue,
+    input: {
+      attempt: number;
+      finalState: string;
+      observedAtIso: string;
+    },
+  ): Promise<void> {
+    if (!trackerClient.createIssueComment) {
+      return;
+    }
+
+    const body = [
+      "Symphony emitted a delivery complete signal for this issue.",
+      "",
+      "## Completion Signal",
+      `- done: true`,
+      `- final_state: ${input.finalState}`,
+      `- attempt: ${input.attempt}`,
+      `- observed_at: ${input.observedAtIso}`,
+      "",
+      "Operator verification:",
+      "- Confirm PR body includes Summary, Why, and Validation.",
+      "- Confirm required package-scoped validation passed.",
+    ].join("\n");
+
+    await safeTrackerWrite("delivery_complete_signal", issue, async () => {
+      await trackerClient.createIssueComment?.({
+        issueId: issue.id,
+        body,
+      });
+    });
+  }
+
+  function recordCompletionSignal(issue: NormalizedIssue, attempt: number, observedAtMs: number): void {
+    completionSignals.set(issue.id, {
+      issue_id: issue.id,
+      issue_identifier: issue.identifier,
+      state: issue.state,
+      attempt,
+      observed_at_ms: observedAtMs,
+      done: true,
+    });
+  }
+
   async function safeTrackerWrite(kind: string, issue: NormalizedIssue, writer: () => Promise<void>): Promise<void> {
     try {
       await writer();
@@ -478,6 +535,7 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
     }
 
     guardrailNotifiedIssueIds.delete(input.issue.id);
+    completionSignals.delete(input.issue.id);
     await moveIssueToInProgress(runtimeTracker, input.issue);
     await publishRunComment(runtimeTracker, input.issue, {
       kind: "started",
@@ -526,7 +584,7 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
           });
         },
       })
-      .then(async () => {
+      .then(async (result) => {
         onWorkerExit(state, {
           issueId: input.issue.id,
           nowMs: deps.nowMs(),
@@ -534,10 +592,20 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
           maxRetryBackoffMs: runtimeConfig.agent.maxRetryBackoffMs,
         });
 
-        await publishRunComment(runtimeTracker, input.issue, {
+        await publishRunComment(runtimeTracker, result.issue, {
           kind: "completed",
           attempt: input.attempt,
         });
+
+        if (isDoneSignalState(result.issue.state, runtimeConfig)) {
+          const observedAtMs = deps.nowMs();
+          recordCompletionSignal(result.issue, input.attempt, observedAtMs);
+          await publishCompletionSignalComment(runtimeTracker, result.issue, {
+            attempt: input.attempt,
+            finalState: result.issue.state,
+            observedAtIso: new Date(observedAtMs).toISOString(),
+          });
+        }
       })
       .catch(async (error) => {
         onWorkerExit(state, {
@@ -672,6 +740,10 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
       }))
       .sort((a, b) => a.due_at_ms - b.due_at_ms);
 
+    const completed: RuntimeSnapshotCompletedRow[] = Array.from(completionSignals.values()).sort(
+      (a, b) => b.observed_at_ms - a.observed_at_ms,
+    );
+
     let activeInputTokens = 0;
     let activeOutputTokens = 0;
     let activeTotalTokens = 0;
@@ -687,6 +759,7 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
     return {
       running,
       retrying,
+      completed,
       codex_totals: {
         input_tokens: completedInputTokens + activeInputTokens,
         output_tokens: completedOutputTokens + activeOutputTokens,
@@ -872,6 +945,19 @@ function hasRecognizedPackageLabel(labels: string[]): boolean {
   }
 
   return false;
+}
+
+function isDoneSignalState(stateName: string, config: EffectiveConfig): boolean {
+  const normalized = stateName.trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+
+  if (normalized === config.tracker.handoffState.trim().toLowerCase()) {
+    return true;
+  }
+
+  return config.tracker.terminalStates.some((state) => state.trim().toLowerCase() === normalized);
 }
 
 function buildRunCommentBody(input: { kind: "started" | "completed" | "failed"; attempt: number; error?: string }): string {

--- a/packages/symphony-service/src/types.ts
+++ b/packages/symphony-service/src/types.ts
@@ -29,6 +29,7 @@ export interface EffectiveConfig {
     endpoint: string;
     apiKey?: string;
     projectSlug?: string;
+    handoffState: string;
     activeStates: string[];
     terminalStates: string[];
   };

--- a/packages/symphony-service/tests/cli.test.ts
+++ b/packages/symphony-service/tests/cli.test.ts
@@ -22,6 +22,7 @@ function makeService(overrides?: Partial<SymphonyService>): SymphonyService {
       return {
         running: [],
         retrying: [],
+        completed: [],
         codex_totals: {
           input_tokens: 0,
           output_tokens: 0,

--- a/packages/symphony-service/tests/config.test.ts
+++ b/packages/symphony-service/tests/config.test.ts
@@ -20,6 +20,7 @@ describe("resolveEffectiveConfig", () => {
     expect(config.codex.clientVersion.length).toBeGreaterThan(0);
     expect(config.codex.clientCapabilities).toEqual({});
     expect(config.agent.maxConcurrentAgents).toBe(10);
+    expect(config.tracker.handoffState).toBe("Human Review");
   });
 
   it("resolves tracker api key from env indirection", () => {
@@ -67,6 +68,16 @@ describe("resolveEffectiveConfig", () => {
     expect(config.codex.clientName).toBe("athena-symphony");
     expect(config.codex.clientVersion).toBe("2.4.6");
     expect(config.codex.clientCapabilities).toEqual({ tools: true });
+  });
+
+  it("supports tracker handoff state override", () => {
+    const config = resolveEffectiveConfig({
+      tracker: {
+        handoff_state: "Ready for Review",
+      },
+    });
+
+    expect(config.tracker.handoffState).toBe("Ready for Review");
   });
 });
 

--- a/packages/symphony-service/tests/httpServer.test.ts
+++ b/packages/symphony-service/tests/httpServer.test.ts
@@ -44,6 +44,16 @@ function makeService(overrides?: Partial<SymphonyService>): SymphonyService {
             error: "no available orchestrator slots",
           },
         ],
+        completed: [
+          {
+            issue_id: "issue-3",
+            issue_identifier: "ATH-102",
+            state: "Human Review",
+            attempt: 1,
+            observed_at_ms: 1_700_000_020_000,
+            done: true,
+          },
+        ],
         codex_totals: {
           input_tokens: 30,
           output_tokens: 12,
@@ -80,9 +90,11 @@ describe("status server", () => {
       expect(stateBody.counts).toEqual({
         running: 1,
         retrying: 1,
+        completed: 1,
       });
       expect(stateBody.running[0].issue_identifier).toBe("ATH-100");
       expect(stateBody.retrying[0].issue_identifier).toBe("ATH-101");
+      expect(stateBody.completed[0].issue_identifier).toBe("ATH-102");
     } finally {
       await statusServer.stop();
     }
@@ -111,6 +123,12 @@ describe("status server", () => {
       expect(missingResponse.status).toBe(404);
       const missingBody = (await missingResponse.json()) as Record<string, any>;
       expect(missingBody.error.code).toBe("issue_not_found");
+
+      const completedResponse = await fetch(`http://${statusServer.host}:${statusServer.port}/api/v1/ATH-102`);
+      expect(completedResponse.status).toBe(200);
+      const completedBody = (await completedResponse.json()) as Record<string, any>;
+      expect(completedBody.status).toBe("completed");
+      expect(completedBody.completed.state).toBe("Human Review");
     } finally {
       await statusServer.stop();
     }

--- a/packages/symphony-service/tests/runtime.test.ts
+++ b/packages/symphony-service/tests/runtime.test.ts
@@ -44,6 +44,7 @@ function config(partial?: Partial<EffectiveConfig>): EffectiveConfig {
       endpoint: partial?.tracker?.endpoint ?? "https://api.linear.app/graphql",
       apiKey: partial?.tracker?.apiKey ?? "key",
       projectSlug: partial?.tracker?.projectSlug ?? "ATH",
+      handoffState: partial?.tracker?.handoffState ?? "Human Review",
       activeStates: partial?.tracker?.activeStates ?? ["Todo", "In Progress"],
       terminalStates: partial?.tracker?.terminalStates ?? ["Done", "Closed"],
     },

--- a/packages/symphony-service/tests/service.test.ts
+++ b/packages/symphony-service/tests/service.test.ts
@@ -456,6 +456,7 @@ describe("createSymphonyService", () => {
     expect(snapshot.codex_totals.total_tokens).toBe(17);
     expect(snapshot.codex_totals.seconds_running).toBe(5);
     expect(snapshot.rate_limits).toEqual({ remaining: 9 });
+    expect(snapshot.completed).toEqual([]);
 
     await service.stop();
   });
@@ -513,6 +514,7 @@ describe("createSymphonyService", () => {
       error: "boom",
     });
     expect(snapshot.retrying[0]!.due_at_ms).toBe(nowMs + 10_000);
+    expect(snapshot.completed).toEqual([]);
 
     await service.stop();
   });
@@ -578,6 +580,96 @@ describe("createSymphonyService", () => {
     expect(transitioned).toEqual(["ATH-777:In Progress"]);
     expect(comments.some((entry) => entry.includes("started work"))).toBe(true);
     expect(comments.some((entry) => entry.includes("finished a run"))).toBe(true);
+    expect(comments.some((entry) => entry.includes("delivery complete signal"))).toBe(false);
+
+    await service.stop();
+  });
+
+  it("records completion signal and emits delivery comment when issue reaches handoff state", async () => {
+    const comments: string[] = [];
+    const candidates = [
+      issue({
+        id: "handoff-1",
+        identifier: "ATH-900",
+        state: "Todo",
+        labels: ["pkg:symphony-service"],
+        description: "Implement orchestration with clear acceptance criteria and validation steps.",
+        team_id: "team-1",
+      }),
+    ];
+
+    const service = createSymphonyService({
+      workflowPath: "/tmp/WORKFLOW.md",
+      deps: {
+        loadWorkflowFile: async () => ({
+          path: "/tmp/WORKFLOW.md",
+          config: {
+            tracker: {
+              kind: "linear",
+              api_key: "key",
+              project_slug: "ATH",
+              handoff_state: "Human Review",
+            },
+            polling: {
+              interval_ms: 1000,
+            },
+            codex: {
+              command: "codex app-server",
+            },
+          },
+          promptTemplate: "Issue {{ issue.identifier }}",
+        }),
+        createTracker: () => ({
+          async fetchCandidateIssues() {
+            return candidates.splice(0, candidates.length);
+          },
+          async fetchIssuesByStates() {
+            return [];
+          },
+          async fetchIssueStatesByIds() {
+            return [];
+          },
+          async createIssueComment(input) {
+            comments.push(input.body);
+          },
+          async updateIssueStateByName() {
+            return true;
+          },
+        }),
+        cleanupTerminalIssueWorkspaces: async () => ({ removed: 0, failed: 0, warnings: [] }),
+        processDueRetries: async () => ({
+          processedIssueIds: [],
+          dispatchedIssueIds: [],
+          requeuedIssueIds: [],
+          releasedIssueIds: [],
+        }),
+        setIntervalFn: () => 1 as unknown as ReturnType<typeof setInterval>,
+        clearIntervalFn: () => {},
+        runIssueAttempt: async (input) => ({
+          exit: "normal" as const,
+          turnCount: 2,
+          workspacePath: "/tmp/fake",
+          issue: {
+            ...input.issue,
+            state: "Human Review",
+          },
+        }),
+      },
+    });
+
+    await service.start();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const snapshot = service.getRuntimeSnapshot();
+    expect(snapshot.completed).toHaveLength(1);
+    expect(snapshot.completed[0]).toMatchObject({
+      issue_id: "handoff-1",
+      issue_identifier: "ATH-900",
+      state: "Human Review",
+      done: true,
+    });
+    expect(comments.some((entry) => entry.includes("delivery complete signal"))).toBe(true);
 
     await service.stop();
   });

--- a/packages/symphony-service/tests/worker.test.ts
+++ b/packages/symphony-service/tests/worker.test.ts
@@ -73,15 +73,17 @@ class FakeCodex {
 }
 
 function config(root: string, overrides?: Partial<EffectiveConfig>): EffectiveConfig {
+  const trackerOverrides = overrides?.tracker;
+
   return {
     tracker: {
-      kind: "linear",
-      endpoint: "https://api.linear.app/graphql",
-      apiKey: "key",
-      projectSlug: "ATH",
-      activeStates: ["Todo", "In Progress"],
-      terminalStates: ["Done", "Closed"],
-      ...overrides?.tracker,
+      kind: trackerOverrides?.kind ?? "linear",
+      endpoint: trackerOverrides?.endpoint ?? "https://api.linear.app/graphql",
+      apiKey: trackerOverrides?.apiKey ?? "key",
+      projectSlug: trackerOverrides?.projectSlug ?? "ATH",
+      handoffState: trackerOverrides?.handoffState ?? "Human Review",
+      activeStates: trackerOverrides?.activeStates ?? ["Todo", "In Progress"],
+      terminalStates: trackerOverrides?.terminalStates ?? ["Done", "Closed"],
     },
     polling: {
       intervalMs: 30_000,


### PR DESCRIPTION
## Summary
- add a configurable tracker handoff state (`tracker.handoff_state`, default `Human Review`) to Symphony runtime config
- introduce an operator-visible done-signal contract in runtime state:
  - record `completed` delivery signals when a run exits in handoff or terminal tracker state
  - expose completed signals in `GET /api/v1/state` and per-issue `GET /api/v1/<issue_identifier>` responses
  - render completed signals in the status dashboard
- emit a structured tracker comment (`delivery complete signal`) when done signal criteria are met
- update Athena workflow/runbook/readme docs to include handoff/done-signal behavior
- add regression tests covering config, service runtime snapshot, dashboard/API responses, and config helpers

## Why
- operators need a deterministic way to know when Symphony work is truly done, not just that a run attempt ended
- prior behavior only showed running/retrying state and generic run comments, which made completion ambiguous
- this change establishes an explicit completion signal pipeline aligned with current in-memory, tracker-driven architecture

## Validation
- `bun run --filter '@athena/symphony-service' test tests/config.test.ts tests/service.test.ts tests/httpServer.test.ts`
- `bun run --filter '@athena/symphony-service' test`
- `bunx tsc --noEmit -p packages/symphony-service/tsconfig.json`
