### PR TITLE
fix: update Symphony token metrics from nested Codex events

### DIFF
--- a/packages/symphony-service/src/codex/protocol.ts
+++ b/packages/symphony-service/src/codex/protocol.ts
@@ -183,12 +183,26 @@ export function isUserInputRequired(message: JsonRpcMessage): boolean {
 
 export function extractUsage(message: JsonRpcMessage): Record<string, number> | null {
   const params = asObject(message.params);
+  const tokenUsage = asObject(params?.tokenUsage);
+  const msg = asObject(params?.msg);
+  const msgInfo = asObject(msg?.info);
 
-  const absoluteUsage =
-    asObject(params?.total_token_usage) ||
-    asObject(params?.token_usage) ||
-    asObject(params?.tokenUsage) ||
-    asObject(params?.usage);
+  const absoluteUsage = firstObject(
+    params?.total_token_usage,
+    params?.token_usage,
+    tokenUsage?.total,
+    params?.tokenUsage,
+    params?.usage,
+    msgInfo?.total_token_usage,
+    msgInfo?.token_usage,
+    asObject(msgInfo?.tokenUsage)?.total,
+    msgInfo?.tokenUsage,
+    msg?.total_token_usage,
+    msg?.token_usage,
+    asObject(msg?.tokenUsage)?.total,
+    msg?.tokenUsage,
+    msg?.usage,
+  );
 
   if (!absoluteUsage) {
     return null;
@@ -218,7 +232,9 @@ export function extractUsage(message: JsonRpcMessage): Record<string, number> | 
 
 export function extractRateLimits(message: JsonRpcMessage): Record<string, unknown> | null {
   const params = asObject(message.params);
-  const limits = asObject(params?.rate_limits) || asObject(params?.rateLimits);
+  const msg = asObject(params?.msg);
+  const msgInfo = asObject(msg?.info);
+  const limits = firstObject(params?.rate_limits, params?.rateLimits, msg?.rate_limits, msg?.rateLimits, msgInfo?.rate_limits, msgInfo?.rateLimits);
   return limits || null;
 }
 
@@ -233,6 +249,17 @@ function asObject(value: unknown): Record<string, unknown> | null {
   }
 
   return value as Record<string, unknown>;
+}
+
+function firstObject(...candidates: unknown[]): Record<string, unknown> | null {
+  for (const candidate of candidates) {
+    const obj = asObject(candidate);
+    if (obj) {
+      return obj;
+    }
+  }
+
+  return null;
 }
 
 function asString(value: unknown): string {

--- a/packages/symphony-service/tests/codexProtocol.test.ts
+++ b/packages/symphony-service/tests/codexProtocol.test.ts
@@ -104,4 +104,68 @@ describe("codex protocol parsing", () => {
 
     expect(extractRateLimits({ params: { rate_limits: { remaining: 10 } } })).toEqual({ remaining: 10 });
   });
+
+  it("extracts usage from thread/tokenUsage/updated total payload", () => {
+    expect(
+      extractUsage({
+        method: "thread/tokenUsage/updated",
+        params: {
+          tokenUsage: {
+            total: {
+              inputTokens: 12419,
+              outputTokens: 313,
+              totalTokens: 12732,
+            },
+            last: {
+              inputTokens: 12419,
+              outputTokens: 313,
+              totalTokens: 12732,
+            },
+          },
+        },
+      }),
+    ).toEqual({
+      input_tokens: 12419,
+      output_tokens: 313,
+      total_tokens: 12732,
+    });
+  });
+
+  it("extracts usage and rate limits from codex/event/token_count msg payload", () => {
+    expect(
+      extractUsage({
+        method: "codex/event/token_count",
+        params: {
+          msg: {
+            info: {
+              total_token_usage: {
+                input_tokens: 11,
+                output_tokens: 5,
+                total_tokens: 16,
+              },
+            },
+          },
+        },
+      }),
+    ).toEqual({
+      input_tokens: 11,
+      output_tokens: 5,
+      total_tokens: 16,
+    });
+
+    expect(
+      extractRateLimits({
+        method: "codex/event/token_count",
+        params: {
+          msg: {
+            rate_limits: {
+              remaining: 999,
+            },
+          },
+        },
+      }),
+    ).toEqual({
+      remaining: 999,
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- extend Codex protocol usage extraction to support nested event payloads used by live app-server events (`thread/tokenUsage/updated` and `codex/event/token_count`)
- extend rate-limit extraction to read nested `msg`/`msg.info` payload variants
- add protocol tests that reproduce the live nested payload shapes to prevent regressions

## Why
- runtime token counters were staying at zero because Symphony only parsed top-level usage fields
- live Codex events report token usage under nested fields, so usage was silently dropped
- this restores operator-visible token telemetry in `/api/v1/state` and the dashboard

## Validation
- `bun run --filter '@athena/symphony-service' test tests/codexProtocol.test.ts`
- `bun run --filter '@athena/symphony-service' test tests/codexClient.test.ts`
- `bun run --filter '@athena/symphony-service' test`
- `bunx tsc --noEmit -p packages/symphony-service/tsconfig.json`
- `bun run --filter '@athena/storefront-webapp' test`