### PR TITLE
Fix type errors from pesewas normalization

### DIFF
--- a/packages/athena-webapp/convex/http/domains/storeFront/routes/security.test.ts
+++ b/packages/athena-webapp/convex/http/domains/storeFront/routes/security.test.ts
@@ -17,14 +17,14 @@ describe("security helpers", () => {
           productSku: "sku-a",
           productSkuId: "sku-id-a",
           quantity: 2,
-          price: 25,
+          price: 2500, // 25 GHS in pesewas
         },
         {
           productId: "product-2",
           productSku: "sku-b",
           productSkuId: "sku-id-b",
           quantity: 1,
-          price: 100,
+          price: 10000, // 100 GHS in pesewas
         },
       ]);
 
@@ -34,27 +34,27 @@ describe("security helpers", () => {
           productSku: "sku-a",
           productSkuId: "sku-id-a",
           quantity: 2,
-          price: 25,
+          price: 2500,
         },
         {
           productId: "product-2",
           productSku: "sku-b",
           productSkuId: "sku-id-b",
           quantity: 1,
-          price: 100,
+          price: 10000,
         },
       ]);
-      expect(result.amount).toBe(15000); // 150 GHS = 15000 pesewas
+      expect(result.amount).toBe(15000); // (2500*2) + (10000*1) = 15000 pesewas
     });
 
-    it("returns amount in pesewas and handles decimal GHS prices", () => {
+    it("returns amount in pesewas (prices already stored as pesewas)", () => {
       const result = buildCanonicalCheckoutProducts([
         {
           productId: "product-1",
           productSku: "sku-a",
           productSkuId: "sku-id-a",
           quantity: 1,
-          price: 29.99,
+          price: 2999, // 29.99 GHS in pesewas
         },
       ]);
       expect(result.amount).toBe(2999);

--- a/packages/storefront-webapp/src/components/checkout/OrderDetails/index.tsx
+++ b/packages/storefront-webapp/src/components/checkout/OrderDetails/index.tsx
@@ -62,7 +62,6 @@ export const PaymentDetails = ({ session }: { session?: CheckoutSession }) => {
     discount: discount as any,
     deliveryFee: session.deliveryFee || 0, // already pesewas
     subtotal: session.amount,
-    isInCents: true,
   });
 
   const originalAmount = session.amount + (session.deliveryFee || 0);

--- a/packages/storefront-webapp/src/lib/storeConfig.ts
+++ b/packages/storefront-webapp/src/lib/storeConfig.ts
@@ -7,14 +7,13 @@ type StoreConfigInput =
   | null
   | undefined;
 
-type WaiveDeliveryFees =
-  | boolean
-  | {
-      withinAccra?: boolean;
-      otherRegions?: boolean;
-      international?: boolean;
-      all?: boolean;
-    };
+type WaiveDeliveryFees = {
+  withinAccra?: boolean;
+  otherRegions?: boolean;
+  international?: boolean;
+  all?: boolean;
+  minimumOrderAmount?: number;
+};
 
 type PromoCodeConfig = {
   promoCodeId: string;
@@ -233,16 +232,14 @@ export const getStoreConfigV2 = (
 
   const waiveDeliveryFees: WaiveDeliveryFees = (() => {
     const value = firstDefined(commerce.waiveDeliveryFees, legacyWaiveFees);
-    if (typeof value === "boolean") {
-      return value;
-    }
+    const record = asRecord(value);
 
     return cleanUndefined({
-      withinAccra: asBoolean(asRecord(value).withinAccra),
-      otherRegions: asBoolean(asRecord(value).otherRegions),
-      international: asBoolean(asRecord(value).international),
-      all: asBoolean(asRecord(value).all),
-      minimumOrderAmount: asNumber(asRecord(value).minimumOrderAmount),
+      withinAccra: asBoolean(record.withinAccra),
+      otherRegions: asBoolean(record.otherRegions),
+      international: asBoolean(record.international),
+      all: asBoolean(record.all),
+      minimumOrderAmount: asNumber(record.minimumOrderAmount),
     });
   })();
 

--- a/packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/incomplete.tsx
+++ b/packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/incomplete.tsx
@@ -31,7 +31,6 @@ function CheckoutIncompleteView() {
     discount: onlineOrder?.discount as Discount | null,
     deliveryFee: onlineOrder?.deliveryFee || 0, // already pesewas
     subtotal: onlineOrder?.amount || 0,
-    isInCents: true,
   });
 
   const { addressLine } = formatDeliveryAddress(

--- a/packages/storefront-webapp/src/routes/shop/checkout/pod-confirmation.tsx
+++ b/packages/storefront-webapp/src/routes/shop/checkout/pod-confirmation.tsx
@@ -54,7 +54,6 @@ const PODPaymentDetails = ({ session }: { session: any }) => {
     discount,
     deliveryFee: session?.deliveryFee || 0, // already pesewas
     subtotal: session?.amount || 0,
-    isInCents: true,
   });
 
   const discountValue = getDiscountValue(items, discount);


### PR DESCRIPTION
## Summary

- **Remove legacy boolean `WaiveDeliveryFees` type**: The `WaiveDeliveryFees` type in `storeConfig.ts` still included `| boolean` after #51 dropped boolean support, causing 14 type errors across checkout components.
- **Remove stale `isInCents` parameter**: Three call sites still passed `isInCents: true` to `getOrderAmount` after the parameter was removed in #51.
- **Fix `security.test.ts` inputs**: Test prices were still in GHS (25, 29.99) instead of pesewas (2500, 2999), causing 2 test failures.

All 207 tests passing, zero type errors.

## Test plan

- [x] `tsc --noEmit` passes for both athena-webapp and storefront-webapp
- [x] All 92 athena-webapp tests pass
- [x] All 115 storefront-webapp tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)