### PR TITLE
[V26-179]: Move repo-local worktrees to repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,6 +176,7 @@ dist
 
 # Local Claude/Codex worktree tracking metadata
 packages/.claude/worktrees/
+/worktrees/
 docs/superpowers/plans/
 docs/superpowers/specs/
 .dual-graph/

--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -331,7 +331,7 @@ bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json
 bunx tsc --noEmit -p packages/storefront-webapp/tsconfig.json
 ```
 
-**Agent worktrees (Symphony):** When Symphony picks up a Linear issue it creates a git worktree under `.claude/worktrees/`. Agents work inside those isolated copies — not in the main checkout. Each worktree is on its own branch (`claude/<branch-name>`).
+**Agent worktrees (Symphony):** When Symphony picks up a Linear issue it creates a git worktree under `worktrees/` at the repository root. Agents work inside those isolated copies — not in the main checkout. Each worktree is on its own branch (`codex/<branch-name>`).
 
 ---
 

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -7,7 +7,7 @@ tracker:
 polling:
   interval_ms: 30000
 workspace:
-  root: $HOME/.athena/symphony-workspaces
+  root: $ATHENA_REPO_ROOT/worktrees
 hooks:
   after_create: bash /Users/kwamina/athena/scripts/symphony/after-create.sh
   before_run: bash /Users/kwamina/athena/scripts/symphony/before-run.sh


### PR DESCRIPTION
## Summary
- point Symphony workspace provisioning at `$ATHENA_REPO_ROOT/worktrees`
- ignore the repo-root `worktrees/` directory and update the manifest to describe the new location
- remove the existing repo-local worktrees under `.claude/worktrees` and `packages/.claude/worktrees`
- preserve dirty repo-local worktrees with named stash backups before removal

## Why
- the repo is moving away from `.claude/worktrees` to a root-level `worktrees/` directory for active workspace creation
- cleaning out the old repo-local worktrees avoids stale nested checkouts and keeps future workspace provisioning aligned with the new config

## Validation
- `git diff --check`
- `git worktree list --porcelain | awk '/^worktree /{print $2}' | grep -E '^/Users/kwamina/athena/(\.claude/worktrees|packages/\.claude/worktrees)/' || true`
- `rg -n "\.athena/symphony-workspaces|\.claude/worktrees" /Users/kwamina/.config/superpowers/worktrees/athena/codex/worktrees-root-cleanup -g '!**/node_modules/**' -g '!**/.git/**'`
- verified stash backups exist with message prefix `codex/worktree-cleanup-backup:` for previously dirty repo-local worktrees

https://linear.app/v26-labs/issue/V26-179/move-repo-local-worktree-storage-to-root-worktrees-and-remove-old
