### PR TITLE
Add [ ] keyboard shortcuts for back/forward navigation

### DIFF
--- a/packages/athena-webapp/src/hooks/use-navigation-keyboard-shortcuts.ts
+++ b/packages/athena-webapp/src/hooks/use-navigation-keyboard-shortcuts.ts
@@ -1,0 +1,34 @@
+import { useEffect } from "react";
+import { useSearch } from "@tanstack/react-router";
+import { useNavigateBack } from "./use-navigate-back";
+
+const INTERACTIVE_TAGS = new Set(["INPUT", "TEXTAREA", "SELECT"]);
+
+export function useNavigationKeyboardShortcuts() {
+  const { o } = useSearch({ strict: false });
+  const navigateBack = useNavigateBack();
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      const el = document.activeElement;
+      if (
+        el &&
+        (INTERACTIVE_TAGS.has(el.tagName) ||
+          (el as HTMLElement).isContentEditable)
+      ) {
+        return;
+      }
+
+      if (e.key === "[" && o) {
+        e.preventDefault();
+        navigateBack();
+      } else if (e.key === "]") {
+        e.preventDefault();
+        window.history.forward();
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [o, navigateBack]);
+}

--- a/packages/athena-webapp/src/routes/__root.tsx
+++ b/packages/athena-webapp/src/routes/__root.tsx
@@ -11,6 +11,7 @@ import { Toaster } from "@/components/ui/sonner";
 import { DefaultCatchBoundary } from "@/components/auth/DefaultCatchBoundary";
 import { NotFoundView } from "@/components/states/not-found/NotFoundView";
 import { z } from "zod";
+import { useNavigationKeyboardShortcuts } from "@/hooks/use-navigation-keyboard-shortcuts";
 
 const rootPageSchema = z.object({
   o: z.string().optional(),
@@ -55,6 +56,8 @@ export const Route = createRootRouteWithContext<{
 });
 
 function RootComponent() {
+  useNavigationKeyboardShortcuts();
+
   return (
     <RootDocument>
       <div className="p-8 bg-transparent">


### PR DESCRIPTION
## Summary
- Adds `[` key shortcut to navigate back using the app's origin-based navigation (`useNavigateBack` / `o` search param)
- Adds `]` key shortcut to go forward via browser history
- `[` only triggers when an origin (`o`) param exists — same behavior as the back arrow button in the page header
- Shortcuts are disabled when focused on input, textarea, select, or contentEditable elements
- Registered globally in the root layout so they work on every page

## Test plan
- [ ] Navigate into a detail page (e.g. click a product from the products list — URL will have `?o=...`)
- [ ] Press `[` — should navigate back to the origin page (same as clicking the back arrow)
- [ ] Press `]` — should go forward in browser history
- [ ] On a page with no `o` param, press `[` — should do nothing
- [ ] Click into a text input, type `[` or `]` — should NOT trigger navigation
- [ ] Verify existing shortcuts (arrow keys for table pagination, `s` for product save) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)