### PR TITLE
[V26-163]: Align storefront checkout client with hardened backend contract

### DIFF
--- a/packages/storefront-webapp/src/api/checkoutSession.test.ts
+++ b/packages/storefront-webapp/src/api/checkoutSession.test.ts
@@ -1,0 +1,145 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  CheckoutSessionError,
+  createCheckoutSession,
+  getCheckoutActionErrorMessage,
+  updateCheckoutSession,
+} from "./checkoutSession";
+
+const fetchMock = vi.fn<typeof fetch>();
+
+const validOrderDetails = {
+  customerDetails: {
+    email: "ada@example.com",
+    firstName: "Ada",
+    lastName: "Lovelace",
+    phoneNumber: "233555555555",
+  },
+  deliveryMethod: "pickup" as const,
+  deliveryOption: null,
+  deliveryFee: null,
+  pickupLocation: "wigclub-hair-studio",
+  deliveryDetails: null,
+  discount: null,
+};
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+
+describe("checkoutSession api", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("sends only the bag id when creating a checkout session", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({
+        _id: "session_123",
+      }),
+    );
+
+    await createCheckoutSession({
+      bagId: "bag_123",
+      bagItems: [
+        {
+          productId: "product_123",
+          productSku: "sku-1",
+          productSkuId: "sku_123",
+          quantity: 2,
+        },
+      ],
+      bagSubtotal: 4200,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [, requestInit] = fetchMock.mock.calls[0];
+
+    expect(JSON.parse(String(requestInit?.body))).toEqual({
+      bagId: "bag_123",
+    });
+  });
+
+  it("does not send client-authored totals when finalizing payment", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({
+        authorization_url: "https://paystack.test/redirect",
+      }),
+    );
+
+    await updateCheckoutSession({
+      action: "finalize-payment",
+      sessionId: "session_123",
+      customerEmail: "ada@example.com",
+      orderDetails: validOrderDetails,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [, requestInit] = fetchMock.mock.calls[0];
+    const payload = JSON.parse(String(requestInit?.body));
+
+    expect(payload).toMatchObject({
+      action: "finalize-payment",
+      customerEmail: "ada@example.com",
+      orderDetails: {
+        ...validOrderDetails,
+        billingDetails: null,
+      },
+    });
+    expect(payload).not.toHaveProperty("amount");
+  });
+
+  it("surfaces checkout status codes and server error metadata", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(
+        {
+          error:
+            "This checkout session has already been completed. Please refresh the page or return to your shopping bag to start a new checkout.",
+          code: "SESSION_ALREADY_FINALIZED",
+        },
+        422,
+      ),
+    );
+
+    await expect(
+      updateCheckoutSession({
+        action: "complete-checkout",
+        sessionId: "session_123",
+        hasCompletedCheckoutSession: true,
+      }),
+    ).rejects.toEqual(
+      expect.objectContaining<Partial<CheckoutSessionError>>({
+        message:
+          "This checkout session has already been completed. Please refresh the page or return to your shopping bag to start a new checkout.",
+        status: 422,
+        code: "SESSION_ALREADY_FINALIZED",
+      }),
+    );
+  });
+
+  it("maps invalid checkout states to an actionable payment message", () => {
+    const error = new CheckoutSessionError(
+      "This checkout session has already been completed.",
+      {
+        status: 422,
+        code: "SESSION_ALREADY_FINALIZED",
+      },
+    );
+
+    expect(getCheckoutActionErrorMessage(error, "finalize-payment")).toBe(
+      "This checkout session has already been completed. Please refresh the page or return to your shopping bag to start a new checkout.",
+    );
+  });
+});

--- a/packages/storefront-webapp/src/api/checkoutSession.ts
+++ b/packages/storefront-webapp/src/api/checkoutSession.ts
@@ -1,29 +1,193 @@
 import config from "@/config";
+import type { CheckoutOrderSubmission } from "@/components/checkout/schemas/webOrderSchema";
 import { CheckoutSession, ProductSku } from "@athena/webapp";
-import { postAnalytics } from "./analytics";
 
 const getBaseUrl = () => `${config.apiGateway.URL}/checkout`;
 
