### PR TITLE
feat: conditional delivery fee waivers with minimum order amount

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,4 @@ dist
 # Local Claude/Codex worktree tracking metadata
 packages/.claude/worktrees/
 docs/superpowers/plans/
+.dual-graph/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,81 @@
+<!-- dgc-policy-v11 -->
+# Dual-Graph Context Policy
+
+This project uses a local dual-graph MCP server for efficient context retrieval.
+
+## MANDATORY: Always follow this order
+
+1. **Call `graph_continue` first** — before any file exploration, grep, or code reading.
+
+2. **If `graph_continue` returns `needs_project=true`**: call `graph_scan` with the
+   current project directory (`pwd`). Do NOT ask the user.
+
+3. **If `graph_continue` returns `skip=true`**: project has fewer than 5 files.
+   Do NOT do broad or recursive exploration. Read only specific files if their names
+   are mentioned, or ask the user what to work on.
+
+4. **Read `recommended_files`** using `graph_read` — **one call per file**.
+   - `graph_read` accepts a single `file` parameter (string). Call it separately for each
+     recommended file. Do NOT pass an array or batch multiple files into one call.
+   - `recommended_files` may contain `file::symbol` entries (e.g. `src/auth.ts::handleLogin`).
+     Pass them verbatim to `graph_read(file: "src/auth.ts::handleLogin")` — it reads only
+     that symbol's lines, not the full file.
+   - Example: if `recommended_files` is `["src/auth.ts::handleLogin", "src/db.ts"]`,
+     call `graph_read(file: "src/auth.ts::handleLogin")` and `graph_read(file: "src/db.ts")`
+     as two separate calls (they can be parallel).
+
+5. **Check `confidence` and obey the caps strictly:**
+   - `confidence=high` -> Stop. Do NOT grep or explore further.
+   - `confidence=medium` -> If recommended files are insufficient, call `fallback_rg`
+     at most `max_supplementary_greps` time(s) with specific terms, then `graph_read`
+     at most `max_supplementary_files` additional file(s). Then stop.
+   - `confidence=low` -> Call `fallback_rg` at most `max_supplementary_greps` time(s),
+     then `graph_read` at most `max_supplementary_files` file(s). Then stop.
+
+## Token Usage
+
+A `token-counter` MCP is available for tracking live token usage.
+
+- To check how many tokens a large file or text will cost **before** reading it:
+  `count_tokens({text: "<content>"})`
+- To log actual usage after a task completes (if the user asks):
+  `log_usage({input_tokens: <est>, output_tokens: <est>, description: "<task>"})`
+- To show the user their running session cost:
+  `get_session_stats()`
+
+Live dashboard URL is printed at startup next to "Token usage".
+
+## Rules
+
+- Do NOT use `rg`, `grep`, or bash file exploration before calling `graph_continue`.
+- Do NOT do broad/recursive exploration at any confidence level.
+- `max_supplementary_greps` and `max_supplementary_files` are hard caps - never exceed them.
+- Do NOT dump full chat history.
+- Do NOT call `graph_retrieve` more than once per turn.
+- After edits, call `graph_register_edit` with the changed files. Use `file::symbol` notation (e.g. `src/auth.ts::handleLogin`) when the edit targets a specific function, class, or hook.
+
+## Context Store
+
+Whenever you make a decision, identify a task, note a next step, fact, or blocker during a conversation, call `graph_add_memory`.
+
+**To add an entry:**
+```
+graph_add_memory(type="decision|task|next|fact|blocker", content="one sentence max 15 words", tags=["topic"], files=["relevant/file.ts"])
+```
+
+**Do NOT write context-store.json directly** — always use `graph_add_memory`. It applies pruning and keeps the store healthy.
+
+**Rules:**
+- Only log things worth remembering across sessions (not every minor detail)
+- `content` must be under 15 words
+- `files` lists the files this decision/task relates to (can be empty)
+- Log immediately when the item arises — not at session end
+
+## Session End
+
+When the user signals they are done (e.g. "bye", "done", "wrap up", "end session"), proactively update `CONTEXT.md` in the project root with:
+- **Current Task**: one sentence on what was being worked on
+- **Key Decisions**: bullet list, max 3 items
+- **Next Steps**: bullet list, max 3 items
+
+Keep `CONTEXT.md` under 20 lines total. Do NOT summarize the full conversation — only what's needed to resume next session.

--- a/packages/athena-webapp/convex/inventory/storeConfigV2.ts
+++ b/packages/athena-webapp/convex/inventory/storeConfigV2.ts
@@ -138,6 +138,7 @@ const normalizeWaiveDeliveryFees = (
     international: asBoolean(record.international),
     otherRegions: asBoolean(record.otherRegions),
     withinAccra: asBoolean(record.withinAccra),
+    minimumOrderAmount: asNumber(record.minimumOrderAmount),
   };
 };
 

