### PR TITLE
Fix order email item prices not converting from pesewas

### DIFF
--- a/packages/athena-webapp/convex/storeFront/onlineOrderUtilFns.ts
+++ b/packages/athena-webapp/convex/storeFront/onlineOrderUtilFns.ts
@@ -60,11 +60,18 @@ export const formatOrderItems = (
     return {
       text: capitalizeWords(item.productName || ""),
       image: item.productImage || "",
-      price: originalPrice === 0 ? "Free" : formatter.format(originalPrice),
+      price:
+        originalPrice === 0
+          ? "Free"
+          : formatter.format(toDisplayAmount(originalPrice)),
       discountedPrice:
-        itemDiscount > 0 ? formatter.format(discountedPrice) : undefined,
+        itemDiscount > 0
+          ? formatter.format(toDisplayAmount(discountedPrice))
+          : undefined,
       savings:
-        totalItemSavings > 0 ? formatter.format(totalItemSavings) : undefined,
+        totalItemSavings > 0
+          ? formatter.format(toDisplayAmount(totalItemSavings))
+          : undefined,
       quantity: String(item.quantity || 0),
       color: item.colorName || "",
       length: item.length ? `${item.length} inches` : undefined,


### PR DESCRIPTION
## Summary
- Fixes item prices in order emails showing raw pesewas values (e.g. "GHS 2,000") instead of display amounts (e.g. "GHS 20")
- The `formatOrderItems()` function in `onlineOrderUtilFns.ts` was passing raw pesewas to the currency formatter for `price`, `discountedPrice`, and `savings`
- Added `toDisplayAmount()` conversion to all three fields, matching the pattern already used for subtotal, total, and delivery fee

## Root cause
After the pesewas migration, `item.price` stores values in pesewas (minor currency units). The formatter was called directly on these values without first converting via `toDisplayAmount()`.

## Test plan
- [ ] Trigger an order status email (confirmation, ready, complete, or canceled)
- [ ] Verify item prices display correctly (e.g. "GHS 20" not "GHS 2,000")
- [ ] Verify discounted prices and savings also display correctly if a promo code is applied
- [ ] Verify subtotal, delivery fee, and total remain correct (they were already working)

🤖 Generated with [Claude Code](https://claude.com/claude-code)