+type CheckoutApiResponse = Record<string, unknown>;
+
+type CreateCheckoutSessionInput = {
+  bagId: string;
+  bagItems?: unknown;
+  bagSubtotal?: number;
+};
+
+type FinalizePaymentInput = {
+  action: "finalize-payment" | "create-pod-order";
+  sessionId: string;
+  isFinalizingPayment?: boolean;
+  customerEmail: string;
+  orderDetails: CheckoutOrderSubmission;
+};
+
+type CompleteCheckoutInput = {
+  action: "complete-checkout";
+  sessionId: string;
+  hasCompletedCheckoutSession?: boolean;
+  orderDetails?: CheckoutOrderSubmission;
+};
+
+type PlaceOrderInput = {
+  action: "place-order";
+  sessionId: string;
+  hasCompletedCheckoutSession?: boolean;
+};
+
+type UpdateOrderInput = {
+  action: "update-order";
+  sessionId: string;
+  placedOrderId: string;
+  hasCompletedCheckoutSession?: boolean;
+};
+
+type CancelOrderInput = {
+  action: "cancel-order";
+  sessionId: string;
+  hasCompletedCheckoutSession?: boolean;
+};
+
+export type CheckoutSessionUpdateInput =
+  | FinalizePaymentInput
+  | CompleteCheckoutInput
+  | PlaceOrderInput
+  | UpdateOrderInput
+  | CancelOrderInput;
+
+type CheckoutAction = CheckoutSessionUpdateInput["action"];
+
+type CheckoutSessionErrorOptions = {
+  status: number;
+  code?: string;
+  payload?: CheckoutApiResponse | null;
+};
+
+export class CheckoutSessionError extends Error {
+  status: number;
+  code?: string;
+  payload?: CheckoutApiResponse | null;
+
+  constructor(message: string, options: CheckoutSessionErrorOptions) {
+    super(message);
+    this.name = "CheckoutSessionError";
+    this.status = options.status;
+    this.code = options.code;
+    this.payload = options.payload;
+  }
+}
+
+const isRecord = (value: unknown): value is CheckoutApiResponse =>
+  typeof value === "object" && value !== null;
+
+const parseJson = async (
+  response: Response,
+): Promise<CheckoutApiResponse | null> => {
+  const text = await response.text();
+
+  if (!text) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(text);
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+};
+
+const getCheckoutErrorMessageFromPayload = (
+  payload: CheckoutApiResponse | null,
+  fallbackMessage: string,
+) => {
+  const error = payload?.error;
+  if (typeof error === "string" && error.length > 0) {
+    return error;
+  }
+
+  const message = payload?.message;
+  if (typeof message === "string" && message.length > 0) {
+    return message;
+  }
+
+  return fallbackMessage;
+};
+
+const parseCheckoutResponse = async <T>(
+  response: Response,
+  fallbackMessage: string,
+): Promise<T> => {
+  const payload = await parseJson(response);
+
+  if (!response.ok) {
+    throw new CheckoutSessionError(
+      getCheckoutErrorMessageFromPayload(payload, fallbackMessage),
+      {
+        status: response.status,
+        code: typeof payload?.code === "string" ? payload.code : undefined,
+        payload,
+      },
+    );
+  }
+
+  return (payload ?? {}) as T;
+};
+
+const defaultCheckoutActionMessage = (action: CheckoutAction) => {
+  if (action === "create-pod-order") {
+    return "We couldn't place your pay-on-delivery order. Please try again.";
+  }
+
+  if (action === "complete-checkout") {
+    return "We couldn't finish loading your completed order. Please try again.";
+  }
+
+  return "We couldn't finalize your payment. Please try again.";
+};
+
+export const getCheckoutActionErrorMessage = (
+  error: unknown,
+  action: CheckoutAction,
+) => {
+  const fallbackMessage = defaultCheckoutActionMessage(action);
+
+  if (!(error instanceof CheckoutSessionError)) {
+    return fallbackMessage;
+  }
+
+  if (error.code === "SESSION_ALREADY_FINALIZED") {
+    return "This checkout session has already been completed. Please refresh the page or return to your shopping bag to start a new checkout.";
+  }
+
+  if (error.status === 403) {
+    return "This checkout session is no longer available for your account. Refresh the page or return to your shopping bag to start again.";
+  }
+
+  if (error.status === 400) {
+    return "We couldn't validate your checkout details. Please review your information and try again.";
+  }
+
+  if (error.status === 422) {
+    if (
+      error.message === "Amount mismatch detected" ||
+      error.message.includes("quantity must be positive") ||
+      error.message.includes("checkoutable items")
+    ) {
+      return "Your bag changed while checkout was open. Refresh your shopping bag and try again.";
+    }
+
+    return error.message || fallbackMessage;
+  }
+
+  return error.message || fallbackMessage;
+};
+
 export async function createCheckoutSession({
   bagId,
-  bagItems,
-  bagSubtotal,
-}: {
-  bagId: string;
-  bagItems: {
-    quantity: number;
-    productSkuId: string;
-    productSku: string;
-    productId: string;
-  }[];
-  bagSubtotal: number;
-}) {
+}: CreateCheckoutSessionInput) {
   const response = await fetch(getBaseUrl(), {
     method: "POST",
     body: JSON.stringify({
       bagId,
-      products: bagItems,
-      amount: bagSubtotal,
     }),
     headers: {
       "Content-Type": "application/json",
@@ -31,13 +195,10 @@ export async function createCheckoutSession({
     credentials: "include",
   });
 
-  const res = await response.json();
-
-  if (!response.ok) {
-    throw new Error("Error initializing checkout session");
-  }
-
-  return res;
+  return await parseCheckoutResponse<CheckoutApiResponse>(
+    response,
+    "Error initializing checkout session",
+  );
 }
 
 export async function getActiveCheckoutSession(): Promise<CheckoutSession | null> {
@@ -45,13 +206,10 @@ export async function getActiveCheckoutSession(): Promise<CheckoutSession | null
     credentials: "include",
   });
 
-  const res = await response.json();
-
-  if (!response.ok) {
-    throw new Error("Error loading active session.");
-  }
-
-  return res;
+  return await parseCheckoutResponse<CheckoutSession | null>(
+    response,
+    "Error loading active session.",
+  );
 }
 
 export async function getPendingCheckoutSessions(): Promise<CheckoutSession[]> {
@@ -59,13 +217,10 @@ export async function getPendingCheckoutSessions(): Promise<CheckoutSession[]> {
     credentials: "include",
   });
 
-  const res = await response.json();
-
-  if (!response.ok) {
-    throw new Error(res.error || "Error loading active session.");
-  }
-
-  return res;
+  return await parseCheckoutResponse<CheckoutSession[]>(
+    response,
+    "Error loading active session.",
+  );
 }
 
 export async function getCheckoutSession(
@@ -75,56 +230,34 @@ export async function getCheckoutSession(
     credentials: "include",
   });
 
