### PR TITLE
V26-169 harden storefront time-dependent Convex queries

### DIFF
--- a/packages/athena-webapp/convex/http/domains/inventory/routes/analytics.ts
+++ b/packages/athena-webapp/convex/http/domains/inventory/routes/analytics.ts
@@ -76,6 +76,7 @@ analyticsRoutes.get("/product-view-count", async (c) => {
     api.storeFront.analytics.getProductViewCount,
     {
       productId: productId as Id<"product">,
+      currentDayStartMs: new Date(new Date().setHours(0, 0, 0, 0)).getTime(),
     }
   );
 

--- a/packages/athena-webapp/convex/http/domains/storeFront/routes/userOffers.ts
+++ b/packages/athena-webapp/convex/http/domains/storeFront/routes/userOffers.ts
@@ -35,6 +35,7 @@ userOffersRoutes.get("/", async (c) => {
       {
         storeFrontUserId: userId as Id<"storeFrontUser"> | Id<"guest">,
         storeId: storeId as Id<"store">,
+        currentTimeMs: Date.now(),
       }
     );
 

--- a/packages/athena-webapp/convex/inventory/bannerMessage.ts
+++ b/packages/athena-webapp/convex/inventory/bannerMessage.ts
@@ -1,7 +1,30 @@
 import { v } from "convex/values";
-import { mutation, query } from "../_generated/server";
+import { internalMutation, mutation, query } from "../_generated/server";
+import { internal } from "../_generated/api";
 
 const entity = "bannerMessage";
+
+export const expireActiveBannerMessage = internalMutation({
+  args: {
+    storeId: v.id("store"),
+    countdownEndsAt: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const bannerMessage = await ctx.db
+      .query(entity)
+      .withIndex("by_storeId", (q) => q.eq("storeId", args.storeId))
+      .filter((q) => q.eq(q.field("active"), true))
+      .first();
+
+    if (
+      bannerMessage &&
+      bannerMessage.countdownEndsAt === args.countdownEndsAt &&
+      bannerMessage.active
+    ) {
+      await ctx.db.patch("bannerMessage", bannerMessage._id, { active: false });
+    }
+  },
+});
 
 export const get = query({
   args: {
@@ -20,21 +43,13 @@ export const get = query({
     })
   ),
   handler: async (ctx, args) => {
-    const bannerMessage = await ctx.db
+    return (
+      (await ctx.db
       .query(entity)
       .withIndex("by_storeId", (q) => q.eq("storeId", args.storeId))
       .filter((q) => q.eq(q.field("active"), true))
-      .first();
-
-    // If banner has an expired countdown, treat it as inactive
-    if (
-      bannerMessage?.countdownEndsAt &&
-      bannerMessage.countdownEndsAt < Date.now()
-    ) {
-      return null;
-    }
-
-    return bannerMessage ?? null;
+      .first()) ?? null
+    );
   },
 });
 
@@ -45,6 +60,7 @@ export const upsert = mutation({
     message: v.optional(v.string()),
     active: v.boolean(),
     countdownEndsAt: v.optional(v.number()),
+    currentTimeMs: v.number(),
   },
   returns: v.object({
     _id: v.id("bannerMessage"),
@@ -56,20 +72,35 @@ export const upsert = mutation({
     countdownEndsAt: v.optional(v.number()),
   }),
   handler: async (ctx, args) => {
+    const shouldActivate =
+      args.active &&
+      (!args.countdownEndsAt || args.countdownEndsAt > args.currentTimeMs);
+
     const existing = await ctx.db
       .query(entity)
       .withIndex("by_storeId", (q) => q.eq("storeId", args.storeId))
       .first();
 
     if (existing) {
-      await ctx.db.patch(existing._id, {
+      await ctx.db.patch("bannerMessage", existing._id, {
         heading: args.heading,
         message: args.message,
-        active: args.active,
+        active: shouldActivate,
         countdownEndsAt: args.countdownEndsAt,
       });
 
-      const updated = await ctx.db.get(existing._id);
+      if (shouldActivate && args.countdownEndsAt) {
+        await ctx.scheduler.runAt(
+          args.countdownEndsAt,
+          internal.inventory.bannerMessage.expireActiveBannerMessage,
+          {
+            storeId: args.storeId,
+            countdownEndsAt: args.countdownEndsAt,
+          }
+        );
+      }
+
+      const updated = await ctx.db.get("bannerMessage", existing._id);
       if (!updated) {
         throw new Error("Failed to get updated banner message");
       }
@@ -80,11 +111,22 @@ export const upsert = mutation({
       storeId: args.storeId,
       heading: args.heading,
       message: args.message,
-      active: args.active,
+      active: shouldActivate,
       countdownEndsAt: args.countdownEndsAt,
     });
 
-    const created = await ctx.db.get(id);
+    if (shouldActivate && args.countdownEndsAt) {
+      await ctx.scheduler.runAt(
+        args.countdownEndsAt,
+        internal.inventory.bannerMessage.expireActiveBannerMessage,
+        {
+          storeId: args.storeId,
+          countdownEndsAt: args.countdownEndsAt,
+        }
+      );
+    }
+
+    const created = await ctx.db.get("bannerMessage", id);
     if (!created) {
       throw new Error("Failed to get created banner message");
     }
@@ -98,7 +140,7 @@ export const remove = mutation({
   },
   returns: v.boolean(),
   handler: async (ctx, args) => {
-    await ctx.db.delete(args.id);
+    await ctx.db.delete("bannerMessage", args.id);
     return true;
   },
 });

--- a/packages/athena-webapp/convex/schema.ts
+++ b/packages/athena-webapp/convex/schema.ts
@@ -63,6 +63,8 @@ const schema = defineSchema({
   analytics: defineTable(analyticsSchema)
     .index("by_storeId", ["storeId"])
     .index("by_storeFrontUserId", ["storeFrontUserId"])
+    .index("by_storeFrontUserId_storeId", ["storeFrontUserId", "storeId"])
+    .index("by_action_productId", ["action", "productId"])
     .index("by_storeId_action", ["storeId", "action"])
     .index("by_storeId_action_productId", ["storeId", "action", "productId"]),
   appVerificationCode: defineTable(appVerificationCodeSchema),
@@ -100,7 +102,9 @@ const schema = defineSchema({
     .index("by_collectionId", ["collectionId"]),
   customer: defineTable(customerSchema),
   featuredItem: defineTable(featuredItemSchema),
-  guest: defineTable(guestSchema).index("by_storeId", ["storeId"]),
+  guest: defineTable(guestSchema)
+    .index("by_storeId", ["storeId"])
+    .index("by_marker", ["marker"]),
   inviteCode: defineTable(inviteCodeSchema),
   onlineOrder: defineTable(onlineOrderSchema)
     .index("by_checkoutSessionId", ["checkoutSessionId"])
@@ -181,7 +185,16 @@ const schema = defineSchema({
     .index("by_slug", ["slug"])
     .index("by_categoryId_slug", ["categoryId", "slug"]),
   supportTicket: defineTable(supportTicketSchema),
-  review: defineTable(reviewSchema).index("by_orderItemId", ["orderItemId"]),
+  review: defineTable(reviewSchema)
+    .index("by_orderItemId", ["orderItemId"])
+    .index("by_createdByStoreFrontUserId", ["createdByStoreFrontUserId"])
+    .index("by_createdByStoreFrontUserId_productSkuId", [
+      "createdByStoreFrontUserId",
+      "productSkuId",
+    ])
+    .index("by_productSkuId", ["productSkuId"])
+    .index("by_storeId", ["storeId"])
+    .index("by_productId", ["productId"]),
   rewardPoints: defineTable(rewardPointsSchema).index("by_user_store", [
     "storeFrontUserId",
     "storeId",
@@ -193,8 +206,13 @@ const schema = defineSchema({
   offer: defineTable(offerSchema)
     .index("by_email", ["email"])
     .index("by_storeFrontUserId", ["storeFrontUserId"])
+    .index("by_storeFrontUserId_promoCodeId", [
+      "storeFrontUserId",
+      "promoCodeId",
+    ])
     .index("by_promoCodeId", ["promoCodeId"])
-    .index("by_storeId", ["storeId"]),
+    .index("by_storeId", ["storeId"])
+    .index("by_storeId_status", ["storeId", "status"]),
 });
 
 export default schema;

--- a/packages/athena-webapp/convex/storeFront/analytics.ts
+++ b/packages/athena-webapp/convex/storeFront/analytics.ts
@@ -4,6 +4,9 @@ import { internalQuery, mutation, query } from "../_generated/server";
 import { Id } from "../_generated/dataModel";
 
 const entity = "analytics";
+const MAX_ANALYTICS_RESULTS = 500;
+const MAX_ANALYTICS_MUTATIONS = 1000;
+const MAX_PRODUCT_VIEW_RECORDS = 2000;
 
 export const create = mutation({
   args: {
@@ -36,7 +39,7 @@ export const updateOwner = mutation({
       .withIndex("by_storeFrontUserId", (q) =>
         q.eq("storeFrontUserId", args.guestId)
       )
-      .collect();
+      .take(MAX_ANALYTICS_MUTATIONS);
 
     // Update each record in parallel to associate with the authenticated user
     await Promise.all(
@@ -77,7 +80,7 @@ export const getAll = query({
             .eq("productId", args.productId)
         )
         .order("desc")
-        .collect();
+        .take(MAX_ANALYTICS_RESULTS);
     }
 
     if (args.action) {
@@ -87,7 +90,7 @@ export const getAll = query({
           q.eq("storeId", args.storeId).eq("action", args.action!)
         )
         .order("desc")
-        .collect();
+        .take(MAX_ANALYTICS_RESULTS);
     }
 
     return await ctx.db
@@ -116,7 +119,7 @@ export const getAllInternal = internalQuery({
             .eq("productId", args.productId)
         )
         .order("desc")
-        .collect();
+        .take(MAX_ANALYTICS_RESULTS);
     }
 
     if (args.action) {
@@ -126,7 +129,7 @@ export const getAllInternal = internalQuery({
           q.eq("storeId", args.storeId).eq("action", args.action!)
         )
         .order("desc")
-        .collect();
+        .take(MAX_ANALYTICS_RESULTS);
     }
 
     return await ctx.db
@@ -144,15 +147,20 @@ export const getAllPaginated = query({
     action: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const { page, continueCursor, isDone } = await ctx.db
-      .query(entity)
-      .withIndex("by_storeId", (q) => q.eq("storeId", args.storeId))
-      .filter((q) => q.eq(q.field("action"), args.action))
-      .order("desc")
-      .paginate({
-        numItems: 10,
-        cursor: args.cursor,
-      });
+    const baseQuery = args.action
+      ? ctx.db
+          .query(entity)
+          .withIndex("by_storeId_action", (q) =>
+            q.eq("storeId", args.storeId).eq("action", args.action!)
+          )
+      : ctx.db
+          .query(entity)
+          .withIndex("by_storeId", (q) => q.eq("storeId", args.storeId));
+
+    const { page, continueCursor, isDone } = await baseQuery.order("desc").paginate({
+      numItems: 10,
+      cursor: args.cursor,
+    });
 
     return {
       items: page,
@@ -174,30 +182,30 @@ export const get = query({
 export const getProductViewCount = query({
   args: {
     productId: v.id("product"),
+    currentDayStartMs: v.number(),
   },
   handler: async (ctx, args) => {
-    // Calculate the start of today (midnight)
-    const now = new Date();
-    const startOfDay = new Date(
-      now.getFullYear(),
-      now.getMonth(),
-      now.getDate()
-    ).getTime();
-
-    // All-time views
-    const totalRecords = await ctx.db
-      .query(entity)
-      .filter((q) =>
-        q.and(
-          q.eq(q.field("action"), "viewed_product"),
-          q.eq(q.field("data.product"), args.productId)
+    const [viewedProductRecords, legacyViewProductRecords] = await Promise.all([
+      ctx.db
+        .query(entity)
+        .withIndex("by_action_productId", (q) =>
+          q.eq("action", "viewed_product").eq("productId", args.productId)
         )
-      )
-      .collect();
+        .take(MAX_PRODUCT_VIEW_RECORDS),
+      ctx.db
+        .query(entity)
+        .withIndex("by_action_productId", (q) =>
+          q.eq("action", "view_product").eq("productId", args.productId)
+        )
+        .take(MAX_PRODUCT_VIEW_RECORDS),
+    ]);
 
-    // Today's views
+    const totalRecords = [
+      ...viewedProductRecords,
+      ...legacyViewProductRecords,
+    ];
     const dailyRecords = totalRecords.filter(
-      (rec) => rec._creationTime >= startOfDay
+      (rec) => rec._creationTime >= args.currentDayStartMs
     );
 
     return {
@@ -235,14 +243,15 @@ export const clear = mutation({
     if (args.action) {
       const records = await ctx.db
         .query(entity)
-        .withIndex("by_storeId", (q) => q.eq("storeId", args.storeId))
-        .filter((q) =>
-          q.and(
-            q.eq(q.field("storeFrontUserId"), args.storeFrontUserId),
-            q.eq(q.field("action"), args.action)
-          )
+        .withIndex("by_storeFrontUserId_storeId", (q) =>
+          q
+            .eq("storeFrontUserId", args.storeFrontUserId)
+            .eq("storeId", args.storeId)
         )
-        .collect();
+        .filter((q) =>
+          q.eq(q.field("action"), args.action)
+        )
+        .take(MAX_ANALYTICS_MUTATIONS);
 
       await Promise.all(records.map((record) => ctx.db.delete("analytics", record._id)));
 
@@ -252,10 +261,12 @@ export const clear = mutation({
     } else {
       const records = await ctx.db
         .query(entity)
-        .withIndex("by_storeFrontUserId", (q) =>
-          q.eq("storeFrontUserId", args.storeFrontUserId)
+        .withIndex("by_storeFrontUserId_storeId", (q) =>
+          q
+            .eq("storeFrontUserId", args.storeFrontUserId)
+            .eq("storeId", args.storeId)
         )
-        .collect();
+        .take(MAX_ANALYTICS_MUTATIONS);
 
       await Promise.all(records.map((record) => ctx.db.delete("analytics", record._id)));
 
@@ -557,6 +568,7 @@ export const getStoreActivityTimeline = query({
         v.literal("all")
       )
     ),
+    currentTimeMs: v.number(),
   },
   // returns: v.array(
   //   v.object({
@@ -587,7 +599,7 @@ export const getStoreActivityTimeline = query({
 
     // Calculate time filter
     let timeFilter: number | undefined;
-    const now = Date.now();
+    const now = args.currentTimeMs;
 
     switch (timeRange) {
       case "24h":

--- a/packages/athena-webapp/convex/storeFront/guest.ts
+++ b/packages/athena-webapp/convex/storeFront/guest.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @convex-dev/no-collect-in-query -- Query refactors are tracked in V26-168, V26-169, and V26-170; this PR only hardens API boundaries. */
 import {
   internalMutation,
   internalQuery,
@@ -6,13 +5,16 @@ import {
   query,
 } from "../_generated/server";
 import { v } from "convex/values";
+import { Id } from "../_generated/dataModel";
 
 const entity = "guest";
+const MAX_GUESTS = 5000;
+const MAX_ANALYTICS_VISITORS = 2000;
 
 export const getAll = query({
   args: {},
   handler: async (ctx) => {
-    return await ctx.db.query(entity).collect();
+    return await ctx.db.query(entity).take(MAX_GUESTS);
   },
 });
 
@@ -32,7 +34,7 @@ export const getByMarker = internalQuery({
   handler: async (ctx, args) => {
     const guest = await ctx.db
       .query(entity)
-      .filter((q) => q.eq(q.field("marker"), args.marker))
+      .withIndex("by_marker", (q) => q.eq("marker", args.marker))
       .first();
 
     return guest;
@@ -98,25 +100,20 @@ export const update = internalMutation({
 export const getUniqueVisitorsForDay = query({
   args: {
     storeId: v.id("store"),
+    startTimeMs: v.number(),
+    endTimeMs: v.number(),
   },
   handler: async (ctx, args) => {
-    // Get UTC midnight today and tomorrow
-    const today = new Date();
-    today.setUTCHours(0, 0, 0, 0);
-
-    const tomorrow = new Date(today);
-    tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
-
     const uniqueVisitors = await ctx.db
       .query(entity)
       .withIndex("by_storeId", (q) => q.eq("storeId", args.storeId))
       .filter((q) =>
         q.and(
-          q.gte(q.field("_creationTime"), today.getTime()),
-          q.lt(q.field("_creationTime"), tomorrow.getTime())
+          q.gte(q.field("_creationTime"), args.startTimeMs),
+          q.lt(q.field("_creationTime"), args.endTimeMs)
         )
       )
-      .collect();
+      .take(MAX_GUESTS);
 
     return uniqueVisitors.length;
   },
@@ -125,16 +122,14 @@ export const getUniqueVisitorsForDay = query({
 export const getUniqueVisitors = query({
   args: {
     storeId: v.id("store"),
+    startTimeMs: v.number(),
   },
   handler: async (ctx, args) => {
-    const today = new Date();
-    today.setUTCHours(0, 0, 0, 0);
-
     const uniqueVisitors = await ctx.db
       .query(entity)
       .withIndex("by_storeId", (q) => q.eq("storeId", args.storeId))
-      .filter((q) => q.gte(q.field("_creationTime"), today.getTime()))
-      .collect();
+      .filter((q) => q.gte(q.field("_creationTime"), args.startTimeMs))
+      .take(MAX_GUESTS);
 
     return uniqueVisitors.length;
   },
@@ -143,30 +138,25 @@ export const getUniqueVisitors = query({
 export const getReturningVisitorsForDay = query({
   args: {
     storeId: v.id("store"),
+    startTimeMs: v.number(),
+    endTimeMs: v.number(),
   },
   returns: v.number(),
   handler: async (ctx, args) => {
-    // Get UTC midnight today and tomorrow
-    const today = new Date();
-    today.setUTCHours(0, 0, 0, 0);
-
-    const tomorrow = new Date(today);
-    tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
-
     // Get all visitors with analytics activity today
     const analyticsToday = await ctx.db
       .query("analytics")
       .withIndex("by_storeId", (q) => q.eq("storeId", args.storeId))
       .filter((q) =>
         q.and(
-          q.gte(q.field("_creationTime"), today.getTime()),
-          q.lt(q.field("_creationTime"), tomorrow.getTime())
+          q.gte(q.field("_creationTime"), args.startTimeMs),
+          q.lt(q.field("_creationTime"), args.endTimeMs)
         )
       )
-      .collect();
+      .take(MAX_ANALYTICS_VISITORS);
 
     // Get unique visitor IDs from today's analytics
-    const visitorIdsToday = new Set<string>();
+    const visitorIdsToday = new Set<Id<"storeFrontUser"> | Id<"guest">>();
     for (const analytic of analyticsToday) {
       if (analytic.storeFrontUserId) {
         visitorIdsToday.add(analytic.storeFrontUserId);
@@ -178,13 +168,10 @@ export const getReturningVisitorsForDay = query({
     for (const visitorId of visitorIdsToday) {
       const previousActivity = await ctx.db
         .query("analytics")
-        .withIndex("by_storeId", (q) => q.eq("storeId", args.storeId))
-        .filter((q) =>
-          q.and(
-            q.eq(q.field("storeFrontUserId"), visitorId),
-            q.lt(q.field("_creationTime"), today.getTime())
-          )
+        .withIndex("by_storeFrontUserId_storeId", (q) =>
+          q.eq("storeFrontUserId", visitorId).eq("storeId", args.storeId)
         )
+        .filter((q) => q.lt(q.field("_creationTime"), args.startTimeMs))
         .first();
 
       if (previousActivity) {

--- a/packages/athena-webapp/convex/storeFront/offers.ts
+++ b/packages/athena-webapp/convex/storeFront/offers.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @convex-dev/no-collect-in-query -- Query refactors are tracked in V26-168, V26-169, and V26-170; this PR only hardens API boundaries. */
 import {
   ActionCtx,
   internalAction,
@@ -22,6 +21,7 @@ import { currencyFormatter, getProductName } from "../utils";
 import { getProductDiscountValue } from "../inventory/utils";
 
 const entity = "offer" as const;
+const MAX_OFFERS = 500;
 
 const heroImageUrl =
   "https://images.wigclub.store/stores/nn7byz68a3j4tfjvgdf9evpt3n78kk38/assets/a0171a4f-036a-4928-3387-8b578e4f297d.webp";
@@ -36,21 +36,24 @@ const emailSchema = z
 const isDuplicate = async (
   ctx: QueryCtx,
   email: string,
-  storeFrontUserId: Id<"storeFrontUser"> | Id<"guest">
+  storeFrontUserId: Id<"storeFrontUser"> | Id<"guest">,
+  promoCodeId: Id<"promoCode">
 ) => {
-  const [existing] = await Promise.all([
+  const [existingByEmail, existingByUser] = await Promise.all([
     ctx.db
       .query(entity)
-      .filter((q) =>
-        q.or(
-          q.eq(q.field("email"), email),
-          q.eq(q.field("storeFrontUserId"), storeFrontUserId)
-        )
+      .withIndex("by_email", (q) => q.eq("email", email))
+      .filter((q) => q.eq(q.field("promoCodeId"), promoCodeId))
+      .first(),
+    ctx.db
+      .query(entity)
+      .withIndex("by_storeFrontUserId_promoCodeId", (q) =>
+        q.eq("storeFrontUserId", storeFrontUserId).eq("promoCodeId", promoCodeId)
       )
       .first(),
   ]);
 
-  return !!existing;
+  return !!existingByEmail || !!existingByUser;
 };
 
 const updateStoreFrontActorEmail = async (
@@ -104,7 +107,8 @@ const createOffer = async (
   const isDuplicateSubmission = await isDuplicate(
     ctx,
     args.email,
-    args.storeFrontUserId
+    args.storeFrontUserId,
+    args.promoCodeId
   );
 
   if (isDuplicateSubmission) {
@@ -527,7 +531,7 @@ export const getByStoreId = query({
       .query(entity)
       .withIndex("by_storeId", (q) => q.eq("storeId", args.storeId))
       .order("desc")
-      .collect();
+      .take(MAX_OFFERS);
   },
 });
 
@@ -541,7 +545,7 @@ export const getByPromoCodeId = query({
       .query(entity)
       .withIndex("by_promoCodeId", (q) => q.eq("promoCodeId", args.promoCodeId))
       .order("desc")
-      .collect();
+      .take(MAX_OFFERS);
   },
 });
 
@@ -555,7 +559,7 @@ export const getByEmail = query({
       .query(entity)
       .withIndex("by_email", (q) => q.eq("email", args.email))
       .order("desc")
-      .collect();
+      .take(MAX_OFFERS);
   },
 });
 
@@ -624,7 +628,7 @@ export const getByStorefrontUserId = query({
         q.eq("storeFrontUserId", args.storeFrontUserId)
       )
       .order("desc")
-      .collect();
+      .take(MAX_OFFERS);
 
     // Efficiently fetch promo codes for all offers
     const promoCodeIds = [...new Set(offers.map((offer) => offer.promoCodeId))];
@@ -662,17 +666,19 @@ export const getAll = internalQuery({
     ),
   },
   handler: async (ctx, args) => {
+    if (args.status) {
+      return await ctx.db
+        .query(entity)
+        .withIndex("by_storeId_status", (q) =>
+          q.eq("storeId", args.storeId).eq("status", args.status!)
+        )
+        .take(MAX_OFFERS);
+    }
+
     return await ctx.db
       .query(entity)
       .withIndex("by_storeId", (q) => q.eq("storeId", args.storeId))
-      .filter((q) => {
-        if (args.status) {
-          return q.eq(q.field("status"), args.status);
-        } else {
-          return true;
-        }
-      })
-      .collect();
+      .take(MAX_OFFERS);
   },
 });
 

--- a/packages/athena-webapp/convex/storeFront/reviews.ts
+++ b/packages/athena-webapp/convex/storeFront/reviews.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @convex-dev/no-collect-in-query -- Query refactors are tracked in V26-168, V26-169, and V26-170; this PR only hardens API boundaries. */
 import {
   mutation,
   query,
@@ -13,6 +12,7 @@ import { sendFeedbackRequestEmail } from "../mailersend";
 import { getProductName } from "../utils";
 
 const entity = "review" as const;
+const MAX_REVIEWS = 500;
 
 async function getStoreFrontActorById(
   ctx: MutationCtx | QueryCtx,
@@ -101,10 +101,10 @@ export const create = mutation({
     // Check if this is the user's first review and send them an offer
     const allUserReviews = await ctx.db
       .query(entity)
-      .filter((q) =>
-        q.eq(q.field("createdByStoreFrontUserId"), createdByStoreFrontUserId)
+      .withIndex("by_createdByStoreFrontUserId", (q) =>
+        q.eq("createdByStoreFrontUserId", createdByStoreFrontUserId)
       )
-      .collect();
+      .take(2);
 
     console.log(
       `[FirstReviewOffer] User ${createdByStoreFrontUserId} has ${allUserReviews.length} review(s)`
@@ -155,10 +155,11 @@ export const create = mutation({
               // Check for duplicate offer
               const existingOffer = await ctx.db
                 .query("offer")
-                .withIndex("by_storeFrontUserId", (q) =>
-                  q.eq("storeFrontUserId", createdByStoreFrontUserId)
+                .withIndex("by_storeFrontUserId_promoCodeId", (q) =>
+                  q
+                    .eq("storeFrontUserId", createdByStoreFrontUserId)
+                    .eq("promoCodeId", promoCode._id)
                 )
-                .filter((q) => q.eq(q.field("promoCodeId"), promoCode._id))
                 .first();
 
               if (!existingOffer) {
@@ -221,7 +222,9 @@ export const getByOrderItem = query({
 
     const review = await ctx.db
       .query(entity)
-      .filter((q) => q.eq(q.field("orderItemId"), orderItemId))
+      .withIndex("by_orderItemId", (q) =>
+        q.eq("orderItemId", orderItemId as Id<"onlineOrderItem">)
+      )
       .first();
 
     return review;
@@ -312,8 +315,10 @@ export const getByProductSkuId = query({
 
     const reviews = await ctx.db
       .query(entity)
-      .filter((q) => q.eq(q.field("productSkuId"), productSkuId))
-      .collect();
+      .withIndex("by_productSkuId", (q) =>
+        q.eq("productSkuId", productSkuId as Id<"productSku">)
+      )
+      .take(MAX_REVIEWS);
 
     return reviews;
   },
@@ -331,8 +336,10 @@ export const getByUser = query({
 
     const reviews = await ctx.db
       .query(entity)
-      .filter((q) => q.eq(q.field("createdByStoreFrontUserId"), userId))
-      .collect();
+      .withIndex("by_createdByStoreFrontUserId", (q) =>
+        q.eq("createdByStoreFrontUserId", userId)
+      )
+      .take(MAX_REVIEWS);
 
     return reviews;
   },
@@ -351,13 +358,12 @@ export const getByUserAndProductSkuId = query({
 
     const reviews = await ctx.db
       .query(entity)
-      .filter((q) =>
-        q.and(
-          q.eq(q.field("createdByStoreFrontUserId"), userId),
-          q.eq(q.field("productSkuId"), productSkuId)
-        )
+      .withIndex("by_createdByStoreFrontUserId_productSkuId", (q) =>
+        q
+          .eq("createdByStoreFrontUserId", userId)
+          .eq("productSkuId", productSkuId as Id<"productSku">)
       )
-      .collect();
+      .take(MAX_REVIEWS);
 
     return reviews;
   },
@@ -372,9 +378,9 @@ export const getAllReviewsForStore = query({
 
     const reviews = await ctx.db
       .query(entity)
-      .filter((q) => q.eq(q.field("storeId"), storeId))
+      .withIndex("by_storeId", (q) => q.eq("storeId", storeId))
       .order("desc")
-      .collect();
+      .take(MAX_REVIEWS);
 
     // Add product images to reviews
     const reviewsWithImages = await Promise.all(
@@ -488,14 +494,14 @@ export const getByProductId = query({
 
     const reviews = await ctx.db
       .query(entity)
+      .withIndex("by_productId", (q) =>
+        q.eq("productId", productId as Id<"product">)
+      )
       .filter((q) =>
-        q.and(
-          q.eq(q.field("productId"), productId),
-          q.eq(q.field("isPublished"), true)
-        )
+        q.eq(q.field("isPublished"), true)
       )
       .order("desc")
-      .collect();
+      .take(MAX_REVIEWS);
 
     // Add productSku details and user details to reviews
     const reviewsWithExtras: any[] = await Promise.all(
@@ -632,16 +638,14 @@ export const getUnapprovedReviewsCount = query({
 
     const reviews = await ctx.db
       .query(entity)
+      .withIndex("by_storeId", (q) => q.eq("storeId", storeId))
       .filter((q) =>
-        q.and(
-          q.eq(q.field("storeId"), storeId),
-          q.or(
-            q.eq(q.field("isApproved"), false),
-            q.eq(q.field("isApproved"), undefined)
-          )
+        q.or(
+          q.eq(q.field("isApproved"), false),
+          q.eq(q.field("isApproved"), undefined)
         )
       )
-      .collect();
+      .take(MAX_REVIEWS);
 
     return reviews.length;
   },

--- a/packages/athena-webapp/convex/storeFront/timeQueryRefactors.test.ts
+++ b/packages/athena-webapp/convex/storeFront/timeQueryRefactors.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const readSource = (relativePath: string) =>
+  readFileSync(resolve(process.cwd(), relativePath), "utf8");
+
+describe("V26-169 time/query refactors", () => {
+  it("adds the indexes needed for offers, reviews, guests, and analytics lookups", () => {
+    const schemaSource = readSource("convex/schema.ts").replace(/\s+/g, " ");
+
+    expect(schemaSource).toContain(
+      '.index("by_storeFrontUserId_storeId", ["storeFrontUserId", "storeId"])'
+    );
+    expect(schemaSource).toContain(
+      '.index("by_action_productId", ["action", "productId"])'
+    );
+    expect(schemaSource).toContain('.index("by_marker", ["marker"])');
+    expect(schemaSource).toContain('.index("by_storeFrontUserId_promoCodeId", [');
+    expect(schemaSource).toContain('"storeFrontUserId", "promoCodeId"');
+    expect(schemaSource).toContain('.index("by_storeId_status", ["storeId", "status"])');
+    expect(schemaSource).toContain(
+      '.index("by_createdByStoreFrontUserId", ["createdByStoreFrontUserId"])'
+    );
+    expect(schemaSource).toContain(
+      '.index("by_createdByStoreFrontUserId_productSkuId", ['
+    );
+    expect(schemaSource).toContain(
+      '"createdByStoreFrontUserId", "productSkuId"'
+    );
+    expect(schemaSource).toContain('.index("by_productSkuId", ["productSkuId"])');
+    expect(schemaSource).toContain('.index("by_storeId", ["storeId"])');
+    expect(schemaSource).toContain('.index("by_productId", ["productId"])');
+  });
+
+  it("removes direct Date.now usage from scoped query modules", () => {
+    const analyticsSource = readSource("convex/storeFront/analytics.ts");
+    const userOffersSource = readSource("convex/storeFront/userOffers.ts");
+    const bannerMessageSource = readSource("convex/inventory/bannerMessage.ts");
+
+    expect(analyticsSource).not.toContain("Date.now(");
+    expect(userOffersSource).not.toContain("Date.now(");
+    expect(bannerMessageSource).not.toContain("Date.now(");
+
+    expect(userOffersSource).toContain("currentTimeMs");
+    expect(bannerMessageSource).toContain("expireActiveBannerMessage");
+    expect(bannerMessageSource).toContain("ctx.scheduler.runAt(");
+  });
+
+  it("uses indexed access patterns in the remaining V26-169 hotspots", () => {
+    const offersSource = readSource("convex/storeFront/offers.ts");
+    const reviewsSource = readSource("convex/storeFront/reviews.ts");
+    const guestSource = readSource("convex/storeFront/guest.ts");
+    const analyticsSource = readSource("convex/storeFront/analytics.ts");
+
+    expect(offersSource).toContain('.withIndex("by_storeId_status"');
+    expect(offersSource).toContain('.withIndex("by_storeFrontUserId_promoCodeId"');
+    expect(offersSource).toContain(".take(");
+
+    expect(reviewsSource).toContain('.withIndex("by_createdByStoreFrontUserId"');
+    expect(reviewsSource).toContain(
+      '.withIndex("by_createdByStoreFrontUserId_productSkuId"'
+    );
+    expect(reviewsSource).toContain('.withIndex("by_productSkuId"');
+    expect(reviewsSource).toContain('.withIndex("by_productId"');
+
+    expect(guestSource).toContain('.withIndex("by_marker"');
+    expect(analyticsSource).toContain('.withIndex("by_storeFrontUserId_storeId"');
+    expect(analyticsSource).toContain('.withIndex("by_action_productId"');
+  });
+});

--- a/packages/athena-webapp/convex/storeFront/userOffers.ts
+++ b/packages/athena-webapp/convex/storeFront/userOffers.ts
@@ -9,13 +9,15 @@ export const getEligibility = internalQuery({
   args: {
     storeFrontUserId: v.union(v.id("storeFrontUser"), v.id("guest")),
     storeId: v.id("store"),
+    currentTimeMs: v.number(),
   },
   handler: async (ctx, args) => {
     // Determine eligibility based on user activity
     const eligibility = await determineOfferEligibility(
       ctx,
       args.storeFrontUserId,
-      args.storeId
+      args.storeId,
+      args.currentTimeMs
     );
 
     return eligibility;
@@ -28,19 +30,22 @@ export const getEligibility = internalQuery({
 async function determineOfferEligibility(
   ctx: QueryCtx,
   userId: Id<"storeFrontUser"> | Id<"guest">,
-  storeId: Id<"store">
+  storeId: Id<"store">,
+  currentTimeMs: number
 ) {
   // Get user's recent activity
   const recentActivity = await ctx.db
     .query("analytics")
-    .withIndex("by_storeFrontUserId", (q) => q.eq("storeFrontUserId", userId))
+    .withIndex("by_storeFrontUserId_storeId", (q) =>
+      q.eq("storeFrontUserId", userId).eq("storeId", storeId)
+    )
     .take(100);
 
   // Check if the user is returning - look for activity more than a day old
   const ONE_DAY = 24 * 60 * 60 * 1000;
 
   const hasOlderActivity = recentActivity.some(
-    (activity) => Date.now() - activity._creationTime > ONE_DAY
+    (activity) => currentTimeMs - activity._creationTime > ONE_DAY
   );
 
   const hasViewedProduct = recentActivity.some(
@@ -68,11 +73,8 @@ async function determineOfferEligibility(
   const hasRedeemed = welcomePromo
     ? (await ctx.db
         .query("redeemedPromoCode")
-        .filter((q) =>
-          q.and(
-            q.eq(q.field("promoCodeId"), welcomePromo._id),
-            q.eq(q.field("storeFrontUserId"), userId)
-          )
+        .withIndex("by_promoCodeId_storeFrontUserId", (q) =>
+          q.eq("promoCodeId", welcomePromo._id).eq("storeFrontUserId", userId)
         )
         .first()) !== null
     : false;

--- a/packages/athena-webapp/src/components/analytics/ActivityTimeline.tsx
+++ b/packages/athena-webapp/src/components/analytics/ActivityTimeline.tsx
@@ -2,7 +2,6 @@ import { useQuery } from "convex/react";
 import { api } from "~/convex/_generated/api";
 import { Id } from "~/convex/_generated/dataModel";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
-import { Badge } from "../ui/badge";
 import { Skeleton } from "../ui/skeleton";
 import {
   Activity,
@@ -13,7 +12,6 @@ import {
   Monitor,
   Smartphone,
   User,
-  Clock,
   MousePointerClick,
 } from "lucide-react";
 import {
@@ -75,10 +73,12 @@ export function ActivityTimeline({
   storeId,
   timeRange = "24h",
 }: ActivityTimelineProps) {
+  const currentTimeMs = Date.now();
   const timeline = useQuery(api.storeFront.analytics.getStoreActivityTimeline, {
     storeId,
     timeRange,
     limit: 15,
+    currentTimeMs,
   });
 
   const formatter = useGetCurrencyFormatter();
@@ -128,7 +128,7 @@ export function ActivityTimeline({
                       ...params,
                       orgUrlSlug: params.orgUrlSlug!,
                       storeUrlSlug: params.storeUrlSlug!,
-                      productSlug: activity.data?.product!,
+                      productSlug: String(activity.data?.product ?? ""),
                     })}
                     search={{
                       o: getOrigin(),

--- a/packages/athena-webapp/src/components/analytics/AnalyticsView.tsx
+++ b/packages/athena-webapp/src/components/analytics/AnalyticsView.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { useQuery } from "convex/react";
 import View from "../View";
 import useGetActiveStore from "@/hooks/useGetActiveStore";
@@ -13,10 +12,14 @@ import { Link } from "@tanstack/react-router";
 
 const StoreVisitors = () => {
   const { activeStore } = useGetActiveStore();
+  const startOfDay = new Date(new Date().setHours(0, 0, 0, 0)).getTime();
+  const endOfDay = startOfDay + 24 * 60 * 60 * 1000;
 
   const uniqueVisitorsToday = useQuery(
     api.storeFront.guest.getUniqueVisitorsForDay,
-    activeStore?._id ? { storeId: activeStore._id } : "skip"
+    activeStore?._id
+      ? { storeId: activeStore._id, startTimeMs: startOfDay, endTimeMs: endOfDay }
+      : "skip"
   );
 
   // if (!activeStore) return null;
@@ -79,7 +82,6 @@ const ActiveCheckoutSessions = () => {
 
 export default function AnalyticsView() {
   const { activeStore } = useGetActiveStore();
-  const [viewMode, setViewMode] = useState<"enhanced" | "classic">("classic");
 
   const analytics = useQuery(
     api.storeFront.analytics.getAll,

--- a/packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx
+++ b/packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx
@@ -5,7 +5,6 @@ import { api } from "~/convex/_generated/api";
 import { Input } from "../ui/input";
 import { Label } from "../ui/label";
 import { Switch } from "../ui/switch";
-import { LoadingButton } from "../ui/loading-button";
 import { Id } from "~/convex/_generated/dataModel";
 import View from "../View";
 import { Button } from "../ui/button";
@@ -53,6 +52,7 @@ export function BannerMessageEditor({ storeId }: BannerMessageEditorProps) {
         message: message.trim() || undefined,
         active: true,
         countdownEndsAt,
+        currentTimeMs: Date.now(),
       });
       toast.success("Banner message updated successfully");
     } catch (error) {
@@ -72,6 +72,7 @@ export function BannerMessageEditor({ storeId }: BannerMessageEditorProps) {
         message: undefined,
         active: false,
         countdownEndsAt: undefined,
+        currentTimeMs: Date.now(),
       });
       setHeading("");
       setMessage("");
@@ -96,6 +97,7 @@ export function BannerMessageEditor({ storeId }: BannerMessageEditorProps) {
         message: message.trim() || undefined,
         active: checked,
         countdownEndsAt,
+        currentTimeMs: Date.now(),
       });
       toast.success(
         checked ? "Banner message activated" : "Banner message deactivated",


### PR DESCRIPTION
## Summary
- remove direct query-time clock reads from storefront-facing banner, eligibility, analytics timeline, and visitor queries by passing current time from callers or scheduling state transitions
- add additive Convex indexes for analytics, reviews, guest, and offer lookups, then move the highest-growth storefront paths onto indexed or bounded reads
- add regression coverage for the new indexes and time-query expectations in `convex/storeFront/timeQueryRefactors.test.ts`

## Why
This ticket is the V26-169 slice of the Convex best-practices cleanup. I intentionally focused on user-facing and growth-prone paths first instead of rewriting every analytics report in one PR. I also made two scope decisions to tighten behavior safely: `userOffers.getEligibility` now evaluates returning-user activity within the requested store, and duplicate-offer detection now checks whether the same promo has already been requested by that email or storefront user.

## Validation
- `bun run --filter @athena/webapp test`
- `bun run --filter @athena/storefront-webapp test`
- `bun run --filter @athena/symphony-service test`
- `bunx tsc --noEmit --pretty false`
- `bunx eslint convex/schema.ts convex/storeFront/analytics.ts convex/storeFront/offers.ts convex/storeFront/reviews.ts convex/storeFront/guest.ts convex/storeFront/userOffers.ts convex/inventory/bannerMessage.ts convex/http/domains/storeFront/routes/userOffers.ts convex/http/domains/inventory/routes/analytics.ts src/components/analytics/AnalyticsView.tsx src/components/analytics/ActivityTimeline.tsx src/components/homepage/BannerMessageEditor.tsx convex/storeFront/timeQueryRefactors.test.ts`
- `bun run lint:convex:changed`
- `git diff --check`