### PR TITLE
[V26-180]: Define and land the new storefront observability contract and shared client helper

### DIFF
--- a/packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx
+++ b/packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx
@@ -1,0 +1,65 @@
+import {
+  type StorefrontObservabilityBaseContext,
+  type StorefrontObservabilityEvent,
+  createStorefrontObservabilityContext,
+  trackStorefrontEvent,
+} from "@/lib/storefrontObservability";
+import { useAuth } from "@/hooks/useAuth";
+import { useRouterState, useSearch } from "@tanstack/react-router";
+import React, { createContext, useContext } from "react";
+
+type StorefrontObservabilityContextValue = {
+  baseContext: StorefrontObservabilityBaseContext;
+  track: (event: StorefrontObservabilityEvent) => Promise<unknown>;
+};
+
+const StorefrontObservabilityContext = createContext<
+  StorefrontObservabilityContextValue | undefined
+>(undefined);
+
+export function StorefrontObservabilityProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const pathname = useRouterState({
+    select: (state) => state.location.pathname,
+  });
+  const { origin, utm_source } = useSearch({ strict: false });
+  const { userId, guestId } = useAuth();
+
+  const baseContext = createStorefrontObservabilityContext({
+    pathname,
+    search: {
+      origin,
+      utm_source,
+    },
+    userId,
+    guestId,
+    storage:
+      typeof window === "undefined" ? undefined : window.sessionStorage,
+  });
+
+  return (
+    <StorefrontObservabilityContext.Provider
+      value={{
+        baseContext,
+        track: (event) => trackStorefrontEvent({ event, baseContext }),
+      }}
+    >
+      {children}
+    </StorefrontObservabilityContext.Provider>
+  );
+}
+
+export function useStorefrontObservability() {
+  const context = useContext(StorefrontObservabilityContext);
+
+  if (!context) {
+    throw new Error(
+      "useStorefrontObservability must be used within a StorefrontObservabilityProvider",
+    );
+  }
+
+  return context;
+}

--- a/packages/storefront-webapp/src/hooks/useStorefrontObservability.ts
+++ b/packages/storefront-webapp/src/hooks/useStorefrontObservability.ts
@@ -1,0 +1,1 @@
+export { useStorefrontObservability } from "@/contexts/StorefrontObservabilityProvider";

--- a/packages/storefront-webapp/src/lib/STOREFRONT_OBSERVABILITY.md
+++ b/packages/storefront-webapp/src/lib/STOREFRONT_OBSERVABILITY.md
@@ -1,0 +1,59 @@
+# Storefront Observability Contract
+
+New storefront telemetry must use `useStorefrontObservability()` or the pure helpers in `storefrontObservability.ts`. New work should not introduce more direct `postAnalytics(...)` calls with ad hoc action names.
+
+## Transport
+
+- `action`: always `storefront_observability`
+- `origin`: preserved as the top-level analytics origin when available
+- `data`: the canonical forward-looking observability payload
+
+## Canonical Payload Fields
+
+- `schemaVersion`
+- `journey`
+- `step`
+- `status`
+- `route`
+- `userType`
+- `sessionId`
+- optional domain ids such as `productId`, `checkoutSessionId`, and `orderId`
+- optional failure metadata:
+  - `errorCategory`
+  - `errorCode`
+  - `errorMessage`
+
+## Journey Taxonomy
+
+- `browse`
+- `product_discovery`
+- `bag`
+- `checkout`
+- `auth`
+
+## Status Model
+
+- `viewed`
+- `started`
+- `succeeded`
+- `failed`
+- `blocked`
+- `canceled`
+
+## Step Naming
+
+Steps must use `snake_case` and should name a single journey milestone, not pack outcome into the step. Examples:
+
+- `landing_page`
+- `product_detail`
+- `bag_view`
+- `payment_submission`
+- `auth_verification`
+
+The outcome belongs in `status`, not in a custom action name.
+
+## Migration Rule
+
+- New storefront telemetry is intentionally forward-looking.
+- Backward compatibility with legacy storefront analytics event names is not required.
+- Historical analytics may remain as-is, but new instrumentation should emit the canonical payload above.

