### PR TITLE
fix(symphony-service): stop in-flight token burn for stuck turns

### DIFF
--- a/packages/symphony-service/src/codex/client.ts
+++ b/packages/symphony-service/src/codex/client.ts
@@ -318,7 +318,7 @@ export class CodexAppServerClient {
     const rateLimits = extractRateLimits(message) ?? undefined;
 
     if (isApprovalRequest(message)) {
-      this.sendRequestResult(message.id, { approved: true });
+      this.sendRequestResult(message.id, buildApprovalResponse(method));
       this.emit({ event: "approval_auto_approved", payload: { method } });
       return;
     }
@@ -478,4 +478,18 @@ export class CodexAppServerClient {
     const joined = this.recentStderr.join("\n").toLowerCase();
     return joined.includes("command not found") || joined.includes("not recognized") || joined.includes("no such file");
   }
+}
+
+function buildApprovalResponse(method: string): Record<string, unknown> {
+  const normalizedMethod = method.toLowerCase();
+  if (normalizedMethod.includes("commandexecution") && normalizedMethod.includes("requestapproval")) {
+    return {
+      approved: true,
+      decision: "approved",
+    };
+  }
+
+  return {
+    approved: true,
+  };
 }

--- a/packages/symphony-service/src/httpServer.ts
+++ b/packages/symphony-service/src/httpServer.ts
@@ -344,6 +344,20 @@ function renderDashboardHtml(state: StateApiResponse): string {
       align-items: center;
       gap: 8px;
     }