--- a/packages/athena-webapp/convex/inventory/utils.ts
+++ b/packages/athena-webapp/convex/inventory/utils.ts
@@ -26,7 +26,7 @@ type Discount = {
  */
 export const getDiscountValue = (
   items: OrderItem[],
-  discount?: Discount | null
+  discount?: Discount | null,
 ): number => {
   if (!discount) return 0;
 
@@ -44,7 +44,7 @@ export const getDiscountValue = (
   if (discount.span === "entire-order" || !discount.span) {
     const subtotal = items.reduce(
       (sum, item) => sum + item.price * item.quantity,
-      0
+      0,
     ); // subtotal is in GHS
 
     if (type === "percentage") {
@@ -80,7 +80,7 @@ export const getDiscountValue = (
  */
 export const getProductDiscountValue = (
   price: number,
-  discount?: Discount | null
+  discount?: Discount | null,
 ): number => {
   if (!discount) return 0;
 
@@ -137,10 +137,10 @@ export const formatDeliveryAddress = (address: Address) => {
 
   if (isGHOrder) {
     const region = ghanaRegions.find((r) => r.code == address.region)?.name;
-    const neighborhood = accraNeighborhoods.find(
-      (n) => n.value == address?.neighborhood
-    )?.label;
-    addressLine = `${address?.houseNumber || ""} ${address?.street}, ${neighborhood}, ${region}`;
+    const neighborhood =
+      accraNeighborhoods.find((n) => n.value == address?.neighborhood)?.label ||
+      address?.neighborhood;
+    addressLine = `${address?.houseNumber || ""} ${address?.street || ""}, ${neighborhood}, ${region}`;
   }
 
   return {

--- a/packages/athena-webapp/src/components/store-configuration/components/FeesView.tsx
+++ b/packages/athena-webapp/src/components/store-configuration/components/FeesView.tsx
@@ -28,6 +28,9 @@ export const FeesView = () => {
   const [waiveWithinAccraFee, setWaiveWithinAccraFee] = useState(false);
   const [waiveOtherRegionsFee, setWaiveOtherRegionsFee] = useState(false);
   const [waiveIntlFee, setWaiveIntlFee] = useState(false);
+  const [minimumOrderAmount, setMinimumOrderAmount] = useState<
+    number | undefined
+  >(undefined);
 
   const handleUpdateFees = async () => {
     const updates = {
@@ -43,6 +46,7 @@ export const FeesView = () => {
       international: waiveIntlFee,
       // Keep a global flag for backward compatibility
       all: waiveWithinAccraFee && waiveOtherRegionsFee && waiveIntlFee,
+      minimumOrderAmount: minimumOrderAmount || undefined,
     };
 
     await updateConfig({
@@ -75,22 +79,28 @@ export const FeesView = () => {
       setWaiveWithinAccraFee(waiveConfig);
       setWaiveOtherRegionsFee(waiveConfig);
       setWaiveIntlFee(waiveConfig);
+      setMinimumOrderAmount(undefined);
     } else if (waiveConfig && typeof waiveConfig === "object") {
       // New format - object with properties
       setWaiveWithinAccraFee(waiveConfig.withinAccra || false);
       setWaiveOtherRegionsFee(waiveConfig.otherRegions || false);
       setWaiveIntlFee(waiveConfig.international || false);
+      setMinimumOrderAmount(waiveConfig.minimumOrderAmount || undefined);
     } else {
       // Default all to false
       setWaiveWithinAccraFee(false);
       setWaiveOtherRegionsFee(false);
       setWaiveIntlFee(false);
+      setMinimumOrderAmount(undefined);
     }
   }, [storeConfig]);
 
   // Function to check if all fees are being waived
   const areAllFeesWaived =
     waiveWithinAccraFee && waiveOtherRegionsFee && waiveIntlFee;
+
+  const isAnyWaiverActive =
+    waiveWithinAccraFee || waiveOtherRegionsFee || waiveIntlFee;
 
   // Function to toggle all fees at once
   const handleToggleAllFees = (checked: boolean) => {
@@ -210,6 +220,31 @@ export const FeesView = () => {
           </p>
         )}
       </div>
+
+      {isAnyWaiverActive && (
+        <div className="container mx-auto py-4 space-y-2">
+          <Label
+            className="text-sm text-muted-foreground"
+            htmlFor="minimum-order-amount"
+          >
+            Minimum order amount for free delivery (
+            {activeStore?.currency.toUpperCase()})
+          </Label>
+          <Input
+            id="minimum-order-amount"
+            type="number"
+            placeholder="Leave empty for unconditional free delivery"
+            value={minimumOrderAmount || ""}
+            onChange={(e) => {
+              const val = parseInt(e.target.value);
+              setMinimumOrderAmount(isNaN(val) || val <= 0 ? undefined : val);
+            }}
+          />
+          <p className="text-xs text-muted-foreground">
+            Leave empty for unconditional free delivery
+          </p>
+        </div>
+      )}
 
       <div className="w-full flex pr-8">
         <LoadingButton

--- a/packages/athena-webapp/types.ts
+++ b/packages/athena-webapp/types.ts
@@ -134,6 +134,7 @@ export type StoreWaiveDeliveryFeesConfig =
       international?: boolean;
       otherRegions?: boolean;
       withinAccra?: boolean;
+      minimumOrderAmount?: number;
     };
 
 export type StoreTaxConfig = {

--- a/packages/docs/superpowers/plans/2026-03-31-conditional-delivery-fee-waiver.md
+++ b/packages/docs/superpowers/plans/2026-03-31-conditional-delivery-fee-waiver.md
@@ -1,0 +1,1037 @@
+# Conditional Delivery Fee Waiver Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an optional minimum order amount threshold to the delivery fee waiver system, so fees are only waived when the cart subtotal meets a configurable amount.
+
+**Architecture:** Extend `StoreWaiveDeliveryFeesConfig` with `minimumOrderAmount`. Propagate a `subtotal` parameter through `isFeeWaived()`, `isAnyFeeWaived()`, and `calculateDeliveryFee()`. Refactor inline waiver logic in `DeliveryDetailsSection.tsx` and `deliveryFees.ts` to use centralized functions. Add admin UI input and storefront nudge message.
+
+**Tech Stack:** TypeScript, React, Vitest, Convex
+
+**Spec:** `docs/superpowers/specs/2026-03-31-conditional-delivery-fee-waiver-design.md`
+
+---
+
+### Task 1: Update type definitions and Convex normalizer
+
+**Files:**
+- Modify: `athena-webapp/types.ts:130-137`
+- Modify: `athena-webapp/convex/inventory/storeConfigV2.ts:127-142`
+
+- [ ] **Step 1: Add `minimumOrderAmount` to `StoreWaiveDeliveryFeesConfig`**
+
+In `athena-webapp/types.ts`, add the field to the object branch of the union:
+
+```typescript
+export type StoreWaiveDeliveryFeesConfig =
+  | boolean
+  | {
+      all?: boolean;
+      international?: boolean;
+      otherRegions?: boolean;
+      withinAccra?: boolean;
+      minimumOrderAmount?: number;
+    };
+```
+
+- [ ] **Step 2: Update Convex normalizer to preserve `minimumOrderAmount`**
+
+In `athena-webapp/convex/inventory/storeConfigV2.ts`, update `normalizeWaiveDeliveryFees` to include the new field:
+
+```typescript
+const normalizeWaiveDeliveryFees = (
+  value: unknown,
+): StoreWaiveDeliveryFeesConfig => {
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  const record = asRecord(value);
+
+  return {
+    all: asBoolean(record.all),
+    international: asBoolean(record.international),
+    otherRegions: asBoolean(record.otherRegions),
+    withinAccra: asBoolean(record.withinAccra),
+    minimumOrderAmount: asNumber(record.minimumOrderAmount),
+  };
+};
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add athena-webapp/types.ts athena-webapp/convex/inventory/storeConfigV2.ts
+git commit -m "feat: add minimumOrderAmount to delivery fee waiver config type and normalizer"
+```
+
+---
+
+### Task 2: Add threshold support to `feeUtils.ts` (TDD)
+
+**Files:**
+- Modify: `storefront-webapp/src/lib/feeUtils.ts`
+- Modify: `storefront-webapp/src/lib/feeUtils.test.ts`
+
+- [ ] **Step 1: Write failing tests for `isFeeWaived` with subtotal**
+
+Add these tests to `storefront-webapp/src/lib/feeUtils.test.ts`:
+
+```typescript
+describe("isFeeWaived with minimumOrderAmount", () => {
+  it("returns true when region waiver is ON and subtotal >= threshold", () => {
+    const config = { withinAccra: true, minimumOrderAmount: 100 };
+    // subtotal is in pesewas: 100 GHS = 10000 pesewas
+    expect(isFeeWaived(config, "within-accra", 10000)).toBe(true);
+  });
+
+  it("returns false when region waiver is ON but subtotal < threshold", () => {
+    const config = { withinAccra: true, minimumOrderAmount: 100 };
+    expect(isFeeWaived(config, "within-accra", 5000)).toBe(false);
+  });
+
+  it("returns true when region waiver is ON and no threshold set (backward compat)", () => {
+    const config = { withinAccra: true };
+    expect(isFeeWaived(config, "within-accra", 5000)).toBe(true);
+  });
+
+  it("returns true when waiveDeliveryFees is boolean true regardless of subtotal", () => {
+    expect(isFeeWaived(true, "within-accra", 100)).toBe(true);
+    expect(isFeeWaived(true, "intl", 0)).toBe(true);
+  });
+
+  it("returns true when threshold is 0 (treated as no threshold)", () => {
+    const config = { withinAccra: true, minimumOrderAmount: 0 };
+    expect(isFeeWaived(config, "within-accra", 0)).toBe(true);
+  });
+
+  it("returns true when all is true and subtotal >= threshold", () => {
+    const config = { all: true, minimumOrderAmount: 50 };
+    expect(isFeeWaived(config, "within-accra", 5000)).toBe(true);
+  });
+
+  it("returns false when all is true but subtotal < threshold", () => {
+    const config = { all: true, minimumOrderAmount: 50 };
+    expect(isFeeWaived(config, "within-accra", 1000)).toBe(false);
+  });
+
+  it("returns false when region waiver is OFF regardless of subtotal", () => {
+    const config = { withinAccra: false, minimumOrderAmount: 10 };
+    expect(isFeeWaived(config, "within-accra", 99999)).toBe(false);
+  });
+
+  it("returns true when subtotal is not provided and no threshold (backward compat)", () => {
+    const config = { withinAccra: true };
+    expect(isFeeWaived(config, "within-accra")).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd storefront-webapp && npx vitest run src/lib/feeUtils.test.ts`
+Expected: FAIL — `isFeeWaived` does not accept a third parameter / does not check threshold.
+
+- [ ] **Step 3: Update `isFeeWaived` to support subtotal threshold**
+
+Update the type and function in `storefront-webapp/src/lib/feeUtils.ts`. The `WaiveDeliveryFeesConfig` type used inline needs `minimumOrderAmount`. Add `subtotal` as an optional third parameter. After the existing logic determines the region flag is ON, check the threshold before returning `true`:
+
+```typescript
+type DeliveryOption = "within-accra" | "outside-accra" | "intl";
+
+type WaiveDeliveryFeesConfig =
+  | boolean
+  | {
+      withinAccra?: boolean;
+      otherRegions?: boolean;
+      international?: boolean;
+      all?: boolean;
+      minimumOrderAmount?: number;
+    }
+  | undefined
+  | null;
+
+// Helper: check threshold. Returns true if waiver should proceed.
+// minimumOrderAmount is in store currency, subtotal is in pesewas.
+// When subtotal is undefined, returns true for backward compatibility —
+// existing callers that don't pass subtotal still get unconditional waivers.
+const meetsThreshold = (
+  minimumOrderAmount: number | undefined,
+  subtotal: number | undefined
+): boolean => {
+  if (!minimumOrderAmount || minimumOrderAmount <= 0) return true;
+  if (subtotal === undefined) return true;
+  return subtotal >= minimumOrderAmount * 100; // toPesewas
+};
+
+export const isFeeWaived = (
+  waiveDeliveryFees: WaiveDeliveryFeesConfig,
+  deliveryOption: DeliveryOption | null,
+  subtotal?: number
+): boolean => {
+  if (typeof waiveDeliveryFees === "boolean") {
+    return waiveDeliveryFees;
+  }
+
+  if (!waiveDeliveryFees || typeof waiveDeliveryFees !== "object") {
+    return false;
+  }
+
+  if (waiveDeliveryFees.all) {
+    return meetsThreshold(waiveDeliveryFees.minimumOrderAmount, subtotal);
+  }
+
+  if (!deliveryOption) {
+    return false;
+  }
+
+  let regionWaived = false;
+  if (deliveryOption === "within-accra") {
+    regionWaived = !!waiveDeliveryFees.withinAccra;
+  } else if (deliveryOption === "outside-accra") {
+    regionWaived = !!waiveDeliveryFees.otherRegions;
+  } else if (deliveryOption === "intl") {
+    regionWaived = !!waiveDeliveryFees.international;
+  }
+
+  if (!regionWaived) return false;
+
+  return meetsThreshold(waiveDeliveryFees.minimumOrderAmount, subtotal);
+};
+```
+
+- [ ] **Step 4: Run tests to verify `isFeeWaived` tests pass**
+
+Run: `cd storefront-webapp && npx vitest run src/lib/feeUtils.test.ts`
+Expected: All `isFeeWaived` tests PASS.
+
+- [ ] **Step 5: Write failing tests for `isAnyFeeWaived` with subtotal**
+
+Add to `storefront-webapp/src/lib/feeUtils.test.ts`:
+
+```typescript
+describe("isAnyFeeWaived with minimumOrderAmount", () => {
+  it("returns false when waivers exist but subtotal is below threshold", () => {
+    const config = { withinAccra: true, minimumOrderAmount: 100 };
+    expect(isAnyFeeWaived(config, 5000)).toBe(false);
+  });
+
+  it("returns true when waivers exist and subtotal meets threshold", () => {
+    const config = { withinAccra: true, minimumOrderAmount: 100 };
+    expect(isAnyFeeWaived(config, 10000)).toBe(true);
+  });
+
+  it("returns true when no threshold is set", () => {
+    const config = { withinAccra: true };
+    expect(isAnyFeeWaived(config, 5000)).toBe(true);
+  });
+
+  it("returns true for legacy boolean true regardless of subtotal", () => {
+    expect(isAnyFeeWaived(true, 0)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 6: Run tests to verify they fail**
+
+Run: `cd storefront-webapp && npx vitest run src/lib/feeUtils.test.ts`
+Expected: FAIL — `isAnyFeeWaived` does not accept a second parameter.
+
+- [ ] **Step 7: Update `isAnyFeeWaived` to support subtotal threshold**
+
+Update in `storefront-webapp/src/lib/feeUtils.ts`:
+
+```typescript
+export const isAnyFeeWaived = (
+  waiveDeliveryFees: WaiveDeliveryFeesConfig,
+  subtotal?: number
+): boolean => {
+  if (typeof waiveDeliveryFees === "boolean") {
+    return waiveDeliveryFees;
+  }
+
+  if (!waiveDeliveryFees || typeof waiveDeliveryFees !== "object") {
+    return false;
+  }
+
+  const anyRegionWaived = !!(
+    waiveDeliveryFees.all ||
+    waiveDeliveryFees.withinAccra ||
+    waiveDeliveryFees.otherRegions ||
+    waiveDeliveryFees.international
+  );
+
+  if (!anyRegionWaived) return false;
+
+  return meetsThreshold(waiveDeliveryFees.minimumOrderAmount, subtotal);
+};
+```
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run: `cd storefront-webapp && npx vitest run src/lib/feeUtils.test.ts`
+Expected: All tests PASS.
+
+- [ ] **Step 9: Write failing tests for `hasWaiverConfigured`**
+
+Add to `storefront-webapp/src/lib/feeUtils.test.ts`:
+
+```typescript
+import { isFeeWaived, isAnyFeeWaived, hasWaiverConfigured } from "./feeUtils";
+
+describe("hasWaiverConfigured", () => {
+  it("returns true when region flag is ON regardless of threshold", () => {
+    const config = { withinAccra: true, minimumOrderAmount: 9999 };
+    expect(hasWaiverConfigured(config, "within-accra")).toBe(true);
+  });
+
+  it("returns false when region flag is OFF", () => {
+    const config = { withinAccra: false, minimumOrderAmount: 10 };
+    expect(hasWaiverConfigured(config, "within-accra")).toBe(false);
+  });
+
+  it("returns true when all is true", () => {
+    const config = { all: true, minimumOrderAmount: 9999 };
+    expect(hasWaiverConfigured(config, "intl")).toBe(true);
+  });
+
+  it("returns true for legacy boolean true", () => {
+    expect(hasWaiverConfigured(true, "within-accra")).toBe(true);
+  });
+
+  it("returns false for legacy boolean false", () => {
+    expect(hasWaiverConfigured(false, "within-accra")).toBe(false);
+  });
+
+  it("returns false for undefined/null", () => {
+    expect(hasWaiverConfigured(undefined, "within-accra")).toBe(false);
+    expect(hasWaiverConfigured(null, "within-accra")).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 10: Run tests to verify they fail**
+
+Run: `cd storefront-webapp && npx vitest run src/lib/feeUtils.test.ts`
+Expected: FAIL — `hasWaiverConfigured` does not exist.
+
+- [ ] **Step 11: Implement `hasWaiverConfigured`**
+
+Add to `storefront-webapp/src/lib/feeUtils.ts`:
+
+```typescript
+export const hasWaiverConfigured = (
+  waiveDeliveryFees: WaiveDeliveryFeesConfig,
+  deliveryOption: DeliveryOption | null
+): boolean => {
+  if (typeof waiveDeliveryFees === "boolean") {
+    return waiveDeliveryFees;
+  }
+
+  if (!waiveDeliveryFees || typeof waiveDeliveryFees !== "object") {
+    return false;
+  }
+
+  if (waiveDeliveryFees.all) return true;
+
+  if (!deliveryOption) return false;
+
+  if (deliveryOption === "within-accra") return !!waiveDeliveryFees.withinAccra;
+  if (deliveryOption === "outside-accra") return !!waiveDeliveryFees.otherRegions;
+  if (deliveryOption === "intl") return !!waiveDeliveryFees.international;
+
+  return false;
+};
+```
+
+- [ ] **Step 12: Write failing test for `getRemainingForFreeDelivery`**
+
+Add to `storefront-webapp/src/lib/feeUtils.test.ts`:
+
+```typescript
+import { isFeeWaived, isAnyFeeWaived, hasWaiverConfigured, getRemainingForFreeDelivery } from "./feeUtils";
+
+describe("getRemainingForFreeDelivery", () => {
+  it("returns remaining pesewas when subtotal is below threshold", () => {
+    const config = { withinAccra: true, minimumOrderAmount: 100 };
+    // 5000 pesewas = 50 GHS, threshold = 100 GHS = 10000 pesewas
+    expect(getRemainingForFreeDelivery(config, "within-accra", 5000)).toBe(5000);
+  });
+
+  it("returns null when subtotal meets threshold", () => {
+    const config = { withinAccra: true, minimumOrderAmount: 100 };
+    expect(getRemainingForFreeDelivery(config, "within-accra", 10000)).toBeNull();
+  });
+
+  it("returns null when no threshold is set (already free)", () => {
+    const config = { withinAccra: true };
+    expect(getRemainingForFreeDelivery(config, "within-accra", 5000)).toBeNull();
+  });
+
+  it("returns null when region waiver is OFF", () => {
+    const config = { withinAccra: false, minimumOrderAmount: 100 };
+    expect(getRemainingForFreeDelivery(config, "within-accra", 5000)).toBeNull();
+  });
+
+  it("returns null when no delivery option selected", () => {
+    const config = { withinAccra: true, minimumOrderAmount: 100 };
+    expect(getRemainingForFreeDelivery(config, null, 5000)).toBeNull();
+  });
+
+  it("returns null for legacy boolean true (no threshold possible)", () => {
+    expect(getRemainingForFreeDelivery(true, "within-accra", 100)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 13: Implement `getRemainingForFreeDelivery`**
+
+Add to `storefront-webapp/src/lib/feeUtils.ts`:
+
+```typescript
+export const getRemainingForFreeDelivery = (
+  waiveDeliveryFees: WaiveDeliveryFeesConfig,
+  deliveryOption: DeliveryOption | null,
+  subtotal: number
+): number | null => {
+  if (!deliveryOption) return null;
+  if (!hasWaiverConfigured(waiveDeliveryFees, deliveryOption)) return null;
+
+  if (typeof waiveDeliveryFees === "boolean") return null;
+  if (!waiveDeliveryFees || typeof waiveDeliveryFees !== "object") return null;
+
+  const { minimumOrderAmount } = waiveDeliveryFees;
+  if (!minimumOrderAmount || minimumOrderAmount <= 0) return null;
+
+  const thresholdInPesewas = minimumOrderAmount * 100;
+  if (subtotal >= thresholdInPesewas) return null;
+
+  return thresholdInPesewas - subtotal;
+};
+```
+
+- [ ] **Step 14: Run all feeUtils tests**
+
+Run: `cd storefront-webapp && npx vitest run src/lib/feeUtils.test.ts`
+Expected: All tests PASS.
+
+- [ ] **Step 15: Commit**
+
+```bash
+git add storefront-webapp/src/lib/feeUtils.ts storefront-webapp/src/lib/feeUtils.test.ts
+git commit -m "feat: add minimumOrderAmount threshold to fee waiver utilities"
+```
+
+---
+
+### Task 3: Refactor `deliveryFees.ts` to use centralized `isFeeWaived()` and add subtotal (TDD)
+
+**Files:**
+- Modify: `storefront-webapp/src/components/checkout/deliveryFees.ts`
+- Modify: `storefront-webapp/src/components/checkout/deliveryFees.test.ts`
+
+- [ ] **Step 1: Run existing tests to establish green baseline**
+
+Run: `cd storefront-webapp && npx vitest run src/components/checkout/deliveryFees.test.ts`
+Expected: All 11 existing tests PASS.
+
+- [ ] **Step 2: Write failing tests for threshold behavior**
+
+Add to `storefront-webapp/src/components/checkout/deliveryFees.test.ts`:
+
+```typescript
+describe("calculateDeliveryFee with minimumOrderAmount threshold", () => {
+  it("waives fee when waiver is ON and subtotal meets threshold", () => {
+    const result = calculateDeliveryFee({
+      deliveryMethod: "delivery",
+      country: "GH",
+      region: "GA",
+      waiveDeliveryFees: { withinAccra: true, minimumOrderAmount: 100 },
+      deliveryFees: { withinAccra: 30, otherRegions: 70, international: 800 },
+      subtotal: 10000, // 100 GHS in pesewas
+    });
+
+    expect(result).toEqual({
+      deliveryFee: 0,
+      deliveryOption: "within-accra",
+    });
+  });
+
+  it("charges fee when waiver is ON but subtotal below threshold", () => {
+    const result = calculateDeliveryFee({
+      deliveryMethod: "delivery",
+      country: "GH",
+      region: "GA",
+      waiveDeliveryFees: { withinAccra: true, minimumOrderAmount: 100 },
+      deliveryFees: { withinAccra: 30, otherRegions: 70, international: 800 },
+      subtotal: 5000, // 50 GHS in pesewas
+    });
+
+    expect(result).toEqual({
+      deliveryFee: 3000,
+      deliveryOption: "within-accra",
+    });
+  });
+
+  it("waives other-regions fee when threshold is met", () => {
+    const result = calculateDeliveryFee({
+      deliveryMethod: "delivery",
+      country: "GH",
+      region: "AS",
+      waiveDeliveryFees: { otherRegions: true, minimumOrderAmount: 200 },
+      deliveryFees: { withinAccra: 30, otherRegions: 70, international: 800 },
+      subtotal: 20000,
+    });
+
+    expect(result).toEqual({
+      deliveryFee: 0,
+      deliveryOption: "outside-accra",
+    });
+  });
+
+  it("waives intl fee when threshold is met", () => {
+    const result = calculateDeliveryFee({
+      deliveryMethod: "delivery",
+      country: "US",
+      region: null,
+      waiveDeliveryFees: { international: true, minimumOrderAmount: 500 },
+      deliveryFees: { withinAccra: 30, otherRegions: 70, international: 800 },
+      subtotal: 50000,
+    });
+
+    expect(result).toEqual({
+      deliveryFee: 0,
+      deliveryOption: "intl",
+    });
+  });
+
+  it("charges intl fee when threshold not met", () => {
+    const result = calculateDeliveryFee({
+      deliveryMethod: "delivery",
+      country: "US",
+      region: null,
+      waiveDeliveryFees: { international: true, minimumOrderAmount: 500 },
+      deliveryFees: { withinAccra: 30, otherRegions: 70, international: 800 },
+      subtotal: 10000,
+    });
+
+    expect(result).toEqual({
+      deliveryFee: 80000,
+      deliveryOption: "intl",
+    });
+  });
+
+  it("backward compat: no subtotal param still waives when no threshold", () => {
+    const result = calculateDeliveryFee({
+      deliveryMethod: "delivery",
+      country: "GH",
+      region: "GA",
+      waiveDeliveryFees: { withinAccra: true },
+      deliveryFees: { withinAccra: 30, otherRegions: 70, international: 800 },
+    });
+
+    expect(result).toEqual({
+      deliveryFee: 0,
+      deliveryOption: "within-accra",
+    });
+  });
+});
+```
+
+- [ ] **Step 3: Run tests to verify new tests fail**
+
+Run: `cd storefront-webapp && npx vitest run src/components/checkout/deliveryFees.test.ts`
+Expected: New tests FAIL (subtotal not in input type, inline logic doesn't check threshold).
+
+- [ ] **Step 4: Refactor `calculateDeliveryFee` to use `isFeeWaived()` and accept subtotal**
+
+Replace the contents of `storefront-webapp/src/components/checkout/deliveryFees.ts`:
+
+```typescript
+import { isFeeWaived } from "@/lib/feeUtils";
+import { toPesewas } from "@/lib/currency";
+import { DeliveryMethod, DeliveryOption } from "./types";
+
+type DeliveryFeeConfig = {
+  withinAccra?: number;
+  otherRegions?: number;
+  international?: number;
+} | null;
+
+type WaiveDeliveryFees =
+  | boolean
+  | {
+      withinAccra?: boolean;
+      otherRegions?: boolean;
+      international?: boolean;
+      all?: boolean;
+      minimumOrderAmount?: number;
+    }
+  | null
+  | undefined;
+
+type CalculateDeliveryFeeInput = {
+  deliveryMethod: DeliveryMethod;
+  country: string;
+  region: string | null;
+  waiveDeliveryFees: WaiveDeliveryFees;
+  deliveryFees: DeliveryFeeConfig;
+  subtotal?: number; // in pesewas
+};
+
+type CalculateDeliveryFeeResult = {
+  deliveryFee: number;
+  deliveryOption: DeliveryOption | null;
+};
+
+const DEFAULT_WITHIN_ACCRA_FEE = 30;
+const DEFAULT_OTHER_REGIONS_FEE = 70;
+const DEFAULT_INTERNATIONAL_FEE = 800;
+
+export function calculateDeliveryFee({
+  deliveryMethod,
+  country,
+  region,
+  waiveDeliveryFees,
+  deliveryFees,
+  subtotal,
+}: CalculateDeliveryFeeInput): CalculateDeliveryFeeResult {
+  if (deliveryMethod === "pickup") {
+    return { deliveryFee: 0, deliveryOption: null };
+  }
+
+  const isGhana = country === "GH";
+  const isGreaterAccra = region === "GA";
+
+  let deliveryOption: DeliveryOption;
+  let baseFee: number;
+
+  if (isGhana) {
+    deliveryOption = isGreaterAccra ? "within-accra" : "outside-accra";
+    const withinAccraFee =
+      deliveryFees?.withinAccra ?? DEFAULT_WITHIN_ACCRA_FEE;
+    const otherRegionsFee =
+      deliveryFees?.otherRegions ?? DEFAULT_OTHER_REGIONS_FEE;
+    baseFee = isGreaterAccra ? withinAccraFee : otherRegionsFee;
+  } else {
+    deliveryOption = "intl";
+    baseFee = deliveryFees?.international ?? DEFAULT_INTERNATIONAL_FEE;
+  }
+
+  const shouldWaive = isFeeWaived(waiveDeliveryFees, deliveryOption, subtotal);
+
+  return {
+    deliveryFee: shouldWaive ? 0 : toPesewas(baseFee),
+    deliveryOption,
+  };
+}
+```
+
+Key changes:
+- Replaced inline Ghana waiver logic (lines 70-76) with `isFeeWaived(waiveDeliveryFees, deliveryOption, subtotal)` — all regions now go through the same centralized function.
+- Added `subtotal?: number` to `CalculateDeliveryFeeInput`.
+- Added `minimumOrderAmount?: number` to local `WaiveDeliveryFees` type.
+
+- [ ] **Step 5: Run all delivery fee tests**
+
+Run: `cd storefront-webapp && npx vitest run src/components/checkout/deliveryFees.test.ts`
+Expected: All tests PASS (both old and new).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add storefront-webapp/src/components/checkout/deliveryFees.ts storefront-webapp/src/components/checkout/deliveryFees.test.ts
+git commit -m "feat: refactor deliveryFees to use centralized isFeeWaived and add subtotal threshold"
+```
+
+---
+
+### Task 4: Update `CheckoutProvider.tsx` to pass subtotal
+
+**Files:**
+- Modify: `storefront-webapp/src/components/checkout/CheckoutProvider.tsx`
+
+- [ ] **Step 1: Compute subtotal from bag and pass through all fee call sites**
+
+In `storefront-webapp/src/components/checkout/CheckoutProvider.tsx`:
+
+1. Import `toPesewas` (already imported).
+
+2. Inside `CheckoutProvider`, compute the subtotal from the bag. Place this after the `bag` destructure (line 83):
+
+```typescript
+const bagSubtotalPesewas =
+  bag?.items?.reduce(
+    (sum: number, item: any) => sum + toPesewas(item.price) * item.quantity,
+    0
+  ) || 0;
+```
+
+3. **Update the user address `useEffect`** (~line 196): pass `subtotal` to `calculateDeliveryFee`:
+
+```typescript
+const { deliveryFee, deliveryOption } = calculateDeliveryFee({
+  deliveryMethod: "delivery",
+  country: country || "",
+  region: region || null,
+  waiveDeliveryFees,
+  deliveryFees,
+  subtotal: bagSubtotalPesewas,
+});
+```
+
+4. **Update `updateState()`** (~line 234-283): pass subtotal to `isAnyFeeWaived` and `isFeeWaived`:
+
+Change line 235:
+```typescript
+const anyFeeWaived = isAnyFeeWaived(waiveDeliveryFees, bagSubtotalPesewas);
+```
+
+Change the international fee recalculation inside `setCheckoutState` (~line 273):
+```typescript
+const shouldWaiveIntlFee = isFeeWaived(waiveDeliveryFees, "intl", bagSubtotalPesewas);
+```
+
+5. **Update `canPlaceOrder()`** (~line 297-303): add threshold check:
+
+```typescript
+if (
+  isAnyFeeWaived(waiveDeliveryFees, bagSubtotalPesewas) &&
+  checkoutState.deliveryMethod === "delivery" &&
+  checkoutState.deliveryFee === null
+) {
+  updateState({ deliveryFee: 0 });
+}
+```
+
+- [ ] **Step 2: Verify the app still builds**
+
+Run: `cd storefront-webapp && npx tsc --noEmit`
+Expected: No type errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add storefront-webapp/src/components/checkout/CheckoutProvider.tsx
+git commit -m "feat: pass bag subtotal to fee waiver functions in CheckoutProvider"
+```
+
+---
+
+### Task 5: Replace inline waiver logic in `DeliveryDetailsSection.tsx`
+
+**Files:**
+- Modify: `storefront-webapp/src/components/checkout/DeliveryDetailsSection.tsx`
+
+- [ ] **Step 1: Add imports and compute subtotal in `RegionFields` component**
+
+In the `RegionFields` component (~line 118), add the `calculateDeliveryFee` import and compute subtotal:
+
+```typescript
+import { calculateDeliveryFee } from "./deliveryFees";
+import { useShoppingBag } from "@/hooks/useShoppingBag";
+```
+
+Inside `RegionFields`:
+```typescript
+const { bag } = useShoppingBag();
+const bagSubtotalPesewas =
+  bag?.items?.reduce(
+    (sum: number, item: any) => sum + toPesewas(item.price) * item.quantity,
+    0
+  ) || 0;
+```
+
+- [ ] **Step 2: Replace mobile region onChange handler (~lines 146-163)**
+
+Replace the inline `shouldWaiveRegionFee` and fee calculation with:
+
+```typescript
+onChange={(e) => {
+  const region = e.target.value;
+
+  const { deliveryFee, deliveryOption } = calculateDeliveryFee({
+    deliveryMethod: "delivery",
+    country: "GH",
+    region,
+    waiveDeliveryFees,
+    deliveryFees,
+    subtotal: bagSubtotalPesewas,
+  });
+
+  updateState({
+    deliveryDetails: {
+      ...checkoutState.deliveryDetails,
+      region,
+      neighborhood:
+        deliveryOption == "within-accra"
+          ? checkoutState?.deliveryDetails?.neighborhood
+          : "",
+    } as Address,
+    deliveryFee,
+    deliveryOption,
+  });
+  field.onChange(region);
+}}
+```
+
+- [ ] **Step 3: Replace desktop region onValueChange handler (~lines 211-228)**
+
+Same pattern as Step 2, replace the inline waiver logic:
+
+```typescript
+onValueChange={(region) => {
+  const { deliveryFee, deliveryOption } = calculateDeliveryFee({
+    deliveryMethod: "delivery",
+    country: "GH",
+    region,
+    waiveDeliveryFees,
+    deliveryFees,
+    subtotal: bagSubtotalPesewas,
+  });
+
+  updateState({
+    deliveryDetails: {
+      ...checkoutState.deliveryDetails,
+      region,
+      neighborhood:
+        deliveryOption == "within-accra"
+          ? checkoutState?.deliveryDetails?.neighborhood
+          : "",
+    } as Address,
+    deliveryFee,
+    deliveryOption,
+  });
+  field.onChange(region);
+}}
+```
+
+- [ ] **Step 4: Update `DeliveryDetailsSection` component country change `useEffect` (~lines 764, 810-816)**
+
+In the `DeliveryDetailsSection` component, compute subtotal and replace the inline fee logic:
+
+```typescript
+const { bag } = useShoppingBag();
+const bagSubtotalPesewas =
+  bag?.items?.reduce(
+    (sum: number, item: any) => sum + toPesewas(item.price) * item.quantity,
+    0
+  ) || 0;
+
+const shouldWaiveIntlFee = isFeeWaived(waiveDeliveryFees, "intl", bagSubtotalPesewas);
+```
+
+For the country change `useEffect` (~lines 805-817), replace the inline fee calculation:
+
+```typescript
+updateState({
+  deliveryDetails: { country } as Address,
+  billingDetails: null,
+  paymentMethod: "online_payment",
+  podPaymentMethod: null,
+  ...calculateDeliveryFee({
+    deliveryMethod: "delivery",
+    country,
+    region: country === "GH" ? "GA" : null,
+    waiveDeliveryFees,
+    deliveryFees,
+    subtotal: bagSubtotalPesewas,
+  }),
+});
+```
+
+Note: When country changes to GH, the existing code defaults to `within-accra`. Use `region: "GA"` to match. For non-GH countries, `region: null` produces `intl`.
+
+- [ ] **Step 5: Verify the app builds**
+
+Run: `cd storefront-webapp && npx tsc --noEmit`
+Expected: No type errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add storefront-webapp/src/components/checkout/DeliveryDetailsSection.tsx
+git commit -m "refactor: replace inline waiver logic in DeliveryDetailsSection with calculateDeliveryFee"
+```
+
+---
+
+### Task 6: Update `BagSummary.tsx` to pass subtotal and show nudge
+
+**Files:**
+- Modify: `storefront-webapp/src/components/checkout/BagSummary.tsx`
+
+- [ ] **Step 1: Update `isFeeWaived` call and add nudge**
+
+In `storefront-webapp/src/components/checkout/BagSummary.tsx`:
+
+1. Update imports:
+```typescript
+import { isFeeWaived, getRemainingForFreeDelivery } from "@/lib/feeUtils";
+import { toPesewas, toDisplayAmount } from "@/lib/currency";
+```
+
+2. Compute subtotal in pesewas (after `bagSubtotal` is available, ~line 141). Note: `bagSubtotal` from `useShoppingBag()` is in display currency, so convert:
+```typescript
+const bagSubtotalPesewas = toPesewas(bagSubtotal);
+```
+
+3. Update the `isFeeWaivedForCurrentOption` call (~line 238):
+```typescript
+const isFeeWaivedForCurrentOption = isFeeWaived(
+  waiveDeliveryFees,
+  checkoutState.deliveryOption,
+  bagSubtotalPesewas
+);
+```
+
+4. Compute the nudge amount:
+```typescript
+const remainingForFreeDelivery = getRemainingForFreeDelivery(
+  waiveDeliveryFees,
+  checkoutState.deliveryOption,
+  bagSubtotalPesewas
+);
+```
+
+5. Add the nudge UI in the summary section, after the delivery fee row (~line 347) and before the discount row:
+
+```tsx
+{remainingForFreeDelivery !== null &&
+  checkoutState.deliveryMethod === "delivery" && (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.4, ease: "easeInOut" }}
+      className="text-xs text-accent2"
+    >
+      <p>
+        Add {formatter.format(toDisplayAmount(remainingForFreeDelivery))} more
+        to get free delivery
+      </p>
+    </motion.div>
+  )}
+```
+
+- [ ] **Step 2: Verify the app builds**
+
+Run: `cd storefront-webapp && npx tsc --noEmit`
+Expected: No type errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add storefront-webapp/src/components/checkout/BagSummary.tsx
+git commit -m "feat: add 'add more for free delivery' nudge in checkout summary"
+```
+
+---
+
+### Task 7: Admin UI — add minimum amount input to `FeesView.tsx`
+
+**Files:**
+- Modify: `athena-webapp/src/components/store-configuration/components/FeesView.tsx`
+
+- [ ] **Step 1: Add state and sync for `minimumOrderAmount`**
+
+Add a new state variable after the existing waiver states (~line 30):
+
+```typescript
+const [minimumOrderAmount, setMinimumOrderAmount] = useState<number | undefined>(undefined);
+```
+
+In the `useEffect` that syncs state from store config (~line 61-89), add syncing for the new field inside the object format branch:
+
+```typescript
+} else if (waiveConfig && typeof waiveConfig === "object") {
+  setWaiveWithinAccraFee(waiveConfig.withinAccra || false);
+  setWaiveOtherRegionsFee(waiveConfig.otherRegions || false);
+  setWaiveIntlFee(waiveConfig.international || false);
+  setMinimumOrderAmount(waiveConfig.minimumOrderAmount || undefined);
+} else {
+  setWaiveWithinAccraFee(false);
+  setWaiveOtherRegionsFee(false);
+  setWaiveIntlFee(false);
+  setMinimumOrderAmount(undefined);
+}
+```
+
+- [ ] **Step 2: Include `minimumOrderAmount` in save payload**
+
+Update `handleUpdateFees` (~line 40-46) to include `minimumOrderAmount`:
+
+```typescript
+const waiveDeliveryFeesConfig = {
+  withinAccra: waiveWithinAccraFee,
+  otherRegions: waiveOtherRegionsFee,
+  international: waiveIntlFee,
+  all: waiveWithinAccraFee && waiveOtherRegionsFee && waiveIntlFee,
+  minimumOrderAmount: minimumOrderAmount || undefined,
+};
+```
+
+- [ ] **Step 3: Add the input field to the UI**
+
+Compute whether any waiver is active:
+
+```typescript
+const anyWaiverActive = waiveWithinAccraFee || waiveOtherRegionsFee || waiveIntlFee;
+```
+
+Add the minimum order amount input between the "Waive all delivery fees" section and the Save button (~after line 211, before line 214):
+
+```tsx
+{anyWaiverActive && (
+  <div className="container mx-auto py-4">
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Label className="text-sm text-muted-foreground">
+          {`Minimum order amount for free delivery (${activeStore?.currency.toUpperCase()})`}
+        </Label>
+        <Input
+          type="number"
+          min={0}
+          placeholder="Leave empty for unconditional free delivery"
+          value={minimumOrderAmount || ""}
+          onChange={(e) => {
+            const val = parseInt(e.target.value);
+            setMinimumOrderAmount(isNaN(val) || val < 0 ? undefined : val);
+          }}
+        />
+        <p className="text-xs text-muted-foreground">
+          Leave empty for unconditional free delivery
+        </p>
+      </div>
+    </div>
+  </div>
+)}
+```
+
+- [ ] **Step 4: Verify the app builds**
+
+Run: `cd athena-webapp && npx tsc --noEmit`
+Expected: No type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add athena-webapp/src/components/store-configuration/components/FeesView.tsx
+git commit -m "feat: add minimum order amount input to admin delivery fees config"
+```
+
+---
+
+### Task 8: Final verification
+
+- [ ] **Step 1: Run all storefront tests**
+
+Run: `cd storefront-webapp && npx vitest run`
+Expected: All tests PASS.
+
+- [ ] **Step 2: Type-check both packages**
+
+Run: `cd storefront-webapp && npx tsc --noEmit`
+Run: `cd athena-webapp && npx tsc --noEmit`
+Expected: No type errors.
+
+- [ ] **Step 3: Commit any remaining fixes if needed**

--- a/packages/docs/superpowers/specs/2026-03-31-conditional-delivery-fee-waiver-design.md
+++ b/packages/docs/superpowers/specs/2026-03-31-conditional-delivery-fee-waiver-design.md
@@ -1,0 +1,141 @@
+# Conditional Delivery Fee Waiver — Minimum Order Amount
+
+**Date:** 2026-03-31
+**Status:** Approved
+
+## Overview
+
+Extend the existing delivery fee waiver system to support a minimum order amount threshold. When configured by the admin, delivery fees are only waived if the customer's cart subtotal (before discounts) meets the threshold. This applies globally across all waived regions.
+
+## Background
+
+Currently, the admin can toggle delivery fee waivers per-region (within Accra, other regions, international) or globally. These are unconditional — when enabled, the fee is always waived. The new feature adds an optional monetary threshold: the waiver only activates when the cart subtotal is at or above the configured amount.
+
+## Design Decisions
+
+- **Subtotal before discounts** is used for threshold comparison. This avoids a confusing UX where applying a discount code removes the free delivery benefit.
+- **Single global threshold** applies to all waived regions equally (no per-region thresholds).
+- **Threshold is an additional condition on existing waivers** — it only applies to regions where the waiver toggle is ON. Regions with waivers OFF always charge the delivery fee regardless of cart amount.
+- **Optional/backward-compatible** — if the threshold is not set (undefined, null, or 0), behavior is identical to today (unconditional waiver).
+- **Frontend-evaluated** (Approach A) — follows the existing trust model where the storefront evaluates config and sends `deliveryFee: 0` or the fee amount. No backend validation changes needed.
+
+## Data Model
+
+Add `minimumOrderAmount` to `StoreWaiveDeliveryFeesConfig` in `athena-webapp/types.ts`:
+
+```typescript
+export type StoreWaiveDeliveryFeesConfig =
+  | boolean
+  | {
+      all?: boolean;
+      international?: boolean;
+      otherRegions?: boolean;
+      withinAccra?: boolean;
+      minimumOrderAmount?: number; // in store currency units (e.g., 100 = GHS 100)
+    };
+```
+
+When `minimumOrderAmount` is `undefined`, `null`, or `0`, waivers are unconditional (existing behavior). When set to a positive number, waivers only apply if cart subtotal >= that amount.
+
+## Fee Utility Changes
+
+### `feeUtils.ts`
+
+**`isFeeWaived(waiveDeliveryFees, deliveryOption, subtotal?)`**
+
+Add an optional `subtotal` parameter (in pesewas). After the existing logic determines the region flag is ON:
+- If `minimumOrderAmount` is set and `subtotal < toPesewas(minimumOrderAmount)`, return `false`
+- Otherwise return `true`
+
+**`isAnyFeeWaived(waiveDeliveryFees, subtotal?)`**
+
+Add an optional `subtotal` parameter (in pesewas). If any region flag is ON but `minimumOrderAmount` is set and `subtotal < threshold`, return `false`. UI indicators (e.g., "free delivery" badges) should only display when the customer's cart actually qualifies.
+
+### `deliveryFees.ts`
+
+**`calculateDeliveryFee()`** — Add optional `subtotal` parameter to `CalculateDeliveryFeeInput`. Pass it through to `isFeeWaived()`. The threshold comparison converts `minimumOrderAmount` to pesewas for an apples-to-apples check.
+
+## Storefront Checkout Integration
+
+### CheckoutProvider.tsx
+
+All call sites that invoke `calculateDeliveryFee()`, `isFeeWaived()`, or `isAnyFeeWaived()` must pass the current bag subtotal. The subtotal is computed from bag items:
+
+```typescript
+const subtotal = bag?.items?.reduce(
+  (sum, item) => sum + toPesewas(item.price) * item.quantity, 0
+) || 0;
+```
+
+Key call sites:
+- `updateState()` — where it calls `isAnyFeeWaived()` and `isFeeWaived()`
+- The `useEffect` that pre-calculates delivery fee from saved user address
+- `canPlaceOrder()` — where it checks waivers
+
+### DeliveryDetailsSection.tsx
+
+The inline waiver logic for region selection also needs the subtotal for the threshold check.
+
+### Reactivity
+
+When the bag changes (items added/removed), the checkout state already re-renders. The subtotal-based threshold check naturally re-evaluates since it reads from bag state.
+
+## "Add more to get free delivery" Nudge
+
+A helper function computes the remaining amount needed:
+
+```typescript
+const getRemainingForFreeDelivery = (
+  waiveDeliveryFees, deliveryOption, subtotal
+) => {
+  // If region waiver is OFF -> return null (no free delivery available)
+  // If no minimumOrderAmount -> return null (already free)
+  // If subtotal >= threshold -> return null (already qualifies)
+  // Otherwise -> return threshold - subtotal (the gap)
+};
+```
+
+Displayed in the order summary / checkout sidebar near the delivery fee line item. Uses the store's currency formatter. Message format: "Add GHS 20 more to get free delivery". Only shown when the return value is a positive number.
+
+## Admin UI Changes
+
+### FeesView.tsx
+
+A single "Minimum order amount for free delivery" input field:
+- Only appears when at least one waiver toggle is ON
+- Sits below the per-region toggles and above the "Save" button
+- Uses the store's currency label (e.g., "GHS")
+- Accepts a number input, stored as `minimumOrderAmount` on the `waiveDeliveryFees` config object
+- When empty or 0, waivers are unconditional (backward compatible)
+- Helper text: "Leave empty for unconditional free delivery"
+
+The value is saved alongside the existing waiver config in `handleUpdateFees()`.
+
+## Testing
+
+### feeUtils.test.ts
+
+- `isFeeWaived()` returns `true` when region waiver is ON and subtotal >= threshold
+- `isFeeWaived()` returns `false` when region waiver is ON but subtotal < threshold
+- `isFeeWaived()` returns `true` when region waiver is ON and no threshold set (backward compat)
+- `isAnyFeeWaived()` returns `false` when waivers exist but subtotal is below threshold
+- `isAnyFeeWaived()` returns `true` when no threshold is set
+
+### deliveryFees.test.ts
+
+- `calculateDeliveryFee()` returns full fee when waiver is ON but subtotal below threshold
+- `calculateDeliveryFee()` returns 0 when waiver is ON and subtotal meets threshold
+
+## Files Affected
+
+| File | Change |
+|------|--------|
+| `athena-webapp/types.ts` | Add `minimumOrderAmount` to `StoreWaiveDeliveryFeesConfig` |
+| `storefront-webapp/src/lib/feeUtils.ts` | Add `subtotal` param to `isFeeWaived()` and `isAnyFeeWaived()` |
+| `storefront-webapp/src/lib/feeUtils.test.ts` | New threshold test cases |
+| `storefront-webapp/src/components/checkout/deliveryFees.ts` | Add `subtotal` param to `calculateDeliveryFee()` |
+| `storefront-webapp/src/components/checkout/deliveryFees.test.ts` | New threshold test cases |
+| `storefront-webapp/src/components/checkout/CheckoutProvider.tsx` | Pass subtotal to fee functions |
+| `storefront-webapp/src/components/checkout/DeliveryDetailsSection.tsx` | Pass subtotal to inline waiver logic |
+| `storefront-webapp/src/components/checkout/OrderDetails/index.tsx` | Add "add more for free delivery" nudge |
+| `athena-webapp/src/components/store-configuration/components/FeesView.tsx` | Add minimum amount input field |

--- a/packages/docs/superpowers/specs/2026-03-31-conditional-delivery-fee-waiver-design.md
+++ b/packages/docs/superpowers/specs/2026-03-31-conditional-delivery-fee-waiver-design.md
@@ -166,5 +166,5 @@ The value is saved alongside the existing waiver config in `handleUpdateFees()`.
 | `storefront-webapp/src/components/checkout/deliveryFees.test.ts` | New threshold test cases + regression tests for refactored Ghana logic |
 | `storefront-webapp/src/components/checkout/CheckoutProvider.tsx` | Pass subtotal to fee functions; fix auto-zero-fee in `updateState()` and `canPlaceOrder()` |
 | `storefront-webapp/src/components/checkout/DeliveryDetailsSection.tsx` | Replace 3 inline waiver locations with `calculateDeliveryFee()` calls, passing subtotal |
-| `storefront-webapp/src/components/checkout/OrderDetails/index.tsx` | Add "add more for free delivery" nudge |
+| `storefront-webapp/src/components/checkout/BagSummary.tsx` | Add "add more for free delivery" nudge + pass subtotal to `isFeeWaived` |
 | `athena-webapp/src/components/store-configuration/components/FeesView.tsx` | Add minimum amount input field |

--- a/packages/docs/superpowers/specs/2026-03-31-conditional-delivery-fee-waiver-design.md
+++ b/packages/docs/superpowers/specs/2026-03-31-conditional-delivery-fee-waiver-design.md
@@ -16,7 +16,7 @@ Currently, the admin can toggle delivery fee waivers per-region (within Accra, o
 - **Subtotal before discounts** is used for threshold comparison. This avoids a confusing UX where applying a discount code removes the free delivery benefit.
 - **Single global threshold** applies to all waived regions equally (no per-region thresholds).
 - **Threshold is an additional condition on existing waivers** — it only applies to regions where the waiver toggle is ON. Regions with waivers OFF always charge the delivery fee regardless of cart amount.
-- **Optional/backward-compatible** — if the threshold is not set (undefined, null, or 0), behavior is identical to today (unconditional waiver).
+- **Optional/backward-compatible** — if the threshold is not set (undefined, null, or 0), behavior is identical to today (unconditional waiver). When `waiveDeliveryFees` is `boolean` (legacy format), there is no object to attach `minimumOrderAmount` to, so `boolean: true` always means unconditional waiver with no threshold.
 - **Frontend-evaluated** (Approach A) — follows the existing trust model where the storefront evaluates config and sends `deliveryFee: 0` or the fee amount. No backend validation changes needed.
 
 ## Data Model
@@ -37,6 +37,10 @@ export type StoreWaiveDeliveryFeesConfig =
 
 When `minimumOrderAmount` is `undefined`, `null`, or `0`, waivers are unconditional (existing behavior). When set to a positive number, waivers only apply if cart subtotal >= that amount.
 
+### Convex Schema
+
+The Convex store config normalizer at `athena-webapp/convex/inventory/storeConfigV2.ts` may validate the shape of `waiveDeliveryFees`. If so, add `minimumOrderAmount` as an optional number field so the mutation accepts the new field.
+
 ## Fee Utility Changes
 
 ### `feeUtils.ts`
@@ -44,6 +48,7 @@ When `minimumOrderAmount` is `undefined`, `null`, or `0`, waivers are unconditio
 **`isFeeWaived(waiveDeliveryFees, deliveryOption, subtotal?)`**
 
 Add an optional `subtotal` parameter (in pesewas). After the existing logic determines the region flag is ON:
+- If `waiveDeliveryFees` is `boolean: true`, return `true` (no threshold possible — backward compat)
 - If `minimumOrderAmount` is set and `subtotal < toPesewas(minimumOrderAmount)`, return `false`
 - Otherwise return `true`
 
@@ -51,9 +56,15 @@ Add an optional `subtotal` parameter (in pesewas). After the existing logic dete
 
 Add an optional `subtotal` parameter (in pesewas). If any region flag is ON but `minimumOrderAmount` is set and `subtotal < threshold`, return `false`. UI indicators (e.g., "free delivery" badges) should only display when the customer's cart actually qualifies.
 
+**New: `hasWaiverConfigured(waiveDeliveryFees, deliveryOption)`**
+
+A new helper that checks whether a waiver is *configured* for the given delivery option, ignoring the threshold. This is needed by the "add more for free delivery" nudge — it needs to know if a waiver exists even when the subtotal doesn't yet meet the threshold. Returns `true` if the region flag is ON regardless of `minimumOrderAmount`.
+
 ### `deliveryFees.ts`
 
-**`calculateDeliveryFee()`** — Add optional `subtotal` parameter to `CalculateDeliveryFeeInput`. Pass it through to `isFeeWaived()`. The threshold comparison converts `minimumOrderAmount` to pesewas for an apples-to-apples check.
+**Prerequisite refactor:** The current `calculateDeliveryFee()` has inline waiver logic for Ghana regions (lines 70-76) that bypasses `isFeeWaived()` — only international calls `isFeeWaived()`. Refactor all three region cases (within-accra, outside-accra, intl) to use `isFeeWaived()` so the threshold logic is centralized.
+
+**`calculateDeliveryFee()`** — Add optional `subtotal` parameter to `CalculateDeliveryFeeInput`. After the refactor above, all regions call `isFeeWaived()` which handles the threshold check. The threshold comparison converts `minimumOrderAmount` to pesewas for an apples-to-apples check.
 
 ## Storefront Checkout Integration
 
@@ -67,14 +78,21 @@ const subtotal = bag?.items?.reduce(
 ) || 0;
 ```
 
-Key call sites:
-- `updateState()` — where it calls `isAnyFeeWaived()` and `isFeeWaived()`
-- The `useEffect` that pre-calculates delivery fee from saved user address
-- `canPlaceOrder()` — where it checks waivers
+**Specific call sites requiring changes:**
+
+1. **`updateState()` (lines 234-283)** — Currently calls `isAnyFeeWaived(waiveDeliveryFees)` and auto-sets `deliveryFee: 0` when method is delivery and fee is null. Must pass `subtotal` and only auto-zero when the threshold is actually met.
+2. **`canPlaceOrder()` (lines 297-303)** — Same pattern: sets `deliveryFee: 0` based solely on `waiveDeliveryFees` being truthy. Must include threshold check.
+3. **The `useEffect` that pre-calculates delivery fee from saved user address (lines 196-202)** — Pass subtotal to `calculateDeliveryFee()`.
 
 ### DeliveryDetailsSection.tsx
 
-The inline waiver logic for region selection also needs the subtotal for the threshold check.
+There are **three separate locations** with inline waiver logic that all need updating:
+
+1. **Mobile region `<select>` onChange handler (~line 146-155)** — Inline `shouldWaiveRegionFee` calculation
+2. **Desktop region `<Select>` onValueChange handler (~line 211-220)** — Duplicate inline waiver logic
+3. **Country change `useEffect` (~line 810-816)** — International fee waiver logic
+
+**Recommended approach:** Replace all three inline waiver calculations with calls to `calculateDeliveryFee()`, passing the subtotal. This centralizes the logic and prevents drift.
 
 ### Reactivity
 
@@ -88,14 +106,19 @@ A helper function computes the remaining amount needed:
 const getRemainingForFreeDelivery = (
   waiveDeliveryFees, deliveryOption, subtotal
 ) => {
-  // If region waiver is OFF -> return null (no free delivery available)
-  // If no minimumOrderAmount -> return null (already free)
-  // If subtotal >= threshold -> return null (already qualifies)
-  // Otherwise -> return threshold - subtotal (the gap)
+  // If no delivery option selected -> return null
+  // If region waiver is OFF (use hasWaiverConfigured) -> return null (no free delivery available)
+  // If no minimumOrderAmount -> return null (already free, no threshold)
+  // If subtotal >= toPesewas(minimumOrderAmount) -> return null (already qualifies)
+  // Otherwise -> return toPesewas(minimumOrderAmount) - subtotal (the gap, in pesewas)
 };
 ```
 
-Displayed in the order summary / checkout sidebar near the delivery fee line item. Uses the store's currency formatter. Message format: "Add GHS 20 more to get free delivery". Only shown when the return value is a positive number.
+Displayed in the order summary / checkout sidebar near the delivery fee line item. Uses the store's currency formatter. Message format: "Add GHS 20 more to get free delivery". Only shown when:
+- A delivery option is selected
+- The selected delivery region has a waiver configured
+- A `minimumOrderAmount` threshold exists
+- The subtotal is below the threshold
 
 ## Admin UI Changes
 
@@ -105,7 +128,9 @@ A single "Minimum order amount for free delivery" input field:
 - Only appears when at least one waiver toggle is ON
 - Sits below the per-region toggles and above the "Save" button
 - Uses the store's currency label (e.g., "GHS")
-- Accepts a number input, stored as `minimumOrderAmount` on the `waiveDeliveryFees` config object
+- Accepts a whole number input (uses `parseInt`, consistent with existing fee inputs), minimum value 0
+- Negative numbers are rejected/ignored
+- Stored as `minimumOrderAmount` on the `waiveDeliveryFees` config object
 - When empty or 0, waivers are unconditional (backward compatible)
 - Helper text: "Leave empty for unconditional free delivery"
 
@@ -118,24 +143,28 @@ The value is saved alongside the existing waiver config in `handleUpdateFees()`.
 - `isFeeWaived()` returns `true` when region waiver is ON and subtotal >= threshold
 - `isFeeWaived()` returns `false` when region waiver is ON but subtotal < threshold
 - `isFeeWaived()` returns `true` when region waiver is ON and no threshold set (backward compat)
+- `isFeeWaived()` returns `true` when `waiveDeliveryFees` is `boolean: true` with any subtotal (legacy backward compat)
 - `isAnyFeeWaived()` returns `false` when waivers exist but subtotal is below threshold
 - `isAnyFeeWaived()` returns `true` when no threshold is set
+- `hasWaiverConfigured()` returns `true` when region flag is ON regardless of threshold
 
 ### deliveryFees.test.ts
 
 - `calculateDeliveryFee()` returns full fee when waiver is ON but subtotal below threshold
 - `calculateDeliveryFee()` returns 0 when waiver is ON and subtotal meets threshold
+- `calculateDeliveryFee()` returns 0 for all Ghana regions when using refactored `isFeeWaived()` path (regression)
 
 ## Files Affected
 
 | File | Change |
 |------|--------|
 | `athena-webapp/types.ts` | Add `minimumOrderAmount` to `StoreWaiveDeliveryFeesConfig` |
-| `storefront-webapp/src/lib/feeUtils.ts` | Add `subtotal` param to `isFeeWaived()` and `isAnyFeeWaived()` |
-| `storefront-webapp/src/lib/feeUtils.test.ts` | New threshold test cases |
-| `storefront-webapp/src/components/checkout/deliveryFees.ts` | Add `subtotal` param to `calculateDeliveryFee()` |
-| `storefront-webapp/src/components/checkout/deliveryFees.test.ts` | New threshold test cases |
-| `storefront-webapp/src/components/checkout/CheckoutProvider.tsx` | Pass subtotal to fee functions |
-| `storefront-webapp/src/components/checkout/DeliveryDetailsSection.tsx` | Pass subtotal to inline waiver logic |
+| `athena-webapp/convex/inventory/storeConfigV2.ts` | Add `minimumOrderAmount` to Convex schema if validated |
+| `storefront-webapp/src/lib/feeUtils.ts` | Add `subtotal` param to `isFeeWaived()` and `isAnyFeeWaived()`; add `hasWaiverConfigured()` |
+| `storefront-webapp/src/lib/feeUtils.test.ts` | New threshold and legacy backward-compat test cases |
+| `storefront-webapp/src/components/checkout/deliveryFees.ts` | Refactor inline Ghana waiver logic to use `isFeeWaived()`; add `subtotal` param |
+| `storefront-webapp/src/components/checkout/deliveryFees.test.ts` | New threshold test cases + regression tests for refactored Ghana logic |
+| `storefront-webapp/src/components/checkout/CheckoutProvider.tsx` | Pass subtotal to fee functions; fix auto-zero-fee in `updateState()` and `canPlaceOrder()` |
+| `storefront-webapp/src/components/checkout/DeliveryDetailsSection.tsx` | Replace 3 inline waiver locations with `calculateDeliveryFee()` calls, passing subtotal |
 | `storefront-webapp/src/components/checkout/OrderDetails/index.tsx` | Add "add more for free delivery" nudge |
 | `athena-webapp/src/components/store-configuration/components/FeesView.tsx` | Add minimum amount input field |

--- a/packages/storefront-webapp/src/components/checkout/BagSummary.tsx
+++ b/packages/storefront-webapp/src/components/checkout/BagSummary.tsx
@@ -17,8 +17,8 @@ import { useAuth } from "@/hooks/useAuth";
 import { useEffect, useState } from "react";
 import { getDiscountValue } from "./utils";
 import { usePromoCodesQueries } from "@/lib/queries/promoCode";
-import { isFeeWaived } from "@/lib/feeUtils";
-import { toDisplayAmount } from "@/lib/currency";
+import { isFeeWaived, getRemainingForFreeDelivery } from "@/lib/feeUtils";
+import { toDisplayAmount, toPesewas } from "@/lib/currency";
 import { Badge } from "../ui/badge";
 import { useDiscountCodeAlert } from "@/hooks/useDiscountCodeAlert";
 import { getStoreConfigV2, getStoreFallbackImageUrl } from "@/lib/storeConfig";
@@ -139,6 +139,7 @@ export function BagSummaryItems({
 function BagSummary() {
   const { formatter, store } = useStoreContext();
   const { bagSubtotal } = useShoppingBag();
+  const subtotalInPesewas = toPesewas(bagSubtotal);
   const { checkoutState, updateState, activeSession, updateActionsState } =
     useCheckout();
   const { userId, guestId } = useAuth();
@@ -237,7 +238,13 @@ function BagSummary() {
 
   const isFeeWaivedForCurrentOption = isFeeWaived(
     waiveDeliveryFees,
-    checkoutState.deliveryOption
+    checkoutState.deliveryOption,
+    subtotalInPesewas
+  );
+  const remainingForFreeDelivery = getRemainingForFreeDelivery(
+    waiveDeliveryFees,
+    checkoutState.deliveryOption,
+    subtotalInPesewas
   );
 
   return (
@@ -344,6 +351,12 @@ function BagSummary() {
                   : formatter.format(toDisplayAmount(checkoutState.deliveryFee || 0))}
               </p>
             </div>
+          )}
+        {remainingForFreeDelivery !== null &&
+          checkoutState.deliveryMethod === "delivery" && (
+            <p className="text-xs text-muted-foreground">
+              Add {formatter.format(toDisplayAmount(remainingForFreeDelivery))} more to get free delivery
+            </p>
           )}
         {Boolean(discountValue) && (
           <div className="flex justify-between">

--- a/packages/storefront-webapp/src/components/checkout/CheckoutProvider.tsx
+++ b/packages/storefront-webapp/src/components/checkout/CheckoutProvider.tsx
@@ -80,7 +80,8 @@ export const CheckoutProvider = ({
   const [actionsState, setActionsState] =
     useState<CheckoutActions>(initialActionsState);
 
-  const { bag } = useShoppingBag();
+  const { bag, bagSubtotal } = useShoppingBag();
+  const subtotalInPesewas = toPesewas(bagSubtotal);
 
   const { user, store } = useStoreContext();
   const storeConfig = getStoreConfigV2(store);
@@ -199,6 +200,7 @@ export const CheckoutProvider = ({
         region: region || null,
         waiveDeliveryFees,
         deliveryFees,
+        subtotal: subtotalInPesewas,
       });
 
       updateState({
@@ -232,7 +234,7 @@ export const CheckoutProvider = ({
   }, [user]);
 
   const updateState = (updates: Partial<CheckoutState>) => {
-    const anyFeeWaived = isAnyFeeWaived(waiveDeliveryFees);
+    const anyFeeWaived = isAnyFeeWaived(waiveDeliveryFees, subtotalInPesewas);
 
     // Prevent setting deliveryMethod to pickup when it's unavailable
     if (!pickupAvailable && updates.deliveryMethod === "pickup") {
@@ -270,7 +272,7 @@ export const CheckoutProvider = ({
         newUpdates.deliveryDetails.country !== "GH" &&
         newUpdates.deliveryOption !== "intl"
       ) {
-        const shouldWaiveIntlFee = isFeeWaived(waiveDeliveryFees, "intl");
+        const shouldWaiveIntlFee = isFeeWaived(waiveDeliveryFees, "intl", subtotalInPesewas);
 
         newUpdates.deliveryOption = "intl";
         newUpdates.deliveryFee = shouldWaiveIntlFee

--- a/packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx
+++ b/packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx
@@ -5,6 +5,8 @@ import { Address } from "../types";
 import { useStoreContext } from "@/contexts/StoreContext";
 import { isFeeWaived } from "@/lib/feeUtils";
 import { getStoreConfigV2 } from "@/lib/storeConfig";
+import { useShoppingBag } from "@/hooks/useShoppingBag";
+import { toPesewas } from "@/lib/currency";
 
 export function StoreSelector() {
   const { updateState, updateActionsState, checkoutState } = useCheckout();
@@ -45,6 +47,8 @@ export function DeliveryOptionsSelector() {
   const storeConfig = getStoreConfigV2(store);
 
   const { deliveryFees, waiveDeliveryFees } = storeConfig.commerce;
+  const { bagSubtotal } = useShoppingBag();
+  const subtotalInPesewas = toPesewas(bagSubtotal);
   const withinAccraFee = deliveryFees?.withinAccra ?? 30;
   const otherRegionsFee = deliveryFees?.otherRegions ?? 70;
   const internationalFee = deliveryFees?.international ?? 800;
@@ -52,13 +56,15 @@ export function DeliveryOptionsSelector() {
   // Replace the waived fee checks with the shared utility function
   const shouldWaiveWithinAccraFee = isFeeWaived(
     waiveDeliveryFees,
-    "within-accra"
+    "within-accra",
+    subtotalInPesewas
   );
   const shouldWaiveOtherRegionsFee = isFeeWaived(
     waiveDeliveryFees,
-    "outside-accra"
+    "outside-accra",
+    subtotalInPesewas
   );
-  const shouldWaiveIntlFee = isFeeWaived(waiveDeliveryFees, "intl");
+  const shouldWaiveIntlFee = isFeeWaived(waiveDeliveryFees, "intl", subtotalInPesewas);
 
   const previousCountryRef = useRef(
     checkoutState.deliveryDetails?.country || undefined

--- a/packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx
+++ b/packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx
@@ -6,7 +6,7 @@ import { useStoreContext } from "@/contexts/StoreContext";
 import { isFeeWaived } from "@/lib/feeUtils";
 import { getStoreConfigV2 } from "@/lib/storeConfig";
 import { useShoppingBag } from "@/hooks/useShoppingBag";
-import { toPesewas } from "@/lib/currency";
+import { toDisplayAmount, toPesewas } from "@/lib/currency";
 
 export function StoreSelector() {
   const { updateState, updateActionsState, checkoutState } = useCheckout();
@@ -49,25 +49,29 @@ export function DeliveryOptionsSelector() {
   const { deliveryFees, waiveDeliveryFees } = storeConfig.commerce;
   const { bagSubtotal } = useShoppingBag();
   const subtotalInPesewas = toPesewas(bagSubtotal);
-  const withinAccraFee = deliveryFees?.withinAccra ?? 30;
-  const otherRegionsFee = deliveryFees?.otherRegions ?? 70;
-  const internationalFee = deliveryFees?.international ?? 800;
+  const withinAccraFee = toPesewas(deliveryFees?.withinAccra ?? 30);
+  const otherRegionsFee = toPesewas(deliveryFees?.otherRegions ?? 70);
+  const internationalFee = toPesewas(deliveryFees?.international ?? 800);
 
   // Replace the waived fee checks with the shared utility function
   const shouldWaiveWithinAccraFee = isFeeWaived(
     waiveDeliveryFees,
     "within-accra",
-    subtotalInPesewas
+    subtotalInPesewas,
   );
   const shouldWaiveOtherRegionsFee = isFeeWaived(
     waiveDeliveryFees,
     "outside-accra",
-    subtotalInPesewas
+    subtotalInPesewas,
   );
-  const shouldWaiveIntlFee = isFeeWaived(waiveDeliveryFees, "intl", subtotalInPesewas);
+  const shouldWaiveIntlFee = isFeeWaived(
+    waiveDeliveryFees,
+    "intl",
+    subtotalInPesewas,
+  );
 
   const previousCountryRef = useRef(
-    checkoutState.deliveryDetails?.country || undefined
+    checkoutState.deliveryDetails?.country || undefined,
   );
 
   const handleChange = (value: string) => {
@@ -166,7 +170,7 @@ export function DeliveryOptionsSelector() {
               {shouldWaiveWithinAccraFee && (
                 <div className="flex items-center gap-2 text-muted-foreground">
                   <p className="text-start line-through">
-                    {formatter.format(withinAccraFee)}
+                    {formatter.format(toDisplayAmount(withinAccraFee))}
                   </p>
                   <p className="text-start">Free</p>
                 </div>
@@ -174,7 +178,7 @@ export function DeliveryOptionsSelector() {
 
               {!shouldWaiveWithinAccraFee && (
                 <p className="text-muted-foreground">
-                  {formatter.format(withinAccraFee)}
+                  {formatter.format(toDisplayAmount(withinAccraFee))}
                 </p>
               )}
             </div>
@@ -188,7 +192,7 @@ export function DeliveryOptionsSelector() {
               {shouldWaiveOtherRegionsFee && (
                 <div className="flex items-center gap-2 text-muted-foreground">
                   <p className="text-start line-through">
-                    {formatter.format(otherRegionsFee)}
+                    {formatter.format(toDisplayAmount(otherRegionsFee))}
                   </p>
                   <p className="text-start">Free</p>
                 </div>
@@ -196,7 +200,7 @@ export function DeliveryOptionsSelector() {
 
               {!shouldWaiveOtherRegionsFee && (
                 <p className="text-muted-foreground">
-                  {formatter.format(otherRegionsFee)}
+                  {formatter.format(toDisplayAmount(otherRegionsFee))}
                 </p>
               )}
             </div>
@@ -214,7 +218,7 @@ export function DeliveryOptionsSelector() {
               {shouldWaiveIntlFee && (
                 <div className="flex items-center gap-2 text-muted-foreground">
                   <p className="text-start line-through">
-                    {formatter.format(internationalFee)}
+                    {formatter.format(toDisplayAmount(internationalFee))}
                   </p>
                   <p className="text-start">Free</p>
                 </div>
@@ -222,7 +226,7 @@ export function DeliveryOptionsSelector() {
 
               {!shouldWaiveIntlFee && (
                 <p className="text-muted-foreground">
-                  {formatter.format(internationalFee)}
+                  {formatter.format(toDisplayAmount(internationalFee))}
                 </p>
               )}
             </div>

--- a/packages/storefront-webapp/src/components/checkout/DeliveryDetails/PickupOptions.tsx
+++ b/packages/storefront-webapp/src/components/checkout/DeliveryDetails/PickupOptions.tsx
@@ -1,7 +1,7 @@
 import { useStoreContext } from "@/contexts/StoreContext";
 import { useCheckout } from "@/hooks/useCheckout";
 import { useShoppingBag } from "@/hooks/useShoppingBag";
-import { toPesewas } from "@/lib/currency";
+import { toDisplayAmount, toPesewas } from "@/lib/currency";
 import { GhostButton } from "@/components/ui/ghost-button";
 import { Truck } from "lucide-react";
 import { StoreIcon } from "lucide-react";
@@ -60,7 +60,7 @@ export const PickupOptions = () => {
   const isFeeWaivedForCurrentOption = isFeeWaived(
     waiveDeliveryFees,
     checkoutState.deliveryOption,
-    subtotalInPesewas
+    subtotalInPesewas,
   );
 
   return (
@@ -135,7 +135,9 @@ export const PickupOptions = () => {
                 {Boolean(checkoutState.deliveryFee) &&
                   !isFeeWaivedForCurrentOption && (
                     <p className="text-xs text-[#EC4683] text-start w-full">
-                      {formatter.format(checkoutState.deliveryFee || 0)}
+                      {formatter.format(
+                        toDisplayAmount(checkoutState.deliveryFee || 0),
+                      )}
                     </p>
                   )}
               </>

--- a/packages/storefront-webapp/src/components/checkout/DeliveryDetails/PickupOptions.tsx
+++ b/packages/storefront-webapp/src/components/checkout/DeliveryDetails/PickupOptions.tsx
@@ -1,5 +1,7 @@
 import { useStoreContext } from "@/contexts/StoreContext";
 import { useCheckout } from "@/hooks/useCheckout";
+import { useShoppingBag } from "@/hooks/useShoppingBag";
+import { toPesewas } from "@/lib/currency";
 import { GhostButton } from "@/components/ui/ghost-button";
 import { Truck } from "lucide-react";
 import { StoreIcon } from "lucide-react";
@@ -28,6 +30,8 @@ export const PickupOptions = () => {
   const { formatter, store } = useStoreContext();
   const storeConfig = getStoreConfigV2(store);
   const { waiveDeliveryFees, fulfillment } = storeConfig.commerce;
+  const { bagSubtotal } = useShoppingBag();
+  const subtotalInPesewas = toPesewas(bagSubtotal);
 
   const isPickup = checkoutState.deliveryMethod === "pickup";
   const isDelivery = checkoutState.deliveryMethod === "delivery";
@@ -55,7 +59,8 @@ export const PickupOptions = () => {
   // Use the shared utility function to determine if the fee should be waived
   const isFeeWaivedForCurrentOption = isFeeWaived(
     waiveDeliveryFees,
-    checkoutState.deliveryOption
+    checkoutState.deliveryOption,
+    subtotalInPesewas
   );
 
   return (

--- a/packages/storefront-webapp/src/components/checkout/DeliveryDetailsSection.tsx
+++ b/packages/storefront-webapp/src/components/checkout/DeliveryDetailsSection.tsx
@@ -27,6 +27,7 @@ import { useStoreContext } from "@/contexts/StoreContext";
 import { isFeeWaived } from "@/lib/feeUtils";
 import { getStoreConfigV2 } from "@/lib/storeConfig";
 import { toPesewas } from "@/lib/currency";
+import { useShoppingBag } from "@/hooks/useShoppingBag";
 
 export const CountryFields = ({ form }: CheckoutFormSectionProps) => {
   const { checkoutState, updateState } = useCheckout();
@@ -120,6 +121,8 @@ const RegionFields = ({ form }: CheckoutFormSectionProps) => {
   const { store } = useStoreContext();
   const storeConfig = getStoreConfigV2(store);
   const { waiveDeliveryFees, deliveryFees } = storeConfig.commerce;
+  const { bagSubtotal } = useShoppingBag();
+  const subtotalInPesewas = toPesewas(bagSubtotal);
 
   return (
     <>
@@ -142,24 +145,18 @@ const RegionFields = ({ form }: CheckoutFormSectionProps) => {
                       const deliveryOption =
                         region == "GA" ? "within-accra" : "outside-accra";
 
-                      // Handle both old boolean format and new object format for backward compatibility
-                      const shouldWaiveRegionFee =
-                        typeof waiveDeliveryFees === "boolean"
-                          ? waiveDeliveryFees
-                          : region == "GA"
-                            ? waiveDeliveryFees?.withinAccra ||
-                              waiveDeliveryFees?.all ||
-                              false
-                            : waiveDeliveryFees?.otherRegions ||
-                              waiveDeliveryFees?.all ||
-                              false;
+                      const shouldWaiveRegionFee = isFeeWaived(
+                        waiveDeliveryFees,
+                        deliveryOption,
+                        subtotalInPesewas
+                      );
 
                       const deliveryFee = shouldWaiveRegionFee
                         ? 0
                         : toPesewas(
                             region == "GA"
                               ? deliveryFees?.withinAccra || 30
-                              : deliveryFees?.otherRegions || 70
+                              : deliveryFees?.otherRegions || 70,
                           );
 
                       updateState({
@@ -207,24 +204,18 @@ const RegionFields = ({ form }: CheckoutFormSectionProps) => {
                     const deliveryOption =
                       region == "GA" ? "within-accra" : "outside-accra";
 
-                    // Handle both old boolean format and new object format for backward compatibility
-                    const shouldWaiveRegionFee =
-                      typeof waiveDeliveryFees === "boolean"
-                        ? waiveDeliveryFees
-                        : region == "GA"
-                          ? waiveDeliveryFees?.withinAccra ||
-                            waiveDeliveryFees?.all ||
-                            false
-                          : waiveDeliveryFees?.otherRegions ||
-                            waiveDeliveryFees?.all ||
-                            false;
+                    const shouldWaiveRegionFee = isFeeWaived(
+                      waiveDeliveryFees,
+                      deliveryOption,
+                      subtotalInPesewas
+                    );
 
                     const deliveryFee = shouldWaiveRegionFee
                       ? 0
                       : toPesewas(
                           region == "GA"
                             ? deliveryFees?.withinAccra || 30
-                            : deliveryFees?.otherRegions || 70
+                            : deliveryFees?.otherRegions || 70,
                         );
 
                     updateState({
@@ -753,7 +744,7 @@ export const DeliveryDetailsSection = ({ form }: CheckoutFormSectionProps) => {
   const { deliveryFees, waiveDeliveryFees } = storeConfig.commerce;
 
   const previousCountryRef = useRef(
-    checkoutState.deliveryDetails?.country || undefined
+    checkoutState.deliveryDetails?.country || undefined,
   );
 
   const previousRegionRef = useRef(checkoutState.deliveryDetails?.region);
@@ -761,7 +752,9 @@ export const DeliveryDetailsSection = ({ form }: CheckoutFormSectionProps) => {
   const [isEnteringNewNeighborhood, setIsEnteringNewNeighborhood] =
     useState(false);
 
-  const shouldWaiveIntlFee = isFeeWaived(waiveDeliveryFees, "intl");
+  const { bagSubtotal: dsBagSubtotal } = useShoppingBag();
+  const dsSubtotalInPesewas = toPesewas(dsBagSubtotal);
+  const shouldWaiveIntlFee = isFeeWaived(waiveDeliveryFees, "intl", dsSubtotalInPesewas);
 
   useEffect(() => {
     // effect to clear state and the form when the country changes

--- a/packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx
+++ b/packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx
@@ -20,8 +20,8 @@ import { getDiscountValue } from "./utils";
 import { redeemPromoCode } from "@/api/promoCodes";
 import { useAuth } from "@/hooks/useAuth";
 import { usePromoCodesQueries } from "@/lib/queries/promoCode";
-import { isFeeWaived } from "@/lib/feeUtils";
-import { toDisplayAmount } from "@/lib/currency";
+import { isFeeWaived, getRemainingForFreeDelivery } from "@/lib/feeUtils";
+import { toDisplayAmount, toPesewas } from "@/lib/currency";
 import { Badge } from "../ui/badge";
 import { motion } from "framer-motion";
 import { toast } from "sonner";
@@ -31,6 +31,7 @@ import { getStoreConfigV2 } from "@/lib/storeConfig";
 export default function MobileBagSummary() {
   const { formatter, store } = useStoreContext();
   const { bagSubtotal } = useShoppingBag();
+  const subtotalInPesewas = toPesewas(bagSubtotal);
   const { checkoutState, updateState, activeSession } = useCheckout();
   const [invalidMessage, setInvalidMessage] = useState("");
   const [code, setCode] = useState("");
@@ -117,7 +118,13 @@ export default function MobileBagSummary() {
   // Use the shared utility function to determine if fee should be waived
   const isFeeWaivedForCurrentOption = isFeeWaived(
     waiveDeliveryFees,
-    checkoutState.deliveryOption
+    checkoutState.deliveryOption,
+    subtotalInPesewas
+  );
+  const remainingForFreeDelivery = getRemainingForFreeDelivery(
+    waiveDeliveryFees,
+    checkoutState.deliveryOption,
+    subtotalInPesewas
   );
 
   const discountSpan =
@@ -235,6 +242,12 @@ export default function MobileBagSummary() {
                         : formatter.format(toDisplayAmount(checkoutState.deliveryFee || 0))}
                     </p>
                   </div>
+                )}
+              {remainingForFreeDelivery !== null &&
+                checkoutState.deliveryMethod === "delivery" && (
+                  <p className="text-xs text-muted-foreground">
+                    Add {formatter.format(toDisplayAmount(remainingForFreeDelivery))} more to get free delivery
+                  </p>
                 )}
               {Boolean(discountValue) && (
                 <div className="flex justify-between">

--- a/packages/storefront-webapp/src/components/checkout/OrderDetails/OrderSummary.tsx
+++ b/packages/storefront-webapp/src/components/checkout/OrderDetails/OrderSummary.tsx
@@ -5,8 +5,8 @@ import { useShoppingBag } from "@/hooks/useShoppingBag";
 import { getDiscountValue } from "../utils";
 import { BagSummaryItems } from "../BagSummary";
 import { Tag } from "lucide-react";
-import { isFeeWaived } from "@/lib/feeUtils";
-import { toDisplayAmount } from "@/lib/currency";
+import { isFeeWaived, getRemainingForFreeDelivery } from "@/lib/feeUtils";
+import { toDisplayAmount, toPesewas } from "@/lib/currency";
 import { Badge } from "@/components/ui/badge";
 import InputWithEndButton from "@/components/ui/input-with-end-button";
 import { useState } from "react";
@@ -18,6 +18,7 @@ import { getStoreConfigV2 } from "@/lib/storeConfig";
 export default function OrderSummary() {
   const { formatter, store } = useStoreContext();
   const { bagSubtotal } = useShoppingBag();
+  const subtotalInPesewas = toPesewas(bagSubtotal);
   const { checkoutState, activeSession, updateState } = useCheckout();
   const storeConfig = getStoreConfigV2(store);
   const { waiveDeliveryFees } = storeConfig.commerce;
@@ -69,7 +70,13 @@ export default function OrderSummary() {
   // Use the shared utility functions for fee waiving logic
   const isFeeWaivedForCurrentOption = isFeeWaived(
     waiveDeliveryFees,
-    checkoutState.deliveryOption
+    checkoutState.deliveryOption,
+    subtotalInPesewas
+  );
+  const remainingForFreeDelivery = getRemainingForFreeDelivery(
+    waiveDeliveryFees,
+    checkoutState.deliveryOption,
+    subtotalInPesewas
   );
 
   const bagItems =
@@ -163,6 +170,13 @@ export default function OrderSummary() {
                   : formatter.format(toDisplayAmount(checkoutState.deliveryFee || 0))}
               </p>
             </div>
+          )}
+
+        {remainingForFreeDelivery !== null &&
+          checkoutState.deliveryMethod === "delivery" && (
+            <p className="text-xs text-muted-foreground">
+              Add {formatter.format(toDisplayAmount(remainingForFreeDelivery))} more to get free delivery
+            </p>
           )}
 
         {Boolean(discountValue) && (

--- a/packages/storefront-webapp/src/components/checkout/deliveryFees.test.ts
+++ b/packages/storefront-webapp/src/components/checkout/deliveryFees.test.ts
@@ -181,4 +181,64 @@ describe("calculateDeliveryFee", () => {
       deliveryOption: null,
     });
   });
+
+  it("waives fee when waiver is ON and subtotal meets threshold", () => {
+    const result = calculateDeliveryFee({
+      deliveryMethod: "delivery",
+      country: "GH",
+      region: "GA",
+      waiveDeliveryFees: { withinAccra: true, minimumOrderAmount: 100 },
+      deliveryFees: { withinAccra: 30, otherRegions: 70, international: 800 },
+      subtotal: 10000,
+    });
+    expect(result).toEqual({ deliveryFee: 0, deliveryOption: "within-accra" });
+  });
+
+  it("charges fee when waiver is ON but subtotal below threshold", () => {
+    const result = calculateDeliveryFee({
+      deliveryMethod: "delivery",
+      country: "GH",
+      region: "GA",
+      waiveDeliveryFees: { withinAccra: true, minimumOrderAmount: 100 },
+      deliveryFees: { withinAccra: 30, otherRegions: 70, international: 800 },
+      subtotal: 5000,
+    });
+    expect(result).toEqual({ deliveryFee: 3000, deliveryOption: "within-accra" });
+  });
+
+  it("waives fee when waiver is ON and no threshold set (backward compat)", () => {
+    const result = calculateDeliveryFee({
+      deliveryMethod: "delivery",
+      country: "GH",
+      region: "GA",
+      waiveDeliveryFees: { withinAccra: true },
+      deliveryFees: { withinAccra: 30, otherRegions: 70, international: 800 },
+      subtotal: 100,
+    });
+    expect(result).toEqual({ deliveryFee: 0, deliveryOption: "within-accra" });
+  });
+
+  it("waives international fee when threshold is met", () => {
+    const result = calculateDeliveryFee({
+      deliveryMethod: "delivery",
+      country: "US",
+      region: null,
+      waiveDeliveryFees: { international: true, minimumOrderAmount: 200 },
+      deliveryFees: { withinAccra: 30, otherRegions: 70, international: 800 },
+      subtotal: 25000,
+    });
+    expect(result).toEqual({ deliveryFee: 0, deliveryOption: "intl" });
+  });
+
+  it("charges international fee when threshold is not met", () => {
+    const result = calculateDeliveryFee({
+      deliveryMethod: "delivery",
+      country: "US",
+      region: null,
+      waiveDeliveryFees: { international: true, minimumOrderAmount: 200 },
+      deliveryFees: { withinAccra: 30, otherRegions: 70, international: 800 },
+      subtotal: 10000,
+    });
+    expect(result).toEqual({ deliveryFee: 80000, deliveryOption: "intl" });
+  });
 });

--- a/packages/storefront-webapp/src/components/checkout/deliveryFees.ts
+++ b/packages/storefront-webapp/src/components/checkout/deliveryFees.ts
@@ -15,6 +15,7 @@ type WaiveDeliveryFees =
       otherRegions?: boolean;
       international?: boolean;
       all?: boolean;
+      minimumOrderAmount?: number;
     }
   | null
   | undefined;
@@ -25,6 +26,7 @@ type CalculateDeliveryFeeInput = {
   region: string | null;
   waiveDeliveryFees: WaiveDeliveryFees;
   deliveryFees: DeliveryFeeConfig;
+  subtotal?: number; // in pesewas
 };
 
 type CalculateDeliveryFeeResult = {
@@ -42,6 +44,7 @@ export function calculateDeliveryFee({
   region,
   waiveDeliveryFees,
   deliveryFees,
+  subtotal,
 }: CalculateDeliveryFeeInput): CalculateDeliveryFeeResult {
   if (deliveryMethod === "pickup") {
     return { deliveryFee: 0, deliveryOption: null };
@@ -67,13 +70,7 @@ export function calculateDeliveryFee({
     baseFee = deliveryFees?.international ?? DEFAULT_INTERNATIONAL_FEE;
   }
 
-  const shouldWaive = isGhana
-    ? typeof waiveDeliveryFees === "boolean"
-      ? waiveDeliveryFees
-      : isGreaterAccra
-        ? waiveDeliveryFees?.withinAccra || waiveDeliveryFees?.all || false
-        : waiveDeliveryFees?.otherRegions || waiveDeliveryFees?.all || false
-    : isFeeWaived(waiveDeliveryFees, "intl");
+  const shouldWaive = isFeeWaived(waiveDeliveryFees, deliveryOption, subtotal);
 
   return {
     deliveryFee: shouldWaive ? 0 : toPesewas(baseFee),

--- a/packages/storefront-webapp/src/components/checkout/utils.ts
+++ b/packages/storefront-webapp/src/components/checkout/utils.ts
@@ -19,7 +19,7 @@ export type BagItem = {
 export const getDiscountValue = (
   items: BagItem[],
   discount?: Discount | null,
-  isInCents?: boolean
+  isInCents?: boolean,
 ): number => {
   if (!discount) return 0;
 
@@ -27,7 +27,7 @@ export const getDiscountValue = (
   if (discount.span === "entire-order") {
     const subtotal = items.reduce(
       (sum, item) => sum + item.price * item.quantity,
-      0
+      0,
     );
 
     if (discount.type === "percentage") {
@@ -105,10 +105,10 @@ export const formatDeliveryAddress = (address: Address) => {
 
   if (isGHOrder) {
     const region = GHANA_REGIONS.find((r) => r.code == address.region)?.name;
-    const neighborhood = accraNeighborhoods.find(
-      (n) => n.value == address?.neighborhood
-    )?.label;
-    addressLine = `${address?.houseNumber || ""} ${address?.street}, ${neighborhood}, ${region}`;
+    const neighborhood =
+      accraNeighborhoods.find((n) => n.value == address?.neighborhood)?.label ||
+      address?.neighborhood;
+    addressLine = `${address?.houseNumber || ""} ${address?.street || ""}, ${neighborhood}, ${region}`;
   }
 
   return {

--- a/packages/storefront-webapp/src/lib/feeUtils.test.ts
+++ b/packages/storefront-webapp/src/lib/feeUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isFeeWaived, isAnyFeeWaived } from "./feeUtils";
+import { isFeeWaived, isAnyFeeWaived, hasWaiverConfigured, getRemainingForFreeDelivery } from "./feeUtils";
 
 describe("isFeeWaived", () => {
   it("returns false for undefined/null waiveDeliveryFees", () => {
@@ -36,6 +36,45 @@ describe("isFeeWaived", () => {
   });
 });
 
+describe("isFeeWaived with minimumOrderAmount", () => {
+  it("returns true when region waiver is ON and subtotal >= threshold", () => {
+    const config = { withinAccra: true, minimumOrderAmount: 100 };
+    expect(isFeeWaived(config, "within-accra", 10000)).toBe(true);
+  });
+  it("returns false when region waiver is ON but subtotal < threshold", () => {
+    const config = { withinAccra: true, minimumOrderAmount: 100 };
+    expect(isFeeWaived(config, "within-accra", 5000)).toBe(false);
+  });
+  it("returns true when region waiver is ON and no threshold set (backward compat)", () => {
+    const config = { withinAccra: true };
+    expect(isFeeWaived(config, "within-accra", 5000)).toBe(true);
+  });
+  it("returns true when waiveDeliveryFees is boolean true regardless of subtotal", () => {
+    expect(isFeeWaived(true, "within-accra", 100)).toBe(true);
+    expect(isFeeWaived(true, "intl", 0)).toBe(true);
+  });
+  it("returns true when threshold is 0 (treated as no threshold)", () => {
+    const config = { withinAccra: true, minimumOrderAmount: 0 };
+    expect(isFeeWaived(config, "within-accra", 0)).toBe(true);
+  });
+  it("returns true when all is true and subtotal >= threshold", () => {
+    const config = { all: true, minimumOrderAmount: 50 };
+    expect(isFeeWaived(config, "within-accra", 5000)).toBe(true);
+  });
+  it("returns false when all is true but subtotal < threshold", () => {
+    const config = { all: true, minimumOrderAmount: 50 };
+    expect(isFeeWaived(config, "within-accra", 1000)).toBe(false);
+  });
+  it("returns false when region waiver is OFF regardless of subtotal", () => {
+    const config = { withinAccra: false, minimumOrderAmount: 10 };
+    expect(isFeeWaived(config, "within-accra", 99999)).toBe(false);
+  });
+  it("returns true when subtotal is not provided and no threshold (backward compat)", () => {
+    const config = { withinAccra: true };
+    expect(isFeeWaived(config, "within-accra")).toBe(true);
+  });
+});
+
 describe("isAnyFeeWaived", () => {
   it("returns false for undefined/null", () => {
     expect(isAnyFeeWaived(undefined)).toBe(false);
@@ -63,5 +102,74 @@ describe("isAnyFeeWaived", () => {
         international: false,
       })
     ).toBe(false);
+  });
+});
+
+describe("isAnyFeeWaived with minimumOrderAmount", () => {
+  it("returns false when waivers exist but subtotal is below threshold", () => {
+    const config = { withinAccra: true, minimumOrderAmount: 100 };
+    expect(isAnyFeeWaived(config, 5000)).toBe(false);
+  });
+  it("returns true when waivers exist and subtotal meets threshold", () => {
+    const config = { withinAccra: true, minimumOrderAmount: 100 };
+    expect(isAnyFeeWaived(config, 10000)).toBe(true);
+  });
+  it("returns true when no threshold is set", () => {
+    const config = { withinAccra: true };
+    expect(isAnyFeeWaived(config, 5000)).toBe(true);
+  });
+  it("returns true for legacy boolean true regardless of subtotal", () => {
+    expect(isAnyFeeWaived(true, 0)).toBe(true);
+  });
+});
+
+describe("hasWaiverConfigured", () => {
+  it("returns true when region flag is ON regardless of threshold", () => {
+    const config = { withinAccra: true, minimumOrderAmount: 9999 };
+    expect(hasWaiverConfigured(config, "within-accra")).toBe(true);
+  });
+  it("returns false when region flag is OFF", () => {
+    const config = { withinAccra: false, minimumOrderAmount: 10 };
+    expect(hasWaiverConfigured(config, "within-accra")).toBe(false);
+  });
+  it("returns true when all is true", () => {
+    const config = { all: true, minimumOrderAmount: 9999 };
+    expect(hasWaiverConfigured(config, "intl")).toBe(true);
+  });
+  it("returns true for legacy boolean true", () => {
+    expect(hasWaiverConfigured(true, "within-accra")).toBe(true);
+  });
+  it("returns false for legacy boolean false", () => {
+    expect(hasWaiverConfigured(false, "within-accra")).toBe(false);
+  });
+  it("returns false for undefined/null", () => {
+    expect(hasWaiverConfigured(undefined, "within-accra")).toBe(false);
+    expect(hasWaiverConfigured(null, "within-accra")).toBe(false);
+  });
+});
+
+describe("getRemainingForFreeDelivery", () => {
+  it("returns remaining pesewas when subtotal is below threshold", () => {
+    const config = { withinAccra: true, minimumOrderAmount: 100 };
+    expect(getRemainingForFreeDelivery(config, "within-accra", 5000)).toBe(5000);
+  });
+  it("returns null when subtotal meets threshold", () => {
+    const config = { withinAccra: true, minimumOrderAmount: 100 };
+    expect(getRemainingForFreeDelivery(config, "within-accra", 10000)).toBeNull();
+  });
+  it("returns null when no threshold is set (already free)", () => {
+    const config = { withinAccra: true };
+    expect(getRemainingForFreeDelivery(config, "within-accra", 5000)).toBeNull();
+  });
+  it("returns null when region waiver is OFF", () => {
+    const config = { withinAccra: false, minimumOrderAmount: 100 };
+    expect(getRemainingForFreeDelivery(config, "within-accra", 5000)).toBeNull();
+  });
+  it("returns null when no delivery option selected", () => {
+    const config = { withinAccra: true, minimumOrderAmount: 100 };
+    expect(getRemainingForFreeDelivery(config, null, 5000)).toBeNull();
+  });
+  it("returns null for legacy boolean true (no threshold possible)", () => {
+    expect(getRemainingForFreeDelivery(true, "within-accra", 100)).toBeNull();
   });
 });

--- a/packages/storefront-webapp/src/lib/feeUtils.ts
+++ b/packages/storefront-webapp/src/lib/feeUtils.ts
@@ -1,25 +1,43 @@
 // We need to define the DeliveryOption type here since it's not exported from CheckoutProvider
 type DeliveryOption = "within-accra" | "outside-accra" | "intl";
 
+type WaiveDeliveryFeesConfig =
+  | boolean
+  | {
+      withinAccra?: boolean;
+      otherRegions?: boolean;
+      international?: boolean;
+      all?: boolean;
+      minimumOrderAmount?: number;
+    }
+  | undefined
+  | null;
+
+// Helper: check threshold. Returns true if waiver should proceed.
+// minimumOrderAmount is in store currency, subtotal is in pesewas.
+// When subtotal is undefined, returns true for backward compatibility —
+// existing callers that don't pass subtotal still get unconditional waivers.
+const meetsThreshold = (
+  minimumOrderAmount: number | undefined,
+  subtotal: number | undefined
+): boolean => {
+  if (!minimumOrderAmount || minimumOrderAmount <= 0) return true;
+  if (subtotal === undefined) return true;
+  return subtotal >= minimumOrderAmount * 100;
+};
+
 /**
  * Determines if a delivery fee should be waived based on the current delivery option
  *
  * @param waiveDeliveryFees - Boolean or object specifying which fees to waive
  * @param deliveryOption - The current delivery option selected by the user
+ * @param subtotal - The cart subtotal in pesewas (optional, for threshold checks)
  * @returns Boolean indicating if the fee should be waived
  */
 export const isFeeWaived = (
-  waiveDeliveryFees:
-    | boolean
-    | {
-        withinAccra?: boolean;
-        otherRegions?: boolean;
-        international?: boolean;
-        all?: boolean;
-      }
-    | undefined
-    | null,
-  deliveryOption: DeliveryOption | null
+  waiveDeliveryFees: WaiveDeliveryFeesConfig,
+  deliveryOption: DeliveryOption | null,
+  subtotal?: number
 ): boolean => {
   // Handle boolean waiveDeliveryFees (legacy format)
   if (typeof waiveDeliveryFees === "boolean") {
@@ -31,9 +49,11 @@ export const isFeeWaived = (
     return false;
   }
 
-  // If "all" is true, all fees are waived
+  const { minimumOrderAmount } = waiveDeliveryFees;
+
+  // If "all" is true, check threshold before returning
   if (waiveDeliveryFees.all) {
-    return true;
+    return meetsThreshold(minimumOrderAmount, subtotal);
   }
 
   // If no delivery option selected, no fee waiver (default state)
@@ -42,16 +62,18 @@ export const isFeeWaived = (
   }
 
   // Check for the specific delivery option
+  let regionFlag = false;
   if (deliveryOption === "within-accra") {
-    return !!waiveDeliveryFees.withinAccra;
+    regionFlag = !!waiveDeliveryFees.withinAccra;
   } else if (deliveryOption === "outside-accra") {
-    return !!waiveDeliveryFees.otherRegions;
+    regionFlag = !!waiveDeliveryFees.otherRegions;
   } else if (deliveryOption === "intl") {
-    return !!waiveDeliveryFees.international;
+    regionFlag = !!waiveDeliveryFees.international;
   }
 
-  // Default to false if option doesn't match
-  return false;
+  if (!regionFlag) return false;
+
+  return meetsThreshold(minimumOrderAmount, subtotal);
 };
 
 /**
@@ -59,16 +81,8 @@ export const isFeeWaived = (
  * Used to display indicators that at least some fee types are being waived
  */
 export const isAnyFeeWaived = (
-  waiveDeliveryFees:
-    | boolean
-    | {
-        withinAccra?: boolean;
-        otherRegions?: boolean;
-        international?: boolean;
-        all?: boolean;
-      }
-    | undefined
-    | null
+  waiveDeliveryFees: WaiveDeliveryFeesConfig,
+  subtotal?: number
 ): boolean => {
   // Handle boolean waiveDeliveryFees (legacy format)
   if (typeof waiveDeliveryFees === "boolean") {
@@ -81,10 +95,100 @@ export const isAnyFeeWaived = (
   }
 
   // Check if any of the fee types are waived
-  return !!(
+  const anyWaived = !!(
     waiveDeliveryFees.all ||
     waiveDeliveryFees.withinAccra ||
     waiveDeliveryFees.otherRegions ||
     waiveDeliveryFees.international
   );
+
+  if (!anyWaived) return false;
+
+  return meetsThreshold(waiveDeliveryFees.minimumOrderAmount, subtotal);
+};
+
+/**
+ * Checks if a waiver is configured for a region, ignoring threshold entirely.
+ * Needed by the nudge feature to determine if a waiver exists before checking
+ * if the subtotal meets the threshold.
+ */
+export const hasWaiverConfigured = (
+  waiveDeliveryFees: WaiveDeliveryFeesConfig,
+  deliveryOption: DeliveryOption | null
+): boolean => {
+  // Handle boolean waiveDeliveryFees (legacy format)
+  if (typeof waiveDeliveryFees === "boolean") {
+    return waiveDeliveryFees;
+  }
+
+  // Handle undefined/null waiveDeliveryFees
+  if (!waiveDeliveryFees || typeof waiveDeliveryFees !== "object") {
+    return false;
+  }
+
+  // If "all" is true, a waiver is configured
+  if (waiveDeliveryFees.all) {
+    return true;
+  }
+
+  // If no delivery option selected, no waiver configured
+  if (!deliveryOption) {
+    return false;
+  }
+
+  // Check for the specific delivery option flag (ignoring threshold)
+  if (deliveryOption === "within-accra") {
+    return !!waiveDeliveryFees.withinAccra;
+  } else if (deliveryOption === "outside-accra") {
+    return !!waiveDeliveryFees.otherRegions;
+  } else if (deliveryOption === "intl") {
+    return !!waiveDeliveryFees.international;
+  }
+
+  return false;
+};
+
+/**
+ * Returns the remaining pesewas needed to reach the free delivery threshold,
+ * or null if not applicable (no waiver configured, no threshold, or already met).
+ *
+ * @param waiveDeliveryFees - Boolean or object specifying which fees to waive
+ * @param deliveryOption - The current delivery option selected by the user
+ * @param subtotal - The cart subtotal in pesewas
+ */
+export const getRemainingForFreeDelivery = (
+  waiveDeliveryFees: WaiveDeliveryFeesConfig,
+  deliveryOption: DeliveryOption | null,
+  subtotal: number
+): number | null => {
+  // Boolean true means always free — no threshold possible
+  if (typeof waiveDeliveryFees === "boolean") {
+    return null;
+  }
+
+  // No config, no delivery option
+  if (!waiveDeliveryFees || typeof waiveDeliveryFees !== "object") {
+    return null;
+  }
+
+  // Must have a waiver configured for the region
+  if (!hasWaiverConfigured(waiveDeliveryFees, deliveryOption)) {
+    return null;
+  }
+
+  const { minimumOrderAmount } = waiveDeliveryFees;
+
+  // No threshold set — already free unconditionally
+  if (!minimumOrderAmount || minimumOrderAmount <= 0) {
+    return null;
+  }
+
+  const thresholdInPesewas = minimumOrderAmount * 100;
+
+  // Already meets threshold
+  if (subtotal >= thresholdInPesewas) {
+    return null;
+  }
+
+  return thresholdInPesewas - subtotal;
 };


### PR DESCRIPTION
## Summary

- Adds a configurable **minimum order amount** threshold for delivery fee waivers — admin sets the amount, and free delivery only applies when the cart subtotal meets it
- Wires `subtotal` through all 8 storefront checkout components that check fee waivers (`CheckoutProvider`, `DeliveryOptionsSelector`, `DeliveryDetailsSection`, `PickupOptions`, `OrderSummary`, `MobileBagSummary`, `BagSummary`)
- Adds **"Add GHS X more to get free delivery"** nudge message in all 3 order summary views when customer is below the threshold
- Adds **"Minimum order amount"** input to admin FeesView, only visible when at least one waiver toggle is ON — leaving it empty keeps waivers unconditional (backward compatible)
- Replaces duplicated inline waiver logic in `DeliveryDetailsSection` and `deliveryFees.ts` with consistent `isFeeWaived()` calls

## Test plan

- [x] 51 unit tests passing (34 feeUtils + 17 deliveryFees)
- [x] TypeScript compiles with no errors (both storefront and admin apps)
- [ ] Manual: Set a minimum order amount in admin, verify free delivery only applies when cart meets threshold
- [ ] Manual: Verify "Add X more" nudge appears when below threshold and disappears when threshold met
- [ ] Manual: Verify leaving minimum amount empty keeps waivers unconditional (no regression)
- [ ] Manual: Verify the minimum amount input only appears when at least one waiver toggle is ON

🤖 Generated with [Claude Code](https://claude.com/claude-code)