### PR TITLE
feat(symphony-service): add worker and continuation token-burn guardrails

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -15,6 +15,11 @@ hooks:
   timeout_ms: 120000
 agent:
   max_concurrent_agents: 2
+  max_turns: 12
+  max_input_tokens_per_attempt: 150000
+  max_issue_input_tokens: 300000
+  max_continuation_runs_per_issue: 2
+  continuation_retry_delay_ms: 30000
   max_retry_backoff_ms: 300000
 codex:
   command: /Applications/Codex.app/Contents/Resources/codex app-server

--- a/packages/symphony-service/CONFORMANCE.md
+++ b/packages/symphony-service/CONFORMANCE.md
@@ -20,8 +20,9 @@ Spec reference: https://github.com/openai/symphony/blob/main/SPEC.md
 | Coding-agent app-server subprocess client with JSON line protocol | Implemented | `src/codex/client.ts`, `src/codex/protocol.ts` | `tests/codexClient.test.ts`, `tests/codexProtocol.test.ts` |
 | Codex launch command config (`codex.command`, default `codex app-server`) | Implemented | `src/config.ts`, `src/service.ts` | `tests/config.test.ts`, `tests/service.test.ts` |
 | Strict prompt rendering with `issue` and `attempt` variables | Implemented | `src/template.ts`, `src/worker.ts` | `tests/template.test.ts`, `tests/worker.test.ts` |
-| Exponential retry queue with continuation retries after normal exit | Implemented | `src/retry.ts`, `src/orchestrator.ts`, `src/runtime.ts` | `tests/retry.test.ts`, `tests/orchestrator.test.ts`, `tests/runtime.test.ts` |
+| Exponential retry queue with bounded continuation retries after normal exit | Implemented | `src/retry.ts`, `src/orchestrator.ts`, `src/runtime.ts`, `src/service.ts`, `src/worker.ts` | `tests/retry.test.ts`, `tests/orchestrator.test.ts`, `tests/runtime.test.ts`, `tests/service.test.ts`, `tests/worker.test.ts` |
 | Configurable retry backoff cap (`agent.max_retry_backoff_ms`) | Implemented | `src/config.ts`, `src/orchestrator.ts`, `src/runtime.ts` | `tests/config.test.ts`, `tests/orchestrator.test.ts` |
+| Runtime token/turn/no-progress guardrails to prevent runaway burn | Implemented | `src/config.ts`, `src/worker.ts`, `src/service.ts` | `tests/config.test.ts`, `tests/worker.test.ts`, `tests/service.test.ts` |
 | Reconciliation that stops runs on terminal/non-active tracker states | Implemented | `src/orchestrator.ts`, `src/runtime.ts`, `src/service.ts` | `tests/orchestrator.test.ts`, `tests/runtime.test.ts`, `tests/service.test.ts` |
 | Workspace cleanup for terminal issues (startup sweep + active transition) | Implemented | `src/startup.ts`, `src/service.ts` | `tests/startup.test.ts`, `tests/service.test.ts` |
 | Structured logs including issue and session context fields | Implemented | `src/service.ts`, `src/worker.ts` | `tests/service.test.ts` |

--- a/packages/symphony-service/README.md
+++ b/packages/symphony-service/README.md
@@ -16,6 +16,7 @@ Spec-aligned Symphony service foundation for Athena.
 - CLI-hosted service loop with optional workflow watch/reload
 - Optional HTTP status server (`--port` or `server.port`) with dashboard + JSON APIs
 - Hook-driven git worktree provisioning for issue workspaces (`after_create`, `before_run`, `before_remove`)
+- Runtime burn guardrails for in-attempt and continuation loops
 
 ## Specification tracking
 
@@ -73,6 +74,22 @@ If labels are missing, scope is inferred from issue text and touched files, and 
 - Symphony records a delivery-complete signal when a run exits with issue state equal to handoff state
   or any terminal state.
 - On signal, Symphony writes a structured tracker comment so operators can quickly verify delivery status.
+
+## Runtime Guardrails
+
+Symphony enforces bounded execution to prevent token-burn loops:
+
+- In-attempt guardrails:
+  - `agent.max_turns` (default: `12`)
+  - `agent.max_input_tokens_per_attempt` (default: `150000`)
+  - no-progress cutoff (3 consecutive turns with unchanged `git status --porcelain`)
+- Continuation guardrails:
+  - `agent.max_issue_input_tokens` (default: `300000`)
+  - `agent.max_continuation_runs_per_issue` (default: `2`)
+  - `agent.continuation_retry_delay_ms` (default: `30000`)
+
+When guardrails trip, Symphony stops continuation, writes a tracker comment with counters/thresholds, and moves
+the issue to the configured handoff state (`tracker.handoff_state`, default `Human Review`).
 
 ## Workspace Hook Notes
 

--- a/packages/symphony-service/src/codex/client.ts
+++ b/packages/symphony-service/src/codex/client.ts
@@ -64,7 +64,7 @@ interface PendingRequest {
 }
 
 interface PendingTurn {
-  resolve: (outcome: TurnOutcome) => void;
+  resolve: (result: { outcome: TurnOutcome; usage?: Record<string, number> }) => void;
   timer: ReturnType<typeof setTimeout>;
 }
 
