### PR TITLE
[V26-175]: continue Convex helper extraction and same-runtime orchestration cleanup in checkout and payment flows

### DIFF
--- a/packages/athena-webapp/convex/storeFront/checkoutSession.ts
+++ b/packages/athena-webapp/convex/storeFront/checkoutSession.ts
@@ -15,6 +15,11 @@ import {
 import { v } from "convex/values";
 import { orderDetailsSchema } from "../schemas/storeFront";
 import { isStoreCheckoutDisabled } from "../inventory/storeConfigV2";
+import {
+  clearBagItems,
+  createOrderFromCheckoutSession,
+  findOrderByExternalReference,
+} from "./helpers/onlineOrder";
 
 const entity = "checkoutSession";
 
@@ -689,9 +694,7 @@ async function handlePlaceOrder(
   session: CheckoutSession
 ) {
   const placedOrder = session.externalReference
-    ? await ctx.runQuery(internal.storeFront.onlineOrder.getInternal, {
-        identifier: session.externalReference,
-      })
+    ? await findOrderByExternalReference(ctx, session.externalReference)
     : null;
 
   if (session.placedOrderId || placedOrder) {
@@ -728,9 +731,7 @@ async function handleOrderCreation(
   orderDetails: any
 ) {
   const placedOrder = session.externalReference
-    ? await ctx.runQuery(internal.storeFront.onlineOrder.getInternal, {
-        identifier: session.externalReference,
-      })
+    ? await findOrderByExternalReference(ctx, session.externalReference)
     : null;
 
   if (session.placedOrderId || placedOrder) {
@@ -748,9 +749,7 @@ async function handleOrderCreation(
 
   if (orderResponse.success) {
     console.log("Order created successfully. Clearing user bag.");
-    await ctx.runMutation(internal.storeFront.bag.clearBag, {
-      id: session.bagId,
-    });
+    await clearBagItems(ctx, session.bagId);
   }
 
   return orderResponse;
@@ -761,9 +760,10 @@ async function createOnlineOrder(
   sessionId: Id<"checkoutSession">,
   orderData: any
 ): Promise<any> {
-  const response = await ctx.runMutation(internal.storeFront.onlineOrder.createInternal, {
+  const response = await createOrderFromCheckoutSession(ctx, {
     checkoutSessionId: sessionId,
     ...orderData,
+    patchSessionPlacedOrderId: true,
   });
 
   if (!response.success) {
@@ -773,7 +773,6 @@ async function createOnlineOrder(
     return { success: false, message: "Failed to create online order." };
   }
 
-  await ctx.db.patch("checkoutSession", sessionId, { placedOrderId: response.orderId });
   return { success: true, orderId: response.orderId };
 }
 

--- a/packages/athena-webapp/convex/storeFront/helperOrchestration.test.ts
+++ b/packages/athena-webapp/convex/storeFront/helperOrchestration.test.ts
@@ -42,4 +42,48 @@ describe("shared helper orchestration", () => {
       "ctx.runQuery(internal.storeFront.bag.getByIdInternal"
     );
   });
+
+  it("extracts shared checkout and order orchestration helpers instead of same-runtime internal order calls", () => {
+    const checkoutSession = readProjectFile(
+      "convex",
+      "storeFront",
+      "checkoutSession.ts"
+    );
+    const onlineOrder = readProjectFile(
+      "convex",
+      "storeFront",
+      "onlineOrder.ts"
+    );
+    const helper = readProjectFile(
+      "convex",
+      "storeFront",
+      "helpers",
+      "onlineOrder.ts"
+    );
+
+    expect(helper).toContain("export async function createOrderFromCheckoutSession");
+    expect(helper).toContain("export async function clearBagItems");
+    expect(helper).toContain("export async function findOrderByExternalReference");
+    expect(helper).toContain("export async function returnOrderItemsToStock");
+
+    expect(checkoutSession).toContain('from "./helpers/onlineOrder"');
+    expect(onlineOrder).toContain('from "./helpers/onlineOrder"');
+
+    expect(checkoutSession).not.toContain(
+      "ctx.runQuery(internal.storeFront.onlineOrder.getInternal"
+    );
+    expect(checkoutSession).not.toContain(
+      "ctx.runMutation(internal.storeFront.bag.clearBag"
+    );
+    expect(checkoutSession).not.toContain(
+      "ctx.runMutation(internal.storeFront.onlineOrder.createInternal"
+    );
+
+    expect(onlineOrder).not.toContain(
+      "ctx.runMutation(internal.storeFront.bag.clearBag"
+    );
+    expect(onlineOrder).not.toContain(
+      "ctx.runMutation(\n            internal.storeFront.onlineOrder.returnAllItemsToStockInternal"
+    );
+  });
 });

--- a/packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts
+++ b/packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts
@@ -1,0 +1,209 @@
+import { Id } from "../../_generated/dataModel";
+import { MutationCtx, QueryCtx } from "../../_generated/server";
+
+const MAX_BAG_ITEMS = 200;
+const MAX_CHECKOUT_SESSION_ITEMS = 200;
+const MAX_ORDER_ITEMS = 200;
+
+function generateOrderNumber() {
+  const timestamp = Math.floor(Date.now() / 1000);
+  const baseOrderNumber = timestamp % 100000;
+  const randomPadding = Math.floor(Math.random() * 10);
+  return (baseOrderNumber * 10 + randomPadding).toString().padStart(5, "0");
+}
+
+export async function findOrderByExternalReference(
+  ctx: QueryCtx | MutationCtx,
+  externalReference: string
+) {
+  return await ctx.db
+    .query("onlineOrder")
+    .withIndex("by_externalReference", (q) =>
+      q.eq("externalReference", externalReference)
+    )
+    .first();
+}
+
+export async function clearBagItems(
+  ctx: MutationCtx,
+  bagId: Id<"bag">
+) {
+  const items = await ctx.db
+    .query("bagItem")
+    .withIndex("by_bagId", (q) => q.eq("bagId", bagId))
+    .take(MAX_BAG_ITEMS);
+
+  await Promise.all(items.map((item) => ctx.db.delete("bagItem", item._id)));
+}
+
+export async function returnOrderItemsToStock(
+  ctx: MutationCtx,
+  orderId: Id<"onlineOrder">
+) {
+  const orderItems = await ctx.db
+    .query("onlineOrderItem")
+    .withIndex("by_orderId", (q) => q.eq("orderId", orderId))
+    .take(MAX_ORDER_ITEMS);
+
+  await Promise.all(
+    orderItems.map(async (item) => {
+      if (item.isRestocked) {
+        console.log("item already restocked", item._id);
+        return;
+      }
+
+      await ctx.db.patch("onlineOrderItem", item._id, {
+        isRefunded: true,
+        isRestocked: true,
+      });
+
+      const productSku = await ctx.db.get("productSku", item.productSkuId);
+      if (!productSku) {
+        return;
+      }
+
+      await ctx.db.patch("productSku", item.productSkuId, {
+        quantityAvailable: productSku.quantityAvailable + item.quantity,
+        inventoryCount: item.isReady
+          ? productSku.inventoryCount + item.quantity
+          : productSku.inventoryCount,
+      });
+    })
+  );
+}
+
+export async function createOrderFromCheckoutSession(
+  ctx: MutationCtx,
+  args: {
+    checkoutSessionId: Id<"checkoutSession">;
+    billingDetails?: any;
+    customerDetails?: any;
+    deliveryDetails?: any;
+    deliveryInstructions?: string | null;
+    deliveryMethod?: string | null;
+    deliveryOption?: string | null;
+    deliveryFee?: number | null;
+    discount?: any;
+    pickupLocation?: string | null;
+    paymentMethod?: any;
+    externalTransactionId?: string;
+    patchSessionPlacedOrderId?: boolean;
+    clearBag?: boolean;
+  }
+) {
+  const session = await ctx.db.get("checkoutSession", args.checkoutSessionId);
+
+  console.log(`creating online order for session: ${session?._id}`);
+
+  if (!session) {
+    return {
+      success: false,
+      error: "Invalid session",
+    };
+  }
+
+  const discount = args.discount ?? session.discount;
+
+  const orderId = await ctx.db.insert("onlineOrder", {
+    storeFrontUserId: session.storeFrontUserId,
+    storeId: session.storeId,
+    checkoutSessionId: args.checkoutSessionId,
+    externalReference: session.externalReference,
+    externalTransactionId:
+      args.externalTransactionId ?? session.externalTransactionId?.toString(),
+    bagId: session.bagId,
+    amount: session.amount,
+    billingDetails: args.billingDetails ?? (session.billingDetails as any),
+    customerDetails: args.customerDetails ?? (session.customerDetails as any),
+    deliveryDetails: args.deliveryDetails ?? (session.deliveryDetails as any),
+    deliveryInstructions:
+      args.deliveryInstructions ?? session.deliveryInstructions,
+    deliveryMethod: args.deliveryMethod ?? session.deliveryMethod ?? "n/a",
+    deliveryOption: args.deliveryOption ?? session.deliveryOption,
+    deliveryFee: args.deliveryFee ?? session.deliveryFee,
+    discount,
+    pickupLocation: args.pickupLocation ?? session.pickupLocation,
+    hasVerifiedPayment: session.hasVerifiedPayment,
+    paymentMethod: args.paymentMethod,
+    orderNumber: generateOrderNumber(),
+    status: "open",
+  });
+
+  const items = await ctx.db
+    .query("checkoutSessionItem")
+    .withIndex("by_sessionId", (q) => q.eq("sesionId", args.checkoutSessionId))
+    .take(MAX_CHECKOUT_SESSION_ITEMS);
+
+  await Promise.all(
+    items.map((item) =>
+      ctx.db.insert("onlineOrderItem", {
+        orderId,
+        productId: item.productId,
+        quantity: item.quantity,
+        productSku: item.productSku,
+        productSkuId: item.productSkuId,
+        storeFrontUserId: item.storeFrontUserId,
+        price: item.price,
+      })
+    )
+  );
+
+  await Promise.all(
+    items.map(async (item) => {
+      const promoCodeItem = await ctx.db
+        .query("promoCodeItem")
+        .withIndex("by_productSkuId", (q) =>
+          q.eq("productSkuId", item.productSkuId)
+        )
+        .first();
+
+      if (promoCodeItem) {
+        await ctx.db.patch("promoCodeItem", promoCodeItem._id, {
+          quantityClaimed:
+            (promoCodeItem.quantityClaimed ?? 0) + item.quantity,
+        });
+      }
+    })
+  );
+
+  if (discount?.id) {
+    if (!discount.isMultipleUses) {
+      await ctx.db.insert("redeemedPromoCode", {
+        promoCodeId: discount.id as Id<"promoCode">,
+        storeFrontUserId: session.storeFrontUserId,
+      });
+    }
+
+    const offer = await ctx.db
+      .query("offer")
+      .withIndex("by_storeFrontUserId", (q) =>
+        q.eq("storeFrontUserId", session.storeFrontUserId)
+      )
+      .filter((q) => q.eq(q.field("promoCodeId"), discount.id))
+      .first();
+
+    if (offer) {
+      await ctx.db.patch("offer", offer._id, {
+        isRedeemed: true,
+        status: "redeemed",
+      });
+    }
+  }
+
+  if (args.patchSessionPlacedOrderId) {
+    await ctx.db.patch("checkoutSession", args.checkoutSessionId, {
+      placedOrderId: orderId,
+    });
+  }
+
+  if (args.clearBag) {
+    await clearBagItems(ctx, session.bagId);
+  }
+
+  console.log("created online order for session.");
+
+  return {
+    success: true,
+    orderId,
+  };
+}

--- a/packages/athena-webapp/convex/storeFront/onlineOrder.ts
+++ b/packages/athena-webapp/convex/storeFront/onlineOrder.ts
@@ -12,9 +12,13 @@ import {
   customerDetailsSchema,
   paymentMethodSchema,
 } from "../schemas/storeFront";
-import { api, internal } from "../_generated/api";
+import { internal } from "../_generated/api";
 import { Doc, Id } from "../_generated/dataModel";
 import { getDiscountValue } from "../inventory/utils";
+import {
+  createOrderFromCheckoutSession,
+  returnOrderItemsToStock,
+} from "./helpers/onlineOrder";
 
 const entity = "onlineOrder";
 const MAX_ORDER_ITEMS = 200;
@@ -28,13 +32,6 @@ async function listOrderItems(
     .query("onlineOrderItem")
     .withIndex("by_orderId", (q) => q.eq("orderId", orderId))
     .take(MAX_ORDER_ITEMS);
-}
-
-function generateOrderNumber() {
-  const timestamp = Math.floor(Date.now() / 1000); // Get current timestamp in seconds
-  const baseOrderNumber = timestamp % 100000; // Reduce to 5 digits
-  const randomPadding = Math.floor(Math.random() * 10); // Add random digit if needed
-  return (baseOrderNumber * 10 + randomPadding).toString().padStart(5, "0"); // Ensure 7 digits
 }
 
 export const create = mutation({
@@ -58,26 +55,8 @@ export const create = mutation({
     paymentMethod: v.optional(paymentMethodSchema),
   },
   handler: async (ctx, args) => {
-    // get the session
-    const session = await ctx.db.get("checkoutSession", args.checkoutSessionId);
-
-    console.log(`creating online order for session: ${session?._id}`);
-
-    if (!session) {
-      return {
-        error: "Invalid session",
-        success: false,
-      };
-    }
-
-    const orderId = await ctx.db.insert(entity, {
-      storeFrontUserId: session?.storeFrontUserId,
-      storeId: session?.storeId,
+    return await createOrderFromCheckoutSession(ctx, {
       checkoutSessionId: args.checkoutSessionId,
-      externalReference: session?.externalReference,
-      externalTransactionId: session?.externalTransactionId?.toString(),
-      bagId: session?.bagId,
-      amount: session?.amount,
       billingDetails: args.billingDetails,
       customerDetails: args.customerDetails,
       deliveryDetails: args.deliveryDetails,
@@ -87,81 +66,8 @@ export const create = mutation({
       deliveryFee: args.deliveryFee,
       discount: args.discount,
       pickupLocation: args.pickupLocation,
-      hasVerifiedPayment: session.hasVerifiedPayment,
       paymentMethod: args.paymentMethod,
-      orderNumber: generateOrderNumber(),
-      status: "open",
     });
-
-    // get the session items using the session id to create the online order items
-    const items = await ctx.db
-      .query("checkoutSessionItem")
-      .withIndex("by_sessionId", (q) => q.eq("sesionId", args.checkoutSessionId))
-      .take(MAX_ORDER_ITEMS);
-
-    await Promise.all(
-      items.map((item) => {
-        return ctx.db.insert("onlineOrderItem", {
-          orderId,
-          productId: item.productId,
-          quantity: item.quantity,
-          productSku: item.productSku,
-          productSkuId: item.productSkuId,
-          storeFrontUserId: item.storeFrontUserId,
-          price: item.price,
-        });
-      })
-    );
-
-    // Check for items in both checkoutSessionItem and promoCodeItem tables
-    await Promise.all(
-      items.map(async (item) => {
-        const promoCodeItem = await ctx.db
-          .query("promoCodeItem")
-          .withIndex("by_productSkuId", (q) =>
-            q.eq("productSkuId", item.productSkuId)
-          )
-          .first();
-
-        if (promoCodeItem) {
-          await ctx.db.patch("promoCodeItem", promoCodeItem._id, {
-            quantityClaimed:
-              (promoCodeItem.quantityClaimed ?? 0) + item.quantity,
-          });
-        }
-      })
-    );
-
-    // update used promo code for this order
-    if (args.discount?.id) {
-      // if the promo code is not multiple uses, insert a redeemed promo code record
-      if (!args.discount.isMultipleUses)
-        await ctx.db.insert("redeemedPromoCode", {
-          promoCodeId: args.discount.id as Id<"promoCode">,
-          storeFrontUserId: session.storeFrontUserId,
-        });
-
-      const offer = await ctx.db
-        .query("offer")
-        .withIndex("by_storeFrontUserId", (q) =>
-          q.eq("storeFrontUserId", session.storeFrontUserId)
-        )
-        .filter((q) =>
-          q.eq(q.field("promoCodeId"), args.discount?.id as Id<"promoCode">)
-        )
-        .first();
-
-      if (offer) {
-        await ctx.db.patch("offer", offer._id, { isRedeemed: true, status: "redeemed" });
-      }
-    }
-
-    console.log("created online order for session.");
-
-    return {
-      success: true,
-      orderId,
-    };
   },
 });
 
@@ -186,25 +92,8 @@ export const createInternal = internalMutation({
     paymentMethod: v.optional(paymentMethodSchema),
   },
   handler: async (ctx, args) => {
-    const session = await ctx.db.get("checkoutSession", args.checkoutSessionId);
-
-    console.log(`creating online order for session: ${session?._id}`);
-
-    if (!session) {
-      return {
-        error: "Invalid session",
-        success: false,
-      };
-    }
-
-    const orderId = await ctx.db.insert(entity, {
-      storeFrontUserId: session?.storeFrontUserId,
-      storeId: session?.storeId,
+    return await createOrderFromCheckoutSession(ctx, {
       checkoutSessionId: args.checkoutSessionId,
-      externalReference: session?.externalReference,
-      externalTransactionId: session?.externalTransactionId?.toString(),
-      bagId: session?.bagId,
-      amount: session?.amount,
       billingDetails: args.billingDetails,
       customerDetails: args.customerDetails,
       deliveryDetails: args.deliveryDetails,
@@ -214,77 +103,8 @@ export const createInternal = internalMutation({
       deliveryFee: args.deliveryFee,
       discount: args.discount,
       pickupLocation: args.pickupLocation,
-      hasVerifiedPayment: session.hasVerifiedPayment,
       paymentMethod: args.paymentMethod,
-      orderNumber: generateOrderNumber(),
-      status: "open",
     });
-
-    const items = await ctx.db
-      .query("checkoutSessionItem")
-      .withIndex("by_sessionId", (q) => q.eq("sesionId", args.checkoutSessionId))
-      .take(MAX_ORDER_ITEMS);
-
-    await Promise.all(
-      items.map((item) => {
-        return ctx.db.insert("onlineOrderItem", {
-          orderId,
-          productId: item.productId,
-          quantity: item.quantity,
-          productSku: item.productSku,
-          productSkuId: item.productSkuId,
-          storeFrontUserId: item.storeFrontUserId,
-          price: item.price,
-        });
-      })
-    );
-
-    await Promise.all(
-      items.map(async (item) => {
-        const promoCodeItem = await ctx.db
-          .query("promoCodeItem")
-          .withIndex("by_productSkuId", (q) =>
-            q.eq("productSkuId", item.productSkuId)
-          )
-          .first();
-
-        if (promoCodeItem) {
-          await ctx.db.patch("promoCodeItem", promoCodeItem._id, {
-            quantityClaimed:
-              (promoCodeItem.quantityClaimed ?? 0) + item.quantity,
-          });
-        }
-      })
-    );
-
-    if (args.discount?.id) {
-      if (!args.discount.isMultipleUses)
-        await ctx.db.insert("redeemedPromoCode", {
-          promoCodeId: args.discount.id as Id<"promoCode">,
-          storeFrontUserId: session.storeFrontUserId,
-        });
-
-      const offer = await ctx.db
-        .query("offer")
-        .withIndex("by_storeFrontUserId", (q) =>
-          q.eq("storeFrontUserId", session.storeFrontUserId)
-        )
-        .filter((q) =>
-          q.eq(q.field("promoCodeId"), args.discount?.id as Id<"promoCode">)
-        )
-        .first();
-
-      if (offer) {
-        await ctx.db.patch("offer", offer._id, { isRedeemed: true, status: "redeemed" });
-      }
-    }
-
-    console.log("created online order for session.");
-
-    return {
-      success: true,
-      orderId,
-    };
   },
 });
 
@@ -295,122 +115,13 @@ export const createFromSession = internalMutation({
     paymentMethod: v.optional(paymentMethodSchema),
   },
   handler: async (ctx, args) => {
-    const session = await ctx.db.get("checkoutSession", args.checkoutSessionId);
-
-    if (!session) {
-      return {
-        success: false,
-        error: "Invalid session",
-      };
-    }
-
-    const orderId = await ctx.db.insert(entity, {
-      storeFrontUserId: session.storeFrontUserId,
-      storeId: session.storeId,
+    return await createOrderFromCheckoutSession(ctx, {
       checkoutSessionId: args.checkoutSessionId,
-      externalReference: session.externalReference,
       externalTransactionId: args.externalTransactionId,
-      bagId: session.bagId,
-      amount: session.amount,
-      billingDetails: session.billingDetails as any,
-      customerDetails: session.customerDetails as any,
-      deliveryDetails: session.deliveryDetails as any,
-      deliveryInstructions: session.deliveryInstructions,
-      deliveryMethod: session.deliveryMethod || "n/a",
-      deliveryOption: session.deliveryOption,
-      deliveryFee: session.deliveryFee,
-      discount: session.discount,
-      pickupLocation: session.pickupLocation,
-      hasVerifiedPayment: session.hasVerifiedPayment,
       paymentMethod: args.paymentMethod,
-      orderNumber: generateOrderNumber(),
-      status: "open",
+      patchSessionPlacedOrderId: true,
+      clearBag: true,
     });
-
-    // get the session items using the session id to create the online order items
-    const items = await ctx.db
-      .query("checkoutSessionItem")
-      .withIndex("by_sessionId", (q) => q.eq("sesionId", args.checkoutSessionId))
-      .take(MAX_ORDER_ITEMS);
-
-    await Promise.all(
-      items.map((item) => {
-        return ctx.db.insert("onlineOrderItem", {
-          orderId,
-          productId: item.productId,
-          quantity: item.quantity,
-          productSku: item.productSku,
-          productSkuId: item.productSkuId,
-          storeFrontUserId: item.storeFrontUserId,
-          price: item.price,
-        });
-      })
-    );
-
-    // Check for items in both checkoutSessionItem and promoCodeItem tables
-    await Promise.all(
-      items.map(async (item) => {
-        const promoCodeItem = await ctx.db
-          .query("promoCodeItem")
-          .withIndex("by_productSkuId", (q) =>
-            q.eq("productSkuId", item.productSkuId)
-          )
-          .first();
-
-        if (promoCodeItem) {
-          await ctx.db.patch("promoCodeItem", promoCodeItem._id, {
-            quantityClaimed:
-              (promoCodeItem.quantityClaimed ?? 0) + item.quantity,
-          });
-        }
-      })
-    );
-
-    // update used promo code for this order
-    if (session.discount?.id) {
-      // if the promo code is not multiple uses, insert a redeemed promo code record
-      if (!session.discount.isMultipleUses)
-        await ctx.db.insert("redeemedPromoCode", {
-          promoCodeId: session.discount.id as Id<"promoCode">,
-          storeFrontUserId: session.storeFrontUserId,
-        });
-
-      const offer = await ctx.db
-        .query("offer")
-        .withIndex("by_storeFrontUserId", (q) =>
-          q.eq("storeFrontUserId", session.storeFrontUserId)
-        )
-        .filter((q) =>
-          q.eq(
-            q.field("promoCodeId"),
-            session.discount?.id as Id<"promoCode">
-          )
-        )
-        .first();
-
-      if (offer) {
-        await ctx.db.patch("offer", offer._id, { isRedeemed: true, status: "redeemed" });
-      }
-    }
-
-    // update the session to reflect that the order has been created
-    await ctx.db.patch("checkoutSession", args.checkoutSessionId, {
-      placedOrderId: orderId,
-    });
-
-    console.log("created online order for session. clearing bag..");
-
-    // clear the bag for the sesion
-    await ctx.runMutation(internal.storeFront.bag.clearBag, {
-      id: session.bagId,
-    });
-
-    console.log("cleared bag for session.");
-
-    return {
-      success: true,
-      orderId,
-    };
   },
 });
 
@@ -707,12 +418,7 @@ export const update = mutation({
           args.update.status === "cancelled" &&
           args.returnItemsToStock !== false
         ) {
-          await ctx.runMutation(
-            internal.storeFront.onlineOrder.returnAllItemsToStockInternal,
-            {
-              orderId: order._id,
-            }
-          );
+          await returnOrderItemsToStock(ctx, order._id);
         }
       }
 
@@ -808,12 +514,7 @@ export const update = mutation({
           args.update.status === "cancelled" &&
           args.returnItemsToStock !== false
         ) {
-          await ctx.runMutation(
-            internal.storeFront.onlineOrder.returnAllItemsToStockInternal,
-            {
-              orderId: order._id,
-            }
-          );
+          await returnOrderItemsToStock(ctx, order._id);
         }
 
         await ctx.db.patch("onlineOrder", order._id, updates);
@@ -860,12 +561,7 @@ export const updateInternal = internalMutation({
           args.update.status === "cancelled" &&
           args.returnItemsToStock !== false
         ) {
-          await ctx.runMutation(
-            internal.storeFront.onlineOrder.returnAllItemsToStockInternal,
-            {
-              orderId: order._id,
-            }
-          );
+          await returnOrderItemsToStock(ctx, order._id);
         }
       }
 
@@ -956,12 +652,7 @@ export const updateInternal = internalMutation({
           args.update.status === "cancelled" &&
           args.returnItemsToStock !== false
         ) {
-          await ctx.runMutation(
-            internal.storeFront.onlineOrder.returnAllItemsToStockInternal,
-            {
-              orderId: order._id,
-            }
-          );
+          await returnOrderItemsToStock(ctx, order._id);
         }
 
         await ctx.db.patch("onlineOrder", order._id, updates);
@@ -1139,31 +830,7 @@ export const updateOrderItemsInternal = internalMutation({
 export const returnAllItemsToStock = mutation({
   args: { orderId: v.id("onlineOrder") },
   handler: async (ctx, args) => {
-    const orderItems = await ctx.db
-      .query("onlineOrderItem")
-      .filter((q) => q.eq(q.field("orderId"), args.orderId))
-      .collect();
-
-    await Promise.all(
-      orderItems.map(async (item) => {
-        if (item.isRestocked) {
-          console.log("item already restocked", item._id);
-          return true;
-        }
-
-        await ctx.db.patch("onlineOrderItem", item._id, { isRefunded: true, isRestocked: true });
-        const productSku = await ctx.db.get("productSku", item.productSkuId);
-        if (productSku) {
-          await ctx.db.patch("productSku", item.productSkuId, {
-            quantityAvailable: productSku.quantityAvailable + item.quantity,
-            inventoryCount: item.isReady
-              ? productSku.inventoryCount + item.quantity
-              : productSku.inventoryCount,
-          });
-        }
-      })
-    );
-
+    await returnOrderItemsToStock(ctx, args.orderId);
     return true;
   },
 });
@@ -1171,31 +838,7 @@ export const returnAllItemsToStock = mutation({
 export const returnAllItemsToStockInternal = internalMutation({
   args: { orderId: v.id("onlineOrder") },
   handler: async (ctx, args) => {
-    const orderItems = await ctx.db
-      .query("onlineOrderItem")
-      .filter((q) => q.eq(q.field("orderId"), args.orderId))
-      .collect();
-
-    await Promise.all(
-      orderItems.map(async (item) => {
-        if (item.isRestocked) {
-          console.log("item already restocked", item._id);
-          return true;
-        }
-
-        await ctx.db.patch("onlineOrderItem", item._id, { isRefunded: true, isRestocked: true });
-        const productSku = await ctx.db.get("productSku", item.productSkuId);
-        if (productSku) {
-          await ctx.db.patch("productSku", item.productSkuId, {
-            quantityAvailable: productSku.quantityAvailable + item.quantity,
-            inventoryCount: item.isReady
-              ? productSku.inventoryCount + item.quantity
-              : productSku.inventoryCount,
-          });
-        }
-      })
-    );
-
+    await returnOrderItemsToStock(ctx, args.orderId);
     return true;
   },
 });


### PR DESCRIPTION
## Summary
- add a shared `convex/storeFront/helpers/onlineOrder.ts` helper layer for direct order lookup, order creation from checkout sessions, bag clearing, and stock return logic
- replace same-runtime `ctx.runQuery` / `ctx.runMutation` chains in `convex/storeFront/checkoutSession.ts` and `convex/storeFront/onlineOrder.ts` with direct helper calls
- extend helper-orchestration regression coverage for the new checkout/order helper path

## Why
- this follow-on continues the helper extraction work intentionally left out of `V26-171` in the more complex checkout and order orchestration modules
- the refactor removes same-runtime internal API hops where plain helper functions are sufficient while keeping the real action/runtime boundaries intact
- checkout/order orchestration is easier to reason about when duplicate order creation, bag clearing, and stock-return flows live behind shared helpers instead of chaining through internal Convex APIs

## Validation
- `bun run --filter '@athena/webapp' lint:convex:changed`
- `bun run vitest run convex/storeFront/helperOrchestration.test.ts`
- `bunx tsc --noEmit --pretty false`
- `git diff --check`

https://linear.app/v26-labs/issue/V26-175/continue-convex-helper-extraction-and-same-runtime-orchestration
