### PR TITLE
[V26-176]: Replace direct Convex auth httpAction bridge calls

### DIFF
--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -7,6 +7,8 @@
 ## PR Preparation
 - Before opening or updating a PR, sync the working branch with the latest `origin/main` (merge or rebase).
 - Run PR-equivalent test checks after syncing with `origin/main`.
+- PR titles must use the format `[V26-123]: title`.
+- Every PR body must include a direct Linear link near the top for the ticket referenced in the title.
 
 ## PR Body Format
 - Every PR body must include these sections:

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -8,7 +8,7 @@
 - Before opening or updating a PR, sync the working branch with the latest `origin/main` (merge or rebase).
 - Run PR-equivalent test checks after syncing with `origin/main`.
 - PR titles must use the format `[V26-123]: title`.
-- Every PR body must include a direct Linear link near the top for the ticket referenced in the title.
+- Every PR body must include a direct Linear link at the end for the ticket referenced in the title.
 
 ## PR Body Format
 - Every PR body must include these sections:

--- a/packages/athena-webapp/convex/http.ts
+++ b/packages/athena-webapp/convex/http.ts
@@ -27,14 +27,13 @@ import {
   offersRoutes,
   userOffersRoutes,
 } from "./http/domains/storeFront/routes";
-import { httpRouter } from "convex/server";
 import { guestRoutes } from "./http/domains/storeFront/routes/guest";
 import { colorRoutes } from "./http/domains/inventory/routes/colors";
 import { savedBagRoutes } from "./http/domains/storeFront/routes/savedBag";
 
 const app: HonoWithConvex<ActionCtx> = new Hono();
 
-const http = httpRouter();
+const http = new HttpRouterWithHono<ActionCtx>(app);
 
 auth.addHttpRoutes(http);
 
@@ -95,30 +94,4 @@ app.route("/offers", offersRoutes);
 
 app.route("/user-offers", userOffersRoutes);
 
-app.get("/.well-known/openid-configuration", async (c) => {
-  const [httpAction] = http.lookup(
-    "/.well-known/openid-configuration",
-    "GET",
-  ) as any;
-  return httpAction(c.env, c.req);
-});
-
-app.get("/.well-known/jwks.json", async (c) => {
-  const [httpAction] = http.lookup("/.well-known/jwks.json", "GET") as any;
-  return httpAction(c.env, c.req);
-});
-
-app.get("/api/auth/signin/*", async (c) => {
-  const [httpAction] = http.lookup("/api/auth/signin/foo", "GET") as any;
-  return httpAction(c.env, c.req);
-});
-
-app.on(["GET", "POST"], "/api/auth/callback/*", async (c) => {
-  const [httpAction] = http.lookup(
-    "/api/auth/callback/foo",
-    c.req.method as any,
-  ) as any;
-  return httpAction(c.env, c.req);
-});
-
-export default new HttpRouterWithHono(app);
+export default http;

--- a/packages/athena-webapp/convex/http/routerComposition.test.ts
+++ b/packages/athena-webapp/convex/http/routerComposition.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const projectRoot = process.cwd();
+const readProjectFile = (...segments: string[]) =>
+  readFileSync(join(projectRoot, ...segments), "utf8");
+
+describe("http router composition", () => {
+  it("registers Convex auth routes on the shared Hono-backed router instead of bridging through http.lookup", () => {
+    const httpRouter = readProjectFile("convex", "http.ts");
+
+    expect(httpRouter).toContain(
+      "const http = new HttpRouterWithHono<ActionCtx>(app);"
+    );
+    expect(httpRouter).toContain("auth.addHttpRoutes(http);");
+    expect(httpRouter).not.toContain("http.lookup(");
+    expect(httpRouter).not.toContain(
+      'app.get("/.well-known/openid-configuration"'
+    );
+    expect(httpRouter).not.toContain('app.get("/.well-known/jwks.json"');
+    expect(httpRouter).not.toContain('app.get("/api/auth/signin/*"');
+    expect(httpRouter).not.toContain(
+      'app.on(["GET", "POST"], "/api/auth/callback/*"'
+    );
+    expect(httpRouter).toContain("export default http;");
+  });
+});


### PR DESCRIPTION
## Summary
- register Convex auth HTTP routes on the shared `HttpRouterWithHono` instance instead of bridging through `http.lookup(...)/httpAction(...)` calls
- remove the manual Hono passthrough handlers for the OpenID, JWKS, signin, and callback auth routes
- add a regression test for the router composition and document the PR title/body convention in `packages/AGENTS.md`

## Why
- the current auth route bridge pattern causes Convex to warn that one Convex function is directly invoking another Convex function
- `HttpRouterWithHono` already supports mixing Hono routes and standard Convex HTTP routes in one router, so using it directly removes the warning at the routing boundary instead of introducing another helper layer
- documenting the PR convention in repo docs makes the new `[ticket]: title` format and Linear-link requirement explicit for future work

## Validation
- `bun run test convex/http/routerComposition.test.ts`
- `bun run test`
- `bunx tsc --noEmit --pretty false`
- `git diff --check`
- `bun run lint:convex:changed`

Linear: [V26-176](https://linear.app/v26-labs/issue/V26-176/replace-direct-convex-httpaction-bridge-calls-in-auth-well-known)