@@ -75,7 +75,7 @@ export class CodexAppServerClient {
   private nextRequestId = 1;
   private initialized = false;
   private pendingTurn: PendingTurn | null = null;
-  private queuedTurnOutcome: TurnOutcome | null = null;
+  private queuedTurnResult: { outcome: TurnOutcome; usage?: Record<string, number> } | null = null;
   private readonly recentStderr: string[] = [];
 
   constructor(
@@ -115,7 +115,7 @@ export class CodexAppServerClient {
     cwd: string;
     title: string;
     prompt: string;
-  }): Promise<{ turnId: string; sessionId: string; outcome: TurnOutcome }> {
+  }): Promise<{ turnId: string; sessionId: string; outcome: TurnOutcome; usage?: Record<string, number> }> {
     this.assertAbsoluteCwd(input.cwd);
 
     if (!this.process) {
@@ -143,8 +143,8 @@ export class CodexAppServerClient {
     const sessionId = `${input.threadId}-${turnId}`;
     this.emit({ event: "session_started", session_id: sessionId });
 
-    const outcome = await this.waitForTurnOutcome();
-    return { turnId, sessionId, outcome };
+    const result = await this.waitForTurnOutcome();
+    return { turnId, sessionId, outcome: result.outcome, usage: result.usage };
   }
 
   stop(): void {
@@ -331,26 +331,26 @@ export class CodexAppServerClient {
 
     if (isUserInputRequired(message)) {
       this.emit({ event: "turn_input_required", payload: { method }, usage, rate_limits: rateLimits });
-      this.resolveTurnOutcome("turn_input_required");
+      this.resolveTurnOutcome("turn_input_required", usage ?? undefined);
       return;
     }
 
     const terminal = getTurnTerminalState(method);
     if (terminal === "completed") {
       this.emit({ event: "turn_completed", payload: { method }, usage, rate_limits: rateLimits });
-      this.resolveTurnOutcome("completed");
+      this.resolveTurnOutcome("completed", usage ?? undefined);
       return;
     }
 
     if (terminal === "failed") {
       this.emit({ event: "turn_failed", payload: { method }, usage, rate_limits: rateLimits });
-      this.resolveTurnOutcome("failed");
+      this.resolveTurnOutcome("failed", usage ?? undefined);
       return;
     }
 
     if (terminal === "cancelled") {
       this.emit({ event: "turn_cancelled", payload: { method }, usage, rate_limits: rateLimits });
-      this.resolveTurnOutcome("cancelled");
+      this.resolveTurnOutcome("cancelled", usage ?? undefined);
       return;
     }
 
@@ -375,37 +375,37 @@ export class CodexAppServerClient {
     proc.stdin.write(`${JSON.stringify({ id, result })}\n`);
   }
 
-  private waitForTurnOutcome(): Promise<TurnOutcome> {
+  private waitForTurnOutcome(): Promise<{ outcome: TurnOutcome; usage?: Record<string, number> }> {
     if (this.pendingTurn) {
       throw new SymphonyError("response_error", "a turn is already in progress");
     }
 
-    if (this.queuedTurnOutcome) {
-      const queued = this.queuedTurnOutcome;
-      this.queuedTurnOutcome = null;
+    if (this.queuedTurnResult) {
+      const queued = this.queuedTurnResult;
+      this.queuedTurnResult = null;
       return Promise.resolve(queued);
     }
 
-    return new Promise<TurnOutcome>((resolve) => {
+    return new Promise<{ outcome: TurnOutcome; usage?: Record<string, number> }>((resolve) => {
       const timer = setTimeout(() => {
         this.pendingTurn = null;
-        resolve("turn_timeout");
+        resolve({ outcome: "turn_timeout" });
       }, this.config.turnTimeoutMs);
 
       this.pendingTurn = { resolve, timer };
     });
   }
 
-  private resolveTurnOutcome(outcome: TurnOutcome): void {
+  private resolveTurnOutcome(outcome: TurnOutcome, usage?: Record<string, number>): void {
     if (!this.pendingTurn) {
-      this.queuedTurnOutcome = outcome;
+      this.queuedTurnResult = { outcome, usage };
       return;
     }
 
     const pending = this.pendingTurn;
     this.pendingTurn = null;
     clearTimeout(pending.timer);
-    pending.resolve(outcome);
+    pending.resolve({ outcome, usage });
   }
 
   private rejectAllPending(error: Error): void {
@@ -419,7 +419,7 @@ export class CodexAppServerClient {
   private teardown(): void {
     this.process = null;
     this.initialized = false;
-    this.queuedTurnOutcome = null;
+    this.queuedTurnResult = null;
 
     if (this.stdoutLineReader) {
       this.stdoutLineReader.removeAllListeners();

--- a/packages/symphony-service/src/config.ts
+++ b/packages/symphony-service/src/config.ts
@@ -48,7 +48,11 @@ export function resolveEffectiveConfig(config: WorkflowConfigMap): EffectiveConf
     agent: {
       maxConcurrentAgents: asPositiveInt(agent.max_concurrent_agents, 10),
       maxRetryBackoffMs: asPositiveInt(agent.max_retry_backoff_ms, 300_000),
-      maxTurns: asPositiveInt(agent.max_turns, 20),
+      maxTurns: asPositiveInt(agent.max_turns, 12),
+      maxInputTokensPerAttempt: asPositiveInt(agent.max_input_tokens_per_attempt, 150_000),
+      maxIssueInputTokens: asPositiveInt(agent.max_issue_input_tokens, 300_000),
+      maxContinuationRunsPerIssue: asPositiveInt(agent.max_continuation_runs_per_issue, 2),
+      continuationRetryDelayMs: asPositiveInt(agent.continuation_retry_delay_ms, 30_000),
       maxConcurrentAgentsByState: normalizeStateLimits(agent.max_concurrent_agents_by_state),
     },
     codex: {

--- a/packages/symphony-service/src/orchestrator.ts
+++ b/packages/symphony-service/src/orchestrator.ts
@@ -33,6 +33,7 @@ export interface RetryScheduleInput {
   maxRetryBackoffMs: number;
   mode: "continuation" | "failure";
   error: string;
+  continuationDelayMs?: number;
 }
 
 export interface ReconcileAction {
@@ -142,7 +143,7 @@ export function selectDispatchCandidates(input: {
 export function scheduleRetry(state: OrchestratorState, input: RetryScheduleInput): RetryEntry {
   const delayMs =
     input.mode === "continuation"
-      ? calculateContinuationDelay()
+      ? calculateContinuationDelay(input.continuationDelayMs ?? 1_000)
       : calculateFailureRetryDelay(input.attempt, input.maxRetryBackoffMs);
 
   const entry: RetryEntry = {
@@ -165,6 +166,9 @@ export function onWorkerExit(
     reason: "normal" | "failure";
     maxRetryBackoffMs: number;
     error?: string;
+    allowContinuation?: boolean;
+    continuationDelayMs?: number;
+    continuationAttempt?: number;
   },
 ): RetryEntry | null {
   const running = state.running.get(input.issueId);
@@ -176,14 +180,20 @@ export function onWorkerExit(
 
   if (input.reason === "normal") {
     state.completed.add(input.issueId);
+
+    if (input.allowContinuation === false) {
+      return null;
+    }
+
     return scheduleRetry(state, {
       issueId: input.issueId,
       identifier: running.issue.identifier,
-      attempt: 1,
+      attempt: input.continuationAttempt ?? Math.max(running.retryAttempt + 1, 1),
       nowMs: input.nowMs,
       maxRetryBackoffMs: input.maxRetryBackoffMs,
       mode: "continuation",
       error: "continuation_retry",
+      continuationDelayMs: input.continuationDelayMs,
     });
   }
 

--- a/packages/symphony-service/src/retry.ts
+++ b/packages/symphony-service/src/retry.ts
@@ -4,6 +4,7 @@ export function calculateFailureRetryDelay(attempt: number, maxRetryBackoffMs: n
   return Math.min(rawDelay, maxRetryBackoffMs);
 }
 
-export function calculateContinuationDelay(): number {
-  return 1_000;
+export function calculateContinuationDelay(continuationDelayMs: number): number {
+  const normalizedDelay = Math.max(1, Math.trunc(continuationDelayMs));
+  return normalizedDelay;
 }

--- a/packages/symphony-service/src/runtime.ts
+++ b/packages/symphony-service/src/runtime.ts
@@ -340,5 +340,6 @@ function requeueRetryEntry(
     maxRetryBackoffMs: input.config.agent.maxRetryBackoffMs,
     mode: options.mode,
     error: options.error,
+    continuationDelayMs: input.config.agent.continuationRetryDelayMs,
   });
 }

--- a/packages/symphony-service/src/service.ts
+++ b/packages/symphony-service/src/service.ts
@@ -49,6 +49,13 @@ interface ActiveWorker {
   stop: () => void;
 }
 
+interface IssueLifecycleMetrics {
+  issueId: string;
+  issueIdentifier: string;
+  lifecycleInputTokens: number;
+  continuationRuns: number;
+}
+
 interface ServiceDependencies {
   loadWorkflowFile: (path: string) => Promise<WorkflowDocument>;
   watchWorkflowFile: (path: string, onReloadRequested: () => void) => FSWatcher;
@@ -208,6 +215,7 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
   const activeWorkers = new Map<string, ActiveWorker>();
   const completionSignals = new Map<string, RuntimeSnapshotCompletedRow>();
   const issueEventBuffers = new Map<string, IssueEventBuffer>();
+  const issueLifecycleMetrics = new Map<string, IssueLifecycleMetrics>();
   const workerTasks = new Set<Promise<void>>();
   const guardrailNotifiedIssueIds = new Set<string>();
   let completedInputTokens = 0;
@@ -383,6 +391,7 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
     state.running.delete(action.issueId);
     state.claimed.delete(action.issueId);
     state.retryAttempts.delete(action.issueId);
+    clearIssueLifecycle(action.issueId);
 
     if (action.action === "terminate_cleanup" && config) {
       const workspace = resolveWorkspaceLocation(config.workspace.root, action.identifier);
@@ -463,6 +472,27 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
     };
   }
 
+  function getOrCreateIssueLifecycle(issueId: string, issueIdentifier: string): IssueLifecycleMetrics {
+    const existing = issueLifecycleMetrics.get(issueId);
+    if (existing) {
+      existing.issueIdentifier = issueIdentifier;
+      return existing;
+    }
+
+    const created: IssueLifecycleMetrics = {
+      issueId,
+      issueIdentifier,
+      lifecycleInputTokens: 0,
+      continuationRuns: 0,
+    };
+    issueLifecycleMetrics.set(issueId, created);
+    return created;
+  }
+
+  function clearIssueLifecycle(issueId: string): void {
+    issueLifecycleMetrics.delete(issueId);
+  }
+
   function evaluateGuardrails(issue: NormalizedIssue): string[] {
     const problems: string[] = [];
 
@@ -504,7 +534,11 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
     });
   }
 
-  async function moveIssueToInProgress(trackerClient: TrackerClient, issue: NormalizedIssue): Promise<void> {
+  async function moveIssueToState(
+    trackerClient: TrackerClient,
+    issue: NormalizedIssue,
+    stateName: string,
+  ): Promise<void> {
     if (!trackerClient.updateIssueStateByName) {
       return;
     }
@@ -512,7 +546,7 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
     await safeTrackerWrite("state_transition", issue, async () => {
       const changed = await trackerClient.updateIssueStateByName?.({
         issue,
-        stateName: "In Progress",
+        stateName,
       });
 
       if (changed) {
@@ -522,11 +556,15 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
           details: {
             issue_id: issue.id,
             issue_identifier: issue.identifier,
-            next_state: "In Progress",
+            next_state: stateName,
           },
         });
       }
     });
+  }
+
+  async function moveIssueToInProgress(trackerClient: TrackerClient, issue: NormalizedIssue): Promise<void> {
+    await moveIssueToState(trackerClient, issue, "In Progress");
   }
 
   async function publishRunComment(
@@ -579,6 +617,54 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
     ].join("\n");
 
     await safeTrackerWrite("delivery_complete_signal", issue, async () => {
+      await trackerClient.createIssueComment?.({
+        issueId: issue.id,
+        body,
+      });
+    });
+  }
+
+  async function publishContinuationGuardrailComment(
+    trackerClient: TrackerClient,
+    issue: NormalizedIssue,
+    input: {
+      reasons: string[];
+      turnCount: number;
+      retryAttempt: number;
+      lifecycleInputTokens: number;
+      maxIssueInputTokens: number;
+      continuationRuns: number;
+      maxContinuationRunsPerIssue: number;
+      maxInputTokensPerAttempt: number;
+    },
+  ): Promise<void> {
+    if (!trackerClient.createIssueComment) {
+      return;
+    }
+
+    const reasonLines = input.reasons.map((reason) => `- ${reason}`).join("\n");
+    const body = [
+      "Symphony paused automatic continuation for this issue after hitting runtime guardrails.",
+      "",
+      "## Guardrail Stop",
+      reasonLines,
+      "",
+      "## Runtime Counters",
+      `- turn_count: ${input.turnCount}`,
+      `- retry_attempt: ${input.retryAttempt}`,
+      `- lifecycle_input_tokens: ${input.lifecycleInputTokens}`,
+      `- continuation_runs: ${input.continuationRuns}`,
+      "",
+      "## Thresholds",
+      `- agent.max_input_tokens_per_attempt: ${input.maxInputTokensPerAttempt}`,
+      `- agent.max_issue_input_tokens: ${input.maxIssueInputTokens}`,
+      `- agent.max_continuation_runs_per_issue: ${input.maxContinuationRunsPerIssue}`,
+      "",
+      `Issue moved to ${config?.tracker.handoffState ?? "Human Review"} for operator handoff.`,
+      "Operator next step: refine scope/instructions and move issue back to an active state to resume.",
+    ].join("\n");
+
+    await safeTrackerWrite("continuation_guardrail_stop", issue, async () => {
       await trackerClient.createIssueComment?.({
         issueId: issue.id,
         body,
@@ -657,6 +743,7 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
     }
 
     guardrailNotifiedIssueIds.delete(input.issue.id);
+    getOrCreateIssueLifecycle(input.issue.id, input.issue.identifier);
     completionSignals.delete(input.issue.id);
     await moveIssueToInProgress(runtimeTracker, input.issue);
     await publishRunComment(runtimeTracker, input.issue, {
@@ -716,12 +803,47 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
         },
       })
       .then(async (result) => {
+        const lifecycle = getOrCreateIssueLifecycle(result.issue.id, result.issue.identifier);
+        lifecycle.lifecycleInputTokens += worker.usage.inputTokens;
+
+        const doneSignalState = isDoneSignalState(result.issue.state, runtimeConfig);
+        const guardrailReasons: string[] = [];
+        if (result.exit === "guardrail_stop") {
+          if (result.guardrail_reason === "attempt_input_budget_exceeded") {
+            guardrailReasons.push(
+              `attempt input token budget exceeded (${worker.usage.inputTokens}/${runtimeConfig.agent.maxInputTokensPerAttempt} this attempt)`,
+            );
+          } else if (result.guardrail_reason === "no_progress_window_exceeded") {
+            guardrailReasons.push("no-progress window exceeded (3 consecutive turns without workspace diff change)");
+          }
+        }
+
+        if (!doneSignalState && lifecycle.continuationRuns >= runtimeConfig.agent.maxContinuationRunsPerIssue) {
+          guardrailReasons.push(
+            `continuation run cap reached (${lifecycle.continuationRuns}/${runtimeConfig.agent.maxContinuationRunsPerIssue})`,
+          );
+        }
+
+        if (!doneSignalState && lifecycle.lifecycleInputTokens >= runtimeConfig.agent.maxIssueInputTokens) {
+          guardrailReasons.push(
+            `lifecycle input token budget exceeded (${lifecycle.lifecycleInputTokens}/${runtimeConfig.agent.maxIssueInputTokens})`,
+          );
+        }
+
+        const allowContinuation = !doneSignalState && guardrailReasons.length === 0;
         const retry = onWorkerExit(state, {
           issueId: input.issue.id,
           nowMs: deps.nowMs(),
           reason: "normal",
           maxRetryBackoffMs: runtimeConfig.agent.maxRetryBackoffMs,
+          allowContinuation,
+          continuationDelayMs: runtimeConfig.agent.continuationRetryDelayMs,
+          continuationAttempt: Math.max(worker.retryAttempt + 1, 1),
         });
+
+        if (!retry) {
+          state.claimed.delete(input.issue.id);
+        }
 
         appendIssueEvent(result.issue.id, result.issue.identifier, {
           source: "service",
@@ -732,15 +854,52 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
           retry_attempt: worker.retryAttempt,
         });
 
-        if (retry) {
+        if (result.exit === "guardrail_stop") {
           appendIssueEvent(result.issue.id, result.issue.identifier, {
             source: "service",
-            kind: "retry_scheduled",
+            kind: "attempt_guardrail_blocked",
+            message: `Attempt guardrail blocked continuation (${result.guardrail_reason ?? "unknown"})`,
+            session_id: worker.sessionId,
+            turn_count: worker.turnCount,
+            retry_attempt: worker.retryAttempt,
+          });
+        }
+
+        if (retry) {
+          if (retry.error === "continuation_retry") {
+            lifecycle.continuationRuns += 1;
+          }
+
+          appendIssueEvent(result.issue.id, result.issue.identifier, {
+            source: "service",
+            kind: retry.error === "continuation_retry" ? "continuation_scheduled" : "retry_scheduled",
             message: `Retry scheduled for ${new Date(retry.dueAtMs).toISOString()} (${retry.error})`,
             session_id: worker.sessionId,
             turn_count: worker.turnCount,
             retry_attempt: retry.attempt,
           });
+        } else if (!doneSignalState && guardrailReasons.length > 0) {
+          appendIssueEvent(result.issue.id, result.issue.identifier, {
+            source: "service",
+            kind: "continuation_guardrail_blocked",
+            message: `Continuation blocked by guardrails: ${guardrailReasons.join(" | ")}`,
+            session_id: worker.sessionId,
+            turn_count: worker.turnCount,
+            retry_attempt: worker.retryAttempt,
+          });
+
+          await moveIssueToState(runtimeTracker, result.issue, runtimeConfig.tracker.handoffState);
+          await publishContinuationGuardrailComment(runtimeTracker, result.issue, {
+            reasons: guardrailReasons,
+            turnCount: worker.turnCount,
+            retryAttempt: worker.retryAttempt,
+            lifecycleInputTokens: lifecycle.lifecycleInputTokens,
+            maxIssueInputTokens: runtimeConfig.agent.maxIssueInputTokens,
+            continuationRuns: lifecycle.continuationRuns,
+            maxContinuationRunsPerIssue: runtimeConfig.agent.maxContinuationRunsPerIssue,
+            maxInputTokensPerAttempt: runtimeConfig.agent.maxInputTokensPerAttempt,
+          });
+          clearIssueLifecycle(result.issue.id);
         }
 
         await publishRunComment(runtimeTracker, result.issue, {
@@ -765,9 +924,13 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
             turn_count: worker.turnCount,
             retry_attempt: worker.retryAttempt,
           });
+          clearIssueLifecycle(result.issue.id);
         }
       })
       .catch(async (error) => {
+        const lifecycle = getOrCreateIssueLifecycle(input.issue.id, input.issue.identifier);
+        lifecycle.lifecycleInputTokens += worker.usage.inputTokens;
+
         const retry = onWorkerExit(state, {
           issueId: input.issue.id,
           nowMs: deps.nowMs(),

--- a/packages/symphony-service/src/types.ts
+++ b/packages/symphony-service/src/types.ts
@@ -50,6 +50,10 @@ export interface EffectiveConfig {
     maxConcurrentAgents: number;
     maxRetryBackoffMs: number;
     maxTurns: number;
+    maxInputTokensPerAttempt: number;
+    maxIssueInputTokens: number;
+    maxContinuationRunsPerIssue: number;
+    continuationRetryDelayMs: number;
     maxConcurrentAgentsByState: Record<string, number>;
   };
   codex: {

--- a/packages/symphony-service/src/worker.ts
+++ b/packages/symphony-service/src/worker.ts
@@ -1,9 +1,14 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import type { TurnOutcome } from "./codex/client";
 import { SymphonyError, toErrorMessage } from "./errors";
 import type { NormalizedIssue, TrackerClient } from "./issue";
 import { buildIssuePrompt } from "./template";
 import type { EffectiveConfig, IssueTemplateInput } from "./types";
 import { ensureWorkspaceForIssue, runAfterRunHook, runBeforeRunHook, type WorkspaceConfig } from "./workspace";
+
+const NO_PROGRESS_WINDOW = 3;
+const execFileAsync = promisify(execFile);
 
 export interface WorkerCodexClient {
   startSession(input: { cwd: string }): Promise<{ threadId: string }>;
@@ -12,7 +17,7 @@ export interface WorkerCodexClient {
     cwd: string;
     title: string;
     prompt: string;
-  }): Promise<{ turnId: string; sessionId: string; outcome: TurnOutcome }>;
+  }): Promise<{ turnId: string; sessionId: string; outcome: TurnOutcome; usage?: Record<string, number> }>;
   stop(): void;
 }
 
@@ -27,10 +32,11 @@ export interface RunIssueAttemptInput {
 }
 
 export interface RunIssueAttemptResult {
-  exit: "normal";
+  exit: "normal" | "guardrail_stop";
   turnCount: number;
   workspacePath: string;
   issue: NormalizedIssue;
+  guardrail_reason?: "attempt_input_budget_exceeded" | "no_progress_window_exceeded";
 }
 
 export async function runIssueAttempt(input: RunIssueAttemptInput): Promise<RunIssueAttemptResult> {
@@ -41,8 +47,11 @@ export async function runIssueAttempt(input: RunIssueAttemptInput): Promise<RunI
   const codex = input.createCodexClient();
   let shouldStopClient = true;
   let turnCount = 0;
+  let cumulativeInputTokens = 0;
   let currentIssue = input.issue;
   let sessionId: string | null = null;
+  let previousFingerprint: string | null = null;
+  let unchangedFingerprintTurns = 0;
 
   try {
     const session = await codex.startSession({
@@ -85,14 +94,81 @@ export async function runIssueAttempt(input: RunIssueAttemptInput): Promise<RunI
         });
       }
 
+      const turnInputTokens = asNumber(turn.usage?.input_tokens ?? turn.usage?.inputTokens) ?? 0;
+      cumulativeInputTokens += turnInputTokens;
+
       input.onLog?.({
         message: "action=turn outcome=completed",
-        details: baseDetails,
+        details: {
+          ...baseDetails,
+          turn_input_tokens: turnInputTokens,
+          cumulative_input_tokens: cumulativeInputTokens,
+        },
       });
 
       const refreshed = await input.tracker.fetchIssueStatesByIds([currentIssue.id]);
       if (Array.isArray(refreshed) && refreshed[0]) {
         currentIssue = refreshed[0];
+      }
+
+      if (!shouldContinueTurns(currentIssue, turnCount, input.config)) {
+        continue;
+      }
+
+      if (cumulativeInputTokens >= input.config.agent.maxInputTokensPerAttempt) {
+        input.onLog?.({
+          message: "action=worker outcome=guardrail_stop reason=attempt_input_budget_exceeded",
+          details: {
+            issue_id: currentIssue.id,
+            issue_identifier: currentIssue.identifier,
+            session_id: sessionId ?? undefined,
+            turn_count: turnCount,
+            cumulative_input_tokens: cumulativeInputTokens,
+            max_input_tokens_per_attempt: input.config.agent.maxInputTokensPerAttempt,
+          },
+        });
+
+        return {
+          exit: "guardrail_stop",
+          guardrail_reason: "attempt_input_budget_exceeded",
+          turnCount,
+          workspacePath: workspace.path,
+          issue: currentIssue,
+        };
+      }
+
+      const fingerprint = await getWorkspaceFingerprint(workspace.path);
+      if (fingerprint !== null) {
+        if (fingerprint === previousFingerprint) {
+          unchangedFingerprintTurns += 1;
+        } else {
+          previousFingerprint = fingerprint;
+          unchangedFingerprintTurns = 1;
+        }
+
+        if (unchangedFingerprintTurns >= NO_PROGRESS_WINDOW) {
+          input.onLog?.({
+            message: "action=worker outcome=guardrail_stop reason=no_progress_window_exceeded",
+            details: {
+              issue_id: currentIssue.id,
+              issue_identifier: currentIssue.identifier,
+              session_id: sessionId ?? undefined,
+              turn_count: turnCount,
+              no_progress_window: NO_PROGRESS_WINDOW,
+            },
+          });
+
+          return {
+            exit: "guardrail_stop",
+            guardrail_reason: "no_progress_window_exceeded",
+            turnCount,
+            workspacePath: workspace.path,
+            issue: currentIssue,
+          };
+        }
+      } else {
+        previousFingerprint = null;
+        unchangedFingerprintTurns = 0;
       }
     }
 
@@ -161,6 +237,18 @@ function shouldContinueTurns(issue: NormalizedIssue, turnCount: number, config: 
   return config.tracker.activeStates.includes(issue.state);
 }
 
+async function getWorkspaceFingerprint(workspacePath: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync("git", ["-C", workspacePath, "status", "--porcelain"], {
+      timeout: 5000,
+      maxBuffer: 1024 * 1024,
+    });
+    return stdout.trim();
+  } catch {
+    return null;
+  }
+}
+
 function toWorkspaceConfig(config: EffectiveConfig): WorkspaceConfig {
   return {
     root: config.workspace.root,
@@ -186,4 +274,12 @@ function toTemplateIssue(issue: NormalizedIssue): IssueTemplateInput {
     created_at: issue.created_at,
     updated_at: issue.updated_at,
   };
+}
+
+function asNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  return null;
 }

--- a/packages/symphony-service/tests/codexClient.test.ts
+++ b/packages/symphony-service/tests/codexClient.test.ts
@@ -213,6 +213,7 @@ for await (const line of rl) {
       });
 
       expect(turn.outcome).toBe("completed");
+      expect(turn.usage).toEqual({ input_tokens: 7, output_tokens: 4, total_tokens: 11 });
       expect(events).toContainEqual(expect.objectContaining({ event: "approval_auto_approved" }));
       expect(events).toContainEqual(expect.objectContaining({ event: "unsupported_tool_call" }));
       expect(events).toContainEqual(expect.objectContaining({ event: "other_message", message: "mock server stderr line" }));

--- a/packages/symphony-service/tests/config.test.ts
+++ b/packages/symphony-service/tests/config.test.ts
@@ -20,6 +20,11 @@ describe("resolveEffectiveConfig", () => {
     expect(config.codex.clientVersion.length).toBeGreaterThan(0);
     expect(config.codex.clientCapabilities).toEqual({});
     expect(config.agent.maxConcurrentAgents).toBe(10);
+    expect(config.agent.maxTurns).toBe(12);
+    expect(config.agent.maxInputTokensPerAttempt).toBe(150000);
+    expect(config.agent.maxIssueInputTokens).toBe(300000);
+    expect(config.agent.maxContinuationRunsPerIssue).toBe(2);
+    expect(config.agent.continuationRetryDelayMs).toBe(30000);
     expect(config.tracker.handoffState).toBe("Human Review");
   });
 

--- a/packages/symphony-service/tests/orchestrator.test.ts
+++ b/packages/symphony-service/tests/orchestrator.test.ts
@@ -88,7 +88,7 @@ describe("dispatch selection", () => {
 });
 
 describe("retry scheduling", () => {
-  it("schedules continuation retry after normal worker exit", () => {
+  it("schedules continuation retry after normal worker exit using incremented attempt", () => {
     const state = createOrchestratorState();
     markIssueRunning(state, issue({ id: "a", identifier: "ATH-1" }), 0, 3);
 
@@ -97,11 +97,33 @@ describe("retry scheduling", () => {
       nowMs: 2000,
       reason: "normal",
       maxRetryBackoffMs: 300000,
+      allowContinuation: true,
+      continuationDelayMs: 30000,
+      continuationAttempt: 4,
     });
 
-    expect(retry?.attempt).toBe(1);
-    expect(retry?.dueAtMs).toBe(3000);
+    expect(retry?.attempt).toBe(4);
+    expect(retry?.dueAtMs).toBe(32000);
     expect(state.completed.has("a")).toBe(true);
+  });
+
+  it("does not schedule continuation retry when continuation is disallowed", () => {
+    const state = createOrchestratorState();
+    markIssueRunning(state, issue({ id: "c", identifier: "ATH-30" }), 0, 2);
+
+    const retry = onWorkerExit(state, {
+      issueId: "c",
+      nowMs: 4000,
+      reason: "normal",
+      maxRetryBackoffMs: 300000,
+      allowContinuation: false,
+      continuationDelayMs: 30000,
+      continuationAttempt: 3,
+    });
+
+    expect(retry).toBeNull();
+    expect(state.retryAttempts.has("c")).toBe(false);
+    expect(state.completed.has("c")).toBe(true);
   });
 
   it("schedules exponential backoff retry after failure", () => {

--- a/packages/symphony-service/tests/retry.test.ts
+++ b/packages/symphony-service/tests/retry.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "vitest";
 import { calculateContinuationDelay, calculateFailureRetryDelay } from "../src/retry";
 
 describe("retry delays", () => {
-  it("uses 1s continuation delay", () => {
-    expect(calculateContinuationDelay()).toBe(1000);
+  it("uses configurable continuation delay", () => {
+    expect(calculateContinuationDelay(30000)).toBe(30000);
   });
 
   it("uses exponential backoff with cap", () => {

--- a/packages/symphony-service/tests/runtime.test.ts
+++ b/packages/symphony-service/tests/runtime.test.ts
@@ -64,7 +64,11 @@ function config(partial?: Partial<EffectiveConfig>): EffectiveConfig {
     agent: {
       maxConcurrentAgents: partial?.agent?.maxConcurrentAgents ?? 2,
       maxRetryBackoffMs: partial?.agent?.maxRetryBackoffMs ?? 300_000,
-      maxTurns: partial?.agent?.maxTurns ?? 20,
+      maxTurns: partial?.agent?.maxTurns ?? 12,
+      maxInputTokensPerAttempt: partial?.agent?.maxInputTokensPerAttempt ?? 150_000,
+      maxIssueInputTokens: partial?.agent?.maxIssueInputTokens ?? 300_000,
+      maxContinuationRunsPerIssue: partial?.agent?.maxContinuationRunsPerIssue ?? 2,
+      continuationRetryDelayMs: partial?.agent?.continuationRetryDelayMs ?? 30_000,
       maxConcurrentAgentsByState: partial?.agent?.maxConcurrentAgentsByState ?? {},
     },
     codex: {
@@ -313,7 +317,11 @@ describe("processDueRetries", () => {
         agent: {
           maxConcurrentAgents: 1,
           maxRetryBackoffMs: 300_000,
-          maxTurns: 20,
+          maxTurns: 12,
+          maxInputTokensPerAttempt: 150_000,
+          maxIssueInputTokens: 300_000,
+          maxContinuationRunsPerIssue: 2,
+          continuationRetryDelayMs: 30_000,
           maxConcurrentAgentsByState: {},
         },
       }),

--- a/packages/symphony-service/tests/service.test.ts
+++ b/packages/symphony-service/tests/service.test.ts
@@ -870,6 +870,73 @@ describe("createSymphonyService", () => {
     await service.stop();
   });
 
+  it("moves issue to handoff and blocks continuation when attempt guardrail stops run", async () => {
+    const comments: string[] = [];
+    const transitioned: string[] = [];
+    const candidates = [
+      issue({
+        id: "guardrail-stop-1",
+        identifier: "ATH-901",
+        state: "Todo",
+        labels: ["pkg:symphony-service"],
+        description: "Implement guardrails with clear acceptance criteria and validation details.",
+        team_id: "team-1",
+      }),
+    ];
+
+    const service = createSymphonyService({
+      workflowPath: "/tmp/WORKFLOW.md",
+      deps: {
+        loadWorkflowFile: async () => workflow(1000),
+        createTracker: () => ({
+          async fetchCandidateIssues() {
+            return candidates.splice(0, candidates.length);
+          },
+          async fetchIssuesByStates() {
+            return [];
+          },
+          async fetchIssueStatesByIds() {
+            return [];
+          },
+          async createIssueComment(input) {
+            comments.push(input.body);
+          },
+          async updateIssueStateByName(input) {
+            transitioned.push(`${input.issue.identifier}:${input.stateName}`);
+            return true;
+          },
+        }),
+        cleanupTerminalIssueWorkspaces: async () => ({ removed: 0, failed: 0, warnings: [] }),
+        processDueRetries: async () => ({
+          processedIssueIds: [],
+          dispatchedIssueIds: [],
+          requeuedIssueIds: [],
+          releasedIssueIds: [],
+        }),
+        setIntervalFn: () => 1 as unknown as ReturnType<typeof setInterval>,
+        clearIntervalFn: () => {},
+        runIssueAttempt: async (input) => ({
+          exit: "guardrail_stop" as const,
+          guardrail_reason: "attempt_input_budget_exceeded" as const,
+          turnCount: 3,
+          workspacePath: "/tmp/fake",
+          issue: input.issue,
+        }),
+      },
+    });
+
+    await service.start();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const snapshot = service.getRuntimeSnapshot();
+    expect(snapshot.retrying).toHaveLength(0);
+    expect(transitioned).toEqual(["ATH-901:In Progress", "ATH-901:Human Review"]);
+    expect(comments.some((entry) => entry.includes("guardrail"))).toBe(true);
+
+    await service.stop();
+  });
+
   it("blocks issues that fail intake guardrails and comments once", async () => {
     const comments: string[] = [];
     const runIssueAttempt = vi.fn(async (input: any) => ({

--- a/packages/symphony-service/tests/worker.test.ts
+++ b/packages/symphony-service/tests/worker.test.ts
@@ -43,9 +43,11 @@ class FakeCodex {
   readonly startedCwds: string[] = [];
   readonly prompts: string[] = [];
   readonly stops: number[] = [];
+  private turnCount = 0;
 
   constructor(
     private readonly runTurnOutcome: "completed" | "failed" | "cancelled" | "turn_timeout" | "port_exit" | "turn_input_required" = "completed",
+    private readonly inputTokensPerTurn = 0,
   ) {}
 
   async startSession(input: { cwd: string }): Promise<{ threadId: string }> {
@@ -58,12 +60,26 @@ class FakeCodex {
     cwd: string;
     title: string;
     prompt: string;
-  }): Promise<{ turnId: string; sessionId: string; outcome: "completed" | "failed" | "cancelled" | "turn_timeout" | "port_exit" | "turn_input_required" }> {
+  }): Promise<{
+    turnId: string;
+    sessionId: string;
+    outcome: "completed" | "failed" | "cancelled" | "turn_timeout" | "port_exit" | "turn_input_required";
+    usage?: { input_tokens: number; output_tokens: number; total_tokens: number };
+  }> {
     this.prompts.push(input.prompt);
+    this.turnCount += 1;
     return {
-      turnId: "turn-1",
-      sessionId: "thread-1-turn-1",
+      turnId: `turn-${this.turnCount}`,
+      sessionId: `thread-1-turn-${this.turnCount}`,
       outcome: this.runTurnOutcome,
+      usage:
+        this.inputTokensPerTurn > 0
+          ? {
+              input_tokens: this.inputTokensPerTurn,
+              output_tokens: 1,
+              total_tokens: this.inputTokensPerTurn + 1,
+            }
+          : undefined,
     };
   }
 
@@ -101,6 +117,10 @@ function config(root: string, overrides?: Partial<EffectiveConfig>): EffectiveCo
       maxConcurrentAgents: 2,
       maxRetryBackoffMs: 300_000,
       maxTurns: 3,
+      maxInputTokensPerAttempt: 150_000,
+      maxIssueInputTokens: 300_000,
+      maxContinuationRunsPerIssue: 2,
+      continuationRetryDelayMs: 30_000,
       maxConcurrentAgentsByState: {},
       ...overrides?.agent,
     },
@@ -205,5 +225,71 @@ describe("runIssueAttempt", () => {
     expect(logs.some((entry) => entry.message.includes("action=turn outcome=failed"))).toBe(true);
     expect(logs.some((entry) => entry.details?.issue_id === "3" && entry.details?.issue_identifier === "ATH-3")).toBe(true);
     expect(logs.some((entry) => entry.details?.session_id === "thread-1-turn-1")).toBe(true);
+  });
+
+  it("stops attempt when per-attempt input token budget is exceeded", async () => {
+    const root = await mkdtemp(join(tmpdir(), "symphony-worker-token-guardrail-"));
+    const logs: Array<{ message: string; details?: Record<string, unknown> }> = [];
+
+    const result = await runIssueAttempt({
+      issue: issue({ id: "4", identifier: "ATH-4", state: "Todo" }),
+      attempt: 1,
+      workflowTemplate: "Issue {{ issue.identifier }}",
+      config: config(root, {
+        agent: {
+          maxTurns: 10,
+          maxInputTokensPerAttempt: 100,
+          maxIssueInputTokens: 300_000,
+          maxContinuationRunsPerIssue: 2,
+          continuationRetryDelayMs: 30_000,
+          maxConcurrentAgents: 2,
+          maxRetryBackoffMs: 300_000,
+          maxConcurrentAgentsByState: {},
+        },
+      }),
+      tracker: new FakeTracker([issue({ id: "4", identifier: "ATH-4", state: "Todo" })]),
+      createCodexClient: () => new FakeCodex("completed", 75) as unknown as CodexAppServerClient,
+      onLog: (entry) => logs.push(entry),
+    });
+
+    expect(result.exit).toBe("guardrail_stop");
+    expect(result.guardrail_reason).toBe("attempt_input_budget_exceeded");
+    expect(result.turnCount).toBe(2);
+    expect(logs.some((entry) => entry.message.includes("guardrail_stop"))).toBe(true);
+  });
+
+  it("stops attempt after no-progress window is exceeded", async () => {
+    const root = await mkdtemp(join(tmpdir(), "symphony-worker-no-progress-"));
+    const logs: Array<{ message: string; details?: Record<string, unknown> }> = [];
+
+    const result = await runIssueAttempt({
+      issue: issue({ id: "5", identifier: "ATH-5", state: "Todo" }),
+      attempt: 1,
+      workflowTemplate: "Issue {{ issue.identifier }}",
+      config: config(root, {
+        hooks: {
+          timeoutMs: 2000,
+          afterCreate: "git init -q",
+        },
+        agent: {
+          maxTurns: 12,
+          maxInputTokensPerAttempt: 150_000,
+          maxIssueInputTokens: 300_000,
+          maxContinuationRunsPerIssue: 2,
+          continuationRetryDelayMs: 30_000,
+          maxConcurrentAgents: 2,
+          maxRetryBackoffMs: 300_000,
+          maxConcurrentAgentsByState: {},
+        },
+      }),
+      tracker: new FakeTracker([issue({ id: "5", identifier: "ATH-5", state: "Todo" })]),
+      createCodexClient: () => new FakeCodex("completed", 10) as unknown as CodexAppServerClient,
+      onLog: (entry) => logs.push(entry),
+    });
+
+    expect(result.exit).toBe("guardrail_stop");
+    expect(result.guardrail_reason).toBe("no_progress_window_exceeded");
+    expect(result.turnCount).toBe(3);
+    expect(logs.some((entry) => entry.message.includes("no_progress_window_exceeded"))).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- add dual-layer burn guardrails to Symphony runtime: in-attempt worker guardrails and post-run continuation guardrails
- add new agent config knobs and defaults for turn/token/continuation budgets (`max_turns=12`, attempt tokens, lifecycle tokens, continuation run cap, continuation retry delay)
- propagate terminal turn usage from codex client into worker loop decisions
- stop runs on attempt guardrails (input token cap and 3-turn no-progress window), emit structured timeline events, and block continuation when guardrails trip
- gate continuation scheduling in orchestrator/service with configurable delay and incrementing continuation attempts (no reset to attempt 1)
- move guardrail-stopped issues to handoff state (`Human Review`) with explicit operator comments and counters/thresholds
- update root workflow defaults and Symphony docs/conformance matrix to reflect guardrail behavior

## Why
- operators observed high token burn before `continuation_retry` appeared; the main churn was happening inside the worker turn loop while issue state stayed active
- continuation retries were always scheduled on normal exit, which could re-dispatch active issues repeatedly and compound cost
- this change enforces bounded execution at both layers so a single issue cannot loop indefinitely and silently consume quota

## Validation
- `bun run --filter '@athena/symphony-service' test`
- `bunx tsc --noEmit -p packages/symphony-service/tsconfig.json`
- `bun run --filter '@athena/storefront-webapp' test`