### PR TITLE
[V26-177]: Ignore generated Convex client files in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,5 +182,6 @@ docs/superpowers/specs/
 
 packages/athena-webapp/stats.html
 packages/storefront-webapp/stats.html
+packages/**/convex/_generated/
 
 .claude/worktrees


### PR DESCRIPTION
## Summary
- add a repo-level ignore rule for generated Convex client output under `packages/**/convex/_generated/`

## Why
- `main` no longer tracks the generated Athena webapp Convex client files, but it was still missing an ignore rule to prevent local regeneration from creating noisy git changes
- this keeps generated Convex output out of normal source control workflows without changing any runtime behavior

## Validation
- `git check-ignore -v packages/athena-webapp/convex/_generated/.ignore-check`
- `git diff --check`

Linear: [V26-177](https://linear.app/v26-labs/issue/V26-177/ignore-generated-convex-client-files-in-git)