+    .section-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+      margin-bottom: 8px;
+    }
+    .section-header h2 {
+      margin-bottom: 0;
+    }
+    .inline-btn {
+      padding: 4px 8px;
+      font-size: 12px;
+    }
     button {
       border: 1px solid #305075;
       background: #12233a;
@@ -459,7 +473,7 @@ function renderDashboardHtml(state: StateApiResponse): string {
       <div>Total tokens: <code id="total-tokens"></code></div>
       <div>Input tokens: <code id="input-tokens"></code></div>
       <div>Output tokens: <code id="output-tokens"></code></div>
-      <div>Runtime seconds: <code id="runtime-seconds"></code></div>
+      <div>Runtime: <code id="runtime-seconds"></code></div>
     </div>
   </div>
   <div class="split">
@@ -517,7 +531,10 @@ function renderDashboardHtml(state: StateApiResponse): string {
     </div>
 
     <div class="card">
-      <h2>Issue Activity</h2>
+      <div class="section-header">
+        <h2>Issue Activity</h2>
+        <button id="activity-collapse-btn" class="inline-btn" type="button" disabled>Collapse</button>
+      </div>
       <div id="activity-meta" class="activity-meta">Select a running or retrying issue to inspect timeline events.</div>
       <table>
         <thead>
@@ -553,7 +570,9 @@ function renderDashboardHtml(state: StateApiResponse): string {
     const activityBody = document.getElementById("activity-body");
     const activityMeta = document.getElementById("activity-meta");
     const activityEmpty = document.getElementById("activity-empty");
+    const activityCollapseBtn = document.getElementById("activity-collapse-btn");
     let selectedIssueIdentifier = null;
+    let latestState = initialState;
 
     function esc(value) {
       return String(value)
@@ -576,6 +595,27 @@ function renderDashboardHtml(state: StateApiResponse): string {
       return value.toLocaleString();
     }
 
+    function formatRuntimeSeconds(value) {
+      if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+        return "0s";
+      }
+
+      const totalSeconds = Math.max(0, value);
+      const hours = Math.floor(totalSeconds / 3600);
+      const minutes = Math.floor((totalSeconds % 3600) / 60);
+      const seconds = Math.floor(totalSeconds % 60);
+
+      if (hours > 0) {
+        return \`\${hours}h \${minutes}m \${seconds}s\`;
+      }
+
+      if (minutes > 0) {
+        return \`\${minutes}m \${seconds}s\`;
+      }
+
+      return \`\${totalSeconds.toFixed(2)}s\`;
+    }
+
     function renderIssueCell(issueIdentifier) {
       const selected = selectedIssueIdentifier === issueIdentifier ? ' data-selected="true"' : "";
       return \`<button type="button" class="issue-link" data-issue-id="\${esc(issueIdentifier)}"\${selected}>\${esc(issueIdentifier)}</button>\`;
@@ -595,6 +635,7 @@ function renderDashboardHtml(state: StateApiResponse): string {
     }
 
     function renderRows(state) {
+      latestState = state;
       document.getElementById("generated-at").textContent = state.generated_at || "";
       document.getElementById("count-running").textContent = formatNumber(state.counts?.running ?? 0);
       document.getElementById("count-retrying").textContent = formatNumber(state.counts?.retrying ?? 0);
@@ -602,7 +643,7 @@ function renderDashboardHtml(state: StateApiResponse): string {
       document.getElementById("total-tokens").textContent = formatNumber(state.codex_totals?.total_tokens ?? 0);
       document.getElementById("input-tokens").textContent = formatNumber(state.codex_totals?.input_tokens ?? 0);
       document.getElementById("output-tokens").textContent = formatNumber(state.codex_totals?.output_tokens ?? 0);
-      document.getElementById("runtime-seconds").textContent = Number(state.codex_totals?.seconds_running ?? 0).toFixed(2);
+      document.getElementById("runtime-seconds").textContent = formatRuntimeSeconds(Number(state.codex_totals?.seconds_running ?? 0));
 
       const running = Array.isArray(state.running) ? state.running : [];
       const retrying = Array.isArray(state.retrying) ? state.retrying : [];
@@ -654,6 +695,7 @@ function renderDashboardHtml(state: StateApiResponse): string {
         activityEmpty.textContent = "No issue selected.";
         activityEmpty.style.display = "block";
         activityMeta.textContent = "Select a running or retrying issue to inspect timeline events.";
+        activityCollapseBtn.disabled = true;
         return;
       }
 
@@ -662,6 +704,7 @@ function renderDashboardHtml(state: StateApiResponse): string {
         activityEmpty.textContent = \`Issue \${selectedIssueIdentifier} is no longer visible in runtime state.\`;
         activityEmpty.style.display = "block";
         activityMeta.textContent = "Issue detail unavailable.";
+        activityCollapseBtn.disabled = false;
         return;
       }
 
@@ -689,6 +732,7 @@ function renderDashboardHtml(state: StateApiResponse): string {
 
       activityEmpty.textContent = "No events yet.";
       activityEmpty.style.display = events.length > 0 ? "none" : "block";
+      activityCollapseBtn.disabled = false;
     }
 
     async function fetchState() {
@@ -760,8 +804,25 @@ function renderDashboardHtml(state: StateApiResponse): string {
         return;
       }
 
+      if (selectedIssueIdentifier === nextIssueIdentifier) {
+        selectedIssueIdentifier = null;
+        renderRows(latestState);
+        renderIssueActivity(null);
+        return;
+      }
+
       selectedIssueIdentifier = nextIssueIdentifier;
       void pollState();
+    });
+
+    activityCollapseBtn.addEventListener("click", () => {
+      if (!selectedIssueIdentifier) {
+        return;
+      }
+
+      selectedIssueIdentifier = null;
+      renderRows(latestState);
+      renderIssueActivity(null);
     });
 
     refreshBtn.addEventListener("click", () => {

--- a/packages/symphony-service/src/service.ts
+++ b/packages/symphony-service/src/service.ts
@@ -56,6 +56,11 @@ interface IssueLifecycleMetrics {
   continuationRuns: number;
 }
 
+interface InFlightGuardrailStop {
+  reason: "attempt_input_budget_exceeded_inflight";
+  observedInputTokens: number;
+}
+
 interface ServiceDependencies {
   loadWorkflowFile: (path: string) => Promise<WorkflowDocument>;
   watchWorkflowFile: (path: string, onReloadRequested: () => void) => FSWatcher;
@@ -216,6 +221,7 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
   const completionSignals = new Map<string, RuntimeSnapshotCompletedRow>();
   const issueEventBuffers = new Map<string, IssueEventBuffer>();
   const issueLifecycleMetrics = new Map<string, IssueLifecycleMetrics>();
+  const inFlightGuardrailStops = new Map<string, InFlightGuardrailStop>();
   const workerTasks = new Set<Promise<void>>();
   const guardrailNotifiedIssueIds = new Set<string>();
   let completedInputTokens = 0;
@@ -419,6 +425,65 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
 
     worker.stop();
     activeWorkers.delete(issueId);
+    inFlightGuardrailStops.delete(issueId);
+  }
+
+  function stopRunningIssueWorker(issueId: string): void {
+    const worker = activeWorkers.get(issueId);
+    if (!worker) {
+      return;
+    }
+
+    worker.stop();
+  }
+
+  function maybeTriggerInFlightAttemptGuardrail(issueId: string): void {
+    if (!config) {
+      return;
+    }
+
+    const worker = activeWorkers.get(issueId);
+    if (!worker) {
+      return;
+    }
+
+    if (worker.usage.inputTokens < config.agent.maxInputTokensPerAttempt) {
+      return;
+    }
+
+    if (inFlightGuardrailStops.has(issueId)) {
+      stopRunningIssueWorker(issueId);
+      return;
+    }
+
+    inFlightGuardrailStops.set(issueId, {
+      reason: "attempt_input_budget_exceeded_inflight",
+      observedInputTokens: worker.usage.inputTokens,
+    });
+
+    appendIssueEvent(issueId, worker.identifier, {
+      source: "service",
+      kind: "attempt_guardrail_blocked",
+      message: `In-flight attempt guardrail triggered (input_tokens=${worker.usage.inputTokens}, limit=${config.agent.maxInputTokensPerAttempt})`,
+      session_id: worker.sessionId,
+      turn_count: worker.turnCount,
+      retry_attempt: worker.retryAttempt,
+    });
+
+    emitLog({
+      level: "warn",
+      message: "action=worker outcome=guardrail_stop reason=attempt_input_budget_exceeded_inflight",
+      details: {
+        issue_id: worker.issueId,
+        issue_identifier: worker.identifier,
+        session_id: worker.sessionId ?? undefined,
+        turn_count: worker.turnCount,
+        input_tokens: worker.usage.inputTokens,
+        max_input_tokens_per_attempt: config.agent.maxInputTokensPerAttempt,
+      },
+    });
+
+    stopRunningIssueWorker(issueId);
   }
 
   function appendIssueEvent(
@@ -491,6 +556,7 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
 
   function clearIssueLifecycle(issueId: string): void {
     issueLifecycleMetrics.delete(issueId);
+    inFlightGuardrailStops.delete(issueId);
   }
 
   function evaluateGuardrails(issue: NormalizedIssue): string[] {
@@ -743,6 +809,7 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
     }
 
     guardrailNotifiedIssueIds.delete(input.issue.id);
+    inFlightGuardrailStops.delete(input.issue.id);
     getOrCreateIssueLifecycle(input.issue.id, input.issue.identifier);
     completionSignals.delete(input.issue.id);
     await moveIssueToInProgress(runtimeTracker, input.issue);
@@ -784,6 +851,7 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
     });
     worker.stop = () => codexClient.stop();
     activeWorkers.set(input.issue.id, worker);
+    maybeTriggerInFlightAttemptGuardrail(input.issue.id);
 
     const task = deps
       .runIssueAttempt({
@@ -803,6 +871,7 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
         },
       })
       .then(async (result) => {
+        inFlightGuardrailStops.delete(result.issue.id);
         const lifecycle = getOrCreateIssueLifecycle(result.issue.id, result.issue.identifier);
         lifecycle.lifecycleInputTokens += worker.usage.inputTokens;
 
@@ -930,6 +999,70 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
       .catch(async (error) => {
         const lifecycle = getOrCreateIssueLifecycle(input.issue.id, input.issue.identifier);
         lifecycle.lifecycleInputTokens += worker.usage.inputTokens;
+        const inFlightStop = inFlightGuardrailStops.get(input.issue.id);
+
+        if (inFlightStop) {
+          inFlightGuardrailStops.delete(input.issue.id);
+
+          const guardrailReasons: string[] = [
+            `attempt input token budget exceeded (${inFlightStop.observedInputTokens}/${runtimeConfig.agent.maxInputTokensPerAttempt} this attempt)`,
+          ];
+          if (lifecycle.lifecycleInputTokens >= runtimeConfig.agent.maxIssueInputTokens) {
+            guardrailReasons.push(
+              `lifecycle input token budget exceeded (${lifecycle.lifecycleInputTokens}/${runtimeConfig.agent.maxIssueInputTokens})`,
+            );
+          }
+
+          const retry = onWorkerExit(state, {
+            issueId: input.issue.id,
+            nowMs: deps.nowMs(),
+            reason: "normal",
+            maxRetryBackoffMs: runtimeConfig.agent.maxRetryBackoffMs,
+            allowContinuation: false,
+          });
+
+          if (!retry) {
+            state.claimed.delete(input.issue.id);
+          }
+
+          appendIssueEvent(input.issue.id, input.issue.identifier, {
+            source: "service",
+            kind: "attempt_guardrail_blocked",
+            message: "In-flight attempt guardrail blocked continuation (attempt_input_budget_exceeded)",
+            session_id: worker.sessionId,
+            turn_count: worker.turnCount,
+            retry_attempt: worker.retryAttempt,
+          });
+
+          appendIssueEvent(input.issue.id, input.issue.identifier, {
+            source: "service",
+            kind: "continuation_guardrail_blocked",
+            message: `Continuation blocked by guardrails: ${guardrailReasons.join(" | ")}`,
+            session_id: worker.sessionId,
+            turn_count: worker.turnCount,
+            retry_attempt: worker.retryAttempt,
+          });
+
+          await moveIssueToState(runtimeTracker, input.issue, runtimeConfig.tracker.handoffState);
+          await publishContinuationGuardrailComment(runtimeTracker, input.issue, {
+            reasons: guardrailReasons,
+            turnCount: worker.turnCount,
+            retryAttempt: worker.retryAttempt,
+            lifecycleInputTokens: lifecycle.lifecycleInputTokens,
+            maxIssueInputTokens: runtimeConfig.agent.maxIssueInputTokens,
+            continuationRuns: lifecycle.continuationRuns,
+            maxContinuationRunsPerIssue: runtimeConfig.agent.maxContinuationRunsPerIssue,
+            maxInputTokensPerAttempt: runtimeConfig.agent.maxInputTokensPerAttempt,
+          });
+
+          await publishRunComment(runtimeTracker, input.issue, {
+            kind: "completed",
+            attempt: input.attempt,
+          });
+
+          clearIssueLifecycle(input.issue.id);
+          return;
+        }
 
         const retry = onWorkerExit(state, {
           issueId: input.issue.id,
@@ -1231,6 +1364,8 @@ export function createSymphonyService(options: CreateSymphonyServiceOptions): Sy
       worker.latestRateLimits = event.rate_limits;
       latestRateLimits = event.rate_limits;
     }
+
+    maybeTriggerInFlightAttemptGuardrail(issueId);
 
     appendIssueEvent(issueId, worker.identifier, {
       timestamp: event.timestamp,

--- a/packages/symphony-service/tests/codexClient.test.ts
+++ b/packages/symphony-service/tests/codexClient.test.ts
@@ -229,6 +229,75 @@ for await (const line of rl) {
     }
   });
 
+  it("sends decision field for command execution approval requests", async () => {
+    const serverPath = await writeMockServer(
+      "command-exec-approval",
+      `
+import readline from "node:readline";
+
+let approvalHandled = false;
+const rl = readline.createInterface({ input: process.stdin });
+for await (const line of rl) {
+  const msg = JSON.parse(line);
+
+  if (msg.method === "initialize") {
+    console.log(JSON.stringify({ id: msg.id, result: { protocolVersion: "test" } }));
+    continue;
+  }
+
+  if (msg.method === "thread/start") {
+    console.log(JSON.stringify({ id: msg.id, result: { thread: { id: "thread-cmd" } } }));
+    continue;
+  }
+
+  if (msg.method === "turn/start") {
+    console.log(JSON.stringify({ id: msg.id, result: { turnId: "turn-cmd-1" } }));
+    console.log(JSON.stringify({ id: "approval-cmd-1", method: "item/commandExecution/requestApproval", params: { command: "echo hi" } }));
+    continue;
+  }
+
+  if (msg.id === "approval-cmd-1") {
+    if (!msg.result || msg.result.decision !== "approved" || msg.result.approved !== true) {
+      process.exitCode = 1;
+      break;
+    }
+    approvalHandled = true;
+  }
+
+  if (approvalHandled) {
+    console.log(JSON.stringify({
+      method: "turn/completed",
+      params: {
+        usage: { input_tokens: 3, output_tokens: 2, total_tokens: 5 },
+      }
+    }));
+  }
+}
+`,
+    );
+
+    const client = new CodexAppServerClient({
+      command: `node ${serverPath}`,
+      readTimeoutMs: 1000,
+      turnTimeoutMs: 1000,
+    });
+
+    try {
+      const session = await client.startSession({ cwd: process.cwd() });
+      const turn = await client.runTurn({
+        threadId: session.threadId,
+        cwd: process.cwd(),
+        title: "ATH-8",
+        prompt: "run",
+      });
+
+      expect(turn.outcome).toBe("completed");
+      expect(turn.usage).toEqual({ input_tokens: 3, output_tokens: 2, total_tokens: 5 });
+    } finally {
+      client.stop();
+    }
+  });
+
   it("uses configurable initialize client metadata", async () => {
     const serverPath = await writeMockServer(
       "metadata",

--- a/packages/symphony-service/tests/service.test.ts
+++ b/packages/symphony-service/tests/service.test.ts
@@ -937,6 +937,113 @@ describe("createSymphonyService", () => {
     await service.stop();
   });
 
+  it("moves issue to handoff and blocks retry when in-flight attempt input budget is exceeded", async () => {
+    const comments: string[] = [];
+    const transitioned: string[] = [];
+    let releaseWorker: (() => void) | null = null;
+    let stopCalled = false;
+    let stopRequested = false;
+    const candidates = [
+      issue({
+        id: "inflight-guardrail-1",
+        identifier: "ATH-902",
+        state: "Todo",
+        labels: ["pkg:symphony-service"],
+        description: "Harden runtime behavior with clear acceptance criteria and validation details.",
+        team_id: "team-1",
+      }),
+    ];
+
+    const service = createSymphonyService({
+      workflowPath: "/tmp/WORKFLOW.md",
+      deps: {
+        loadWorkflowFile: async () => workflow(1000),
+        createTracker: () => ({
+          async fetchCandidateIssues() {
+            return candidates.splice(0, candidates.length);
+          },
+          async fetchIssuesByStates() {
+            return [];
+          },
+          async fetchIssueStatesByIds() {
+            return [];
+          },
+          async createIssueComment(input) {
+            comments.push(input.body);
+          },
+          async updateIssueStateByName(input) {
+            transitioned.push(`${input.issue.identifier}:${input.stateName}`);
+            return true;
+          },
+        }),
+        createCodexClient: (_config, onEvent) => {
+          onEvent?.({
+            event: "notification",
+            timestamp: new Date().toISOString(),
+            session_id: "thread-902-turn-1",
+            usage: {
+              input_tokens: 175_000,
+              output_tokens: 22,
+              total_tokens: 175_022,
+            },
+          });
+
+          return {
+            async startSession() {
+              return { threadId: "thread-902" };
+            },
+            async runTurn() {
+              return { turnId: "turn-1", sessionId: "thread-902-turn-1", outcome: "completed" as const };
+            },
+            stop() {
+              stopCalled = true;
+              stopRequested = true;
+              releaseWorker?.();
+            },
+          };
+        },
+        cleanupTerminalIssueWorkspaces: async () => ({ removed: 0, failed: 0, warnings: [] }),
+        processDueRetries: async () => ({
+          processedIssueIds: [],
+          dispatchedIssueIds: [],
+          requeuedIssueIds: [],
+          releasedIssueIds: [],
+        }),
+        setIntervalFn: () => 1 as unknown as ReturnType<typeof setInterval>,
+        clearIntervalFn: () => {},
+        runIssueAttempt: async () => {
+          if (stopRequested) {
+            throw new Error("codex turn ended with non-completed outcome: port_exit");
+          }
+
+          await new Promise<void>((resolve) => {
+            releaseWorker = resolve;
+          });
+
+          throw new Error("codex turn ended with non-completed outcome: port_exit");
+        },
+      },
+    });
+
+    await service.start();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    await service.runTickOnce();
+    for (let index = 0; index < 20 && !transitioned.includes("ATH-902:Human Review"); index += 1) {
+      await Promise.resolve();
+    }
+
+    const snapshot = service.getRuntimeSnapshot();
+    expect(stopCalled).toBe(true);
+    expect(snapshot.retrying).toHaveLength(0);
+    expect(transitioned).toEqual(["ATH-902:In Progress", "ATH-902:Human Review"]);
+    expect(comments.some((entry) => entry.includes("paused automatic continuation"))).toBe(true);
+    expect(comments.some((entry) => entry.includes("attempt input token budget exceeded"))).toBe(true);
+
+    await service.stop();
+  });
+
   it("blocks issues that fail intake guardrails and comments once", async () => {
     const comments: string[] = [];
     const runIssueAttempt = vi.fn(async (input: any) => ({


### PR DESCRIPTION
## Summary
- fix Codex command-execution approval handling by sending the required `decision` field (while preserving existing `approved: true` behavior)
- add an in-flight attempt token guardrail in Symphony service so a running worker is stopped as soon as live input tokens exceed `agent.max_input_tokens_per_attempt`, without waiting for turn completion
- route in-flight guardrail-triggered runs to handoff (`Human Review`) and suppress failure retries, with explicit guardrail comments and timeline events
- add regression tests for command-execution approval response shape and in-flight token-budget enforcement/handoff behavior
- improve the runtime dashboard UX: format runtime duration as `h/m/s` and add collapsible issue activity details (collapse button + toggle-off on re-click)

## Why
- current runtime behavior can accumulate very high input tokens while a turn is still active (`turn_count = 0`) because existing guardrails only execute after a turn completes
- live timeline events showed command-execution approval requests failing deserialization due to missing `decision`, contributing to long-running/stuck turn behavior
- operators needed clearer high-level runtime readability and a way to collapse activity details after inspecting an issue

## Validation
- `bun run --filter '@athena/symphony-service' test`
- `bunx tsc --noEmit -p packages/symphony-service/tsconfig.json`
- `bun run --filter '@athena/storefront-webapp' test`