--- a/packages/storefront-webapp/src/lib/storefrontObservability.test.ts
+++ b/packages/storefront-webapp/src/lib/storefrontObservability.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  STOREFRONT_OBSERVABILITY_ACTION,
+  STOREFRONT_OBSERVABILITY_SESSION_KEY,
+  createStorefrontObservabilityContext,
+  createStorefrontObservabilityPayload,
+  getOrCreateStorefrontObservabilitySessionId,
+  trackStorefrontEvent,
+} from "./storefrontObservability";
+
+function createMemoryStorage(): Storage {
+  const store = new Map<string, string>();
+
+  return {
+    get length() {
+      return store.size;
+    },
+    clear() {
+      store.clear();
+    },
+    getItem(key) {
+      return store.get(key) ?? null;
+    },
+    key(index) {
+      return Array.from(store.keys())[index] ?? null;
+    },
+    removeItem(key) {
+      store.delete(key);
+    },
+    setItem(key, value) {
+      store.set(key, value);
+    },
+  };
+}
+
+describe("storefront observability", () => {
+  let storage: Storage;
+
+  beforeEach(() => {
+    storage = createMemoryStorage();
+  });
+
+  it("creates a normalized payload with standard metadata", () => {
+    const payload = createStorefrontObservabilityPayload(
+      {
+        journey: "checkout",
+        step: "payment_submission",
+        status: "started",
+        context: {
+          checkoutSessionId: "session_123",
+          orderId: "order_123",
+          productId: "product_123",
+        },
+      },
+      {
+        route: "/shop/checkout/session_123",
+        origin: "homepage",
+        sessionId: "session_ctx_123",
+        userType: "guest",
+      },
+    );
+
+    expect(payload).toEqual({
+      action: STOREFRONT_OBSERVABILITY_ACTION,
+      origin: "homepage",
+      productId: "product_123",
+      data: {
+        schemaVersion: 1,
+        journey: "checkout",
+        step: "payment_submission",
+        status: "started",
+        route: "/shop/checkout/session_123",
+        userType: "guest",
+        sessionId: "session_ctx_123",
+        checkoutSessionId: "session_123",
+        orderId: "order_123",
+        productId: "product_123",
+      },
+    });
+  });
+
+  it("resolves origin, user type, and a stable session id from runtime context", () => {
+    const firstContext = createStorefrontObservabilityContext({
+      pathname: "/shop",
+      search: {
+        utm_source: "instagram",
+      },
+      guestId: "guest_123",
+      storage,
+    });
+
+    const secondContext = createStorefrontObservabilityContext({
+      pathname: "/shop/bag",
+      search: {
+        origin: "homepage",
+      },
+      guestId: "guest_123",
+      storage,
+    });
+
+    expect(firstContext).toMatchObject({
+      route: "/shop",
+      origin: "instagram",
+      userType: "guest",
+    });
+    expect(secondContext).toMatchObject({
+      route: "/shop/bag",
+      origin: "homepage",
+      userType: "guest",
+    });
+    expect(firstContext.sessionId).toBe(secondContext.sessionId);
+    expect(storage.getItem(STOREFRONT_OBSERVABILITY_SESSION_KEY)).toBe(
+      firstContext.sessionId,
+    );
+    expect(getOrCreateStorefrontObservabilitySessionId(storage)).toBe(
+      firstContext.sessionId,
+    );
+  });
+
+  it("fails predictably when required event fields are invalid", () => {
+    expect(() =>
+      createStorefrontObservabilityPayload(
+        {
+          journey: "checkout",
+          step: "Checkout Step",
+          status: "started",
+        },
+        {
+          route: "/shop/checkout",
+          sessionId: "session_ctx_123",
+          userType: "authenticated",
+        },
+      ),
+    ).toThrow(/step/i);
+  });
+
+  it("emits representative events through the shared helper", async () => {
+    const transport = vi.fn().mockResolvedValue({ ok: true });
+
+    await trackStorefrontEvent({
+      event: {
+        journey: "bag",
+        step: "bag_view",
+        status: "viewed",
+        context: {
+          checkoutSessionId: "session_123",
+        },
+      },
+      baseContext: {
+        route: "/shop/bag",
+        origin: "homepage",
+        sessionId: "session_ctx_123",
+        userType: "authenticated",
+      },
+      transport,
+    });
+
+    expect(transport).toHaveBeenCalledWith({
+      action: STOREFRONT_OBSERVABILITY_ACTION,
+      origin: "homepage",
+      productId: undefined,
+      data: {
+        schemaVersion: 1,
+        journey: "bag",
+        step: "bag_view",
+        status: "viewed",
+        route: "/shop/bag",
+        userType: "authenticated",
+        sessionId: "session_ctx_123",
+        checkoutSessionId: "session_123",
+      },
+    });
+  });
+});

