### PR TITLE
Add 's' keyboard shortcut to save product

### DIFF
--- a/packages/athena-webapp/src/components/add-product/ProductView.tsx
+++ b/packages/athena-webapp/src/components/add-product/ProductView.tsx
@@ -13,7 +13,7 @@ import {
   Save,
 } from "lucide-react";
 import { LoadingButton } from "../ui/loading-button";
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { convertImagesToWebp, getUploadImagesData } from "@/lib/imageUtils";
 import { AlertModal } from "../ui/modals/alert-modal";
 import ProductPage from "./ProductPage";
@@ -370,6 +370,32 @@ function ProductViewContent() {
     if (activeProduct?._id || productId) await modifyProduct();
     else await saveProduct();
   };
+
+  const onSubmitRef = useRef(onSubmit);
+  onSubmitRef.current = onSubmit;
+
+  useEffect(() => {
+    const INTERACTIVE_TAGS = new Set(["INPUT", "TEXTAREA", "SELECT"]);
+
+    function handleKeyDown(e: KeyboardEvent) {
+      const el = document.activeElement;
+      if (
+        el &&
+        (INTERACTIVE_TAGS.has(el.tagName) ||
+          (el as HTMLElement).isContentEditable)
+      ) {
+        return;
+      }
+
+      if (e.key === "s") {
+        e.preventDefault();
+        onSubmitRef.current();
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, []);
 
   // const retryDeletingImages = async () => {
   //   setIsDeletingImages(true);


### PR DESCRIPTION
## Summary
- Adds an `s` key shortcut in the ProductView component that triggers save (new product) or update (existing product)
- Automatically disabled when focus is on an input, textarea, select, or contentEditable element to avoid accidental saves while typing
- Uses a ref-based pattern to always call the latest `onSubmit` without stale closures

## Test plan
- [ ] Open a product edit page, press `s` — verify the product saves
- [ ] Open the add-new-product page, press `s` — verify it creates the product
- [ ] Click into a text input (e.g. product name), type something with the letter "s" — verify it does NOT trigger a save
- [ ] Verify the save button still works as before via click

🤖 Generated with [Claude Code](https://claude.com/claude-code)