### PR TITLE
feat: cmd+k go-to-page navigation on products list

### DIFF
--- a/packages/athena-webapp/src/components/products/products-table/components/add-product-command.tsx
+++ b/packages/athena-webapp/src/components/products/products-table/components/add-product-command.tsx
@@ -1,14 +1,29 @@
 import {
   CommandDialog,
+  CommandEmpty,
   CommandGroup,
   CommandInput,
   CommandItem,
   CommandList,
 } from "@/components/ui/command";
+import { Table } from "@tanstack/react-table";
 import { useEffect, useState } from "react";
 
-export function AddProductCommand({ show }: { show?: boolean }) {
+interface AddProductCommandProps<TData> {
+  show?: boolean;
+  table: Table<TData>;
+}
+
+export function AddProductCommand<TData>({
+  show,
+  table,
+}: AddProductCommandProps<TData>) {
   const [open, setOpen] = useState(show);
+  const [value, setValue] = useState("");
+
+  const pageCount = table.getPageCount();
+  const parsed = parseInt(value, 10);
+  const targetPage = !isNaN(parsed) && parsed >= 1 && parsed <= pageCount ? parsed : null;
 
   useEffect(() => {
     const down = (e: KeyboardEvent) => {
@@ -21,14 +36,39 @@ export function AddProductCommand({ show }: { show?: boolean }) {
     return () => document.removeEventListener("keydown", down);
   }, []);
 
+  function goToPage(page: number) {
+    table.setPageIndex(page - 1);
+    setOpen(false);
+    setValue("");
+  }
+
   return (
-    <CommandDialog open={open} onOpenChange={setOpen}>
-      <CommandInput placeholder="Type a command or search..." />
+    <CommandDialog
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) setValue("");
+      }}
+    >
+      <CommandInput
+        placeholder={`Go to page (1–${pageCount})...`}
+        value={value}
+        onValueChange={setValue}
+      />
       <CommandList>
-        <CommandGroup heading="Suggestions">
-          <CommandItem>Calendar</CommandItem>
-          <CommandItem>Search Emoji</CommandItem>
-          <CommandItem>Calculator</CommandItem>
+        <CommandEmpty>No matching page.</CommandEmpty>
+        {targetPage && (
+          <CommandGroup heading="Navigation">
+            <CommandItem onSelect={() => goToPage(targetPage)}>
+              Go to page {targetPage}
+            </CommandItem>
+          </CommandGroup>
+        )}
+        <CommandGroup heading="Quick jump">
+          <CommandItem onSelect={() => goToPage(1)}>First page</CommandItem>
+          <CommandItem onSelect={() => goToPage(pageCount)}>
+            Last page
+          </CommandItem>
         </CommandGroup>
       </CommandList>
     </CommandDialog>

--- a/packages/athena-webapp/src/components/products/products-table/components/data-table.tsx
+++ b/packages/athena-webapp/src/components/products/products-table/components/data-table.tsx
@@ -77,7 +77,7 @@ export function DataTable<TData, TValue>({
 
   return (
     <div className="space-y-4">
-      <AddProductCommand />
+      <AddProductCommand table={table} />
       {showToolbar && <DataTableToolbar table={table} />}
       {/* <div className="flex">
         <ProductSubcategoryToggleGroup />


### PR DESCRIPTION
## Summary
- Adds a functional go-to-page interface to the `Cmd+K` command palette on the products list
- Type a page number → a `Go to page N` item appears → press Enter to jump directly there
- `First page` and `Last page` quick-jump items always visible

## Why
Navigating large product categories required arrow-keying through every page one by one. This lets users jump to any page instantly without leaving the keyboard.

## Validation
1. Open a category with more than 20 products
2. Press `Cmd+K` — dialog opens with focused input and placeholder showing page range
3. Type a valid page number → `Go to page N` appears → Enter jumps to that page
4. Type an out-of-range number → no jump item shown
5. Click `First page` / `Last page` → jumps correctly
6. Press `Escape` → closes without navigating
7. Arrow key pagination still works normally