### PR TITLE
feat: add per-issue activity timeline visibility in Symphony

### DIFF
--- a/packages/symphony-service/CONFORMANCE.md
+++ b/packages/symphony-service/CONFORMANCE.md
@@ -25,7 +25,7 @@ Spec reference: https://github.com/openai/symphony/blob/main/SPEC.md
 | Reconciliation that stops runs on terminal/non-active tracker states | Implemented | `src/orchestrator.ts`, `src/runtime.ts`, `src/service.ts` | `tests/orchestrator.test.ts`, `tests/runtime.test.ts`, `tests/service.test.ts` |
 | Workspace cleanup for terminal issues (startup sweep + active transition) | Implemented | `src/startup.ts`, `src/service.ts` | `tests/startup.test.ts`, `tests/service.test.ts` |
 | Structured logs including issue and session context fields | Implemented | `src/service.ts`, `src/worker.ts` | `tests/service.test.ts` |
-| Operator-visible observability (structured logs; optional snapshot/status surface) | Implemented | `src/service.ts` (`getRuntimeSnapshot`), `src/cli.ts` | `tests/service.test.ts`, `tests/cli.test.ts` |
+| Operator-visible observability (structured logs; optional snapshot/status surface) | Implemented | `src/service.ts` (`getRuntimeSnapshot`, `getRuntimeIssueSnapshot`), `src/httpServer.ts`, `src/cli.ts` | `tests/service.test.ts`, `tests/httpServer.test.ts`, `tests/cli.test.ts` |
 
 ## Extension Conformance (`SPEC` §18.2)
 

--- a/packages/symphony-service/README.md
+++ b/packages/symphony-service/README.md
@@ -29,9 +29,22 @@ When enabled (`--port` or `server.port` in `WORKFLOW.md`), the service exposes:
 - `GET /api/v1/state`
 - `GET /api/v1/<issue_identifier>`
 - `POST /api/v1/refresh`
+ 
+`/api/v1/state` includes `completed` delivery signals (issue, final state, attempt, observed timestamp), and
+`GET /api/v1/<issue_identifier>` can return `status: "completed"` when a done signal is present in runtime state.
 
-`/api/v1/state` now includes `completed` delivery signals (issue, final state, attempt, observed timestamp), and
-`/api/v1/<issue_identifier>` can return `status: "completed"` when a done signal is present in runtime state.
+`GET /api/v1/<issue_identifier>` now includes bounded in-memory timeline visibility fields for active issues:
+
+- `events` (structured lifecycle + codex activity records)
+- `events_count`
+- `events_limit` (currently `200`)
+- `events_truncated` (true when older events were dropped)
+
+Dashboard behavior:
+
+- Click any running/retrying issue to open the inline **Issue Activity** panel.
+- Timeline updates on the existing 2-second polling cadence.
+- Timelines are in-memory only and reset when the Symphony process restarts.
 
 ## Commands
 

