### PR TITLE
Add bulk operations page for batch SKU price updates

### DIFF
--- a/packages/athena-webapp/convex/inventory/products.ts
+++ b/packages/athena-webapp/convex/inventory/products.ts
@@ -792,6 +792,49 @@ export const removeAllProductsForStore = mutation({
   },
 });
 
+export const batchUpdateSkuPrices = mutation({
+  args: {
+    updates: v.array(
+      v.object({
+        id: v.id("productSku"),
+        price: v.number(),
+        netPrice: v.number(),
+      })
+    ),
+  },
+  handler: async (ctx, args) => {
+    if (args.updates.length === 0) {
+      return { success: true, updatedCount: 0 };
+    }
+
+    const results = await Promise.allSettled(
+      args.updates.map(async (update) => {
+        if (update.price < 0 || update.netPrice < 0) {
+          throw new Error(`Invalid price for SKU ${update.id}: prices must be non-negative`);
+        }
+        await ctx.db.patch(update.id, {
+          price: update.price,
+          netPrice: update.netPrice,
+        });
+      })
+    );
+
+    const failedCount = results.filter((r) => r.status === "rejected").length;
+
+    if (failedCount > 0) {
+      console.error(
+        `batchUpdateSkuPrices: ${failedCount} of ${args.updates.length} updates failed`
+      );
+    }
+
+    return {
+      success: failedCount === 0,
+      updatedCount: args.updates.length - failedCount,
+      failedCount,
+    };
+  },
+});
+
 export const batchGet = query({
   args: {
     ids: v.array(v.id(entity)),

--- a/packages/athena-webapp/src/components/app-sidebar.tsx
+++ b/packages/athena-webapp/src/components/app-sidebar.tsx
@@ -40,6 +40,7 @@ import {
   XCircle,
   ChevronDown,
   ShoppingCart,
+  Layers,
 } from "lucide-react";
 import { AppHeader } from "./Navbar";
 import { Link } from "@tanstack/react-router";
@@ -76,34 +77,34 @@ export function AppSidebar() {
 
   const orders = useQuery(
     api.storeFront.onlineOrder.getAllOnlineOrders,
-    activeStore?._id ? { storeId: activeStore._id } : "skip"
+    activeStore?._id ? { storeId: activeStore._id } : "skip",
   );
 
   const openOrders = orders?.filter((o: any) => o.status === "open")?.length;
 
   const readyOrders = orders?.filter((o: any) =>
-    o.status.includes("ready")
+    o.status.includes("ready"),
   )?.length;
 
   const outForDeliveryOrders = orders?.filter(
-    (o: any) => o.status === "out-for-delivery"
+    (o: any) => o.status === "out-for-delivery",
   )?.length;
 
   const completedOrders = orders?.filter((o: any) =>
-    ["delivered", "picked-up"].includes(o.status)
+    ["delivered", "picked-up"].includes(o.status),
   )?.length;
 
   const refundedOrders = orders?.filter(
-    (o: any) => o.status === "refunded"
+    (o: any) => o.status === "refunded",
   )?.length;
 
   const cancelledOrders = orders?.filter(
-    (o: any) => o.status === "cancelled"
+    (o: any) => o.status === "cancelled",
   )?.length;
 
   const unapprovedReviewsCount = useQuery(
     api.storeFront.reviews.getUnapprovedReviewsCount,
-    activeStore?._id ? { storeId: activeStore._id } : "skip"
+    activeStore?._id ? { storeId: activeStore._id } : "skip",
   );
 
   const { hasFullAdminAccess } = usePermissions();
@@ -455,6 +456,24 @@ export function AppSidebar() {
                     </SidebarMenuButton>
                   </SidebarMenuSubItem>
                 </SidebarMenuSub> */}
+              </SidebarMenuItem>
+
+              {/* Bulk operations section */}
+              <SidebarMenuItem>
+                <SidebarMenuButton disabled={!hasFullAdminAccess} asChild>
+                  <Link
+                    to="/$orgUrlSlug/store/$storeUrlSlug/bulk-operations"
+                    params={(p) => ({
+                      ...p,
+                      orgUrlSlug: activeOrganization?.slug,
+                      storeUrlSlug: activeStore?.slug,
+                    })}
+                    className="flex items-center"
+                  >
+                    <Layers className="w-4 h-4" />
+                    <p className="font-medium">Bulk Operations</p>
+                  </Link>
+                </SidebarMenuButton>
               </SidebarMenuItem>
 
               {/* Promo codes section */}

--- a/packages/athena-webapp/src/components/bulk-operations/BulkOperationsFilters.tsx
+++ b/packages/athena-webapp/src/components/bulk-operations/BulkOperationsFilters.tsx
@@ -1,0 +1,183 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  BulkOperationType,
+  OPERATION_LABELS,
+} from "~/src/hooks/useBulkOperations";
+import { useGetCategories } from "~/src/hooks/useGetCategories";
+import { Loader2 } from "lucide-react";
+
+interface BulkOperationsFiltersProps {
+  operation: BulkOperationType;
+  operationValue: string;
+  validationError: string | null;
+  skuCount: number;
+  hasPreview: boolean;
+  onOperationChange: (op: BulkOperationType) => void;
+  onOperationValueChange: (val: string) => void;
+  onLoadProducts: (categorySlug?: string, nameSearch?: string) => void;
+  onCalculatePreview: () => void;
+  isLoading?: boolean;
+}
+
+export function BulkOperationsFilters({
+  operation,
+  operationValue,
+  validationError,
+  skuCount,
+  hasPreview,
+  onOperationChange,
+  onOperationValueChange,
+  onLoadProducts,
+  onCalculatePreview,
+  isLoading,
+}: BulkOperationsFiltersProps) {
+  const [categorySlug, setCategorySlug] = useState<string>("");
+  const [nameSearch, setNameSearch] = useState("");
+
+  const categories = useGetCategories();
+
+  const handleLoadProducts = () => {
+    onLoadProducts(categorySlug || undefined, nameSearch || undefined);
+  };
+
+  return (
+    <div className="space-y-6 p-6 border rounded-lg">
+      <div>
+        <h3 className="text-lg font-medium">Bulk Price Update</h3>
+        <p className="text-sm text-muted-foreground mt-1">
+          Filter products, choose an operation, and preview changes before
+          applying.
+        </p>
+      </div>
+
+      {/* Filters Row */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div className="space-y-2">
+          <Label>Category</Label>
+          <Select
+            value={categorySlug || "all"}
+            onValueChange={(v) => setCategorySlug(v === "all" ? "" : v)}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="All categories" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All categories</SelectItem>
+              {categories?.map((cat) => (
+                <SelectItem key={cat._id} value={cat.slug}>
+                  {cat.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <Label>Product name</Label>
+          <Input
+            placeholder="Search by name..."
+            value={nameSearch}
+            onChange={(e) => setNameSearch(e.target.value)}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label className="invisible">Action</Label>
+          <Button
+            onClick={handleLoadProducts}
+            className="w-full"
+            disabled={isLoading}
+          >
+            {isLoading ? (
+              <>
+                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                Loading...
+              </>
+            ) : (
+              "Load Products"
+            )}
+          </Button>
+        </div>
+      </div>
+
+      {/* Operation Row — only show after products are loaded */}
+      {skuCount > 0 && (
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-4 pt-4 border-t">
+          <div className="space-y-2">
+            <Label>Target field</Label>
+            <Select value="price" disabled>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="price">Price</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Operation</Label>
+            <Select
+              value={operation}
+              onValueChange={(v) => onOperationChange(v as BulkOperationType)}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {Object.entries(OPERATION_LABELS).map(([key, label]) => (
+                  <SelectItem key={key} value={key}>
+                    {label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Value</Label>
+            <Input
+              type="number"
+              placeholder="Enter value..."
+              value={operationValue}
+              onChange={(e) => onOperationValueChange(e.target.value)}
+              min={0}
+              step="any"
+            />
+            {validationError && (
+              <p className="text-sm text-destructive">{validationError}</p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label className="invisible">Action</Label>
+            <Button
+              onClick={onCalculatePreview}
+              className="w-full"
+              disabled={!operationValue || !!validationError}
+              variant={hasPreview ? "outline" : "default"}
+            >
+              {hasPreview ? "Recalculate Preview" : "Calculate Preview"}
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {skuCount > 0 && (
+        <p className="text-sm text-muted-foreground">
+          {skuCount} SKU{skuCount !== 1 ? "s" : ""} loaded
+        </p>
+      )}
+    </div>
+  );
+}

--- a/packages/athena-webapp/src/components/bulk-operations/BulkOperationsPage.tsx
+++ b/packages/athena-webapp/src/components/bulk-operations/BulkOperationsPage.tsx
@@ -1,0 +1,192 @@
+import { useQuery } from "convex/react";
+import { api } from "~/convex/_generated/api";
+import useGetActiveStore from "~/src/hooks/useGetActiveStore";
+import { useBulkOperations } from "~/src/hooks/useBulkOperations";
+import { useGetCategories } from "~/src/hooks/useGetCategories";
+import { BulkOperationsFilters } from "./BulkOperationsFilters";
+import { BulkOperationsPreview } from "./BulkOperationsPreview";
+import View from "../View";
+import { useState, useCallback, useMemo } from "react";
+import { Id } from "~/convex/_generated/dataModel";
+import { EmptyState } from "../states/empty/empty-state";
+import { PackageSearch, SearchX } from "lucide-react";
+
+export default function BulkOperationsPage() {
+  const { activeStore } = useGetActiveStore();
+  const categories = useGetCategories();
+  const [filterParams, setFilterParams] = useState<{
+    categorySlug?: string;
+    nameSearch?: string;
+  } | null>(null);
+
+  const {
+    skus,
+    operation,
+    operationValue,
+    excludedSkuIds,
+    isApplying,
+    hasPreview,
+    previewRows,
+    selectedPreviewRows,
+    validSelectedRows,
+    validationError,
+    setOperation,
+    setOperationValue,
+    loadSkus,
+    calculatePreview,
+    toggleSkuExclusion,
+    selectAll,
+    deselectAll,
+    applyChanges,
+  } = useBulkOperations();
+
+  const products = useQuery(
+    api.inventory.products.getAll,
+    activeStore?._id && filterParams
+      ? {
+          storeId: activeStore._id,
+          category: filterParams.categorySlug
+            ? [filterParams.categorySlug]
+            : undefined,
+          filters: { isPriceZero: true },
+        }
+      : "skip"
+  );
+
+  // Build a category ID → name lookup from fetched categories
+  const categoryMap = useMemo(() => {
+    if (!categories) return new Map<string, string>();
+    return new Map(categories.map((c) => [c._id, c.name]));
+  }, [categories]);
+
+  // Collect all unique color IDs from loaded products to resolve names
+  const colorIds = useMemo(() => {
+    if (!products) return [];
+    const ids = new Set<Id<"color">>();
+    for (const product of products) {
+      for (const sku of product.skus) {
+        if (sku.color) ids.add(sku.color);
+      }
+    }
+    return Array.from(ids);
+  }, [products]);
+
+  // Fetch color details for all referenced colors
+  const colors = useQuery(
+    api.inventory.colors.getAll,
+    activeStore?._id ? { storeId: activeStore._id } : "skip"
+  );
+
+  const colorMap = useMemo(() => {
+    if (!colors) return new Map<string, string>();
+    return new Map(colors.map((c: any) => [c._id, c.name]));
+  }, [colors]);
+
+  // When products arrive from the query, process them into the hook
+  const isLoading = filterParams !== null && products === undefined;
+
+  // Load products into the bulk operations hook when query results arrive
+  const productsLoaded =
+    filterParams !== null && products !== undefined && products !== null;
+
+  // Filter by name client-side if a search term was provided
+  const filteredProducts = productsLoaded
+    ? filterParams.nameSearch
+      ? products.filter((p) =>
+          p.name.toLowerCase().includes(filterParams.nameSearch!.toLowerCase())
+        )
+      : products
+    : null;
+
+  // Enrich products with category names and SKUs with color names
+  const enrichedProducts = useMemo(() => {
+    if (!filteredProducts) return null;
+    return filteredProducts.map((product) => ({
+      ...product,
+      categoryName: categoryMap.get(product.categoryId) || undefined,
+      skus: product.skus.map((sku) => ({
+        ...sku,
+        colorName: sku.color ? colorMap.get(sku.color) || undefined : undefined,
+      })),
+    }));
+  }, [filteredProducts, categoryMap, colorMap]);
+
+  // Auto-load SKUs when enriched products are ready
+  if (enrichedProducts && enrichedProducts.length > 0 && skus.length === 0) {
+    loadSkus(enrichedProducts);
+  }
+
+  // Determine empty states
+  const hasSearched = filterParams !== null && !isLoading;
+  const noProductsFound = hasSearched && enrichedProducts?.length === 0;
+  const productsLoadedButNoSkus =
+    hasSearched &&
+    enrichedProducts &&
+    enrichedProducts.length > 0 &&
+    enrichedProducts.every((p) => p.skus.length === 0);
+
+  // Handle re-loading when filter params change: reset SKUs
+  const handleLoadProductsWithReset = useCallback(
+    (categorySlug?: string, nameSearch?: string) => {
+      // Force a fresh load by clearing current state
+      loadSkus([]);
+      setFilterParams({ categorySlug, nameSearch });
+    },
+    [loadSkus]
+  );
+
+  return (
+    <View
+      hideBorder
+      hideHeaderBottomBorder
+      header={
+        <div className="container mx-auto flex gap-2">
+          <div className="flex items-center gap-8">
+            <p className="font-medium">Bulk Operations</p>
+          </div>
+        </div>
+      }
+    >
+      <div className="container mx-auto space-y-6 py-6">
+        <BulkOperationsFilters
+          operation={operation}
+          operationValue={operationValue}
+          validationError={validationError}
+          skuCount={skus.length}
+          hasPreview={hasPreview}
+          onOperationChange={setOperation}
+          onOperationValueChange={setOperationValue}
+          onLoadProducts={handleLoadProductsWithReset}
+          onCalculatePreview={calculatePreview}
+          isLoading={isLoading}
+        />
+
+        {(noProductsFound || productsLoadedButNoSkus) && (
+          <EmptyState
+            icon={<SearchX className="w-10 h-10" />}
+            title="No products found"
+            description={
+              filterParams?.nameSearch
+                ? `No products matching "${filterParams.nameSearch}" were found. Try adjusting your filters.`
+                : "No products matched your filters. Try selecting a different category or clearing your filters."
+            }
+          />
+        )}
+
+        {hasPreview && previewRows.length > 0 && (
+          <BulkOperationsPreview
+            previewRows={previewRows}
+            excludedSkuIds={excludedSkuIds}
+            selectedCount={selectedPreviewRows.length}
+            validSelectedCount={validSelectedRows.length}
+            isApplying={isApplying}
+            onToggleExclusion={toggleSkuExclusion}
+            onSelectAll={selectAll}
+            onDeselectAll={deselectAll}
+            onApply={applyChanges}
+          />
+        )}
+      </div>
+    </View>
+  );
+}

--- a/packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.test.tsx
+++ b/packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.test.tsx
@@ -1,0 +1,227 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { BulkOperationsPreview } from "./BulkOperationsPreview";
+import type { PreviewRow } from "~/src/hooks/useBulkOperations";
+
+// Mock the currency formatter hook
+vi.mock("~/src/hooks/useGetCurrencyFormatter", () => ({
+  useGetCurrencyFormatter: () =>
+    new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "GHS",
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }),
+}));
+
+// Mock getProductName to return productName directly for test simplicity
+vi.mock("~/src/lib/productUtils", () => ({
+  getProductName: (item: any) => item.productName || "",
+}));
+
+const makeRow = (overrides: Partial<PreviewRow> = {}): PreviewRow => ({
+  skuId: "sku-1" as any,
+  productName: "Test Product",
+  sku: "SKU-001",
+  currentPricePesewas: 10000,
+  currentNetPricePesewas: 10000,
+  areProcessingFeesAbsorbed: true,
+  newNetPricePesewas: 20000,
+  newPricePesewas: 20000,
+  hasWarning: false,
+  ...overrides,
+});
+
+const defaultProps = {
+  excludedSkuIds: new Set<string>(),
+  selectedCount: 1,
+  validSelectedCount: 1,
+  isApplying: false,
+  onToggleExclusion: vi.fn(),
+  onSelectAll: vi.fn(),
+  onDeselectAll: vi.fn(),
+  onApply: vi.fn(),
+};
+
+describe("BulkOperationsPreview", () => {
+  it("renders correct number of data rows", () => {
+    const rows = [
+      makeRow({ skuId: "sku-1" as any, productName: "Product A" }),
+      makeRow({ skuId: "sku-2" as any, productName: "Product B" }),
+      makeRow({ skuId: "sku-3" as any, productName: "Product C" }),
+    ];
+
+    render(
+      <BulkOperationsPreview
+        {...defaultProps}
+        previewRows={rows}
+        selectedCount={3}
+        validSelectedCount={3}
+      />
+    );
+
+    expect(screen.getByText("Product A")).toBeInTheDocument();
+    expect(screen.getByText("Product B")).toBeInTheDocument();
+    expect(screen.getByText("Product C")).toBeInTheDocument();
+  });
+
+  it("renders nothing when previewRows is empty", () => {
+    const { container } = render(
+      <BulkOperationsPreview {...defaultProps} previewRows={[]} />
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("shows warning icon for rows with hasWarning", () => {
+    const rows = [
+      makeRow({
+        hasWarning: true,
+        newNetPricePesewas: -500,
+        newPricePesewas: -500,
+      }),
+    ];
+
+    render(<BulkOperationsPreview {...defaultProps} previewRows={rows} />);
+
+    // The warning count text should appear
+    expect(screen.getByText(/1 with invalid price/)).toBeInTheDocument();
+  });
+
+  it("disables Apply button when validSelectedCount is 0", () => {
+    const rows = [makeRow({ hasWarning: true })];
+
+    render(
+      <BulkOperationsPreview
+        {...defaultProps}
+        previewRows={rows}
+        selectedCount={0}
+        validSelectedCount={0}
+      />
+    );
+
+    const applyButton = screen.getByRole("button", {
+      name: /Apply Changes/,
+    });
+    expect(applyButton).toBeDisabled();
+  });
+
+  it("enables Apply button when there are valid selected rows", () => {
+    const rows = [makeRow()];
+
+    render(
+      <BulkOperationsPreview
+        {...defaultProps}
+        previewRows={rows}
+        selectedCount={1}
+        validSelectedCount={1}
+      />
+    );
+
+    const applyButton = screen.getByRole("button", {
+      name: /Apply Changes/,
+    });
+    expect(applyButton).not.toBeDisabled();
+  });
+
+  it("shows correct selected count in summary bar", () => {
+    const rows = [
+      makeRow({ skuId: "sku-1" as any }),
+      makeRow({ skuId: "sku-2" as any }),
+      makeRow({ skuId: "sku-3" as any }),
+    ];
+
+    render(
+      <BulkOperationsPreview
+        {...defaultProps}
+        previewRows={rows}
+        selectedCount={2}
+        validSelectedCount={2}
+      />
+    );
+
+    expect(screen.getByText("2 of 3 SKUs selected")).toBeInTheDocument();
+  });
+
+  it("calls onToggleExclusion when checkbox is clicked", async () => {
+    const onToggle = vi.fn();
+    const rows = [makeRow({ skuId: "sku-1" as any })];
+
+    render(
+      <BulkOperationsPreview
+        {...defaultProps}
+        previewRows={rows}
+        onToggleExclusion={onToggle}
+      />
+    );
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    // First checkbox is "select all", second is the row checkbox
+    await userEvent.click(checkboxes[1]);
+    expect(onToggle).toHaveBeenCalledWith("sku-1");
+  });
+
+  it("calls onApply when Apply button is clicked", async () => {
+    const onApply = vi.fn();
+    const rows = [makeRow()];
+
+    render(
+      <BulkOperationsPreview
+        {...defaultProps}
+        previewRows={rows}
+        onApply={onApply}
+      />
+    );
+
+    const applyButton = screen.getByRole("button", {
+      name: /Apply Changes/,
+    });
+    await userEvent.click(applyButton);
+    expect(onApply).toHaveBeenCalled();
+  });
+
+  it("shows loading state when isApplying is true", () => {
+    const rows = [makeRow()];
+
+    render(
+      <BulkOperationsPreview
+        {...defaultProps}
+        previewRows={rows}
+        isApplying={true}
+      />
+    );
+
+    expect(screen.getByText("Applying...")).toBeInTheDocument();
+  });
+
+  it("displays current and new prices correctly", () => {
+    const rows = [
+      makeRow({
+        currentNetPricePesewas: 10000,
+        newNetPricePesewas: 20000,
+      }),
+    ];
+
+    render(<BulkOperationsPreview {...defaultProps} previewRows={rows} />);
+
+    // 10000 pesewas = GHS 100, 20000 pesewas = GHS 200
+    // Use regex to match currency-formatted output flexibly
+    expect(screen.getByText(/100\.00/)).toBeInTheDocument();
+    expect(screen.getByText(/200\.00/)).toBeInTheDocument();
+  });
+
+  it("dims excluded rows", () => {
+    const rows = [makeRow({ skuId: "sku-1" as any })];
+
+    const { container } = render(
+      <BulkOperationsPreview
+        {...defaultProps}
+        previewRows={rows}
+        excludedSkuIds={new Set(["sku-1"])}
+      />
+    );
+
+    const tableRows = container.querySelectorAll("tbody tr");
+    expect(tableRows[0]).toHaveClass("opacity-50");
+  });
+});

--- a/packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.tsx
+++ b/packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.tsx
@@ -1,0 +1,267 @@
+import { useMemo, useState } from "react";
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  getPaginationRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Button } from "@/components/ui/button";
+import { AlertTriangle, ArrowRight, Loader2 } from "lucide-react";
+import { toDisplayAmount } from "~/convex/lib/currency";
+import { useGetCurrencyFormatter } from "~/src/hooks/useGetCurrencyFormatter";
+import { getProductName } from "~/src/lib/productUtils";
+import type { PreviewRow } from "~/src/hooks/useBulkOperations";
+
+interface BulkOperationsPreviewProps {
+  previewRows: PreviewRow[];
+  excludedSkuIds: Set<string>;
+  selectedCount: number;
+  validSelectedCount: number;
+  isApplying: boolean;
+  onToggleExclusion: (skuId: string) => void;
+  onSelectAll: () => void;
+  onDeselectAll: () => void;
+  onApply: () => void;
+}
+
+export function BulkOperationsPreview({
+  previewRows,
+  excludedSkuIds,
+  selectedCount,
+  validSelectedCount,
+  isApplying,
+  onToggleExclusion,
+  onSelectAll,
+  onDeselectAll,
+  onApply,
+}: BulkOperationsPreviewProps) {
+  const currencyFormatter = useGetCurrencyFormatter();
+
+  const formatPrice = (pesewas: number): string => {
+    const displayAmount = toDisplayAmount(pesewas);
+    return currencyFormatter.format(displayAmount);
+  };
+
+  const allSelected = excludedSkuIds.size === 0;
+  const noneSelected = excludedSkuIds.size === previewRows.length;
+
+  const columns = useMemo<ColumnDef<PreviewRow>[]>(
+    () => [
+      {
+        id: "select",
+        header: () => (
+          <Checkbox
+            checked={allSelected}
+            onCheckedChange={() => {
+              if (allSelected) {
+                onDeselectAll();
+              } else {
+                onSelectAll();
+              }
+            }}
+            aria-label="Select all"
+          />
+        ),
+        cell: ({ row }) => (
+          <Checkbox
+            checked={!excludedSkuIds.has(row.original.skuId)}
+            onCheckedChange={() => onToggleExclusion(row.original.skuId)}
+            aria-label={`Select ${row.original.productName}`}
+          />
+        ),
+        size: 40,
+      },
+      {
+        id: "productName",
+        header: "Product",
+        cell: ({ row }) =>
+          getProductName({
+            productName: row.original.productName,
+            productCategory: row.original.productCategory,
+            colorName: row.original.colorName,
+            length: row.original.length,
+          }),
+      },
+      {
+        accessorKey: "sku",
+        header: "SKU",
+      },
+      {
+        id: "variant",
+        header: "Variant",
+        cell: ({ row }) => {
+          const parts = [row.original.colorName, row.original.size].filter(
+            Boolean
+          );
+          return parts.length > 0 ? parts.join(" / ") : "-";
+        },
+      },
+      {
+        id: "currentPrice",
+        header: "Current Price",
+        cell: ({ row }) => formatPrice(row.original.currentNetPricePesewas),
+      },
+      {
+        id: "arrow",
+        header: "",
+        cell: () => <ArrowRight className="w-4 h-4 text-muted-foreground" />,
+        size: 40,
+      },
+      {
+        id: "newPrice",
+        header: "New Price",
+        cell: ({ row }) => {
+          const { newNetPricePesewas, hasWarning } = row.original;
+          return (
+            <div className="flex items-center gap-2">
+              <span className={hasWarning ? "text-destructive font-medium" : ""}>
+                {formatPrice(newNetPricePesewas)}
+              </span>
+              {hasWarning && (
+                <AlertTriangle className="w-4 h-4 text-destructive" />
+              )}
+            </div>
+          );
+        },
+      },
+    ],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [excludedSkuIds, allSelected, onSelectAll, onDeselectAll, onToggleExclusion, currencyFormatter]
+  );
+
+  const table = useReactTable({
+    data: previewRows,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    initialState: {
+      pagination: { pageSize: 20 },
+    },
+  });
+
+  if (previewRows.length === 0) return null;
+
+  const warningCount = previewRows.filter((r) => r.hasWarning).length;
+
+  return (
+    <div className="space-y-4 border rounded-lg">
+      <div className="rounded-md">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <TableHead key={header.id}>
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext()
+                        )}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow
+                  key={row.id}
+                  className={
+                    excludedSkuIds.has(row.original.skuId) ? "opacity-50" : ""
+                  }
+                >
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext()
+                      )}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell
+                  colSpan={columns.length}
+                  className="h-24 text-center"
+                >
+                  No results.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Pagination */}
+      {table.getPageCount() > 1 && (
+        <div className="flex items-center justify-between px-6 py-2">
+          <p className="text-sm text-muted-foreground">
+            Page {table.getState().pagination.pageIndex + 1} of{" "}
+            {table.getPageCount()}
+          </p>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => table.previousPage()}
+              disabled={!table.getCanPreviousPage()}
+            >
+              Previous
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => table.nextPage()}
+              disabled={!table.getCanNextPage()}
+            >
+              Next
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* Summary Bar */}
+      <div className="flex items-center justify-between px-6 py-4 border-t bg-muted/50 rounded-b-lg">
+        <div className="flex items-center gap-4">
+          <p className="text-sm font-medium">
+            {selectedCount} of {previewRows.length} SKU
+            {previewRows.length !== 1 ? "s" : ""} selected
+          </p>
+          {warningCount > 0 && (
+            <p className="text-sm text-destructive flex items-center gap-1">
+              <AlertTriangle className="w-4 h-4" />
+              {warningCount} with invalid price (will be skipped)
+            </p>
+          )}
+        </div>
+        <Button
+          onClick={onApply}
+          disabled={validSelectedCount === 0 || isApplying}
+        >
+          {isApplying ? (
+            <>
+              <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+              Applying...
+            </>
+          ) : (
+            `Apply Changes (${validSelectedCount})`
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/athena-webapp/src/hooks/useBulkOperations.test.ts
+++ b/packages/athena-webapp/src/hooks/useBulkOperations.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyOperation,
+  calculatePriceWithFee,
+  computePreview,
+  validateOperationValue,
+  type SkuRow,
+} from "./useBulkOperations";
+
+// --- applyOperation ---
+
+describe("applyOperation", () => {
+  describe("multiply", () => {
+    it("multiplies the price by the given value", () => {
+      expect(applyOperation("multiply", 100, 2)).toBe(200);
+    });
+
+    it("handles decimal multipliers", () => {
+      expect(applyOperation("multiply", 100, 0.5)).toBe(50);
+    });
+
+    it("returns null for zero value", () => {
+      expect(applyOperation("multiply", 100, 0)).toBeNull();
+    });
+
+    it("returns null for negative value", () => {
+      expect(applyOperation("multiply", 100, -1)).toBeNull();
+    });
+  });
+
+  describe("divide", () => {
+    it("divides the price by the given value", () => {
+      expect(applyOperation("divide", 200, 2)).toBe(100);
+    });
+
+    it("handles division resulting in decimals", () => {
+      expect(applyOperation("divide", 100, 3)).toBeCloseTo(33.333, 2);
+    });
+
+    it("returns null for zero value (divide by zero)", () => {
+      expect(applyOperation("divide", 100, 0)).toBeNull();
+    });
+
+    it("returns null for negative value", () => {
+      expect(applyOperation("divide", 100, -2)).toBeNull();
+    });
+  });
+
+  describe("set", () => {
+    it("sets the price to the given value", () => {
+      expect(applyOperation("set", 100, 50)).toBe(50);
+    });
+
+    it("allows setting to zero", () => {
+      expect(applyOperation("set", 100, 0)).toBe(0);
+    });
+  });
+
+  describe("increase_percent", () => {
+    it("increases price by percentage", () => {
+      expect(applyOperation("increase_percent", 100, 15)).toBeCloseTo(115);
+    });
+
+    it("handles 100% increase", () => {
+      expect(applyOperation("increase_percent", 50, 100)).toBe(100);
+    });
+  });
+
+  describe("decrease_percent", () => {
+    it("decreases price by percentage", () => {
+      expect(applyOperation("decrease_percent", 100, 25)).toBe(75);
+    });
+
+    it("handles 100% decrease (results in zero)", () => {
+      expect(applyOperation("decrease_percent", 100, 100)).toBe(0);
+    });
+
+    it("can result in negative for >100% decrease", () => {
+      expect(applyOperation("decrease_percent", 100, 150)).toBe(-50);
+    });
+  });
+
+  describe("increase_fixed", () => {
+    it("adds a fixed amount to the price", () => {
+      expect(applyOperation("increase_fixed", 100, 20)).toBe(120);
+    });
+  });
+
+  describe("decrease_fixed", () => {
+    it("subtracts a fixed amount from the price", () => {
+      expect(applyOperation("decrease_fixed", 100, 20)).toBe(80);
+    });
+
+    it("can result in negative", () => {
+      expect(applyOperation("decrease_fixed", 10, 20)).toBe(-10);
+    });
+  });
+});
+
+// --- calculatePriceWithFee ---
+
+describe("calculatePriceWithFee", () => {
+  it("returns the net price when fees are absorbed", () => {
+    expect(calculatePriceWithFee(100, true)).toBe(100);
+  });
+
+  it("adds processing fee when not absorbed", () => {
+    // PAYSTACK_PROCESSING_FEE is 1.95%
+    // 100 + (100 * 1.95 / 100) = 100 + 1.95 = 101.95, rounded to 102
+    expect(calculatePriceWithFee(100, false)).toBe(102);
+  });
+
+  it("rounds the fee result", () => {
+    // 50 + (50 * 1.95 / 100) = 50 + 0.975 = 50.975, rounded to 51
+    expect(calculatePriceWithFee(50, false)).toBe(51);
+  });
+
+  it("handles zero price", () => {
+    expect(calculatePriceWithFee(0, false)).toBe(0);
+    expect(calculatePriceWithFee(0, true)).toBe(0);
+  });
+});
+
+// --- validateOperationValue ---
+
+describe("validateOperationValue", () => {
+  it("returns null for valid multiply value", () => {
+    expect(validateOperationValue("multiply", 2)).toBeNull();
+  });
+
+  it("returns error for zero multiply value", () => {
+    expect(validateOperationValue("multiply", 0)).toBe(
+      "Value must be greater than 0"
+    );
+  });
+
+  it("returns error for negative divide value", () => {
+    expect(validateOperationValue("divide", -1)).toBe(
+      "Value must be greater than 0"
+    );
+  });
+
+  it("returns error for NaN", () => {
+    expect(validateOperationValue("set", NaN)).toBe(
+      "Please enter a valid number"
+    );
+  });
+
+  it("returns error for negative set value", () => {
+    expect(validateOperationValue("set", -5)).toBe("Price cannot be negative");
+  });
+
+  it("allows zero for set", () => {
+    expect(validateOperationValue("set", 0)).toBeNull();
+  });
+
+  it("allows any value for increase/decrease operations", () => {
+    expect(validateOperationValue("increase_percent", 50)).toBeNull();
+    expect(validateOperationValue("decrease_percent", 50)).toBeNull();
+    expect(validateOperationValue("increase_fixed", 10)).toBeNull();
+    expect(validateOperationValue("decrease_fixed", 10)).toBeNull();
+  });
+});
+
+// --- computePreview ---
+
+describe("computePreview", () => {
+  const makeSku = (
+    overrides: Partial<SkuRow> = {}
+  ): SkuRow => ({
+    skuId: "test-sku-1" as any,
+    productName: "Test Product",
+    sku: "SKU-001",
+    currentPricePesewas: 10000, // 100.00 display
+    currentNetPricePesewas: 10000,
+    areProcessingFeesAbsorbed: true,
+    ...overrides,
+  });
+
+  it("computes correct preview for multiply operation", () => {
+    const skus = [makeSku()];
+    const result = computePreview(skus, "multiply", 2);
+
+    expect(result).toHaveLength(1);
+    // 100 * 2 = 200 display = 20000 pesewas
+    expect(result[0].newNetPricePesewas).toBe(20000);
+    expect(result[0].hasWarning).toBe(false);
+  });
+
+  it("computes correct preview for divide operation", () => {
+    const skus = [makeSku()];
+    const result = computePreview(skus, "divide", 100);
+
+    // 100 / 100 = 1.00 display = 100 pesewas
+    expect(result[0].newNetPricePesewas).toBe(100);
+    expect(result[0].hasWarning).toBe(false);
+  });
+
+  it("computes correct preview for set operation", () => {
+    const skus = [makeSku()];
+    const result = computePreview(skus, "set", 50);
+
+    // Set to 50 display = 5000 pesewas
+    expect(result[0].newNetPricePesewas).toBe(5000);
+    expect(result[0].hasWarning).toBe(false);
+  });
+
+  it("flags negative results with warning", () => {
+    const skus = [makeSku({ currentNetPricePesewas: 1000 })]; // 10.00 display
+    const result = computePreview(skus, "decrease_fixed", 20);
+
+    // 10 - 20 = -10 display = -1000 pesewas
+    expect(result[0].newNetPricePesewas).toBe(-1000);
+    expect(result[0].hasWarning).toBe(true);
+  });
+
+  it("flags zero results with warning", () => {
+    const skus = [makeSku()];
+    const result = computePreview(skus, "decrease_percent", 100);
+
+    // 100 - 100% = 0
+    expect(result[0].newNetPricePesewas).toBe(0);
+    expect(result[0].hasWarning).toBe(true);
+  });
+
+  it("applies processing fees when not absorbed", () => {
+    const skus = [makeSku({ areProcessingFeesAbsorbed: false })];
+    const result = computePreview(skus, "set", 100);
+
+    // netPrice = 100 display = 10000 pesewas
+    expect(result[0].newNetPricePesewas).toBe(10000);
+    // price = 100 + 1.95% = 101.95 rounded to 102 = 10200 pesewas
+    expect(result[0].newPricePesewas).toBe(10200);
+  });
+
+  it("handles multiple SKUs", () => {
+    const skus = [
+      makeSku({ skuId: "sku-1" as any, currentNetPricePesewas: 10000 }),
+      makeSku({ skuId: "sku-2" as any, currentNetPricePesewas: 20000 }),
+    ];
+    const result = computePreview(skus, "multiply", 2);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].newNetPricePesewas).toBe(20000);
+    expect(result[1].newNetPricePesewas).toBe(40000);
+  });
+
+  it("handles invalid operation (divide by zero)", () => {
+    const skus = [makeSku()];
+    const result = computePreview(skus, "divide", 0);
+
+    expect(result[0].hasWarning).toBe(true);
+    // Falls back to current prices
+    expect(result[0].newNetPricePesewas).toBe(10000);
+  });
+});

--- a/packages/athena-webapp/src/hooks/useBulkOperations.ts
+++ b/packages/athena-webapp/src/hooks/useBulkOperations.ts
@@ -1,0 +1,313 @@
+import { useState, useMemo, useCallback } from "react";
+import { useMutation } from "convex/react";
+import { api } from "~/convex/_generated/api";
+import { Id } from "~/convex/_generated/dataModel";
+import { toPesewas, toDisplayAmount } from "~/convex/lib/currency";
+import { PAYSTACK_PROCESSING_FEE } from "~/src/lib/constants";
+import { toast } from "sonner";
+
+// --- Types ---
+
+export type BulkOperationType =
+  | "multiply"
+  | "divide"
+  | "set"
+  | "increase_percent"
+  | "decrease_percent"
+  | "increase_fixed"
+  | "decrease_fixed";
+
+export interface SkuRow {
+  skuId: Id<"productSku">;
+  productName: string;
+  productCategory?: string;
+  sku: string;
+  colorName?: string;
+  size?: string;
+  length?: number;
+  currentPricePesewas: number;
+  currentNetPricePesewas: number;
+  areProcessingFeesAbsorbed: boolean;
+}
+
+export interface PreviewRow extends SkuRow {
+  newNetPricePesewas: number;
+  newPricePesewas: number;
+  hasWarning: boolean;
+}
+
+export const OPERATION_LABELS: Record<BulkOperationType, string> = {
+  multiply: "Multiply by",
+  divide: "Divide by",
+  set: "Set to",
+  increase_percent: "Increase by %",
+  decrease_percent: "Decrease by %",
+  increase_fixed: "Increase by fixed amount",
+  decrease_fixed: "Decrease by fixed amount",
+};
+
+// --- Pure calculation functions (exported for testing) ---
+
+/**
+ * Apply a bulk operation to a display-amount price.
+ * Input and output are in display units (e.g. GHS, not pesewas).
+ * Returns the new display-amount, or null if the operation is invalid.
+ */
+export function applyOperation(
+  operation: BulkOperationType,
+  currentDisplayPrice: number,
+  value: number
+): number | null {
+  switch (operation) {
+    case "multiply":
+      if (value <= 0) return null;
+      return currentDisplayPrice * value;
+    case "divide":
+      if (value <= 0) return null;
+      return currentDisplayPrice / value;
+    case "set":
+      return value;
+    case "increase_percent":
+      return currentDisplayPrice * (1 + value / 100);
+    case "decrease_percent":
+      return currentDisplayPrice * (1 - value / 100);
+    case "increase_fixed":
+      return currentDisplayPrice + value;
+    case "decrease_fixed":
+      return currentDisplayPrice - value;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Calculate the final price (with processing fee) from a net price.
+ * Both input and output are in display units.
+ */
+export function calculatePriceWithFee(
+  netDisplayPrice: number,
+  areProcessingFeesAbsorbed: boolean
+): number {
+  if (areProcessingFeesAbsorbed) {
+    return netDisplayPrice;
+  }
+  const fee = (netDisplayPrice * PAYSTACK_PROCESSING_FEE) / 100;
+  return Math.round(netDisplayPrice + fee);
+}
+
+/**
+ * Compute preview rows from SKU data, an operation, and a value.
+ */
+export function computePreview(
+  skus: SkuRow[],
+  operation: BulkOperationType,
+  value: number
+): PreviewRow[] {
+  return skus.map((sku) => {
+    const currentNetDisplay = toDisplayAmount(sku.currentNetPricePesewas);
+    const newNetDisplay = applyOperation(operation, currentNetDisplay, value);
+
+    if (newNetDisplay === null) {
+      return {
+        ...sku,
+        newNetPricePesewas: sku.currentNetPricePesewas,
+        newPricePesewas: sku.currentPricePesewas,
+        hasWarning: true,
+      };
+    }
+
+    const newPriceDisplay = calculatePriceWithFee(
+      newNetDisplay,
+      sku.areProcessingFeesAbsorbed
+    );
+
+    const newNetPesewas = toPesewas(newNetDisplay);
+    const newPricePesewas = toPesewas(newPriceDisplay);
+
+    return {
+      ...sku,
+      newNetPricePesewas: newNetPesewas,
+      newPricePesewas: newPricePesewas,
+      hasWarning: newNetPesewas <= 0,
+    };
+  });
+}
+
+/**
+ * Validate that the operation value is acceptable.
+ */
+export function validateOperationValue(
+  operation: BulkOperationType,
+  value: number
+): string | null {
+  if (isNaN(value)) return "Please enter a valid number";
+
+  if (operation === "multiply" || operation === "divide") {
+    if (value <= 0) return "Value must be greater than 0";
+  }
+
+  if (operation === "set" && value < 0) {
+    return "Price cannot be negative";
+  }
+
+  return null;
+}
+
+// --- Hook ---
+
+export function useBulkOperations() {
+  const [skus, setSkus] = useState<SkuRow[]>([]);
+  const [operation, setOperation] = useState<BulkOperationType>("multiply");
+  const [operationValue, setOperationValue] = useState<string>("");
+  const [excludedSkuIds, setExcludedSkuIds] = useState<Set<string>>(new Set());
+  const [isApplying, setIsApplying] = useState(false);
+  const [hasPreview, setHasPreview] = useState(false);
+
+  const batchUpdateSkuPrices = useMutation(
+    api.inventory.products.batchUpdateSkuPrices
+  );
+
+  const parsedValue = parseFloat(operationValue);
+  const validationError = isNaN(parsedValue)
+    ? operationValue.length > 0
+      ? "Please enter a valid number"
+      : null
+    : validateOperationValue(operation, parsedValue);
+
+  const previewRows = useMemo(() => {
+    if (!hasPreview || isNaN(parsedValue) || validationError) return [];
+    return computePreview(skus, operation, parsedValue);
+  }, [skus, operation, parsedValue, hasPreview, validationError]);
+
+  const selectedPreviewRows = useMemo(
+    () => previewRows.filter((row) => !excludedSkuIds.has(row.skuId)),
+    [previewRows, excludedSkuIds]
+  );
+
+  const validSelectedRows = useMemo(
+    () => selectedPreviewRows.filter((row) => !row.hasWarning),
+    [selectedPreviewRows]
+  );
+
+  const loadSkus = useCallback(
+    (
+      products: Array<{
+        name: string;
+        categoryName?: string;
+        areProcessingFeesAbsorbed?: boolean;
+        skus: Array<{
+          _id: Id<"productSku">;
+          sku?: string;
+          colorName?: string;
+          size?: string;
+          length?: number;
+          price: number;
+          netPrice?: number;
+        }>;
+      }>
+    ) => {
+      const rows: SkuRow[] = products.flatMap((product) =>
+        product.skus.map((sku) => ({
+          skuId: sku._id,
+          productName: product.name,
+          productCategory: product.categoryName,
+          sku: sku.sku || "",
+          colorName: sku.colorName,
+          size: sku.size,
+          length: sku.length,
+          currentPricePesewas: sku.price,
+          currentNetPricePesewas: sku.netPrice ?? sku.price,
+          areProcessingFeesAbsorbed: product.areProcessingFeesAbsorbed ?? true,
+        }))
+      );
+      setSkus(rows);
+      setExcludedSkuIds(new Set());
+      setHasPreview(false);
+    },
+    []
+  );
+
+  const calculatePreview = useCallback(() => {
+    setHasPreview(true);
+  }, []);
+
+  const toggleSkuExclusion = useCallback((skuId: string) => {
+    setExcludedSkuIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(skuId)) {
+        next.delete(skuId);
+      } else {
+        next.add(skuId);
+      }
+      return next;
+    });
+  }, []);
+
+  const selectAll = useCallback(() => {
+    setExcludedSkuIds(new Set());
+  }, []);
+
+  const deselectAll = useCallback(() => {
+    setExcludedSkuIds(new Set(skus.map((s) => s.skuId)));
+  }, [skus]);
+
+  const applyChanges = useCallback(async () => {
+    if (validSelectedRows.length === 0) return;
+
+    setIsApplying(true);
+    try {
+      const updates = validSelectedRows.map((row) => ({
+        id: row.skuId,
+        price: row.newPricePesewas,
+        netPrice: row.newNetPricePesewas,
+      }));
+
+      const result = await batchUpdateSkuPrices({ updates });
+
+      if (result.success) {
+        toast.success(
+          `Updated ${result.updatedCount} SKU${result.updatedCount !== 1 ? "s" : ""} successfully`
+        );
+        // Reset state
+        setSkus([]);
+        setHasPreview(false);
+        setOperationValue("");
+        setExcludedSkuIds(new Set());
+      } else {
+        toast.error(
+          `${result.updatedCount} updated, ${result.failedCount} failed`
+        );
+      }
+    } catch (error) {
+      toast.error("Failed to apply bulk update", {
+        description: (error as Error).message,
+      });
+    } finally {
+      setIsApplying(false);
+    }
+  }, [validSelectedRows, batchUpdateSkuPrices]);
+
+  return {
+    // State
+    skus,
+    operation,
+    operationValue,
+    excludedSkuIds,
+    isApplying,
+    hasPreview,
+    previewRows,
+    selectedPreviewRows,
+    validSelectedRows,
+    validationError,
+
+    // Actions
+    setOperation,
+    setOperationValue,
+    loadSkus,
+    calculatePreview,
+    toggleSkuExclusion,
+    selectAll,
+    deselectAll,
+    applyChanges,
+  };
+}

--- a/packages/athena-webapp/src/routeTree.gen.ts
+++ b/packages/athena-webapp/src/routeTree.gen.ts
@@ -32,6 +32,7 @@ import { Route as AuthedOrgUrlSlugStoreStoreUrlSlugLogsIndexRouteImport } from '
 import { Route as AuthedOrgUrlSlugStoreStoreUrlSlugDashboardIndexRouteImport } from './routes/_authed/$orgUrlSlug/store/$storeUrlSlug/dashboard.index'
 import { Route as AuthedOrgUrlSlugStoreStoreUrlSlugConfigurationIndexRouteImport } from './routes/_authed/$orgUrlSlug/store/$storeUrlSlug/configuration.index'
 import { Route as AuthedOrgUrlSlugStoreStoreUrlSlugCheckoutSessionsIndexRouteImport } from './routes/_authed/$orgUrlSlug/store/$storeUrlSlug/checkout-sessions.index'
+import { Route as AuthedOrgUrlSlugStoreStoreUrlSlugBulkOperationsIndexRouteImport } from './routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bulk-operations/index'
 import { Route as AuthedOrgUrlSlugStoreStoreUrlSlugBagsIndexRouteImport } from './routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.index'
 import { Route as AuthedOrgUrlSlugStoreStoreUrlSlugAssetsIndexRouteImport } from './routes/_authed/$orgUrlSlug/store/$storeUrlSlug/assets.index'
 import { Route as AuthedOrgUrlSlugStoreStoreUrlSlugUsersUserIdRouteImport } from './routes/_authed/$orgUrlSlug/store/$storeUrlSlug/users.$userId'
@@ -192,6 +193,12 @@ const AuthedOrgUrlSlugStoreStoreUrlSlugCheckoutSessionsIndexRoute =
   AuthedOrgUrlSlugStoreStoreUrlSlugCheckoutSessionsIndexRouteImport.update({
     id: '/$orgUrlSlug/store/$storeUrlSlug/checkout-sessions/',
     path: '/$orgUrlSlug/store/$storeUrlSlug/checkout-sessions/',
+    getParentRoute: () => AuthedRoute,
+  } as any)
+const AuthedOrgUrlSlugStoreStoreUrlSlugBulkOperationsIndexRoute =
+  AuthedOrgUrlSlugStoreStoreUrlSlugBulkOperationsIndexRouteImport.update({
+    id: '/$orgUrlSlug/store/$storeUrlSlug/bulk-operations/',
+    path: '/$orgUrlSlug/store/$storeUrlSlug/bulk-operations/',
     getParentRoute: () => AuthedRoute,
   } as any)
 const AuthedOrgUrlSlugStoreStoreUrlSlugBagsIndexRoute =
@@ -401,6 +408,7 @@ export interface FileRoutesByFullPath {
   '/$orgUrlSlug/store/$storeUrlSlug/users/$userId': typeof AuthedOrgUrlSlugStoreStoreUrlSlugUsersUserIdRoute
   '/$orgUrlSlug/store/$storeUrlSlug/assets/': typeof AuthedOrgUrlSlugStoreStoreUrlSlugAssetsIndexRoute
   '/$orgUrlSlug/store/$storeUrlSlug/bags/': typeof AuthedOrgUrlSlugStoreStoreUrlSlugBagsIndexRoute
+  '/$orgUrlSlug/store/$storeUrlSlug/bulk-operations/': typeof AuthedOrgUrlSlugStoreStoreUrlSlugBulkOperationsIndexRoute
   '/$orgUrlSlug/store/$storeUrlSlug/checkout-sessions/': typeof AuthedOrgUrlSlugStoreStoreUrlSlugCheckoutSessionsIndexRoute
   '/$orgUrlSlug/store/$storeUrlSlug/configuration/': typeof AuthedOrgUrlSlugStoreStoreUrlSlugConfigurationIndexRoute
   '/$orgUrlSlug/store/$storeUrlSlug/dashboard/': typeof AuthedOrgUrlSlugStoreStoreUrlSlugDashboardIndexRoute
@@ -454,6 +462,7 @@ export interface FileRoutesByTo {
   '/$orgUrlSlug/store/$storeUrlSlug/users/$userId': typeof AuthedOrgUrlSlugStoreStoreUrlSlugUsersUserIdRoute
   '/$orgUrlSlug/store/$storeUrlSlug/assets': typeof AuthedOrgUrlSlugStoreStoreUrlSlugAssetsIndexRoute
   '/$orgUrlSlug/store/$storeUrlSlug/bags': typeof AuthedOrgUrlSlugStoreStoreUrlSlugBagsIndexRoute
+  '/$orgUrlSlug/store/$storeUrlSlug/bulk-operations': typeof AuthedOrgUrlSlugStoreStoreUrlSlugBulkOperationsIndexRoute
   '/$orgUrlSlug/store/$storeUrlSlug/checkout-sessions': typeof AuthedOrgUrlSlugStoreStoreUrlSlugCheckoutSessionsIndexRoute
   '/$orgUrlSlug/store/$storeUrlSlug/configuration': typeof AuthedOrgUrlSlugStoreStoreUrlSlugConfigurationIndexRoute
   '/$orgUrlSlug/store/$storeUrlSlug/dashboard': typeof AuthedOrgUrlSlugStoreStoreUrlSlugDashboardIndexRoute
@@ -510,6 +519,7 @@ export interface FileRoutesById {
   '/_authed/$orgUrlSlug/store/$storeUrlSlug/users/$userId': typeof AuthedOrgUrlSlugStoreStoreUrlSlugUsersUserIdRoute
   '/_authed/$orgUrlSlug/store/$storeUrlSlug/assets/': typeof AuthedOrgUrlSlugStoreStoreUrlSlugAssetsIndexRoute
   '/_authed/$orgUrlSlug/store/$storeUrlSlug/bags/': typeof AuthedOrgUrlSlugStoreStoreUrlSlugBagsIndexRoute
+  '/_authed/$orgUrlSlug/store/$storeUrlSlug/bulk-operations/': typeof AuthedOrgUrlSlugStoreStoreUrlSlugBulkOperationsIndexRoute
   '/_authed/$orgUrlSlug/store/$storeUrlSlug/checkout-sessions/': typeof AuthedOrgUrlSlugStoreStoreUrlSlugCheckoutSessionsIndexRoute
   '/_authed/$orgUrlSlug/store/$storeUrlSlug/configuration/': typeof AuthedOrgUrlSlugStoreStoreUrlSlugConfigurationIndexRoute
   '/_authed/$orgUrlSlug/store/$storeUrlSlug/dashboard/': typeof AuthedOrgUrlSlugStoreStoreUrlSlugDashboardIndexRoute
@@ -566,6 +576,7 @@ export interface FileRouteTypes {
     | '/$orgUrlSlug/store/$storeUrlSlug/users/$userId'
     | '/$orgUrlSlug/store/$storeUrlSlug/assets/'
     | '/$orgUrlSlug/store/$storeUrlSlug/bags/'
+    | '/$orgUrlSlug/store/$storeUrlSlug/bulk-operations/'
     | '/$orgUrlSlug/store/$storeUrlSlug/checkout-sessions/'
     | '/$orgUrlSlug/store/$storeUrlSlug/configuration/'
     | '/$orgUrlSlug/store/$storeUrlSlug/dashboard/'
@@ -619,6 +630,7 @@ export interface FileRouteTypes {
     | '/$orgUrlSlug/store/$storeUrlSlug/users/$userId'
     | '/$orgUrlSlug/store/$storeUrlSlug/assets'
     | '/$orgUrlSlug/store/$storeUrlSlug/bags'
+    | '/$orgUrlSlug/store/$storeUrlSlug/bulk-operations'
     | '/$orgUrlSlug/store/$storeUrlSlug/checkout-sessions'
     | '/$orgUrlSlug/store/$storeUrlSlug/configuration'
     | '/$orgUrlSlug/store/$storeUrlSlug/dashboard'
@@ -674,6 +686,7 @@ export interface FileRouteTypes {
     | '/_authed/$orgUrlSlug/store/$storeUrlSlug/users/$userId'
     | '/_authed/$orgUrlSlug/store/$storeUrlSlug/assets/'
     | '/_authed/$orgUrlSlug/store/$storeUrlSlug/bags/'
+    | '/_authed/$orgUrlSlug/store/$storeUrlSlug/bulk-operations/'
     | '/_authed/$orgUrlSlug/store/$storeUrlSlug/checkout-sessions/'
     | '/_authed/$orgUrlSlug/store/$storeUrlSlug/configuration/'
     | '/_authed/$orgUrlSlug/store/$storeUrlSlug/dashboard/'
@@ -875,6 +888,13 @@ declare module '@tanstack/react-router' {
       path: '/$orgUrlSlug/store/$storeUrlSlug/checkout-sessions'
       fullPath: '/$orgUrlSlug/store/$storeUrlSlug/checkout-sessions/'
       preLoaderRoute: typeof AuthedOrgUrlSlugStoreStoreUrlSlugCheckoutSessionsIndexRouteImport
+      parentRoute: typeof AuthedRoute
+    }
+    '/_authed/$orgUrlSlug/store/$storeUrlSlug/bulk-operations/': {
+      id: '/_authed/$orgUrlSlug/store/$storeUrlSlug/bulk-operations/'
+      path: '/$orgUrlSlug/store/$storeUrlSlug/bulk-operations'
+      fullPath: '/$orgUrlSlug/store/$storeUrlSlug/bulk-operations/'
+      preLoaderRoute: typeof AuthedOrgUrlSlugStoreStoreUrlSlugBulkOperationsIndexRouteImport
       parentRoute: typeof AuthedRoute
     }
     '/_authed/$orgUrlSlug/store/$storeUrlSlug/bags/': {
@@ -1108,6 +1128,7 @@ interface AuthedRouteChildren {
   AuthedOrgUrlSlugStoreStoreUrlSlugUsersUserIdRoute: typeof AuthedOrgUrlSlugStoreStoreUrlSlugUsersUserIdRoute
   AuthedOrgUrlSlugStoreStoreUrlSlugAssetsIndexRoute: typeof AuthedOrgUrlSlugStoreStoreUrlSlugAssetsIndexRoute
   AuthedOrgUrlSlugStoreStoreUrlSlugBagsIndexRoute: typeof AuthedOrgUrlSlugStoreStoreUrlSlugBagsIndexRoute
+  AuthedOrgUrlSlugStoreStoreUrlSlugBulkOperationsIndexRoute: typeof AuthedOrgUrlSlugStoreStoreUrlSlugBulkOperationsIndexRoute
   AuthedOrgUrlSlugStoreStoreUrlSlugCheckoutSessionsIndexRoute: typeof AuthedOrgUrlSlugStoreStoreUrlSlugCheckoutSessionsIndexRoute
   AuthedOrgUrlSlugStoreStoreUrlSlugConfigurationIndexRoute: typeof AuthedOrgUrlSlugStoreStoreUrlSlugConfigurationIndexRoute
   AuthedOrgUrlSlugStoreStoreUrlSlugDashboardIndexRoute: typeof AuthedOrgUrlSlugStoreStoreUrlSlugDashboardIndexRoute
@@ -1173,6 +1194,8 @@ const AuthedRouteChildren: AuthedRouteChildren = {
     AuthedOrgUrlSlugStoreStoreUrlSlugAssetsIndexRoute,
   AuthedOrgUrlSlugStoreStoreUrlSlugBagsIndexRoute:
     AuthedOrgUrlSlugStoreStoreUrlSlugBagsIndexRoute,
+  AuthedOrgUrlSlugStoreStoreUrlSlugBulkOperationsIndexRoute:
+    AuthedOrgUrlSlugStoreStoreUrlSlugBulkOperationsIndexRoute,
   AuthedOrgUrlSlugStoreStoreUrlSlugCheckoutSessionsIndexRoute:
     AuthedOrgUrlSlugStoreStoreUrlSlugCheckoutSessionsIndexRoute,
   AuthedOrgUrlSlugStoreStoreUrlSlugConfigurationIndexRoute:

--- a/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bulk-operations/index.tsx
+++ b/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bulk-operations/index.tsx
@@ -1,0 +1,8 @@
+import { createFileRoute } from "@tanstack/react-router";
+import BulkOperationsPage from "~/src/components/bulk-operations/BulkOperationsPage";
+
+export const Route = createFileRoute(
+  "/_authed/$orgUrlSlug/store/$storeUrlSlug/bulk-operations/",
+)({
+  component: BulkOperationsPage,
+});

--- a/packages/athena-webapp/vitest.config.ts
+++ b/packages/athena-webapp/vitest.config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
+      "~": path.resolve(__dirname),
     },
   },
 });


### PR DESCRIPTION
## Summary
- Adds a dedicated **Bulk Operations** admin page (`/bulk-operations`) for batch-updating SKU prices
- Two-panel UI: filter/select products in the top panel, preview current→new prices per SKU in the bottom panel with the ability to exclude individual rows before applying
- Supports 7 operations: multiply, divide, set to fixed, increase/decrease by percentage, increase/decrease by fixed amount
- Uses `getProductName` for proper product name formatting and store currency formatter for price display
- Empty state handled when no products match filters

## What's included
- **Backend**: `batchUpdateSkuPrices` Convex mutation in `convex/inventory/products.ts`
- **Hook**: `useBulkOperations` with extracted pure calculation functions (`applyOperation`, `computePreview`, `calculatePriceWithFee`, `validateOperationValue`)
- **Components**: `BulkOperationsPage`, `BulkOperationsFilters`, `BulkOperationsPreview`
- **Route**: `/_authed/$orgUrlSlug/store/$storeUrlSlug/bulk-operations/`
- **Navigation**: Sidebar link gated behind `hasFullAdminAccess`
- **Tests**: 48 tests (37 unit + 11 component) — all passing

## Test plan
- [ ] Navigate to Bulk Operations from the admin sidebar
- [ ] Filter by category and/or product name — verify correct products load
- [ ] Select "Divide by 100" — verify preview shows correct current→new prices
- [ ] Uncheck a few SKUs — verify they're excluded from the count
- [ ] Apply — verify prices updated in database
- [ ] Navigate to an individual product edit page — confirm prices match
- [ ] Test empty state: filter with no matches — verify empty state message appears
- [ ] Test edge cases: zero/negative price results show warning icons, Apply button disabled when no valid SKUs selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)