### PR TITLE
fix: avoid false port_exit failures after terminal transition

### DIFF
--- a/packages/symphony-service/src/worker.ts
+++ b/packages/symphony-service/src/worker.ts
@@ -86,6 +86,28 @@ export async function runIssueAttempt(input: RunIssueAttemptInput): Promise<RunI
           details: baseDetails,
         });
 
+        const refreshed = await input.tracker.fetchIssueStatesByIds([currentIssue.id]);
+        if (Array.isArray(refreshed) && refreshed[0]) {
+          currentIssue = refreshed[0];
+          const stillActive = input.config.tracker.activeStates.includes(currentIssue.state);
+          if (!stillActive) {
+            input.onLog?.({
+              message: `action=turn outcome=terminal_after_non_completed reason=${turn.outcome}`,
+              details: {
+                ...baseDetails,
+                refreshed_state: currentIssue.state,
+              },
+            });
+
+            return {
+              exit: "normal",
+              turnCount,
+              workspacePath: workspace.path,
+              issue: currentIssue,
+            };
+          }
+        }
+
         throw new SymphonyError("worker_turn_failed", `codex turn ended with non-completed outcome: ${turn.outcome}`, {
           details: {
             ...baseDetails,

--- a/packages/symphony-service/src/workspace.ts
+++ b/packages/symphony-service/src/workspace.ts
@@ -221,10 +221,25 @@ async function pathExists(path: string): Promise<boolean> {
     await stat(path);
     return true;
   } catch (error) {
-    if (toErrorMessage(error).toLowerCase().includes("enoent")) {
+    if (isMissingPathError(error)) {
       return false;
     }
 
     throw error;
   }
+}
+
+function isMissingPathError(error: unknown): boolean {
+  if (error && typeof error === "object") {
+    const maybeNodeError = error as { code?: unknown; errno?: unknown; message?: unknown };
+    if (maybeNodeError.code === "ENOENT") {
+      return true;
+    }
+    if (maybeNodeError.errno === -2) {
+      return true;
+    }
+  }
+
+  const message = toErrorMessage(error).toLowerCase();
+  return message.includes("enoent") || message.includes("no such file or directory");
 }

--- a/packages/symphony-service/tests/worker.test.ts
+++ b/packages/symphony-service/tests/worker.test.ts
@@ -227,6 +227,28 @@ describe("runIssueAttempt", () => {
     expect(logs.some((entry) => entry.details?.session_id === "thread-1-turn-1")).toBe(true);
   });
 
+  it("treats port_exit as clean completion when the issue already transitioned out of active states", async () => {
+    const root = await mkdtemp(join(tmpdir(), "symphony-worker-port-exit-terminal-"));
+    const logs: Array<{ message: string; details?: Record<string, unknown> }> = [];
+
+    const result = await runIssueAttempt({
+      issue: issue({ id: "9", identifier: "ATH-9", state: "Todo" }),
+      attempt: 1,
+      workflowTemplate: "Issue {{ issue.identifier }}",
+      config: config(root),
+      tracker: new FakeTracker([
+        issue({ id: "9", identifier: "ATH-9", state: "Done" }),
+      ]),
+      createCodexClient: () => new FakeCodex("port_exit") as unknown as CodexAppServerClient,
+      onLog: (entry) => logs.push(entry),
+    });
+
+    expect(result.exit).toBe("normal");
+    expect(result.issue.state).toBe("Done");
+    expect(result.turnCount).toBe(1);
+    expect(logs.some((entry) => entry.message.includes("action=turn outcome=terminal_after_non_completed"))).toBe(true);
+  });
+
   it("stops attempt when per-attempt input token budget is exceeded", async () => {
     const root = await mkdtemp(join(tmpdir(), "symphony-worker-token-guardrail-"));
     const logs: Array<{ message: string; details?: Record<string, unknown> }> = [];


### PR DESCRIPTION
## Summary
- treat non-completed turn outcomes (`port_exit`, etc.) as clean attempt completion when a fresh tracker read shows the issue already left active states (for example `Done`/`Human Review`)
- add a worker regression test for the terminal-after-`port_exit` scenario to lock behavior
- harden workspace existence checks to recognize missing-path errors across Bun/Node error shapes (`code`, `errno`, and message variants)

## Why
- Linear logs on `V26-162` showed the issue reached `Done` before Symphony posted a `port_exit` failure comment, which misclassified a terminal transition as a run failure
- the same investigation exposed brittle ENOENT detection in workspace probing that can surface as `No such file or directory` under Bun and disrupt worker runs

## Validation
- `bun run --filter '@athena/symphony-service' test`
- `bunx tsc --noEmit -p packages/symphony-service/tsconfig.json`
- `bun run --filter '@athena/storefront-webapp' test`