--- a/packages/symphony-service/src/httpServer.ts
+++ b/packages/symphony-service/src/httpServer.ts
@@ -256,51 +256,51 @@ function toIssueResponse(
   service: SymphonyService,
   issueIdentifier: string,
 ): Record<string, unknown> | null {
-  const runtime = service.getRuntimeSnapshot();
-  const running = runtime.running.find((row) => row.issue_identifier === issueIdentifier);
-  const retry = runtime.retrying.find((row) => row.issue_identifier === issueIdentifier);
-  const completed = runtime.completed.find((row) => row.issue_identifier === issueIdentifier);
-
-  if (!running && !retry && !completed) {
+  const issue = service.getRuntimeIssueSnapshot(issueIdentifier);
+  if (!issue) {
     return null;
   }
 
   return {
-    issue_identifier: issueIdentifier,
-    issue_id: running?.issue_id ?? retry?.issue_id ?? completed?.issue_id ?? "",
-    status: running ? "running" : retry ? "retrying" : "completed",
-    running: running
+    issue_identifier: issue.issue_identifier,
+    issue_id: issue.issue_id,
+    status: issue.status,
+    running: issue.running
       ? {
-          state: running.state,
-          session_id: running.session_id,
-          turn_count: running.turn_count,
-          retry_attempt: running.retry_attempt,
-          started_at: toIso(running.started_at_ms),
-          last_event_at: toIsoNullable(running.last_codex_timestamp_ms),
+          state: issue.running.state,
+          session_id: issue.running.session_id,
+          turn_count: issue.running.turn_count,
+          retry_attempt: issue.running.retry_attempt,
+          started_at: toIso(issue.running.started_at_ms),
+          last_event_at: toIsoNullable(issue.running.last_codex_timestamp_ms),
           tokens: {
-            input_tokens: running.codex_input_tokens,
-            output_tokens: running.codex_output_tokens,
-            total_tokens: running.codex_total_tokens,
+            input_tokens: issue.running.codex_input_tokens,
+            output_tokens: issue.running.codex_output_tokens,
+            total_tokens: issue.running.codex_total_tokens,
           },
         }
       : null,
-    retry: retry
+    retry: issue.retry
       ? {
-          attempt: retry.attempt,
-          due_at: toIso(retry.due_at_ms),
-          error: retry.error,
+          attempt: issue.retry.attempt,
+          due_at: toIso(issue.retry.due_at_ms),
+          error: issue.retry.error,
         }
       : null,
-    completed: completed
+    completed: issue.completed
       ? {
-          state: completed.state,
-          attempt: completed.attempt,
-          observed_at: toIso(completed.observed_at_ms),
-          done: completed.done,
+          state: issue.completed.state,
+          attempt: issue.completed.attempt,
+          observed_at: toIso(issue.completed.observed_at_ms),
+          done: issue.completed.done,
         }
       : null,
-    codex_totals: runtime.codex_totals,
-    rate_limits: runtime.rate_limits,
+    codex_totals: issue.codex_totals,
+    rate_limits: issue.rate_limits,
+    events: issue.events,
+    events_count: issue.events_count,
+    events_limit: issue.events_limit,
+    events_truncated: issue.events_truncated,
   };
 }
 
@@ -355,6 +355,20 @@ function renderDashboardHtml(state: StateApiResponse): string {
     button[disabled] {
       opacity: 0.5;
       cursor: not-allowed;
+    }
+    .issue-link {
+      border: none;
+      background: transparent;
+      color: #8dd3ff;
+      padding: 0;
+      border-radius: 0;
+      text-decoration: underline;
+      text-decoration-style: dotted;
+    }
+    .issue-link[data-selected="true"] {
+      color: #9bffb2;
+      text-decoration-style: solid;
+      font-weight: 700;
     }
     .card {
       border: 1px solid #263241;
@@ -411,6 +425,11 @@ function renderDashboardHtml(state: StateApiResponse): string {
     }
     a:hover {
       text-decoration: underline;
+    }
+    .activity-meta {
+      margin-bottom: 8px;
+      color: #a9bfd8;
+      font-size: 12px;
     }
     @media (max-width: 860px) {
       .stats {
@@ -498,6 +517,28 @@ function renderDashboardHtml(state: StateApiResponse): string {
     </div>
 
     <div class="card">
+      <h2>Issue Activity</h2>
+      <div id="activity-meta" class="activity-meta">Select a running or retrying issue to inspect timeline events.</div>
+      <table>
+        <thead>
+          <tr>
+            <th>Seq</th>
+            <th>Timestamp</th>
+            <th>Source</th>
+            <th>Kind</th>
+            <th>Message</th>
+            <th>Session</th>
+            <th>Turn</th>
+            <th>Retry</th>
+            <th>Tokens</th>
+          </tr>
+        </thead>
+        <tbody id="activity-body"></tbody>
+      </table>
+      <div id="activity-empty" class="empty">No issue selected.</div>
+    </div>
+
+    <div class="card">
       <h2>Rate Limits</h2>
       <pre id="rate-limits"></pre>
       <div class="muted">API endpoints: <code>/api/v1/state</code>, <code>/api/v1/refresh</code></div>
@@ -507,6 +548,12 @@ function renderDashboardHtml(state: StateApiResponse): string {
     const initialState = ${initialStateJson};
     const refreshBtn = document.getElementById("refresh-btn");
     const refreshStatus = document.getElementById("refresh-status");
+    const runningBody = document.getElementById("running-body");
+    const retryingBody = document.getElementById("retrying-body");
+    const activityBody = document.getElementById("activity-body");
+    const activityMeta = document.getElementById("activity-meta");
+    const activityEmpty = document.getElementById("activity-empty");
+    let selectedIssueIdentifier = null;
 
     function esc(value) {
       return String(value)
@@ -529,6 +576,24 @@ function renderDashboardHtml(state: StateApiResponse): string {
       return value.toLocaleString();
     }
 
+    function renderIssueCell(issueIdentifier) {
+      const selected = selectedIssueIdentifier === issueIdentifier ? ' data-selected="true"' : "";
+      return \`<button type="button" class="issue-link" data-issue-id="\${esc(issueIdentifier)}"\${selected}>\${esc(issueIdentifier)}</button>\`;
+    }
+
+    function formatTokensFromUsage(usage) {
+      if (!usage || typeof usage !== "object") {
+        return "—";
+      }
+      const total = typeof usage.total_tokens === "number" ? usage.total_tokens : null;
+      const input = typeof usage.input_tokens === "number" ? usage.input_tokens : null;
+      const output = typeof usage.output_tokens === "number" ? usage.output_tokens : null;
+      if (total === null && input === null && output === null) {
+        return "—";
+      }
+      return \`\${formatNumber(total ?? (input ?? 0) + (output ?? 0))} (in:\${formatNumber(input ?? 0)} out:\${formatNumber(output ?? 0)})\`;
+    }
+
     function renderRows(state) {
       document.getElementById("generated-at").textContent = state.generated_at || "";
       document.getElementById("count-running").textContent = formatNumber(state.counts?.running ?? 0);
@@ -543,10 +608,9 @@ function renderDashboardHtml(state: StateApiResponse): string {
       const retrying = Array.isArray(state.retrying) ? state.retrying : [];
       const completed = Array.isArray(state.completed) ? state.completed : [];
 
-      const runningBody = document.getElementById("running-body");
       runningBody.innerHTML = running
         .map((row) => \`<tr>
-          <td><a href="/api/v1/\${encodeURIComponent(row.issue_identifier)}">\${esc(row.issue_identifier)}</a></td>
+          <td>\${renderIssueCell(row.issue_identifier)}</td>
           <td>\${esc(row.state)}</td>
           <td>\${formatNumber(row.turn_count)}</td>
           <td>\${formatNumber(row.retry_attempt)}</td>
@@ -558,10 +622,9 @@ function renderDashboardHtml(state: StateApiResponse): string {
         .join("");
       document.getElementById("running-empty").style.display = running.length > 0 ? "none" : "block";
 
-      const retryingBody = document.getElementById("retrying-body");
       retryingBody.innerHTML = retrying
         .map((row) => \`<tr>
-          <td><a href="/api/v1/\${encodeURIComponent(row.issue_identifier)}">\${esc(row.issue_identifier)}</a></td>
+          <td>\${renderIssueCell(row.issue_identifier)}</td>
           <td>\${formatNumber(row.attempt)}</td>
           <td>\${formatDate(row.due_at)}</td>
           <td>\${esc(row.error)}</td>
@@ -585,12 +648,76 @@ function renderDashboardHtml(state: StateApiResponse): string {
       document.getElementById("rate-limits").textContent = rateLimits;
     }
 
+    function renderIssueActivity(issueResponse) {
+      if (!selectedIssueIdentifier) {
+        activityBody.innerHTML = "";
+        activityEmpty.textContent = "No issue selected.";
+        activityEmpty.style.display = "block";
+        activityMeta.textContent = "Select a running or retrying issue to inspect timeline events.";
+        return;
+      }
+
+      if (!issueResponse) {
+        activityBody.innerHTML = "";
+        activityEmpty.textContent = \`Issue \${selectedIssueIdentifier} is no longer visible in runtime state.\`;
+        activityEmpty.style.display = "block";
+        activityMeta.textContent = "Issue detail unavailable.";
+        return;
+      }
+
+      const events = Array.isArray(issueResponse.events) ? [...issueResponse.events].sort((a, b) => b.seq - a.seq) : [];
+      const running = issueResponse.running;
+      const retry = issueResponse.retry;
+      const statusLabel = issueResponse.status || "unknown";
+      const turns = running ? running.turn_count : "—";
+      const retryAttempt = running ? running.retry_attempt : (retry ? retry.attempt : "—");
+      activityMeta.textContent = \`Issue \${selectedIssueIdentifier} | status: \${statusLabel} | turns: \${turns} | retry: \${retryAttempt} | events: \${formatNumber(issueResponse.events_count ?? events.length)} / \${formatNumber(issueResponse.events_limit ?? 0)}\${issueResponse.events_truncated ? " (truncated)" : ""}\`;
+
+      activityBody.innerHTML = events
+        .map((event) => \`<tr>
+          <td>\${formatNumber(event.seq)}</td>
+          <td>\${formatDate(event.timestamp)}</td>
+          <td>\${esc(event.source ?? "—")}</td>
+          <td>\${esc(event.kind ?? "—")}</td>
+          <td>\${esc(event.message ?? "—")}</td>
+          <td>\${esc(event.session_id ?? "—")}</td>
+          <td>\${event.turn_count == null ? "—" : formatNumber(event.turn_count)}</td>
+          <td>\${event.retry_attempt == null ? "—" : formatNumber(event.retry_attempt)}</td>
+          <td>\${formatTokensFromUsage(event.usage)}</td>
+        </tr>\`)
+        .join("");
+
+      activityEmpty.textContent = "No events yet.";
+      activityEmpty.style.display = events.length > 0 ? "none" : "block";
+    }
+
     async function fetchState() {
       const response = await fetch("/api/v1/state");
       if (!response.ok) {
         throw new Error(\`state request failed: \${response.status}\`);
       }
       return await response.json();
+    }
+
+    async function fetchIssue(issueIdentifier) {
+      const response = await fetch(\`/api/v1/\${encodeURIComponent(issueIdentifier)}\`);
+      if (response.status === 404) {
+        return null;
+      }
+      if (!response.ok) {
+        throw new Error(\`issue request failed: \${response.status}\`);
+      }
+      return await response.json();
+    }
+
+    async function refreshSelectedIssue() {
+      if (!selectedIssueIdentifier) {
+        renderIssueActivity(null);
+        return;
+      }
+
+      const issueResponse = await fetchIssue(selectedIssueIdentifier);
+      renderIssueActivity(issueResponse);
     }
 
     async function refreshNow() {
@@ -603,6 +730,7 @@ function renderDashboardHtml(state: StateApiResponse): string {
         }
         const state = await fetchState();
         renderRows(state);
+        await refreshSelectedIssue();
         refreshStatus.textContent = "updated";
       } catch (error) {
         refreshStatus.textContent = String(error instanceof Error ? error.message : error);
@@ -615,16 +743,33 @@ function renderDashboardHtml(state: StateApiResponse): string {
       try {
         const state = await fetchState();
         renderRows(state);
+        await refreshSelectedIssue();
       } catch (error) {
         refreshStatus.textContent = String(error instanceof Error ? error.message : error);
       }
     }
+
+    document.addEventListener("click", (event) => {
+      const target = event.target;
+      if (!(target instanceof HTMLElement) || !target.classList.contains("issue-link")) {
+        return;
+      }
+
+      const nextIssueIdentifier = target.getAttribute("data-issue-id");
+      if (!nextIssueIdentifier) {
+        return;
+      }
+
+      selectedIssueIdentifier = nextIssueIdentifier;
+      void pollState();
+    });
 
     refreshBtn.addEventListener("click", () => {
       void refreshNow();
     });
 
     renderRows(initialState);
+    renderIssueActivity(null);
     setInterval(() => {
       void pollState();
     }, 2000);

--- a/packages/symphony-service/src/service.ts
+++ b/packages/symphony-service/src/service.ts
@@ -22,6 +22,7 @@ const REQUIRED_PACKAGE_LABELS = new Set([
 ]);
 const REQUIRED_PACKAGE_SUFFIXES = new Set(Array.from(REQUIRED_PACKAGE_LABELS).map((label) => label.replace(/^pkg:/, "")));
 const MIN_DESCRIPTION_LENGTH = 24;
+const ISSUE_EVENT_LIMIT = 200;
 type IntervalHandle = ReturnType<typeof setInterval>;
 type TimeoutHandle = ReturnType<typeof setTimeout>;
 
@@ -112,6 +113,46 @@ export interface RuntimeSnapshotCompletedRow {
   done: boolean;
 }
 
+export interface RuntimeIssueEventUsage {
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+}
+
+export interface RuntimeIssueEvent {
+  seq: number;
+  timestamp: string;
+  source: "service" | "worker" | "codex";
+  kind: string;
+  message: string;
+  session_id: string | null;
+  turn_count: number | null;
+  retry_attempt: number | null;
+  usage?: RuntimeIssueEventUsage;
+  rate_limits?: Record<string, unknown>;
+}
+
+interface IssueEventBuffer {
+  events: RuntimeIssueEvent[];
+  nextSeq: number;
+  dropped: number;
+}
+
+export interface RuntimeIssueSnapshot {
+  issue_identifier: string;
+  issue_id: string;
+  status: "running" | "retrying" | "completed";
+  running: RuntimeSnapshotRunningRow | null;
+  retry: RuntimeSnapshotRetryRow | null;
+  completed: RuntimeSnapshotCompletedRow | null;
+  codex_totals: RuntimeSnapshot["codex_totals"];
+  rate_limits: RuntimeSnapshot["rate_limits"];
+  events: RuntimeIssueEvent[];
+  events_count: number;
+  events_limit: number;
+  events_truncated: boolean;
+}
+
 export interface RuntimeSnapshot {
   running: RuntimeSnapshotRunningRow[];
   retrying: RuntimeSnapshotRetryRow[];
@@ -132,6 +173,7 @@ export interface SymphonyService {
   runTickOnce(): Promise<void>;
   getSnapshot(): SymphonyServiceSnapshot;
   getRuntimeSnapshot(): RuntimeSnapshot;
+  getRuntimeIssueSnapshot(issueIdentifier: string): RuntimeIssueSnapshot | null;
 }
 
 export function formatServiceLogLine(entry: ServiceLogEntry): string {
@@ -165,6 +207,7 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
 
   const activeWorkers = new Map<string, ActiveWorker>();
   const completionSignals = new Map<string, RuntimeSnapshotCompletedRow>();
+  const issueEventBuffers = new Map<string, IssueEventBuffer>();
   const workerTasks = new Set<Promise<void>>();
   const guardrailNotifiedIssueIds = new Set<string>();
   let completedInputTokens = 0;
@@ -326,6 +369,15 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
       return;
     }
 
+    appendIssueEvent(action.issueId, action.identifier, {
+      source: "service",
+      kind: "reconcile_terminated",
+      message: `Reconcile terminated run (${action.action})`,
+      session_id: activeWorkers.get(action.issueId)?.sessionId ?? null,
+      turn_count: activeWorkers.get(action.issueId)?.turnCount ?? null,
+      retry_attempt: activeWorkers.get(action.issueId)?.retryAttempt ?? null,
+    });
+
     terminateRunningIssue(action.issueId);
 
     state.running.delete(action.issueId);
@@ -358,6 +410,57 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
 
     worker.stop();
     activeWorkers.delete(issueId);
+  }
+
+  function appendIssueEvent(
+    issueId: string,
+    issueIdentifier: string,
+    input: Omit<RuntimeIssueEvent, "seq" | "timestamp"> & { timestamp?: string },
+  ): void {
+    let buffer = issueEventBuffers.get(issueId);
+    if (!buffer) {
+      buffer = {
+        events: [],
+        nextSeq: 1,
+        dropped: 0,
+      };
+      issueEventBuffers.set(issueId, buffer);
+    }
+
+    const event: RuntimeIssueEvent = {
+      seq: buffer.nextSeq,
+      timestamp: input.timestamp ?? new Date().toISOString(),
+      source: input.source,
+      kind: input.kind,
+      message: input.message || `${input.source}:${input.kind}`,
+      session_id: input.session_id ?? null,
+      turn_count: input.turn_count ?? null,
+      retry_attempt: input.retry_attempt ?? null,
+      usage: input.usage,
+      rate_limits: input.rate_limits,
+    };
+    buffer.events.push(event);
+    buffer.nextSeq += 1;
+
+    if (buffer.events.length > ISSUE_EVENT_LIMIT) {
+      buffer.events.splice(0, buffer.events.length - ISSUE_EVENT_LIMIT);
+      buffer.dropped += 1;
+    }
+  }
+
+  function getIssueEvents(issueId: string): { events: RuntimeIssueEvent[]; dropped: number } {
+    const buffer = issueEventBuffers.get(issueId);
+    if (!buffer) {
+      return {
+        events: [],
+        dropped: 0,
+      };
+    }
+
+    return {
+      events: buffer.events.map((event) => ({ ...event })),
+      dropped: buffer.dropped,
+    };
   }
 
   function evaluateGuardrails(issue: NormalizedIssue): string[] {
@@ -523,9 +626,28 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
     const runtimeConfig = config;
     const runtimeTracker = tracker;
     const runtimeWorkflow = workflow;
+
+    appendIssueEvent(input.issue.id, input.issue.identifier, {
+      source: "service",
+      kind: "dispatch_started",
+      message: `Dispatch started for ${input.issue.identifier}`,
+      session_id: null,
+      turn_count: 0,
+      retry_attempt: input.attempt,
+    });
+
     const guardrailProblems = evaluateGuardrails(input.issue);
 
     if (guardrailProblems.length > 0) {
+      appendIssueEvent(input.issue.id, input.issue.identifier, {
+        source: "service",
+        kind: "guardrail_blocked",
+        message: `Dispatch blocked by guardrails: ${guardrailProblems.join(" | ")}`,
+        session_id: null,
+        turn_count: 0,
+        retry_attempt: input.attempt,
+      });
+
       if (!guardrailNotifiedIssueIds.has(input.issue.id)) {
         await publishGuardrailComment(runtimeTracker, input.issue, guardrailProblems);
         guardrailNotifiedIssueIds.add(input.issue.id);
@@ -540,6 +662,15 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
     await publishRunComment(runtimeTracker, input.issue, {
       kind: "started",
       attempt: input.attempt,
+    });
+
+    appendIssueEvent(input.issue.id, input.issue.identifier, {
+      source: "service",
+      kind: "run_started",
+      message: `Run started (attempt ${input.attempt})`,
+      session_id: null,
+      turn_count: 0,
+      retry_attempt: input.attempt,
     });
 
     const startedAtMs = deps.nowMs();
@@ -585,12 +716,32 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
         },
       })
       .then(async (result) => {
-        onWorkerExit(state, {
+        const retry = onWorkerExit(state, {
           issueId: input.issue.id,
           nowMs: deps.nowMs(),
           reason: "normal",
           maxRetryBackoffMs: runtimeConfig.agent.maxRetryBackoffMs,
         });
+
+        appendIssueEvent(result.issue.id, result.issue.identifier, {
+          source: "service",
+          kind: "run_completed",
+          message: `Run completed (attempt ${input.attempt})`,
+          session_id: worker.sessionId,
+          turn_count: worker.turnCount,
+          retry_attempt: worker.retryAttempt,
+        });
+
+        if (retry) {
+          appendIssueEvent(result.issue.id, result.issue.identifier, {
+            source: "service",
+            kind: "retry_scheduled",
+            message: `Retry scheduled for ${new Date(retry.dueAtMs).toISOString()} (${retry.error})`,
+            session_id: worker.sessionId,
+            turn_count: worker.turnCount,
+            retry_attempt: retry.attempt,
+          });
+        }
 
         await publishRunComment(runtimeTracker, result.issue, {
           kind: "completed",
@@ -605,16 +756,45 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
             finalState: result.issue.state,
             observedAtIso: new Date(observedAtMs).toISOString(),
           });
+
+          appendIssueEvent(result.issue.id, result.issue.identifier, {
+            source: "service",
+            kind: "done_signal_emitted",
+            message: `Done signal emitted for state ${result.issue.state}`,
+            session_id: worker.sessionId,
+            turn_count: worker.turnCount,
+            retry_attempt: worker.retryAttempt,
+          });
         }
       })
       .catch(async (error) => {
-        onWorkerExit(state, {
+        const retry = onWorkerExit(state, {
           issueId: input.issue.id,
           nowMs: deps.nowMs(),
           reason: "failure",
           maxRetryBackoffMs: runtimeConfig.agent.maxRetryBackoffMs,
           error: toErrorMessage(error),
         });
+
+        appendIssueEvent(input.issue.id, input.issue.identifier, {
+          source: "service",
+          kind: "run_failed",
+          message: `Run failed: ${toErrorMessage(error)}`,
+          session_id: worker.sessionId,
+          turn_count: worker.turnCount,
+          retry_attempt: worker.retryAttempt,
+        });
+
+        if (retry) {
+          appendIssueEvent(input.issue.id, input.issue.identifier, {
+            source: "service",
+            kind: "retry_scheduled",
+            message: `Retry scheduled for ${new Date(retry.dueAtMs).toISOString()} (${retry.error})`,
+            session_id: worker.sessionId,
+            turn_count: worker.turnCount,
+            retry_attempt: retry.attempt,
+          });
+        }
 
         await publishRunComment(runtimeTracker, input.issue, {
           kind: "failed",
@@ -770,6 +950,39 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
     };
   }
 
+  function getRuntimeIssueSnapshot(issueIdentifier: string): RuntimeIssueSnapshot | null {
+    const runtime = getRuntimeSnapshot();
+    const running = runtime.running.find((row) => row.issue_identifier === issueIdentifier) ?? null;
+    const retry = runtime.retrying.find((row) => row.issue_identifier === issueIdentifier) ?? null;
+    const completed = runtime.completed.find((row) => row.issue_identifier === issueIdentifier) ?? null;
+
+    if (!running && !retry && !completed) {
+      return null;
+    }
+
+    const issueId = running?.issue_id ?? retry?.issue_id ?? completed?.issue_id;
+    if (!issueId) {
+      return null;
+    }
+
+    const { events, dropped } = getIssueEvents(issueId);
+
+    return {
+      issue_identifier: issueIdentifier,
+      issue_id: issueId,
+      status: running ? "running" : retry ? "retrying" : "completed",
+      running,
+      retry,
+      completed,
+      codex_totals: runtime.codex_totals,
+      rate_limits: runtime.rate_limits,
+      events,
+      events_count: events.length,
+      events_limit: ISSUE_EVENT_LIMIT,
+      events_truncated: dropped > 0,
+    };
+  }
+
   function onWorkerLifecycleLog(
     issueId: string,
     entry: {
@@ -803,6 +1016,15 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
         state.running.set(issueId, runningEntry);
       }
     }
+
+    appendIssueEvent(issueId, worker.identifier, {
+      source: "worker",
+      kind: "worker_log",
+      message: entry.message,
+      session_id: worker.sessionId,
+      turn_count: worker.turnCount,
+      retry_attempt: worker.retryAttempt,
+    });
   }
 
   function onWorkerCodexEvent(issueId: string, event: CodexRuntimeEvent): void {
@@ -846,6 +1068,18 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
       worker.latestRateLimits = event.rate_limits;
       latestRateLimits = event.rate_limits;
     }
+
+    appendIssueEvent(issueId, worker.identifier, {
+      timestamp: event.timestamp,
+      source: "codex",
+      kind: normalizeCodexEventKind(event.event),
+      message: formatCodexEventMessage(event),
+      session_id: worker.sessionId,
+      turn_count: worker.turnCount,
+      retry_attempt: worker.retryAttempt,
+      usage: normalizeUsage(event.usage),
+      rate_limits: normalizeRateLimits(event.rate_limits),
+    });
   }
 
   function finalizeWorkerMetrics(issueId: string): void {
@@ -873,6 +1107,7 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
     runTickOnce,
     getSnapshot,
     getRuntimeSnapshot,
+    getRuntimeIssueSnapshot,
   };
 }
 
@@ -986,6 +1221,60 @@ function buildRunCommentBody(input: { kind: "started" | "completed" | "failed"; 
     `Error: ${input.error ?? "unknown failure"}`,
     `Timestamp: ${timestamp}`,
   ].join("\n");
+}
+
+function normalizeCodexEventKind(eventName: CodexRuntimeEvent["event"]): string {
+  return `codex_${eventName}`;
+}
+
+function formatCodexEventMessage(event: CodexRuntimeEvent): string {
+  const method = extractCodexMethod(event.payload);
+  if (method) {
+    return `${event.event}: ${method}`;
+  }
+
+  if (event.message) {
+    return event.message;
+  }
+
+  return `codex event: ${event.event}`;
+}
+
+function extractCodexMethod(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return null;
+  }
+
+  const method = (payload as { method?: unknown }).method;
+  return typeof method === "string" && method.trim().length > 0 ? method : null;
+}
+
+function normalizeUsage(usage: Record<string, number> | undefined): RuntimeIssueEventUsage | undefined {
+  if (!usage) {
+    return undefined;
+  }
+
+  const inputTokens = asNumber(usage.input_tokens ?? usage.inputTokens);
+  const outputTokens = asNumber(usage.output_tokens ?? usage.outputTokens);
+  const totalTokens = asNumber(usage.total_tokens ?? usage.totalTokens);
+
+  if (inputTokens === null && outputTokens === null && totalTokens === null) {
+    return undefined;
+  }
+
+  return {
+    input_tokens: inputTokens ?? 0,
+    output_tokens: outputTokens ?? 0,
+    total_tokens: totalTokens ?? (inputTokens ?? 0) + (outputTokens ?? 0),
+  };
+}
+
+function normalizeRateLimits(rateLimits: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
+  if (!rateLimits || typeof rateLimits !== "object") {
+    return undefined;
+  }
+
+  return rateLimits;
 }
 
 function formatLogValue(value: unknown): string {

--- a/packages/symphony-service/tests/cli.test.ts
+++ b/packages/symphony-service/tests/cli.test.ts
@@ -32,6 +32,9 @@ function makeService(overrides?: Partial<SymphonyService>): SymphonyService {
         rate_limits: null,
       };
     },
+    getRuntimeIssueSnapshot() {
+      return null;
+    },
     ...overrides,
   };
 }

--- a/packages/symphony-service/tests/httpServer.test.ts
+++ b/packages/symphony-service/tests/httpServer.test.ts
@@ -67,8 +67,137 @@ function makeService(overrides?: Partial<SymphonyService>): SymphonyService {
         },
       };
     },
+    getRuntimeIssueSnapshot(issueIdentifier: string) {
+      if (issueIdentifier === "ATH-101") {
+        return {
+          issue_identifier: "ATH-101",
+          issue_id: "issue-2",
+          status: "retrying",
+          running: null,
+          retry: {
+            issue_id: "issue-2",
+            issue_identifier: "ATH-101",
+            attempt: 2,
+            due_at_ms: 1_700_000_010_000,
+            error: "no available orchestrator slots",
+          },
+          codex_totals: {
+            input_tokens: 30,
+            output_tokens: 12,
+            total_tokens: 42,
+            seconds_running: 180,
+          },
+          rate_limits: {
+            rpm: {
+              remaining: 900,
+            },
+          },
+          events: [],
+          events_count: 0,
+          events_limit: 200,
+          events_truncated: false,
+        };
+      }
+
+      if (issueIdentifier === "ATH-102") {
+        return {
+          issue_identifier: "ATH-102",
+          issue_id: "issue-3",
+          status: "completed",
+          running: null,
+          retry: null,
+          completed: {
+            issue_id: "issue-3",
+            issue_identifier: "ATH-102",
+            state: "Human Review",
+            attempt: 1,
+            observed_at_ms: 1_700_000_020_000,
+            done: true,
+          },
+          codex_totals: {
+            input_tokens: 30,
+            output_tokens: 12,
+            total_tokens: 42,
+            seconds_running: 180,
+          },
+          rate_limits: {
+            rpm: {
+              remaining: 900,
+            },
+          },
+          events: [],
+          events_count: 0,
+          events_limit: 200,
+          events_truncated: false,
+        };
+      }
+
+      if (issueIdentifier !== "ATH-100") {
+        return null;
+      }
+
+      return {
+        issue_identifier: "ATH-100",
+        issue_id: "issue-1",
+        status: "running",
+        running: {
+          state: "In Progress",
+          session_id: "thread-1-turn-1",
+          turn_count: 3,
+          retry_attempt: 1,
+          started_at_ms: 1_700_000_000_000,
+          last_codex_timestamp_ms: 1_700_000_000_500,
+          codex_input_tokens: 10,
+          codex_output_tokens: 4,
+          codex_total_tokens: 14,
+        },
+        retry: null,
+        completed: null,
+        codex_totals: {
+          input_tokens: 30,
+          output_tokens: 12,
+          total_tokens: 42,
+          seconds_running: 180,
+        },
+        rate_limits: {
+          rpm: {
+            remaining: 900,
+          },
+        },
+        events: [
+          {
+            seq: 1,
+            timestamp: "2026-03-30T00:00:00.000Z",
+            source: "service",
+            kind: "dispatch_started",
+            message: "Dispatch started for ATH-100",
+            session_id: null,
+            turn_count: 0,
+            retry_attempt: 1,
+          },
+          {
+            seq: 2,
+            timestamp: "2026-03-30T00:00:01.000Z",
+            source: "codex",
+            kind: "codex_notification",
+            message: "Codex notification received",
+            session_id: "thread-1-turn-1",
+            turn_count: 0,
+            retry_attempt: 1,
+            usage: {
+              input_tokens: 10,
+              output_tokens: 4,
+              total_tokens: 14,
+            },
+          },
+        ],
+        events_count: 2,
+        events_limit: 200,
+        events_truncated: false,
+      };
+    },
     ...overrides,
-  };
+  } as SymphonyService;
 }
 
 describe("status server", () => {
@@ -83,6 +212,7 @@ describe("status server", () => {
       expect(rootResponse.status).toBe(200);
       const rootBody = await rootResponse.text();
       expect(rootBody).toContain("Symphony Runtime Status");
+      expect(rootBody).toContain("Issue Activity");
 
       const stateResponse = await fetch(`http://${statusServer.host}:${statusServer.port}/api/v1/state`);
       expect(stateResponse.status).toBe(200);
@@ -112,6 +242,11 @@ describe("status server", () => {
       const runningBody = (await runningResponse.json()) as Record<string, any>;
       expect(runningBody.status).toBe("running");
       expect(runningBody.issue_id).toBe("issue-1");
+      expect(runningBody.events_count).toBe(2);
+      expect(runningBody.events_limit).toBe(200);
+      expect(runningBody.events_truncated).toBe(false);
+      expect(runningBody.events[0].kind).toBe("dispatch_started");
+      expect(runningBody.events[1].kind).toBe("codex_notification");
 
       const retryResponse = await fetch(`http://${statusServer.host}:${statusServer.port}/api/v1/ATH-101`);
       expect(retryResponse.status).toBe(200);

--- a/packages/symphony-service/tests/service.test.ts
+++ b/packages/symphony-service/tests/service.test.ts
@@ -461,6 +461,202 @@ describe("createSymphonyService", () => {
     await service.stop();
   });
 
+  it("exposes per-issue runtime snapshot with structured timeline events", async () => {
+    let nowMs = 50_000;
+    let releaseWorker: (() => void) | null = null;
+    const candidates = [issue({ id: "timeline-1", identifier: "ATH-550", state: "In Progress" })];
+
+    const service = createSymphonyService({
+      workflowPath: "/tmp/WORKFLOW.md",
+      deps: {
+        nowMs: () => nowMs,
+        loadWorkflowFile: async () => workflow(1000),
+        createTracker: () => ({
+          async fetchCandidateIssues() {
+            return candidates.splice(0, candidates.length);
+          },
+          async fetchIssuesByStates() {
+            return [];
+          },
+          async fetchIssueStatesByIds() {
+            return [];
+          },
+        }),
+        cleanupTerminalIssueWorkspaces: async () => ({ removed: 0, failed: 0, warnings: [] }),
+        processDueRetries: async () => ({
+          processedIssueIds: [],
+          dispatchedIssueIds: [],
+          requeuedIssueIds: [],
+          releasedIssueIds: [],
+        }),
+        setIntervalFn: () => {
+          return 1 as unknown as ReturnType<typeof setInterval>;
+        },
+        clearIntervalFn: () => {
+          return;
+        },
+        createCodexClient: (_config, onEvent) => {
+          onEvent?.({
+            event: "notification",
+            timestamp: new Date(nowMs).toISOString(),
+            session_id: "thread-550-turn-1",
+            usage: {
+              input_tokens: 22,
+              output_tokens: 8,
+              total_tokens: 30,
+            },
+            rate_limits: {
+              remaining: 5,
+            },
+          });
+
+          return {
+            async startSession() {
+              return { threadId: "thread-550" };
+            },
+            async runTurn() {
+              return { turnId: "turn-1", sessionId: "thread-550-turn-1", outcome: "completed" as const };
+            },
+            stop() {
+              releaseWorker?.();
+            },
+          };
+        },
+        runIssueAttempt: async (input) => {
+          input.onLog?.({
+            message: "action=turn outcome=completed",
+            details: {
+              issue_id: input.issue.id,
+              issue_identifier: input.issue.identifier,
+              session_id: "thread-550-turn-1",
+            },
+          });
+
+          await new Promise<void>((resolve) => {
+            releaseWorker = resolve;
+          });
+
+          return {
+            exit: "normal" as const,
+            turnCount: 1,
+            workspacePath: "/tmp/fake",
+            issue: input.issue,
+          };
+        },
+      },
+    });
+
+    await service.start();
+
+    const issueSnapshot = (service as any).getRuntimeIssueSnapshot("ATH-550");
+    expect(issueSnapshot).not.toBeNull();
+    expect(issueSnapshot.status).toBe("running");
+    expect(issueSnapshot.events_count).toBeGreaterThan(0);
+    expect(issueSnapshot.events_limit).toBe(200);
+    expect(issueSnapshot.events_truncated).toBe(false);
+
+    const seqs = issueSnapshot.events.map((event: { seq: number }) => event.seq);
+    expect(seqs).toEqual([...seqs].sort((a, b) => a - b));
+    expect(issueSnapshot.events.some((event: { kind: string }) => event.kind === "dispatch_started")).toBe(true);
+    expect(issueSnapshot.events.some((event: { kind: string }) => event.kind === "worker_log")).toBe(true);
+    expect(issueSnapshot.events.some((event: { kind: string }) => event.kind === "codex_notification")).toBe(true);
+    expect(
+      issueSnapshot.events.some(
+        (event: { kind: string; usage?: { total_tokens: number } }) =>
+          event.kind === "codex_notification" && event.usage?.total_tokens === 30,
+      ),
+    ).toBe(true);
+
+    await service.stop();
+  });
+
+  it("caps per-issue timeline event history with truncation metadata", async () => {
+    const candidates = [issue({ id: "timeline-cap-1", identifier: "ATH-551", state: "In Progress" })];
+
+    const service = createSymphonyService({
+      workflowPath: "/tmp/WORKFLOW.md",
+      deps: {
+        loadWorkflowFile: async () => workflow(1000),
+        createTracker: () => ({
+          async fetchCandidateIssues() {
+            return candidates.splice(0, candidates.length);
+          },
+          async fetchIssuesByStates() {
+            return [];
+          },
+          async fetchIssueStatesByIds() {
+            return [];
+          },
+        }),
+        cleanupTerminalIssueWorkspaces: async () => ({ removed: 0, failed: 0, warnings: [] }),
+        processDueRetries: async () => ({
+          processedIssueIds: [],
+          dispatchedIssueIds: [],
+          requeuedIssueIds: [],
+          releasedIssueIds: [],
+        }),
+        setIntervalFn: () => {
+          return 1 as unknown as ReturnType<typeof setInterval>;
+        },
+        clearIntervalFn: () => {
+          return;
+        },
+        createCodexClient: (_config, onEvent) => {
+          for (let i = 0; i < 260; i += 1) {
+            onEvent?.({
+              event: "notification",
+              timestamp: new Date(60_000 + i).toISOString(),
+              session_id: "thread-551-turn-1",
+              usage: {
+                total_tokens: i + 1,
+              },
+            });
+          }
+
+          return {
+            async startSession() {
+              return { threadId: "thread-551" };
+            },
+            async runTurn() {
+              return { turnId: "turn-1", sessionId: "thread-551-turn-1", outcome: "completed" as const };
+            },
+            stop() {},
+          };
+        },
+        runIssueAttempt: async (input) => {
+          input.onLog?.({
+            message: "action=turn outcome=completed",
+            details: {
+              issue_id: input.issue.id,
+              issue_identifier: input.issue.identifier,
+              session_id: "thread-551-turn-1",
+            },
+          });
+
+          return {
+            exit: "normal" as const,
+            turnCount: 1,
+            workspacePath: "/tmp/fake",
+            issue: input.issue,
+          };
+        },
+      },
+    });
+
+    await service.start();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const issueSnapshot = (service as any).getRuntimeIssueSnapshot("ATH-551");
+    expect(issueSnapshot).not.toBeNull();
+    expect(issueSnapshot.events_count).toBe(200);
+    expect(issueSnapshot.events_limit).toBe(200);
+    expect(issueSnapshot.events_truncated).toBe(true);
+    expect(issueSnapshot.events[0].seq).toBeGreaterThan(1);
+
+    await service.stop();
+  });
+
   it("includes retry queue rows in runtime snapshot after worker failure", async () => {
     let nowMs = 10_000;
     const candidates = [issue({ id: "retry-1", identifier: "ATH-401", state: "Todo" })];


### PR DESCRIPTION
## Summary
- add bounded per-issue activity timelines in `symphony-service` runtime (`200` events per issue, in-memory ring buffer)
- capture structured timeline records from service lifecycle, worker lifecycle logs, and Codex runtime events
- add `getRuntimeIssueSnapshot(issueIdentifier)` to expose enriched issue runtime details with additive timeline metadata (`events`, `events_count`, `events_limit`, `events_truncated`)
- update `/api/v1/<issue_identifier>` to use the new issue snapshot and include timeline data while preserving existing fields
- add dashboard issue drill-down UI: clicking running/retrying issues now opens an inline **Issue Activity** panel with live polling updates
- preserve and merge upstream completed-signal behavior while introducing timeline visibility
- update docs (`README`, `CONFORMANCE`) and add/adjust tests in `service`, `httpServer`, and `cli`

## Why
- operators needed actionable in-progress visibility for active tasks beyond aggregate counters
- worker and Codex events were already emitted but not retained/exposed for operator inspection
- this change makes run progress debuggable from the server dashboard and issue API without changing core orchestration algorithms or adding persistence complexity

## Validation
- `bun run --filter '@athena/symphony-service' test tests/service.test.ts tests/httpServer.test.ts`
- `bun run --filter '@athena/symphony-service' test`
- `bunx tsc --noEmit -p packages/symphony-service/tsconfig.json`
- `bun run --filter '@athena/storefront-webapp' test`