--- a/packages/storefront-webapp/src/lib/storefrontObservability.ts
+++ b/packages/storefront-webapp/src/lib/storefrontObservability.ts
@@ -1,0 +1,205 @@
+import { postAnalytics } from "@/api/analytics";
+import { z } from "zod";
+
+export const STOREFRONT_OBSERVABILITY_ACTION = "storefront_observability";
+export const STOREFRONT_OBSERVABILITY_SCHEMA_VERSION = 1;
+export const STOREFRONT_OBSERVABILITY_SESSION_KEY =
+  "athena.storefront.observability.session_id";
+
+const stepPattern = /^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$/;
+
+export const storefrontObservabilityJourneySchema = z.enum([
+  "browse",
+  "product_discovery",
+  "bag",
+  "checkout",
+  "auth",
+]);
+
+export const storefrontObservabilityStatusSchema = z.enum([
+  "viewed",
+  "started",
+  "succeeded",
+  "failed",
+  "blocked",
+  "canceled",
+]);
+
+export const storefrontObservabilityUserTypeSchema = z.enum([
+  "authenticated",
+  "guest",
+  "unknown",
+]);
+
+export const storefrontObservabilityErrorCategorySchema = z.enum([
+  "network",
+  "validation",
+  "authorization",
+  "server",
+  "client_render",
+  "unknown",
+]);
+
+const storefrontObservabilitySearchSchema = z.object({
+  origin: z.string().optional(),
+  utm_source: z.string().optional(),
+});
+
+const storefrontObservabilityBaseContextSchema = z.object({
+  route: z.string().min(1).startsWith("/"),
+  origin: z.string().optional(),
+  sessionId: z.string().min(1),
+  userType: storefrontObservabilityUserTypeSchema,
+});
+
+const storefrontObservabilityErrorSchema = z.object({
+  category: storefrontObservabilityErrorCategorySchema,
+  code: z.string().min(1).optional(),
+  message: z.string().min(1).optional(),
+});
+
+const storefrontObservabilityEventSchema = z.object({
+  journey: storefrontObservabilityJourneySchema,
+  step: z.string().regex(stepPattern, {
+    message: "Observability steps must use snake_case names.",
+  }),
+  status: storefrontObservabilityStatusSchema,
+  context: z.record(z.string(), z.unknown()).optional(),
+  error: storefrontObservabilityErrorSchema.optional(),
+});
+
+export type StorefrontObservabilityJourney = z.infer<
+  typeof storefrontObservabilityJourneySchema
+>;
+export type StorefrontObservabilityStatus = z.infer<
+  typeof storefrontObservabilityStatusSchema
+>;
+export type StorefrontObservabilityUserType = z.infer<
+  typeof storefrontObservabilityUserTypeSchema
+>;
+export type StorefrontObservabilityErrorCategory = z.infer<
+  typeof storefrontObservabilityErrorCategorySchema
+>;
+export type StorefrontObservabilityEvent = z.infer<
+  typeof storefrontObservabilityEventSchema
+>;
+export type StorefrontObservabilityBaseContext = z.infer<
+  typeof storefrontObservabilityBaseContextSchema
+>;
+
+type StorefrontObservabilityRuntimeContext = {
+  pathname: string;
+  search?: {
+    origin?: string;
+    utm_source?: string;
+  };
+  userId?: string;
+  guestId?: string;
+  storage?: Pick<Storage, "getItem" | "setItem">;
+};
+
+type StorefrontObservabilityTransportPayload = Parameters<
+  typeof postAnalytics
+>[0];
+
+type StorefrontObservabilityTransport = (
+  payload: StorefrontObservabilityTransportPayload,
+) => Promise<unknown>;
+
+export function getOrCreateStorefrontObservabilitySessionId(
+  storage?: Pick<Storage, "getItem" | "setItem">,
+) {
+  if (!storage) {
+    return "server_render";
+  }
+
+  const existingSessionId = storage.getItem(
+    STOREFRONT_OBSERVABILITY_SESSION_KEY,
+  );
+
+  if (existingSessionId) {
+    return existingSessionId;
+  }
+
+  const sessionId =
+    typeof crypto !== "undefined" && "randomUUID" in crypto
+      ? crypto.randomUUID()
+      : `session_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+
+  storage.setItem(STOREFRONT_OBSERVABILITY_SESSION_KEY, sessionId);
+
+  return sessionId;
+}
+
+export function createStorefrontObservabilityContext(
+  runtimeContext: StorefrontObservabilityRuntimeContext,
+): StorefrontObservabilityBaseContext {
+  const search = storefrontObservabilitySearchSchema.parse(
+    runtimeContext.search ?? {},
+  );
+
+  const userType: StorefrontObservabilityUserType = runtimeContext.userId
+    ? "authenticated"
+    : runtimeContext.guestId
+      ? "guest"
+      : "unknown";
+
+  return storefrontObservabilityBaseContextSchema.parse({
+    route: runtimeContext.pathname || "/",
+    origin: search.origin ?? search.utm_source,
+    sessionId: getOrCreateStorefrontObservabilitySessionId(
+      runtimeContext.storage,
+    ),
+    userType,
+  });
+}
+
+export function createStorefrontObservabilityPayload(
+  event: StorefrontObservabilityEvent,
+  baseContext: StorefrontObservabilityBaseContext,
+): StorefrontObservabilityTransportPayload {
+  const parsedEvent = storefrontObservabilityEventSchema.parse(event);
+  const parsedBaseContext =
+    storefrontObservabilityBaseContextSchema.parse(baseContext);
+
+  const data: Record<string, unknown> = {
+    schemaVersion: STOREFRONT_OBSERVABILITY_SCHEMA_VERSION,
+    journey: parsedEvent.journey,
+    step: parsedEvent.step,
+    status: parsedEvent.status,
+    route: parsedBaseContext.route,
+    userType: parsedBaseContext.userType,
+    sessionId: parsedBaseContext.sessionId,
+    ...(parsedEvent.context ?? {}),
+  };
+
+  if (parsedEvent.error) {
+    data.errorCategory = parsedEvent.error.category;
+    data.errorCode = parsedEvent.error.code;
+    data.errorMessage = parsedEvent.error.message;
+  }
+
+  return {
+    action: STOREFRONT_OBSERVABILITY_ACTION,
+    origin: parsedBaseContext.origin,
+    data,
+    productId:
+      typeof parsedEvent.context?.productId === "string"
+        ? parsedEvent.context.productId
+        : undefined,
+  };
+}
+
+export async function trackStorefrontEvent({
+  event,
+  baseContext,
+  transport = postAnalytics,
+}: {
+  event: StorefrontObservabilityEvent;
+  baseContext: StorefrontObservabilityBaseContext;
+  transport?: StorefrontObservabilityTransport;
+}) {
+  const payload = createStorefrontObservabilityPayload(event, baseContext);
+
+  return transport(payload);
+}

--- a/packages/storefront-webapp/src/routes/__root.tsx
+++ b/packages/storefront-webapp/src/routes/__root.tsx
@@ -12,6 +12,7 @@ import {
   NavigationBarProvider,
   useNavigationBarContext,
 } from "@/contexts/NavigationBarProvider";
+import { StorefrontObservabilityProvider } from "@/contexts/StorefrontObservabilityProvider";
 import { getNavBarWrapperClass } from "@/components/navigation-bar/navBarStyles";
 
 const productsPageSchema = z.object({
@@ -61,14 +62,16 @@ function RootComponent() {
   return (
     <StoreProvider>
       <RootDocument>
-        <div className="flex flex-col bg-background">
-          <div className={navBarClassname}>
-            <NavigationBar />
+        <StorefrontObservabilityProvider>
+          <div className="flex flex-col bg-background">
+            <div className={navBarClassname}>
+              <NavigationBar />
+            </div>
+            <main className="flex-grow bg-background">
+              <Outlet />
+            </main>
           </div>
-          <main className="flex-grow bg-background">
-            <Outlet />
-          </main>
-        </div>
+        </StorefrontObservabilityProvider>
       </RootDocument>
     </StoreProvider>
   );


### PR DESCRIPTION
## Summary
- add a forward-looking storefront observability contract with canonical journey, status, step, and failure metadata
- add a shared provider and hook that enrich new telemetry with route, origin, user type, and session correlation context
- document the migration rule and add regression tests for payload normalization and context resolution

## Why
- downstream observability tickets need one shared schema and helper instead of inventing their own event shapes
- this keeps the foundation ticket scoped to contract/helper work without bundling broad journey instrumentation yet
- the new path is intentionally forward-looking and is not constrained by legacy storefront analytics naming

## Validation
- `bun run --filter '@athena/storefront-webapp' test`
- `bunx tsc --noEmit --pretty false` *(fails on pre-existing storefront issues in `src/client.tsx`, checkout form typing, auth/server-action files, and checkout routes)*
- `git diff --check HEAD~1..HEAD`

https://linear.app/v26-labs/issue/V26-180/define-and-land-the-new-storefront-observability-contract-and-shared
