### PR TITLE
fix(athena-webapp): harden checkout/order validation and authz

### DIFF
--- a/packages/athena-webapp/convex/http/domains/storeFront/routes/checkout.ts
+++ b/packages/athena-webapp/convex/http/domains/storeFront/routes/checkout.ts
@@ -8,8 +8,99 @@ import {
 } from "../../../utils";
 import { Id } from "../../../../_generated/dataModel";
 import { isStoreCheckoutDisabled } from "../../../../inventory/storeConfigV2";
+import { z } from "zod";
+import {
+  buildCanonicalCheckoutProducts,
+  hasValidPositiveQuantity,
+  isAmountTampered,
+  isAuthorizedResourceOwner,
+} from "./security";
 
 const checkoutRoutes: HonoWithConvex<ActionCtx> = new Hono();
+
+const createCheckoutSchema = z
+  .object({
+    bagId: z.string().min(1),
+  })
+  .passthrough();
+
+const checkoutActionSchema = z
+  .object({
+    customerEmail: z.string().email().optional(),
+    amount: z.number().finite().optional(),
+    hasCompletedCheckoutSession: z.boolean().optional(),
+    action: z.enum([
+      "finalize-payment",
+      "complete-checkout",
+      "place-order",
+      "create-pod-order",
+      "cancel-order",
+      "update-order",
+    ]),
+    orderDetails: z.unknown().optional(),
+    placedOrderId: z.string().optional(),
+  })
+  .passthrough();
+
+const checkoutOrderDetailsSchema = z
+  .object({
+    billingDetails: z.record(z.string(), z.any()).nullable(),
+    customerDetails: z
+      .object({
+        email: z.string().email(),
+        firstName: z.string().min(1),
+        lastName: z.string().min(1),
+        phoneNumber: z.string().min(1),
+      })
+      .optional(),
+    deliveryDetails: z.union([z.record(z.string(), z.any()), z.string(), z.null()]),
+    deliveryFee: z.number().nullable(),
+    deliveryMethod: z.string().min(1),
+    deliveryOption: z.string().nullable(),
+    deliveryInstructions: z.string().optional(),
+    pickupLocation: z.string().nullable(),
+    discount: z.any().nullable().optional(),
+    paymentMethod: z
+      .union([z.literal("online_payment"), z.literal("payment_on_delivery")])
+      .optional(),
+    podPaymentMethod: z
+      .union([z.literal("cash"), z.literal("mobile_money")])
+      .optional(),
+  })
+  .passthrough();
+
+type CanonicalBagItem = {
+  productId: string;
+  productSku: string;
+  productSkuId: string;
+  quantity: number;
+  price: number;
+};
+
+const hasValidCanonicalBagItem = (item: any): item is CanonicalBagItem => {
+  return (
+    typeof item?.productId === "string" &&
+    typeof item?.productSkuId === "string" &&
+    typeof item?.productSku === "string" &&
+    Number.isFinite(item?.price) &&
+    item.price > 0 &&
+    hasValidPositiveQuantity(item?.quantity)
+  );
+};
+
+const hasValidSessionItems = (items: any[] | undefined): boolean => {
+  if (!items || items.length === 0) {
+    return false;
+  }
+
+  return items.every(
+    (item) =>
+      hasValidPositiveQuantity(item.quantity) &&
+      typeof item.price === "number" &&
+      Number.isFinite(item.price) &&
+      item.price > 0
+  );
+};
 
 checkoutRoutes.post("/", async (c) => {
   const { storeId } = getStoreDataFromRequest(c);
@@ -23,19 +114,55 @@ checkoutRoutes.post("/", async (c) => {
     return c.json({ error: "Store id missing" }, 404);
   }
 
-  const { products, bagId, amount } = await c.req.json();
+  const parsedPayload = createCheckoutSchema.safeParse(await c.req.json());
+
+  if (!parsedPayload.success) {
+    return c.json({ error: "Invalid checkout payload" }, 400);
+  }
 
   try {
-    const session = await c.env.runMutation(
-      api.storeFront.checkoutSession.create,
-      {
-        storeId: storeId as Id<"store">,
-        storeFrontUserId: userId as Id<"storeFrontUser"> | Id<"guest">,
-        products,
-        bagId,
-        amount,
-      }
-    );
+    const bag = await c.env.runQuery(api.storeFront.bag.getById, {
+      id: parsedPayload.data.bagId as Id<"bag">,
+    });
+
+    if (!bag) {
+      return c.json({ error: "Bag not found" }, 404);
+    }
+
+    if (!isAuthorizedResourceOwner(bag.storeFrontUserId, userId)) {
+      return c.json({ error: "Forbidden" }, 403);
+    }
+
+    if (bag.storeId !== storeId) {
+      return c.json({ error: "Forbidden" }, 403);
+    }
+
+    if (!Array.isArray(bag.items) || bag.items.length === 0) {
+      return c.json({ error: "Bag has no checkoutable items" }, 422);
+    }
+
+    if (!bag.items.every(hasValidCanonicalBagItem)) {
+      return c.json(
+        { error: "Invalid bag item data: quantity and price must be valid" },
+        422
+      );
+    }
+
+    const canonicalCheckout = buildCanonicalCheckoutProducts(bag.items);
+
+    const session = await c.env.runMutation(api.storeFront.checkoutSession.create, {
+      storeId: storeId as Id<"store">,
+      storeFrontUserId: userId as Id<"storeFrontUser"> | Id<"guest">,
+      products: canonicalCheckout.products.map((product) => ({
+        productId: product.productId as Id<"product">,
+        productSkuId: product.productSkuId as Id<"productSku">,
+        productSku: product.productSku,
+        quantity: product.quantity,
+        price: product.price,
+      })),
+      bagId: parsedPayload.data.bagId as Id<"bag">,
+      amount: canonicalCheckout.amount,
+    });
 
     return c.json(session);
   } catch (e) {
@@ -57,6 +184,12 @@ checkoutRoutes.post("/:checkoutSessionId", async (c) => {
     return c.json({ error: "Store or organization id missing" }, 404);
   }
 
+  const parsedBody = checkoutActionSchema.safeParse(await c.req.json());
+
+  if (!parsedBody.success) {
+    return c.json({ error: "Invalid checkout action payload" }, 400);
+  }
+
   const {
     customerEmail,
     amount,
@@ -64,30 +197,46 @@ checkoutRoutes.post("/:checkoutSessionId", async (c) => {
     action,
     orderDetails,
     placedOrderId,
-  } = await c.req.json();
+  } = parsedBody.data;
+
+  const session = await c.env.runQuery(api.storeFront.checkoutSession.getById, {
+    sessionId: checkoutSessionId as Id<"checkoutSession">,
+  });
+
+  if (!session) {
+    return c.json({ error: "Checkout session not found" }, 404);
+  }
+
+  if (!isAuthorizedResourceOwner(session.storeFrontUserId, userId)) {
+    return c.json({ error: "Forbidden" }, 403);
+  }
 
   try {
     if (action == "finalize-payment") {
-      // Log entry point for payment finalization
-      console.log(
-        `[CHECKOUT-START] Finalize payment request received | Session: ${checkoutSessionId} | Email: ${customerEmail} | Amount: ${amount} | Delivery method: ${orderDetails?.deliveryMethod} | Delivery fee: ${orderDetails?.deliveryFee} | POD method: ${orderDetails?.podPaymentMethod || "N/A"}`
-      );
-      console.log(
-        `[CHECKOUT-START] Order details:`,
-        JSON.stringify(
-          {
-            customerDetails: orderDetails?.customerDetails,
-            deliveryDetails: orderDetails?.deliveryDetails,
-            deliveryOption: orderDetails?.deliveryOption,
-            pickupLocation: orderDetails?.pickupLocation,
-            discount: orderDetails?.discount,
-          },
-          null,
-          2
-        )
-      );
+      if (!hasValidSessionItems(session.items)) {
+        return c.json(
+          { error: "Invalid checkout session item data: quantity must be positive" },
+          422
+        );
+      }
 
-      // check that the store is still active
+      const parsedOrderDetails = checkoutOrderDetailsSchema.safeParse(orderDetails);
+
+      if (!parsedOrderDetails.success) {
+        return c.json({ error: "Invalid order details payload" }, 400);
+      }
+
+      if (
+        parsedOrderDetails.data.deliveryFee !== null &&
+        parsedOrderDetails.data.deliveryFee < 0
+      ) {
+        return c.json({ error: "Delivery fee must be zero or positive" }, 422);
+      }
+
+      if (isAmountTampered(session.amount, amount)) {
+        return c.json({ error: "Amount mismatch detected" }, 422);
+      }
+
       const store = await c.env.runQuery(api.inventory.stores.getByIdOrSlug, {
         identifier: storeId,
         organizationId: organizationId as Id<"organization">,
@@ -102,18 +251,7 @@ checkoutRoutes.post("/:checkoutSessionId", async (c) => {
         });
       }
 
-      // check that the session is not already completed
-      const session = await c.env.runQuery(
-        api.storeFront.checkoutSession.getById,
-        {
-          sessionId: checkoutSessionId as Id<"checkoutSession">,
-        }
-      );
-
-      if (session?.hasCompletedPayment) {
-        console.log(
-          `[CHECKOUT-FAILURE] Session already completed | Session: ${checkoutSessionId}`
-        );
+      if (session?.hasCompletedPayment || session.placedOrderId) {
         return c.json({
           success: false,
           message:
@@ -122,26 +260,17 @@ checkoutRoutes.post("/:checkoutSessionId", async (c) => {
         });
       }
 
-      const payment = await c.env.runAction(
-        api.storeFront.payment.createTransaction,
-        {
-          customerEmail,
-          amount,
-          checkoutSessionId: checkoutSessionId as Id<"checkoutSession">,
-          orderDetails: {
-            ...orderDetails,
-            billingDetails: null,
-            deliveryDetails: orderDetails.deliveryDetails ?? null,
-          },
-        }
-      );
-
-      // Log successful payment response
-      const hasAuthUrl = "authorization_url" in payment;
-      const isSuccess = "success" in payment && payment.success;
-      console.log(
-        `[CHECKOUT-${hasAuthUrl || isSuccess ? "SUCCESS" : "FAILURE"}] Payment action completed | Session: ${checkoutSessionId} | Has Auth URL: ${hasAuthUrl}`
-      );
+      const payment = await c.env.runAction(api.storeFront.payment.createTransaction, {
+        customerEmail: customerEmail || "",
+        amount: session.amount,
+        checkoutSessionId: checkoutSessionId as Id<"checkoutSession">,
+        orderDetails: {
+          ...parsedOrderDetails.data,
+          billingDetails: null,
+          deliveryDetails: (parsedOrderDetails.data.deliveryDetails ?? null) as any,
+          discount: session.discount ?? null,
+        },
+      });
 
       return c.json(payment);
     }
@@ -173,14 +302,22 @@ checkoutRoutes.post("/:checkoutSessionId", async (c) => {
           }
         }
 
+        const parsedOrderDetails = checkoutOrderDetailsSchema.safeParse(orderDetailsToUse);
+
+        if (!parsedOrderDetails.success) {
+          return c.json({ error: "Invalid order details payload" }, 400);
+        }
+
         const res = await c.env.runMutation(
           internal.storeFront.checkoutSession.updateCheckoutSession,
           {
             id: checkoutSessionId as Id<"checkoutSession">,
             hasCompletedCheckoutSession: true,
             orderDetails: {
+              ...parsedOrderDetails.data,
               billingDetails: null,
-              ...orderDetailsToUse,
+              deliveryDetails: (parsedOrderDetails.data.deliveryDetails ?? null) as any,
+              discount: session.discount ?? null,
             },
           }
         );
@@ -206,7 +343,30 @@ checkoutRoutes.post("/:checkoutSessionId", async (c) => {
     }
 
     if (action == "create-pod-order") {
-      // check that the store is still active
+      if (!hasValidSessionItems(session.items)) {
+        return c.json(
+          { error: "Invalid checkout session item data: quantity must be positive" },
+          422
+        );
+      }
+
+      const parsedOrderDetails = checkoutOrderDetailsSchema.safeParse(orderDetails);
+
+      if (!parsedOrderDetails.success) {
+        return c.json({ error: "Invalid order details payload" }, 400);
+      }
+
+      if (
+        parsedOrderDetails.data.deliveryFee !== null &&
+        parsedOrderDetails.data.deliveryFee < 0
+      ) {
+        return c.json({ error: "Delivery fee must be zero or positive" }, 422);
+      }
+
+      if (isAmountTampered(session.amount, amount)) {
+        return c.json({ error: "Amount mismatch detected" }, 422);
+      }
+
       const store = await c.env.runQuery(api.inventory.stores.getByIdOrSlug, {
         identifier: storeId,
         organizationId: organizationId as Id<"organization">,
@@ -221,30 +381,36 @@ checkoutRoutes.post("/:checkoutSessionId", async (c) => {
         });
       }
 
-      const podOrder = await c.env.runAction(
-        api.storeFront.payment.createPODOrder,
-        {
-          customerEmail,
-          amount,
-          checkoutSessionId: checkoutSessionId as Id<"checkoutSession">,
-          orderDetails: {
-            ...orderDetails,
-            billingDetails: null,
-            deliveryDetails: orderDetails.deliveryDetails ?? null,
+      if (session?.hasCompletedPayment || session.placedOrderId) {
+        return c.json(
+          {
+            success: false,
+            message: "This checkout session has already been completed.",
+            code: "SESSION_ALREADY_FINALIZED",
           },
-        }
-      );
+          422
+        );
+      }
+
+      const podOrder = await c.env.runAction(api.storeFront.payment.createPODOrder, {
+        customerEmail: customerEmail || "",
+        amount: session.amount,
+        checkoutSessionId: checkoutSessionId as Id<"checkoutSession">,
+        orderDetails: {
+          ...parsedOrderDetails.data,
+          billingDetails: null,
+          deliveryDetails: (parsedOrderDetails.data.deliveryDetails ?? null) as any,
+          discount: session.discount ?? null,
+        },
+      });
 
       return c.json(podOrder);
     }
 
     if (action == "cancel-order") {
-      const res = await c.env.runAction(
-        api.storeFront.checkoutSession.cancelOrder,
-        {
-          id: checkoutSessionId as Id<"checkoutSession">,
-        }
-      );
+      const res = await c.env.runAction(api.storeFront.checkoutSession.cancelOrder, {
+        id: checkoutSessionId as Id<"checkoutSession">,
+      });
 
       return c.json(res);
     }
@@ -262,7 +428,7 @@ checkoutRoutes.post("/:checkoutSessionId", async (c) => {
       return c.json(res);
     }
 
-    return c.json({});
+    return c.json({ error: "Unsupported checkout action" }, 400);
   } catch (e) {
     console.log(
       `[CHECKOUT-FAILURE] Error in checkout endpoint | Session: ${checkoutSessionId} | Action: ${action} | Error: ${(e as Error).message}`
@@ -279,12 +445,9 @@ checkoutRoutes.get("/active", async (c) => {
   }
 
   try {
-    const session = await c.env.runQuery(
-      api.storeFront.checkoutSession.getActiveCheckoutSession,
-      {
-        storeFrontUserId: userId as Id<"storeFrontUser"> | Id<"guest">,
-      }
-    );
+    const session = await c.env.runQuery(api.storeFront.checkoutSession.getActiveCheckoutSession, {
+      storeFrontUserId: userId as Id<"storeFrontUser"> | Id<"guest">,
+    });
 
     return c.json(session);
   } catch (e) {
@@ -299,20 +462,32 @@ checkoutRoutes.get("/pending", async (c) => {
     return c.json({ error: "Customer id missing" }, 404);
   }
 
-  const session = await c.env.runQuery(
-    api.storeFront.checkoutSession.getPendingCheckoutSessions,
-    { storeFrontUserId: userId as Id<"storeFrontUser"> | Id<"guest"> }
-  );
+  const session = await c.env.runQuery(api.storeFront.checkoutSession.getPendingCheckoutSessions, {
+    storeFrontUserId: userId as Id<"storeFrontUser"> | Id<"guest">,
+  });
 
   return c.json(session);
 });
 
 checkoutRoutes.get("/:sessionId", async (c) => {
   const { sessionId } = c.req.param();
+  const userId = getStorefrontUserFromRequest(c);
+
+  if (!userId) {
+    return c.json({ error: "Customer id missing" }, 404);
+  }
 
   const session = await c.env.runQuery(api.storeFront.checkoutSession.getById, {
     sessionId: sessionId as Id<"checkoutSession">,
   });
+
+  if (!session) {
+    return c.json({ error: "Checkout session not found" }, 404);
+  }
+
+  if (!isAuthorizedResourceOwner(session.storeFrontUserId, userId)) {
+    return c.json({ error: "Forbidden" }, 403);
+  }
 
   return c.json(session);
 });

--- a/packages/athena-webapp/convex/http/domains/storeFront/routes/onlineOrder.ts
+++ b/packages/athena-webapp/convex/http/domains/storeFront/routes/onlineOrder.ts
@@ -4,6 +4,7 @@ import { ActionCtx } from "../../../../_generated/server";
 import { api } from "../../../../_generated/api";
 import { Id } from "../../../../_generated/dataModel";
 import { getStorefrontUserFromRequest } from "../../../utils";
+import { isAuthorizedResourceOwner } from "./security";
 
 const onlineOrderRoutes: HonoWithConvex<ActionCtx> = new Hono();
 
@@ -23,20 +24,23 @@ onlineOrderRoutes.get("/", async (c) => {
 
 onlineOrderRoutes.get("/:orderId", async (c) => {
   const { orderId } = c.req.param();
+  const userId = getStorefrontUserFromRequest(c);
 
-  // const userId = getStorefrontUserFromRequest(c);
-
-  // if (!userId) {
-  //   return c.json({ error: "User id missing" }, 404);
-  // }
+  if (!userId) {
+    return c.json({ error: "User id missing" }, 404);
+  }
 
   const order = await c.env.runQuery(api.storeFront.onlineOrder.get, {
     identifier: orderId as Id<"onlineOrder">,
   });
 
-  // if (order?.storeFrontUserId !== userId) {
-  //   return c.json({ error: "Unauthorized" }, 401);
-  // }
+  if (!order) {
+    return c.json({ error: "Order not found" }, 404);
+  }
+
+  if (!isAuthorizedResourceOwner(order.storeFrontUserId, userId)) {
+    return c.json({ error: "Forbidden" }, 403);
+  }
 
   return c.json(order);
 });

--- a/packages/athena-webapp/convex/http/domains/storeFront/routes/paystack.ts
+++ b/packages/athena-webapp/convex/http/domains/storeFront/routes/paystack.ts
@@ -8,26 +8,78 @@ import {
   calculateOrderAmount,
   getOrderDiscountValue,
 } from "../../../../storeFront/helpers/paymentHelpers";
+import {
+  isDuplicateChargeSuccess,
+  isValidPaystackSignature,
+} from "./security";
 
 const paystackRoutes: HonoWithConvex<ActionCtx> = new Hono();
 
 paystackRoutes.post("/", async (c) => {
-  const payload = await c.req.json();
+  const secret = process.env.PAYSTACK_SECRET_KEY;
+  const signature = c.req.header("x-paystack-signature");
+  const rawPayload = await c.req.text();
 
-  console.log("received payload", payload);
+  if (!secret) {
+    return c.json({ error: "PAYSTACK_SECRET_KEY is not configured" }, 500);
+  }
+
+  if (!signature) {
+    return c.json({ error: "Missing webhook signature" }, 401);
+  }
+
+  if (!isValidPaystackSignature(rawPayload, secret, signature)) {
+    return c.json({ error: "Invalid webhook signature" }, 401);
+  }
+
+  let payload: any;
+
+  try {
+    payload = JSON.parse(rawPayload);
+  } catch {
+    return c.json({ error: "Invalid webhook payload" }, 400);
+  }
 
   const { checkout_session_id, order_details } = payload?.data?.metadata || {};
 
   if (payload?.event == "charge.success" && checkout_session_id) {
-    console.log(`charge successful for session: ${checkout_session_id}`);
+    const incomingTransactionId = payload?.data?.id?.toString();
+
+    if (!incomingTransactionId) {
+      return c.json({ error: "Missing transaction identifier" }, 400);
+    }
+
+    const [session, existingOrder] = await Promise.all([
+      c.env.runQuery(api.storeFront.checkoutSession.getById, {
+        sessionId: checkout_session_id as Id<"checkoutSession">,
+      }),
+      c.env.runQuery(api.storeFront.onlineOrder.getByCheckoutSessionId, {
+        checkoutSessionId: checkout_session_id as Id<"checkoutSession">,
+      }),
+    ]);
+
+    if (!session) {
+      return c.json({ message: "Checkout session not found" });
+    }
+
+    if (
+      isDuplicateChargeSuccess({
+        hasCompletedPayment: Boolean(session.hasCompletedPayment),
+        placedOrderId: session.placedOrderId,
+        hasExistingOrder: Boolean(existingOrder),
+        incomingTransactionId,
+        existingTransactionId: session.externalTransactionId,
+      })
+    ) {
+      return c.json({ message: "Duplicate charge.success ignored" });
+    }
 
     // place order
-    console.log("creating order..");
     const createOrderResponse = await c.env.runMutation(
       internal.storeFront.onlineOrder.createFromSession,
       {
         checkoutSessionId: checkout_session_id as Id<"checkoutSession">,
-        externalTransactionId: payload.data.id.toString(),
+        externalTransactionId: incomingTransactionId,
         paymentMethod: {
           last4: payload?.data?.authorization?.last4,
           brand: payload?.data?.authorization?.brand,
@@ -66,10 +118,6 @@ paystackRoutes.post("/", async (c) => {
         });
         const discountValue = getOrderDiscountValue(items, discount);
 
-        console.log(
-          "sending payment verification emails after order creation..."
-        );
-
         // Send emails using the service
         const emailResults = await sendPaymentVerificationEmails({
           order,
@@ -79,14 +127,6 @@ paystackRoutes.post("/", async (c) => {
           didSendNewOrderEmail: order.didSendNewOrderReceivedEmail || false,
           didSendConfirmationEmail: order.didSendConfirmationEmail || false,
         });
-
-        if (emailResults.confirmationSent) {
-          console.log("confirmation email sent");
-        }
-
-        if (emailResults.adminNotificationSent) {
-          console.log("admin notification email sent");
-        }
 
         // Update order with email status flags
         await c.env.runMutation(api.storeFront.onlineOrder.update, {
@@ -102,30 +142,42 @@ paystackRoutes.post("/", async (c) => {
       }
     }
 
+    const orderDetailsFromWebhook =
+      order_details && typeof order_details === "object" ? order_details : {};
+
     // update important fields first
-    await c.env.runMutation(
-      internal.storeFront.checkoutSession.updateCheckoutSession,
-      {
-        id: checkout_session_id as Id<"checkoutSession">,
-        hasCompletedPayment: true,
-        externalTransactionId: payload.data.id.toString(),
-        paymentMethod: {
-          last4: payload?.data?.authorization?.last4,
-          brand: payload?.data?.authorization?.brand,
-          bank: payload?.data?.authorization?.bank,
-          channel: payload?.data?.authorization?.channel,
-        },
-        orderDetails: {
-          ...order_details,
-          deliveryInstructions: order_details.deliveryInstructions || "",
-          billingDetails: null,
-          deliveryFee: order_details.deliveryFee
-            ? parseFloat(order_details.deliveryFee)
-            : null,
-          discount: order_details.discount || null,
-        },
-      }
-    );
+    await c.env.runMutation(internal.storeFront.checkoutSession.updateCheckoutSession, {
+      id: checkout_session_id as Id<"checkoutSession">,
+      hasCompletedPayment: true,
+      externalTransactionId: incomingTransactionId,
+      paymentMethod: {
+        last4: payload?.data?.authorization?.last4,
+        brand: payload?.data?.authorization?.brand,
+        bank: payload?.data?.authorization?.bank,
+        channel: payload?.data?.authorization?.channel,
+      },
+      orderDetails: {
+        ...orderDetailsFromWebhook,
+        billingDetails: null,
+        deliveryDetails:
+          orderDetailsFromWebhook.deliveryDetails ?? session.deliveryDetails ?? null,
+        deliveryInstructions:
+          orderDetailsFromWebhook.deliveryInstructions ||
+          session.deliveryInstructions ||
+          "",
+        deliveryFee:
+          typeof orderDetailsFromWebhook.deliveryFee === "number"
+            ? orderDetailsFromWebhook.deliveryFee
+            : session.deliveryFee ?? null,
+        deliveryMethod:
+          orderDetailsFromWebhook.deliveryMethod ?? session.deliveryMethod ?? "delivery",
+        deliveryOption:
+          orderDetailsFromWebhook.deliveryOption ?? session.deliveryOption ?? null,
+        pickupLocation:
+          orderDetailsFromWebhook.pickupLocation ?? session.pickupLocation ?? null,
+        discount: session.discount ?? null,
+      },
+    });
   }
 
   if (payload?.event == "refund.processed") {

--- a/packages/athena-webapp/convex/http/domains/storeFront/routes/security.test.ts
+++ b/packages/athena-webapp/convex/http/domains/storeFront/routes/security.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCanonicalCheckoutProducts,
+  hasValidPositiveQuantity,
+  isAuthorizedResourceOwner,
+  isAmountTampered,
+  isDuplicateChargeSuccess,
+  isValidPaystackSignature,
+} from "./security";
+
+describe("security helpers", () => {
+  describe("buildCanonicalCheckoutProducts", () => {
+    it("builds canonical products and amount from bag items", () => {
+      const result = buildCanonicalCheckoutProducts([
+        {
+          productId: "product-1",
+          productSku: "sku-a",
+          productSkuId: "sku-id-a",
+          quantity: 2,
+          price: 25,
+        },
+        {
+          productId: "product-2",
+          productSku: "sku-b",
+          productSkuId: "sku-id-b",
+          quantity: 1,
+          price: 100,
+        },
+      ]);
+
+      expect(result.products).toEqual([
+        {
+          productId: "product-1",
+          productSku: "sku-a",
+          productSkuId: "sku-id-a",
+          quantity: 2,
+          price: 25,
+        },
+        {
+          productId: "product-2",
+          productSku: "sku-b",
+          productSkuId: "sku-id-b",
+          quantity: 1,
+          price: 100,
+        },
+      ]);
+      expect(result.amount).toBe(150);
+    });
+  });
+
+  describe("hasValidPositiveQuantity", () => {
+    it("returns false for zero or negative quantities", () => {
+      expect(hasValidPositiveQuantity(0)).toBe(false);
+      expect(hasValidPositiveQuantity(-1)).toBe(false);
+      expect(hasValidPositiveQuantity(2)).toBe(true);
+    });
+  });
+
+  describe("isAuthorizedResourceOwner", () => {
+    it("returns true only for matching owners", () => {
+      expect(isAuthorizedResourceOwner("owner-1", "owner-1")).toBe(true);
+      expect(isAuthorizedResourceOwner("owner-1", "owner-2")).toBe(false);
+      expect(isAuthorizedResourceOwner("owner-1", null)).toBe(false);
+    });
+  });
+
+  describe("isAmountTampered", () => {
+    it("detects mismatched amount", () => {
+      expect(isAmountTampered(100, 100)).toBe(false);
+      expect(isAmountTampered(100, 101)).toBe(true);
+    });
+  });
+
+  describe("isValidPaystackSignature", () => {
+    it("validates signed payloads and rejects bad signatures", () => {
+      const body = JSON.stringify({
+        event: "charge.success",
+        data: { id: 10 },
+      });
+      const secret = "test_secret";
+
+      const valid = isValidPaystackSignature(body, secret);
+      expect(
+        isValidPaystackSignature(body, secret, valid.computedSignature)
+      ).toBe(true);
+      expect(
+        isValidPaystackSignature(body, secret, "bad-signature")
+      ).toBe(false);
+    });
+  });
+
+  describe("isDuplicateChargeSuccess", () => {
+    it("flags duplicates for already-paid or already-ordered sessions", () => {
+      expect(
+        isDuplicateChargeSuccess({
+          hasCompletedPayment: true,
+          placedOrderId: undefined,
+          hasExistingOrder: false,
+          incomingTransactionId: "tx-1",
+          existingTransactionId: undefined,
+        })
+      ).toBe(true);
+
+      expect(
+        isDuplicateChargeSuccess({
+          hasCompletedPayment: false,
+          placedOrderId: "order-1",
+          hasExistingOrder: false,
+          incomingTransactionId: "tx-1",
+          existingTransactionId: undefined,
+        })
+      ).toBe(true);
+
+      expect(
+        isDuplicateChargeSuccess({
+          hasCompletedPayment: false,
+          placedOrderId: undefined,
+          hasExistingOrder: true,
+          incomingTransactionId: "tx-1",
+          existingTransactionId: undefined,
+        })
+      ).toBe(true);
+
+      expect(
+        isDuplicateChargeSuccess({
+          hasCompletedPayment: false,
+          placedOrderId: undefined,
+          hasExistingOrder: false,
+          incomingTransactionId: "tx-1",
+          existingTransactionId: "tx-1",
+        })
+      ).toBe(true);
+
+      expect(
+        isDuplicateChargeSuccess({
+          hasCompletedPayment: false,
+          placedOrderId: undefined,
+          hasExistingOrder: false,
+          incomingTransactionId: "tx-1",
+          existingTransactionId: "tx-2",
+        })
+      ).toBe(false);
+    });
+  });
+});

--- a/packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts
+++ b/packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts
@@ -1,0 +1,128 @@
+import { createHmac, timingSafeEqual } from "crypto";
+
+type BagCheckoutItem = {
+  productId: string;
+  productSku: string;
+  productSkuId: string;
+  quantity: number;
+  price: number;
+};
+
+type CanonicalCheckoutProduct = {
+  productId: string;
+  productSku: string;
+  productSkuId: string;
+  quantity: number;
+  price: number;
+};
+
+type DuplicateChargeSuccessInput = {
+  hasCompletedPayment: boolean;
+  placedOrderId?: string;
+  hasExistingOrder: boolean;
+  incomingTransactionId?: string;
+  existingTransactionId?: string;
+};
+
+export function hasValidPositiveQuantity(value: number): boolean {
+  return Number.isInteger(value) && value > 0;
+}
+
+export function isAuthorizedResourceOwner(
+  resourceOwnerId: string | null | undefined,
+  requestUserId: string | null | undefined
+): boolean {
+  if (!resourceOwnerId || !requestUserId) {
+    return false;
+  }
+
+  return resourceOwnerId === requestUserId;
+}
+
+export function buildCanonicalCheckoutProducts(items: BagCheckoutItem[]): {
+  products: CanonicalCheckoutProduct[];
+  amount: number;
+} {
+  const products = items.map((item) => ({
+    productId: item.productId,
+    productSku: item.productSku,
+    productSkuId: item.productSkuId,
+    quantity: item.quantity,
+    price: item.price,
+  }));
+
+  const rawAmount = products.reduce(
+    (total, item) => total + item.price * item.quantity,
+    0
+  );
+
+  return {
+    products,
+    amount: Math.round(rawAmount * 100) / 100,
+  };
+}
+
+export function isAmountTampered(
+  expectedAmount: number,
+  providedAmount: number | undefined | null
+): boolean {
+  if (providedAmount === undefined || providedAmount === null) {
+    return false;
+  }
+
+  return Math.abs(expectedAmount - providedAmount) > 0.0001;
+}
+
+export function isDuplicateChargeSuccess(
+  input: DuplicateChargeSuccessInput
+): boolean {
+  if (input.hasCompletedPayment || Boolean(input.placedOrderId)) {
+    return true;
+  }
+
+  if (input.hasExistingOrder) {
+    return true;
+  }
+
+  if (
+    input.incomingTransactionId &&
+    input.existingTransactionId &&
+    input.incomingTransactionId === input.existingTransactionId
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+export function isValidPaystackSignature(
+  payload: string,
+  secret: string
+): { computedSignature: string };
+export function isValidPaystackSignature(
+  payload: string,
+  secret: string,
+  signature: string
+): boolean;
+export function isValidPaystackSignature(
+  payload: string,
+  secret: string,
+  signature?: string
+): { computedSignature: string } | boolean {
+  const computedSignature = createHmac("sha512", secret)
+    .update(payload)
+    .digest("hex");
+
+  if (signature === undefined) {
+    return { computedSignature };
+  }
+
+  if (computedSignature.length !== signature.length) {
+    return false;
+  }
+
+  return timingSafeEqual(
+    Buffer.from(computedSignature, "utf8"),
+    Buffer.from(signature, "utf8")
+  );
+}

--- a/packages/athena-webapp/convex/storeFront/payment.ts
+++ b/packages/athena-webapp/convex/storeFront/payment.ts
@@ -67,7 +67,7 @@ export const createTransaction = action({
       }
 
       // Extract and calculate order amount
-      const discount = session.discount || args.orderDetails.discount;
+      const discount = session.discount;
       const items = (session.items || [])
         .filter(
           (item) =>
@@ -83,7 +83,7 @@ export const createTransaction = action({
 
       // Log calculation inputs
       console.log(
-        `[CHECKOUT-CALCULATION] Amount calculation inputs | Session: ${args.checkoutSessionId} | Items count: ${items.length} | Subtotal: ${args.amount * 100} | Delivery fee: ${(args.orderDetails.deliveryFee || 0) * 100} | Has discount: ${!!discount}`
+        `[CHECKOUT-CALCULATION] Amount calculation inputs | Session: ${args.checkoutSessionId} | Items count: ${items.length} | Subtotal: ${session.amount * 100} | Delivery fee: ${(args.orderDetails.deliveryFee || 0) * 100} | Has discount: ${!!discount}`
       );
       console.log(
         `[CHECKOUT-CALCULATION] Items breakdown:`,
@@ -107,7 +107,7 @@ export const createTransaction = action({
         items,
         discount,
         deliveryFee: (args.orderDetails.deliveryFee || 0) * 100,
-        subtotal: args.amount * 100,
+        subtotal: session.amount * 100,
       });
 
       // Log calculation result
@@ -128,8 +128,8 @@ export const createTransaction = action({
         metadata: {
           cancel_action: `${appUrl}/shop/checkout?origin=paystack`,
           checkout_session_id: args.checkoutSessionId,
-          checkout_session_amount: args.amount.toString(),
-          order_details: args.orderDetails,
+          checkout_session_amount: session.amount.toString(),
+          order_details: { ...args.orderDetails, discount: session.discount ?? null },
           amount_to_charge: amountToCharge.toString(),
         },
       });
@@ -147,7 +147,7 @@ export const createTransaction = action({
             id: args.checkoutSessionId,
             isFinalizingPayment: true,
             externalReference: response.data.reference,
-            orderDetails: args.orderDetails,
+            orderDetails: { ...args.orderDetails, discount: session.discount ?? null },
           }
         );
       } catch (error) {
@@ -192,6 +192,17 @@ export const createPODOrder = action({
     console.log(`Creating POD order for session: ${args.checkoutSessionId}`);
 
     try {
+      const session = await ctx.runQuery(api.storeFront.checkoutSession.getById, {
+        sessionId: args.checkoutSessionId,
+      });
+
+      if (!session) {
+        return {
+          success: false,
+          message: "Session not found",
+        };
+      }
+
       // Generate POD reference
       const podReference = generatePODReference(args.checkoutSessionId);
 
@@ -213,6 +224,7 @@ export const createPODOrder = action({
           orderDetails: {
             ...args.orderDetails,
             paymentMethod: "payment_on_delivery",
+            discount: session.discount ?? null,
           },
           paymentMethod,
         }
@@ -240,7 +252,7 @@ export const createPODOrder = action({
           items: order.items || [],
           discount: order.discount || 0,
           deliveryFee: (args.orderDetails.deliveryFee || 0) * 100,
-          subtotal: args.amount * 100,
+          subtotal: session.amount * 100,
         });
 
         // Send confirmation and admin notification emails


### PR DESCRIPTION
## Summary
- harden storefront checkout creation by recomputing pricing and totals from canonical server-side cart data instead of trusting client-provided price/amount fields
- enforce stricter input validation and ownership checks across checkout/order endpoints so cross-user access and invalid action payloads are rejected
- add webhook protection for Paystack processing, including signature verification and duplicate-event/idempotency handling to prevent replayed `charge.success` from creating duplicate side effects
- add focused security regression coverage in `convex/http/domains/storeFront/routes/security.test.ts` for tampering, authorization, and webhook hardening scenarios

## Why
- `V26-162` is a security hardening issue: the API previously accepted client-influenced monetary values and had weak guardrails around checkout/order access and webhook trust boundaries
- these changes move critical trust decisions to server-owned data and reject malformed or unauthorized operations early, reducing fraud and unauthorized data access risk

## Validation
- `bun run --filter '@athena/webapp' test` (pass)
- `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json` (pass)