-  const res = await response.json();
-
-  if (!response.ok) {
-    throw new Error(res.error || "Error loading session.");
-  }
-
-  return res;
+  return await parseCheckoutResponse<CheckoutSession & { items: ProductSku[] }>(
+    response,
+    "Error loading session.",
+  );
 }
 
-export async function updateCheckoutSession({
-  action,
-  sessionId,
-  isFinalizingPayment,
-  hasCompletedCheckoutSession,
-  externalReference,
-  customerEmail,
-  amount,
-  orderDetails,
-  placedOrderId,
-}: {
-  action:
-    | "finalize-payment"
-    | "complete-checkout"
-    | "place-order"
-    | "update-order"
-    | "cancel-order"
-    | "create-pod-order";
-  sessionId: string;
-  isFinalizingPayment?: boolean;
-  hasCompletedCheckoutSession?: boolean;
-  externalReference?: string;
-  customerEmail?: string;
-  amount?: number;
-  orderDetails?: any;
-  placedOrderId?: string;
-}) {
-  const response = await fetch(`${getBaseUrl()}/${sessionId}`, {
+export async function updateCheckoutSession(
+  input: CheckoutSessionUpdateInput,
+): Promise<CheckoutApiResponse> {
+  const response = await fetch(`${getBaseUrl()}/${input.sessionId}`, {
     method: "POST",
     body: JSON.stringify({
-      action,
-      isFinalizingPayment,
-      customerEmail,
-      amount,
-      externalReference,
-      hasCompletedCheckoutSession,
-      orderDetails: {
-        ...orderDetails,
-        billingDetails: null,
-      },
-      placedOrderId,
+      action: input.action,
+      isFinalizingPayment:
+        "isFinalizingPayment" in input ? input.isFinalizingPayment : undefined,
+      customerEmail: "customerEmail" in input ? input.customerEmail : undefined,
+      hasCompletedCheckoutSession:
+        "hasCompletedCheckoutSession" in input
+          ? input.hasCompletedCheckoutSession
+          : undefined,
+      orderDetails:
+        "orderDetails" in input && input.orderDetails
+          ? {
+              ...input.orderDetails,
+              billingDetails: null,
+            }
+          : undefined,
+      placedOrderId: "placedOrderId" in input ? input.placedOrderId : undefined,
     }),
     headers: {
       "Content-Type": "application/json",
@@ -132,13 +265,10 @@ export async function updateCheckoutSession({
     credentials: "include",
   });
 
-  const res = await response.json();
-
-  if (!response.ok) {
-    throw new Error(res.error || "Error updating checkout session.");
-  }
-
-  return res;
+  return await parseCheckoutResponse<CheckoutApiResponse>(
+    response,
+    "Error updating checkout session.",
+  );
 }
 
 export async function verifyCheckoutSessionPayment({
@@ -150,11 +280,8 @@ export async function verifyCheckoutSessionPayment({
     credentials: "include",
   });
 
-  const res = await response.json();
-
-  if (!response.ok) {
-    throw new Error(res.error || "Error loading active session.");
-  }
-
-  return res;
+  return await parseCheckoutResponse<CheckoutApiResponse>(
+    response,
+    "Error loading active session.",
+  );
 }

--- a/packages/storefront-webapp/src/components/checkout/BagSummary.tsx
+++ b/packages/storefront-webapp/src/components/checkout/BagSummary.tsx
@@ -1,7 +1,6 @@
 import { useStoreContext } from "@/contexts/StoreContext";
 import { useShoppingBag } from "@/hooks/useShoppingBag";
 import { getProductName } from "@/lib/productUtils";
-import { ProductSku } from "@athena/webapp";
 import { Discount } from "./types";
 import { useCheckout } from "@/hooks/useCheckout";
 import { Link } from "@tanstack/react-router";
@@ -23,13 +22,26 @@ import { Badge } from "../ui/badge";
 import { useDiscountCodeAlert } from "@/hooks/useDiscountCodeAlert";
 import { getStoreConfigV2, getStoreFallbackImageUrl } from "@/lib/storeConfig";
 
+type BagSummaryItem = {
+  colorName?: string | null;
+  length?: number;
+  price: number;
+  productCategory?: string;
+  productImage?: string;
+  productName?: string;
+  productSku?: string;
+  productSkuId: string;
+  quantity: number;
+  size?: string;
+};
+
 function SummaryItem({
   item,
   formatter,
   discount,
   totalItemsInBag,
 }: {
-  item: any;
+  item: BagSummaryItem;
   formatter: Intl.NumberFormat;
   discount?: Discount | null;
   totalItemsInBag: number;
@@ -110,7 +122,7 @@ export function BagSummaryItems({
   items,
   discount,
 }: {
-  items: ProductSku[];
+  items: BagSummaryItem[];
   discount?: Discount | null;
 }) {
   const { formatter } = useStoreContext();
@@ -121,7 +133,7 @@ export function BagSummaryItems({
 
   return (
     <div className="space-y-12 w-full">
-      {items?.map((item: ProductSku, index: number) => (
+      {items?.map((item, index: number) => (
         <SummaryItem
           formatter={formatter}
           item={item}

--- a/packages/storefront-webapp/src/components/checkout/CheckoutProvider.tsx
+++ b/packages/storefront-webapp/src/components/checkout/CheckoutProvider.tsx
@@ -397,7 +397,12 @@ export const CheckoutProvider = ({
 
   if (isLoading || data === undefined) return null;
 
-  if (checkoutState.bag === null) {
+  const hasServerBackedCheckout =
+    Boolean(data?.placedOrderId) ||
+    Boolean(data?.hasCompletedPayment) ||
+    Boolean(data?.hasVerifiedPayment);
+
+  if (checkoutState.bag === null && !hasServerBackedCheckout) {
     return <NoCheckoutSession />;
   }
 

--- a/packages/storefront-webapp/src/components/checkout/PaymentSection.tsx
+++ b/packages/storefront-webapp/src/components/checkout/PaymentSection.tsx
@@ -1,5 +1,9 @@
 import { useState } from "react";
-import { webOrderSchema } from "./schemas/webOrderSchema";
+import { getCheckoutActionErrorMessage } from "@/api/checkoutSession";
+import {
+  CheckoutOrderSubmission,
+  webOrderSchema,
+} from "./schemas/webOrderSchema";
 import { useCheckout } from "@/hooks/useCheckout";
 import { CheckedState } from "@radix-ui/react-checkbox";
 import { Separator } from "../ui/separator";
@@ -22,24 +26,19 @@ export const PaymentSection = ({ form }: CheckoutFormSectionProps) => {
 
   const { user } = useStoreContext();
 
-  const { bagSubtotal, updateCheckoutSession } = useShoppingBag();
+  const { updateCheckoutSession } = useShoppingBag();
 
   const [isProceedingToPayment, setIsProceedingToPayment] = useState(false);
   const [didAcceptStoreTerms, setDidAcceptStoreTerms] = useState(false);
   const [didAcceptCommsTerms, setDidAcceptCommsTerms] = useState(false);
-  const [errorFinalizingPayment, setErrorFinalizingPayment] = useState(false);
-
   const [errorMessage, setErrorMessage] = useState("");
 
   const onSubmit = async () => {
-    setErrorFinalizingPayment(false);
     setErrorMessage("");
 
     try {
       const canProceedToPayment = await canPlaceOrder();
       const { data } = webOrderSchema.safeParse(checkoutState);
-
-      const total = bagSubtotal;
 
       if (!canProceedToPayment || !data || !activeSession._id) {
         throw new Error("Invalid order state");
@@ -58,7 +57,6 @@ export const PaymentSection = ({ form }: CheckoutFormSectionProps) => {
               paymentMethod: checkoutState.paymentMethod,
               podPaymentMethod: checkoutState.podPaymentMethod,
             },
-            total
           ),
           postAnalytics({
             action: "finalized_payment_on_delivery_checkout",
@@ -73,13 +71,14 @@ export const PaymentSection = ({ form }: CheckoutFormSectionProps) => {
         const podResult = results[0];
         if (podResult.status === "fulfilled") {
           const podResponse = podResult.value;
-          if (podResponse?.success) {
+          if (podResponse?.success === true) {
             // Redirect to POD confirmation page
             window.open("/shop/checkout/pod-confirmation", "_self");
           } else {
             setErrorMessage(
-              podResponse?.message ||
-                "Failed to create payment on delivery order"
+              typeof podResponse?.message === "string"
+                ? podResponse.message
+                : "Failed to create payment on delivery order"
             );
           }
         } else {
@@ -103,7 +102,6 @@ export const PaymentSection = ({ form }: CheckoutFormSectionProps) => {
               ...data,
               deliveryDetails: data.deliveryDetails ?? null,
             },
-            total
           ),
           postAnalytics({
             action: "finalized_checkout",
@@ -118,11 +116,13 @@ export const PaymentSection = ({ form }: CheckoutFormSectionProps) => {
         const paymentResult = results[0];
         if (paymentResult.status === "fulfilled") {
           const paymentResponse = paymentResult.value;
-          if (paymentResponse?.authorization_url) {
+          if (typeof paymentResponse?.authorization_url === "string") {
             window.open(paymentResponse.authorization_url, "_self");
-          } else if (!paymentResponse?.success) {
+          } else if (paymentResponse?.success !== true) {
             setErrorMessage(
-              paymentResponse?.message || "Failed to finalize payment"
+              typeof paymentResponse?.message === "string"
+                ? paymentResponse.message
+                : "Failed to finalize payment"
             );
           } else {
             throw new Error("No authorization URL received");
@@ -143,28 +143,35 @@ export const PaymentSection = ({ form }: CheckoutFormSectionProps) => {
       }
     } catch (error) {
       console.error("Payment error:", error);
-      setErrorFinalizingPayment(true);
+      setErrorMessage(
+        getCheckoutActionErrorMessage(
+          error,
+          checkoutState.paymentMethod === "payment_on_delivery"
+            ? "create-pod-order"
+            : "finalize-payment",
+        ),
+      );
     } finally {
       setIsProceedingToPayment(false);
     }
   };
 
-  const processCheckoutSession = async (orderData: any, total: number) => {
+  const processCheckoutSession = async (orderData: CheckoutOrderSubmission) => {
     return await updateCheckoutSession({
       action: "finalize-payment",
       sessionId: activeSession._id,
       customerEmail: checkoutState.customerDetails?.email || "",
-      amount: total,
       orderDetails: orderData,
     });
   };
 
-  const processPODCheckoutSession = async (orderData: any, total: number) => {
+  const processPODCheckoutSession = async (
+    orderData: CheckoutOrderSubmission,
+  ) => {
     return await updateCheckoutSession({
       action: "create-pod-order",
       sessionId: activeSession._id,
       customerEmail: checkoutState.customerDetails?.email || "",
-      amount: total,
       orderDetails: orderData,
     });
   };
@@ -304,20 +311,6 @@ export const PaymentSection = ({ form }: CheckoutFormSectionProps) => {
           className="text-sm text-red-600 font-medium"
         >
           Please provide all the required information
-        </motion.p>
-      )}
-
-      {errorFinalizingPayment && (
-        <motion.p
-          initial={{ opacity: 0, y: -2 }}
-          animate={{
-            opacity: 1,
-            y: 0,
-            transition: { duration: 0.3, ease: "easeInOut" },
-          }}
-          className="text-sm text-red-600 font-medium"
-        >
-          There was an error finalizing your payment. Please try again.
         </motion.p>
       )}
 

--- a/packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.ts
+++ b/packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.ts
@@ -174,3 +174,10 @@ export const webOrderSchema = z
       }
     }
   });
+
+export type CheckoutOrderDetails = z.infer<typeof webOrderSchema>;
+
+export type CheckoutOrderSubmission = CheckoutOrderDetails & {
+  paymentMethod?: "online_payment" | "payment_on_delivery";
+  podPaymentMethod?: "cash" | "mobile_money" | null;
+};

--- a/packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx
+++ b/packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx
@@ -433,24 +433,12 @@ export default function ShoppingBag() {
   });
 
   const handleOnCheckoutClick = async () => {
-    // send post
-    const bagItems =
-      bag?.items.map((item: any) => ({
-        productSkuId: item.productSkuId,
-        quantity: item.quantity,
-        productSku: item.productSku,
-        productId: item.productId,
-        price: item.price,
-      })) || [];
-
     setIsProcessingCheckoutRequest(true);
     setError(null);
 
     try {
       const res = await obtainCheckoutSession({
-        bagItems,
         bagId: bag?._id as string,
-        bagSubtotal: bagSubtotal, // pesewas — backend recalculates canonical amount from bag items
       });
 
       if (res.session) {
@@ -467,7 +455,11 @@ export default function ShoppingBag() {
           to: "/shop/checkout",
         });
       } else {
-        setError(res.message);
+        setError(
+          typeof res.message === "string"
+            ? res.message
+            : "Unable to start checkout right now.",
+        );
         setIsProcessingCheckoutRequest(false);
       }
     } catch (e) {

--- a/packages/storefront-webapp/src/hooks/useShoppingBag.ts
+++ b/packages/storefront-webapp/src/hooks/useShoppingBag.ts
@@ -8,6 +8,7 @@ import {
   createCheckoutSession,
   updateCheckoutSession as updateCheckoutSessionAPI,
 } from "@/api/checkoutSession";
+import type { CheckoutOrderSubmission } from "@/components/checkout/schemas/webOrderSchema";
 import {
   addItemToSavedBag,
   removeItemFromSavedBag,
@@ -362,31 +363,16 @@ export const useShoppingBag = () => {
   };
 
   const obtainCheckoutSessionMutation = useMutation({
-    mutationFn: ({
-      bagId,
-      bagItems,
-      bagSubtotal,
-    }: {
-      bagId: string;
-      bagItems: {
-        quantity: number;
-        productSkuId: string;
-        productSku: string;
-        productId: string;
-      }[];
-      bagSubtotal: number;
-    }) =>
+    mutationFn: ({ bagId }: { bagId: string }) =>
       createCheckoutSession({
         bagId,
-        bagItems,
-        bagSubtotal,
       }),
     onError: () => {
       setOperationSuccessful(false);
     },
     onSuccess: (res) => {
       setOperationSuccessful(true);
-      if (res.unavailableProducts) {
+      if (isUnavailableProductList(res.unavailableProducts)) {
         setUnavailableProducts(res.unavailableProducts);
       } else {
         setUnavailableProducts([]);
@@ -399,22 +385,19 @@ export const useShoppingBag = () => {
       sessionId,
       isFinalizingPayment,
       customerEmail,
-      amount,
       orderDetails,
       action = "finalize-payment",
     }: {
       isFinalizingPayment?: boolean;
       sessionId: string;
       customerEmail: string;
-      amount: number;
-      orderDetails: any;
+      orderDetails: CheckoutOrderSubmission;
       action?: "finalize-payment" | "create-pod-order";
     }) =>
       updateCheckoutSessionAPI({
         isFinalizingPayment,
         sessionId,
         customerEmail,
-        amount,
         action,
         orderDetails,
       }),
@@ -432,23 +415,12 @@ export const useShoppingBag = () => {
 
   const obtainCheckoutSession = async ({
     bagId,
-    bagItems,
-    bagSubtotal,
   }: {
     bagId: string;
-    bagItems: {
-      quantity: number;
-      productSkuId: string;
-      productSku: string;
-      productId: string;
-    }[];
-    bagSubtotal: number;
   }) => {
     setOperationSuccessful(null);
     return await obtainCheckoutSessionMutation.mutateAsync({
       bagId,
-      bagItems,
-      bagSubtotal,
     });
   };
 
@@ -456,15 +428,13 @@ export const useShoppingBag = () => {
     isFinalizingPayment,
     sessionId,
     customerEmail,
-    amount,
     orderDetails,
     action = "finalize-payment",
   }: {
     isFinalizingPayment?: boolean;
     sessionId: string;
     customerEmail: string;
-    amount: number;
-    orderDetails: any;
+    orderDetails: CheckoutOrderSubmission;
     action?: "finalize-payment" | "create-pod-order";
   }) => {
     setOperationSuccessful(null);
@@ -473,7 +443,6 @@ export const useShoppingBag = () => {
       isFinalizingPayment,
       sessionId,
       customerEmail,
-      amount,
       orderDetails,
       action,
     });
@@ -504,4 +473,17 @@ export const useShoppingBag = () => {
     areProductsUnavailable,
     updateCheckoutSession,
   };
+};
+const isUnavailableProductList = (
+  value: unknown,
+): value is UnavailableProducts => {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (item) =>
+        typeof item?.productSkuId === "string" &&
+        typeof item?.requested === "number" &&
+        typeof item?.available === "number",
+    )
+  );
 };

--- a/packages/storefront-webapp/src/lib/productUtils.ts
+++ b/packages/storefront-webapp/src/lib/productUtils.ts
@@ -1,11 +1,22 @@
 import { BagItem, ProductSku, SavedBagItem } from "@athena/webapp";
 import { capitalizeWords } from "./utils";
 
+type ProductNameInput =
+  | ProductSku
+  | BagItem
+  | SavedBagItem
+  | {
+      colorName?: string | null;
+      length?: number;
+      productCategory?: string;
+      productName?: string;
+    };
+
 /**
  * Gets the formatted product name from a product SKU
  */
 export function getProductName(
-  item: ProductSku | BagItem | SavedBagItem
+  item: ProductNameInput
 ): string {
   if (item.productCategory == "Hair") {
     if (!item.colorName) {

--- a/packages/storefront-webapp/src/routes/shop/checkout/complete.index.tsx
+++ b/packages/storefront-webapp/src/routes/shop/checkout/complete.index.tsx
@@ -23,14 +23,13 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { AnimatePresence, motion } from "framer-motion";
 import { ArrowLeft } from "lucide-react";
 import { useEffect, useState } from "react";
-import { webOrderSchema } from "@/components/checkout/CheckoutProvider";
 
 export const Route = createFileRoute("/shop/checkout/complete/")({
   component: () => <CheckoutCompleteView />,
 });
 
 export const CheckoutComplete = () => {
-  const { checkoutState, activeSession, onlineOrder } = useCheckout();
+  const { activeSession, onlineOrder } = useCheckout();
   const { bag } = useShoppingBag();
   const { userId } = useAuth();
   const queryClient = useQueryClient();
@@ -50,15 +49,12 @@ export const CheckoutComplete = () => {
         return;
       }
 
-      const { data } = webOrderSchema.safeParse(checkoutState);
-
       try {
         await Promise.allSettled([
           updateCheckoutSession({
             action: "complete-checkout",
             sessionId: activeSession._id,
             hasCompletedCheckoutSession: true,
-            orderDetails: data,
           }),
           postAnalytics({
             action: "completed_checkout",
@@ -83,7 +79,6 @@ export const CheckoutComplete = () => {
   ]);
 
   const retryOrderCreation = async () => {
-    const { data } = webOrderSchema.safeParse(checkoutState);
     setIsRetrying(true);
     setHasOrderError(false);
 
@@ -92,7 +87,6 @@ export const CheckoutComplete = () => {
         action: "complete-checkout",
         sessionId: activeSession._id,
         hasCompletedCheckoutSession: true,
-        orderDetails: data,
       });
 
       queryClient.invalidateQueries({ queryKey: bagQueries.activeBagKey() });
@@ -147,7 +141,7 @@ export const CheckoutComplete = () => {
     );
   }
 
-  const bagItems = onlineOrder?.items || checkoutState.bag.items;
+  const bagItems = onlineOrder?.items ?? [];
   const hasBagItems = (bag?.items?.length ?? 0) > 0;
 
   const deliveryMessage =

--- a/packages/storefront-webapp/src/routes/shop/checkout/pod-confirmation.tsx
+++ b/packages/storefront-webapp/src/routes/shop/checkout/pod-confirmation.tsx
@@ -15,7 +15,6 @@ import { useAuth } from "@/hooks/useAuth";
 import { GuestRewardsPrompt } from "@/components/rewards/GuestRewardsPrompt";
 import {
   CheckoutProvider,
-  webOrderSchema,
 } from "@/components/checkout/CheckoutProvider";
 import { useCheckout } from "@/hooks/useCheckout";
 
@@ -30,22 +29,20 @@ export const Route = createFileRoute("/shop/checkout/pod-confirmation")({
 });
 
 // Payment details component specific to POD
-const PODPaymentDetails = ({ session }: { session: any }) => {
+const PODPaymentDetails = ({
+  items,
+  session,
+}: {
+  items: { productSkuId: string; quantity: number; price: number }[];
+  session: any;
+}) => {
   const { formatter } = useStoreContext();
-  const { checkoutState } = useCheckout();
 
   if (!session?.paymentMethod) {
     return null;
   }
 
   const podPaymentMethod = session.paymentMethod?.podPaymentMethod || "cash";
-
-  const items =
-    checkoutState.bag?.items?.map((item: any) => ({
-      productSkuId: item.productSkuId,
-      quantity: item.quantity,
-      price: item.price,
-    })) || [];
 
   const discount = session?.discount as any;
 
@@ -153,6 +150,15 @@ const PODPickupDetails = ({ session }: { session: any }) => {
 
 // Order details component for POD
 const PODOrderDetails = ({ session }: { session: any }) => {
+  const { onlineOrder } = useCheckout();
+
+  const items =
+    onlineOrder?.items?.map((item: any) => ({
+      productSkuId: item.productSkuId,
+      quantity: item.quantity,
+      price: item.price,
+    })) || [];
+
   return (
     <motion.div
       initial={{ opacity: 0 }}
@@ -164,7 +170,7 @@ const PODOrderDetails = ({ session }: { session: any }) => {
       className="grid grid-cols-1 lg:grid-cols-2 w-full lg:w-[80%] gap-8"
     >
       <PODPickupDetails session={session} />
-      <PODPaymentDetails session={session} />
+      <PODPaymentDetails items={items} session={session} />
     </motion.div>
   );
 };
@@ -172,7 +178,7 @@ const PODOrderDetails = ({ session }: { session: any }) => {
 const PODConfirmationContent = () => {
   const { userId } = useAuth();
   const isGuest = userId === undefined;
-  const { checkoutState } = useCheckout();
+  const { onlineOrder } = useCheckout();
   const queryClient = useQueryClient();
   const bagQueries = useBagQueries();
 
@@ -187,15 +193,12 @@ const PODConfirmationContent = () => {
     const completePODCheckoutSession = async () => {
       if (!session?._id || session.hasCompletedCheckoutSession) return;
 
-      const { data } = webOrderSchema.safeParse(checkoutState);
-
       try {
         await Promise.all([
           updateCheckoutSession({
             action: "complete-checkout",
             sessionId: session._id,
             hasCompletedCheckoutSession: true,
-            orderDetails: data,
           }),
 
           postAnalytics({
@@ -217,7 +220,7 @@ const PODConfirmationContent = () => {
     if (session && session.placedOrderId) {
       completePODCheckoutSession();
     }
-  }, [session, checkoutState, queryClient, bagQueries]);
+  }, [session, queryClient, bagQueries]);
 
   if (isLoading || session === undefined) return null;
 
@@ -292,7 +295,7 @@ const PODConfirmationContent = () => {
           <p className="text-xs">Your order</p>
 
           <BagSummaryItems
-            items={checkoutState.bag.items}
+            items={onlineOrder?.items || []}
             discount={session.discount as Discount | null}
           />
         </motion.div>


### PR DESCRIPTION
## Summary
- stop sending client-authored checkout totals and bag item pricing assumptions to the storefront checkout endpoints
- add typed checkout request/error handling plus regression tests for hardened-contract payloads and invalid checkout states
- rely on canonical server session/order data for checkout completion and POD confirmation flows instead of local checkout state

## Why
- V26-162 hardened the backend checkout contract, so the storefront client needed to stop acting as an authority for totals and item pricing
- typed payloads and normalized checkout errors make 400/403/422 responses clearer for users and safer for future refactors
- completion flows should keep working even when local checkout state is stale or missing after payment redirects

## Validation
- `bun run test` ✅ (11 files, 119 tests)
- `git diff --check` ✅
- `bunx tsc --noEmit --pretty false` ⚠️ fails on pre-existing repo issues in `src/client.tsx`, checkout form typing, and route/server-action files
- `bunx vite build` ⚠️ timed out after 30 seconds locally

https://linear.app/v26-labs/issue/V26-163/align-storefront-checkout-client-with-hardened-backend-contract
