### PR TITLE
[V26-181]: Instrument core storefront user journeys with the new observability model

### DIFF
--- a/packages/storefront-webapp/src/components/EntityPage.tsx
+++ b/packages/storefront-webapp/src/components/EntityPage.tsx
@@ -1,14 +1,18 @@
 import { useQuery } from "@tanstack/react-query";
 import { useParams, useSearch } from "@tanstack/react-router";
+import { useEffect, useRef } from "react";
 import ProductsPage from "./ProductsPage";
 import { useProductQueries } from "@/lib/queries/product";
-import { useTrackEvent } from "@/hooks/useTrackEvent";
+import { useStorefrontObservability } from "@/hooks/useStorefrontObservability";
+import { createCategoryBrowseViewedEvent } from "@/lib/storefrontJourneyEvents";
 import { slugToWords } from "@/lib/utils";
 
 export default function EntityPage() {
   const search = useSearch({ from: "/_layout/_shopLayout" });
+  const lastTrackedDiscoveryView = useRef<string | null>(null);
 
   const { categorySlug, subcategorySlug } = useParams({ strict: false });
+  const { track } = useStorefrontObservability();
 
   const productQueries = useProductQueries();
 
@@ -32,15 +36,22 @@ export default function EntityPage() {
     skus = bestSellers.map((bestSeller: any) => bestSeller.productSku);
   }
 
-  useTrackEvent({
-    action: subcategorySlug
-      ? `viewed_${slugToWords(subcategorySlug)}_page`
-      : `viewed_${slugToWords(categorySlug ?? "")}_page`,
-    data: {
-      category: categorySlug,
-      subcategory: subcategorySlug,
-    },
-  });
+  useEffect(() => {
+    const discoveryKey = `${categorySlug ?? ""}:${subcategorySlug ?? ""}`;
+
+    if (lastTrackedDiscoveryView.current === discoveryKey) return;
+
+    lastTrackedDiscoveryView.current = discoveryKey;
+
+    void track(
+      createCategoryBrowseViewedEvent({
+        categorySlug,
+        subcategorySlug,
+      }),
+    ).catch((error) => {
+      console.error("Failed to track category browse view:", error);
+    });
+  }, [categorySlug, subcategorySlug, track]);
 
   const isLoading = isLoadingProducts || isLoadingBestSellers;
 

--- a/packages/storefront-webapp/src/components/HomePage.tsx
+++ b/packages/storefront-webapp/src/components/HomePage.tsx
@@ -3,7 +3,6 @@ import Footer from "./footer/Footer";
 import { useEffect, useRef, useState } from "react";
 import { useNavigationBarContext } from "@/contexts/NavigationBarProvider";
 import { useProductQueries } from "@/lib/queries/product";
-import { useTrackEvent } from "@/hooks/useTrackEvent";
 import { MARKER_KEY } from "@/lib/constants";
 import { ProductReminderBar } from "./ProductReminderBar";
 import { PromoAlert } from "./home/PromoAlert";
@@ -29,6 +28,8 @@ import { ProductActionBar } from "./ProductActionBar";
 import { useShoppingBag } from "@/hooks/useShoppingBag";
 import { LeaveAReviewModal } from "./ui/modals/LeaveAReviewModal";
 import { getStoreConfigV2 } from "@/lib/storeConfig";
+import { useStorefrontObservability } from "@/hooks/useStorefrontObservability";
+import { createLandingPageViewedEvent } from "@/lib/storefrontJourneyEvents";
 
 const origin = "homepage";
 
@@ -36,9 +37,11 @@ export default function HomePage() {
   const homeHeroRef = useRef<HTMLDivElement>(null);
   const bestSellersRef = useRef<HTMLDivElement>(null);
   const footerRef = useRef<HTMLDivElement>(null);
+  const hasTrackedLandingPageView = useRef(false);
 
   const { store } = useStoreContext();
   const storeConfig = getStoreConfigV2(store);
+  const { track } = useStorefrontObservability();
 
   // console.log("store", store);
 
@@ -95,8 +98,6 @@ export default function HomePage() {
     productQueries.featured()
   );
 
-  const s = useSearch({ strict: false });
-
   // Handle scroll events - now only runs after localStorage is loaded
   useEffect(() => {
     // Don't add scroll listener until localStorage state is fully loaded
@@ -141,10 +142,15 @@ export default function HomePage() {
     }
   }, []);
 
-  useTrackEvent({
-    action: "viewed_homepage",
-    origin: s.utm_source,
-  });
+  useEffect(() => {
+    if (hasTrackedLandingPageView.current) return;
+
+    hasTrackedLandingPageView.current = true;
+
+    void track(createLandingPageViewedEvent()).catch((error) => {
+      console.error("Failed to track landing page view:", error);
+    });
+  }, [track]);
 
   const handleClickOnDiscountCode = async () => {
     openDiscountModal();

--- a/packages/storefront-webapp/src/components/checkout/Checkout.tsx
+++ b/packages/storefront-webapp/src/components/checkout/Checkout.tsx
@@ -2,7 +2,7 @@ import { CheckoutProvider } from "./CheckoutProvider";
 import { useCheckout } from "@/hooks/useCheckout";
 import { AnimatePresence, motion } from "framer-motion";
 import BagSummary from "./BagSummary";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import MobileBagSummary from "./MobileBagSummary";
 import { CheckoutForm } from "./CheckoutForm";
 import { TrustSignals } from "../communication/TrustSignals";
@@ -12,10 +12,29 @@ import { getStoreConfigV2 } from "@/lib/storeConfig";
 import { useStoreContext } from "@/contexts/StoreContext";
 import { toDisplayAmount, toPesewas } from "@/lib/currency";
 import { useShoppingBag } from "@/hooks/useShoppingBag";
+import { useStorefrontObservability } from "@/hooks/useStorefrontObservability";
+import { createCheckoutDetailsViewedEvent } from "@/lib/storefrontJourneyEvents";
 
 const MainComponent = () => {
-  const { activeSession, checkoutState } = useCheckout();
+  const { activeSession } = useCheckout();
   const navigate = useNavigate();
+  const { track } = useStorefrontObservability();
+  const lastTrackedCheckoutSession = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!activeSession?._id) return;
+    if (lastTrackedCheckoutSession.current === activeSession._id) return;
+
+    lastTrackedCheckoutSession.current = activeSession._id;
+
+    void track(
+      createCheckoutDetailsViewedEvent({
+        checkoutSessionId: activeSession._id,
+      }),
+    ).catch((error) => {
+      console.error("Failed to track checkout details view:", error);
+    });
+  }, [activeSession?._id, track]);
 
   useEffect(() => {
     const origin = new URLSearchParams(window.location.search).get("origin");

--- a/packages/storefront-webapp/src/components/checkout/PaymentSection.tsx
+++ b/packages/storefront-webapp/src/components/checkout/PaymentSection.tsx
@@ -16,15 +16,17 @@ import { Link } from "@tanstack/react-router";
 import { updateUser } from "@/api/storeFrontUser";
 import { useStoreContext } from "@/contexts/StoreContext";
 import { CheckoutFormSectionProps } from "./CustomerInfoSection";
-import { postAnalytics } from "@/api/analytics";
 import { updateGuest } from "@/api/guest";
 import OrderSummary from "./OrderDetails/OrderSummary";
 import { PaymentMethodSection } from "./PaymentMethodSection";
+import { useStorefrontObservability } from "@/hooks/useStorefrontObservability";
+import { createPaymentSubmissionStartedEvent } from "@/lib/storefrontJourneyEvents";
 
 export const PaymentSection = ({ form }: CheckoutFormSectionProps) => {
   const { activeSession, canPlaceOrder, checkoutState } = useCheckout();
 
   const { user } = useStoreContext();
+  const { track } = useStorefrontObservability();
 
   const { updateCheckoutSession } = useShoppingBag();
 
@@ -58,13 +60,13 @@ export const PaymentSection = ({ form }: CheckoutFormSectionProps) => {
               podPaymentMethod: checkoutState.podPaymentMethod,
             },
           ),
-          postAnalytics({
-            action: "finalized_payment_on_delivery_checkout",
-            data: {
+          track(
+            createPaymentSubmissionStartedEvent({
               checkoutSessionId: activeSession._id,
+              paymentMethod: checkoutState.paymentMethod,
               podPaymentMethod: checkoutState.podPaymentMethod,
-            },
-          }),
+            }),
+          ),
           user ? updateUserInformation() : updateUserInformation("guest"),
         ]);
         // Check the critical operation (order processing) result
@@ -103,12 +105,12 @@ export const PaymentSection = ({ form }: CheckoutFormSectionProps) => {
               deliveryDetails: data.deliveryDetails ?? null,
             },
           ),
-          postAnalytics({
-            action: "finalized_checkout",
-            data: {
+          track(
+            createPaymentSubmissionStartedEvent({
               checkoutSessionId: activeSession._id,
-            },
-          }),
+              paymentMethod: checkoutState.paymentMethod,
+            }),
+          ),
           user ? updateUserInformation() : updateUserInformation("guest"),
         ]);
 

--- a/packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx
+++ b/packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx
@@ -42,7 +42,6 @@ import { useNavigationBarContext } from "@/contexts/NavigationBarProvider";
 import { useCheckoutSessionQueries } from "@/lib/queries/checkout";
 import { usePromoCodesQueries } from "@/lib/queries/promoCode";
 import { postAnalytics } from "@/api/analytics";
-import { useTrackEvent } from "@/hooks/useTrackEvent";
 import { useDiscountCodeAlert } from "@/hooks/useDiscountCodeAlert";
 import { WelcomeBackModal } from "../ui/modals/WelcomeBackModal";
 import { useProductDiscount } from "@/hooks/useProductDiscount";
@@ -50,6 +49,12 @@ import { DiscountBadge } from "../product-page/DiscountBadge";
 import { useInventoryStatus } from "@/hooks/useInventoryStatus";
 import { getStoreConfigV2 } from "@/lib/storeConfig";
 import { toDisplayAmount } from "@/lib/currency";
+import { useStorefrontObservability } from "@/hooks/useStorefrontObservability";
+import {
+  createBagRemoveSucceededEvent,
+  createBagViewedEvent,
+  createCheckoutStartEvent,
+} from "@/lib/storefrontJourneyEvents";
 
 const PendingItem = ({ session, count }: { session: any; count: number }) => {
   return (
@@ -346,8 +351,10 @@ export default function ShoppingBag() {
   const [bagAction, setBagAction] = useState<ShoppingBagAction>("idle");
   const [updateCounter, forceUpdate] = useReducer((x) => x + 1, 0);
   const itemTotalsRef = useRef<Map<string, number>>(new Map());
+  const hasTrackedBagView = useRef(false);
   const { formatter, userId, isNavbarShowing, store } = useStoreContext();
   const storeConfig = getStoreConfigV2(store);
+  const { track } = useStorefrontObservability();
 
   const { setNavBarLayout, setAppLocation } = useNavigationBarContext();
 
@@ -425,12 +432,20 @@ export default function ShoppingBag() {
     checkoutSessionQueries.pendingSessions()
   );
 
-  const { origin } = useSearch({ strict: false });
+  useEffect(() => {
+    if (hasTrackedBagView.current || bag === undefined) return;
 
-  useTrackEvent({
-    action: "viewed_shopping_bag",
-    origin,
-  });
+    hasTrackedBagView.current = true;
+
+    void track(
+      createBagViewedEvent({
+        bagId: bag?._id,
+        itemCount: bag?.items?.length ?? 0,
+      }),
+    ).catch((error) => {
+      console.error("Failed to track bag view:", error);
+    });
+  }, [bag, track]);
 
   const handleOnCheckoutClick = async () => {
     setIsProcessingCheckoutRequest(true);
@@ -442,14 +457,27 @@ export default function ShoppingBag() {
       });
 
       if (res.session) {
+        const checkoutSessionId =
+          typeof res.session === "object" &&
+          res.session !== null &&
+          "_id" in res.session &&
+          typeof res.session._id === "string"
+            ? res.session._id
+            : undefined;
+
         queryClient.setQueryData(["active-checkout-session", userId], {
           session: res.session,
         });
 
-        await postAnalytics({
-          action: "initiated_checkout",
-          data: {},
-        }).catch((error) => console.error("Failed to post analytics:", error));
+        await track(
+          createCheckoutStartEvent({
+            bagId: bag?._id,
+            itemCount: bag?.items?.length ?? 0,
+            checkoutSessionId,
+          }),
+        ).catch((error) => {
+          console.error("Failed to track checkout start:", error);
+        });
 
         navigate({
           to: "/shop/checkout",
@@ -516,14 +544,13 @@ export default function ShoppingBag() {
     const item = bag?.items.find((i: BagItem) => i._id === itemId);
     await Promise.all([
       deleteItemFromBag(itemId),
-      postAnalytics({
-        action: "removed_product_from_bag",
-        data: {
-          product: item?.productId,
+      track(
+        createBagRemoveSucceededEvent({
+          productId: item?.productId,
           productSku: item?.productSku,
-          productImageUrl: item?.productImage,
-        },
-      }),
+          quantity: item?.quantity,
+        }),
+      ),
     ]);
   };
 

--- a/packages/storefront-webapp/src/hooks/useProductPageLogic.ts
+++ b/packages/storefront-webapp/src/hooks/useProductPageLogic.ts
@@ -9,10 +9,16 @@ import { useQuery } from "@tanstack/react-query";
 import { postAnalytics } from "@/api/analytics";
 import { isSoldOut, hasLowStock, sortSkusByLength } from "@/lib/productUtils";
 import { useProductDiscount } from "@/hooks/useProductDiscount";
+import { useStorefrontObservability } from "@/hooks/useStorefrontObservability";
+import {
+  createBagAddSucceededEvent,
+  createProductDetailViewedEvent,
+} from "@/lib/storefrontJourneyEvents";
 
 export function useProductPageLogic() {
   const { productSlug } = useParams({ strict: false });
   const { formatter } = useStoreContext();
+  const { track } = useStorefrontObservability();
   const {
     bag,
     deleteItemFromSavedBag,
@@ -35,6 +41,7 @@ export function useProductPageLogic() {
 
   const { variant } = useSearch({ strict: false });
   const [selectedSku, setSelectedSku] = useState<ProductSku | null>(null);
+  const lastTrackedProductView = useRef<string | null>(null);
 
   const isPromoCodeItemInBag = bag?.items?.find(
     (item: BagItem) => item.productSkuId === promoCodeItem?._id
@@ -72,6 +79,26 @@ export function useProductPageLogic() {
     return () => clearTimeout(t);
   }, [addedItemSuccessfully]);
 
+  useEffect(() => {
+    if (!product?._id) return;
+
+    const trackedSku = selectedSku?.sku ?? variant;
+    const trackKey = `${product._id}:${trackedSku ?? ""}`;
+
+    if (lastTrackedProductView.current === trackKey) return;
+
+    lastTrackedProductView.current = trackKey;
+
+    void track(
+      createProductDetailViewedEvent({
+        productId: product._id,
+        productSku: trackedSku,
+      }),
+    ).catch((error) => {
+      console.error("Failed to track product detail view:", error);
+    });
+  }, [product?._id, selectedSku?.sku, track, variant]);
+
   const bagItem = bag?.items?.find(
     (item: BagItem) => item.productSku === selectedSku?.sku
   );
@@ -86,15 +113,13 @@ export function useProductPageLogic() {
     if (bagItem) {
       await Promise.all([
         updateBag({ itemId: bagItem._id, quantity: bagItem.quantity + 1 }),
-        postAnalytics({
-          action: "updated_product_in_bag",
-          data: {
-            product: productSlug,
+        track(
+          createBagAddSucceededEvent({
+            productId: product?._id ?? productSlug,
             productSku: selectedSku?.sku,
-            productImageUrl: selectedSku?.images?.[0],
             quantity: bagItem.quantity + 1,
-          },
-        }),
+          }),
+        ),
       ]);
     } else {
       await Promise.all([
@@ -104,14 +129,13 @@ export function useProductPageLogic() {
           productSkuId: selectedSku?._id as string,
           productSku: selectedSku?.sku as string,
         }),
-        postAnalytics({
-          action: "added_product_to_bag",
-          data: {
-            product: productSlug,
+        track(
+          createBagAddSucceededEvent({
+            productId: product?._id ?? productSlug,
             productSku: selectedSku?.sku,
-            productImageUrl: selectedSku?.images?.[0],
-          },
-        }),
+            quantity: 1,
+          }),
+        ),
       ]);
     }
 

--- a/packages/storefront-webapp/src/lib/storefrontJourneyEvents.test.ts
+++ b/packages/storefront-webapp/src/lib/storefrontJourneyEvents.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createAuthEntryViewedEvent,
+  createAuthVerificationSucceededEvent,
+  createBagAddSucceededEvent,
+  createCategoryBrowseViewedEvent,
+  createCheckoutCompletionBlockedEvent,
+  createCheckoutCompletionCanceledEvent,
+  createCheckoutCompletionSucceededEvent,
+  createLandingPageViewedEvent,
+  createOrderReviewViewedEvent,
+  createPaymentSubmissionStartedEvent,
+  createProductDetailViewedEvent,
+} from "./storefrontJourneyEvents";
+
+describe("storefront journey events", () => {
+  it("creates the landing page browse milestone", () => {
+    expect(createLandingPageViewedEvent()).toEqual({
+      journey: "browse",
+      step: "landing_page",
+      status: "viewed",
+    });
+  });
+
+  it("creates category and product discovery milestones with context", () => {
+    expect(
+      createCategoryBrowseViewedEvent({
+        categorySlug: "hair",
+        subcategorySlug: "closures",
+      }),
+    ).toEqual({
+      journey: "product_discovery",
+      step: "category_browse",
+      status: "viewed",
+      context: {
+        categorySlug: "hair",
+        subcategorySlug: "closures",
+      },
+    });
+
+    expect(
+      createProductDetailViewedEvent({
+        productId: "product_123",
+        productSku: "sku_123",
+        categorySlug: "hair",
+      }),
+    ).toEqual({
+      journey: "product_discovery",
+      step: "product_detail",
+      status: "viewed",
+      context: {
+        productId: "product_123",
+        productSku: "sku_123",
+        categorySlug: "hair",
+      },
+    });
+  });
+
+  it("creates bag and checkout progression milestones", () => {
+    expect(
+      createBagAddSucceededEvent({
+        productId: "product_123",
+        productSku: "sku_123",
+        quantity: 1,
+      }),
+    ).toEqual({
+      journey: "bag",
+      step: "bag_add",
+      status: "succeeded",
+      context: {
+        productId: "product_123",
+        productSku: "sku_123",
+        quantity: 1,
+      },
+    });
+
+    expect(
+      createOrderReviewViewedEvent({
+        checkoutSessionId: "checkout_123",
+      }),
+    ).toEqual({
+      journey: "checkout",
+      step: "order_review",
+      status: "viewed",
+      context: {
+        checkoutSessionId: "checkout_123",
+      },
+    });
+
+    expect(
+      createPaymentSubmissionStartedEvent({
+        checkoutSessionId: "checkout_123",
+        paymentMethod: "online_payment",
+      }),
+    ).toEqual({
+      journey: "checkout",
+      step: "payment_submission",
+      status: "started",
+      context: {
+        checkoutSessionId: "checkout_123",
+        paymentMethod: "online_payment",
+      },
+    });
+  });
+
+  it("creates canonical checkout terminal milestones", () => {
+    expect(
+      createCheckoutCompletionSucceededEvent({
+        checkoutSessionId: "checkout_123",
+        orderId: "order_123",
+      }),
+    ).toEqual({
+      journey: "checkout",
+      step: "checkout_completion",
+      status: "succeeded",
+      context: {
+        checkoutSessionId: "checkout_123",
+        orderId: "order_123",
+      },
+    });
+
+    expect(
+      createCheckoutCompletionBlockedEvent({
+        checkoutSessionId: "checkout_123",
+        orderId: "order_123",
+      }),
+    ).toEqual({
+      journey: "checkout",
+      step: "checkout_completion",
+      status: "blocked",
+      context: {
+        checkoutSessionId: "checkout_123",
+        orderId: "order_123",
+      },
+    });
+
+    expect(
+      createCheckoutCompletionCanceledEvent({
+        checkoutSessionId: "checkout_123",
+      }),
+    ).toEqual({
+      journey: "checkout",
+      step: "checkout_completion",
+      status: "canceled",
+      context: {
+        checkoutSessionId: "checkout_123",
+      },
+    });
+  });
+
+  it("creates auth continuity milestones", () => {
+    expect(
+      createAuthEntryViewedEvent({
+        mode: "login",
+        origin: "guest-rewards",
+        email: "shopper@example.com",
+      }),
+    ).toEqual({
+      journey: "auth",
+      step: "login_entry",
+      status: "viewed",
+      context: {
+        entryOrigin: "guest-rewards",
+        email: "shopper@example.com",
+      },
+    });
+
+    expect(
+      createAuthVerificationSucceededEvent({
+        email: "shopper@example.com",
+      }),
+    ).toEqual({
+      journey: "auth",
+      step: "auth_verification",
+      status: "succeeded",
+      context: {
+        email: "shopper@example.com",
+      },
+    });
+  });
+});

--- a/packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts
+++ b/packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts
@@ -1,0 +1,383 @@
+import type { StorefrontObservabilityEvent } from "@/lib/storefrontObservability";
+
+type JourneyContext = Record<string, unknown>;
+
+type AuthMode = "login" | "signup";
+
+function compactContext(context: JourneyContext) {
+  const compactedEntries = Object.entries(context).filter(
+    ([, value]) => value !== undefined && value !== null,
+  );
+
+  if (compactedEntries.length === 0) {
+    return undefined;
+  }
+
+  return Object.fromEntries(compactedEntries);
+}
+
+function createJourneyEvent({
+  journey,
+  step,
+  status,
+  context,
+}: StorefrontObservabilityEvent) {
+  return {
+    journey,
+    step,
+    status,
+    context: context ? compactContext(context) : undefined,
+  } satisfies StorefrontObservabilityEvent;
+}
+
+export function createLandingPageViewedEvent() {
+  return createJourneyEvent({
+    journey: "browse",
+    step: "landing_page",
+    status: "viewed",
+  });
+}
+
+export function createCategoryBrowseViewedEvent({
+  categorySlug,
+  subcategorySlug,
+}: {
+  categorySlug?: string;
+  subcategorySlug?: string;
+}) {
+  return createJourneyEvent({
+    journey: "product_discovery",
+    step: "category_browse",
+    status: "viewed",
+    context: {
+      categorySlug,
+      subcategorySlug,
+    },
+  });
+}
+
+export function createProductDetailViewedEvent({
+  productId,
+  productSku,
+  categorySlug,
+  subcategorySlug,
+}: {
+  productId: string;
+  productSku?: string;
+  categorySlug?: string;
+  subcategorySlug?: string;
+}) {
+  return createJourneyEvent({
+    journey: "product_discovery",
+    step: "product_detail",
+    status: "viewed",
+    context: {
+      productId,
+      productSku,
+      categorySlug,
+      subcategorySlug,
+    },
+  });
+}
+
+export function createBagViewedEvent({
+  bagId,
+  itemCount,
+}: {
+  bagId?: string;
+  itemCount?: number;
+} = {}) {
+  return createJourneyEvent({
+    journey: "bag",
+    step: "bag_view",
+    status: "viewed",
+    context: {
+      bagId,
+      itemCount,
+    },
+  });
+}
+
+export function createBagAddSucceededEvent({
+  productId,
+  productSku,
+  quantity,
+}: {
+  productId?: string;
+  productSku?: string;
+  quantity?: number;
+}) {
+  return createJourneyEvent({
+    journey: "bag",
+    step: "bag_add",
+    status: "succeeded",
+    context: {
+      productId,
+      productSku,
+      quantity,
+    },
+  });
+}
+
+export function createBagRemoveSucceededEvent({
+  productId,
+  productSku,
+  quantity,
+}: {
+  productId?: string;
+  productSku?: string;
+  quantity?: number;
+}) {
+  return createJourneyEvent({
+    journey: "bag",
+    step: "bag_remove",
+    status: "succeeded",
+    context: {
+      productId,
+      productSku,
+      quantity,
+    },
+  });
+}
+
+export function createCheckoutStartEvent({
+  bagId,
+  itemCount,
+  checkoutSessionId,
+}: {
+  bagId?: string;
+  itemCount?: number;
+  checkoutSessionId?: string;
+} = {}) {
+  return createJourneyEvent({
+    journey: "bag",
+    step: "checkout_start",
+    status: "started",
+    context: {
+      bagId,
+      itemCount,
+      checkoutSessionId,
+    },
+  });
+}
+
+export function createCheckoutDetailsViewedEvent({
+  checkoutSessionId,
+}: {
+  checkoutSessionId?: string;
+} = {}) {
+  return createJourneyEvent({
+    journey: "checkout",
+    step: "checkout_details",
+    status: "viewed",
+    context: {
+      checkoutSessionId,
+    },
+  });
+}
+
+export function createOrderReviewViewedEvent({
+  checkoutSessionId,
+}: {
+  checkoutSessionId: string;
+}) {
+  return createJourneyEvent({
+    journey: "checkout",
+    step: "order_review",
+    status: "viewed",
+    context: {
+      checkoutSessionId,
+    },
+  });
+}
+
+export function createPaymentSubmissionStartedEvent({
+  checkoutSessionId,
+  paymentMethod,
+  podPaymentMethod,
+}: {
+  checkoutSessionId: string;
+  paymentMethod?: string | null;
+  podPaymentMethod?: string | null;
+}) {
+  return createJourneyEvent({
+    journey: "checkout",
+    step: "payment_submission",
+    status: "started",
+    context: {
+      checkoutSessionId,
+      paymentMethod,
+      podPaymentMethod,
+    },
+  });
+}
+
+export function createPaymentVerificationStartedEvent({
+  checkoutSessionId,
+  externalReference,
+}: {
+  checkoutSessionId?: string;
+  externalReference?: string | null;
+} = {}) {
+  return createJourneyEvent({
+    journey: "checkout",
+    step: "payment_verification",
+    status: "started",
+    context: {
+      checkoutSessionId,
+      externalReference,
+    },
+  });
+}
+
+function createCheckoutCompletionEvent({
+  status,
+  checkoutSessionId,
+  orderId,
+  deliveryMethod,
+}: {
+  status: "succeeded" | "blocked" | "canceled";
+  checkoutSessionId?: string;
+  orderId?: string;
+  deliveryMethod?: string;
+}) {
+  return createJourneyEvent({
+    journey: "checkout",
+    step: "checkout_completion",
+    status,
+    context: {
+      checkoutSessionId,
+      orderId,
+      deliveryMethod,
+    },
+  });
+}
+
+export function createCheckoutCompletionSucceededEvent({
+  checkoutSessionId,
+  orderId,
+  deliveryMethod,
+}: {
+  checkoutSessionId?: string;
+  orderId?: string;
+  deliveryMethod?: string;
+}) {
+  return createCheckoutCompletionEvent({
+    status: "succeeded",
+    checkoutSessionId,
+    orderId,
+    deliveryMethod,
+  });
+}
+
+export function createCheckoutCompletionBlockedEvent({
+  checkoutSessionId,
+  orderId,
+  deliveryMethod,
+}: {
+  checkoutSessionId?: string;
+  orderId?: string;
+  deliveryMethod?: string;
+}) {
+  return createCheckoutCompletionEvent({
+    status: "blocked",
+    checkoutSessionId,
+    orderId,
+    deliveryMethod,
+  });
+}
+
+export function createCheckoutCompletionCanceledEvent({
+  checkoutSessionId,
+  orderId,
+  deliveryMethod,
+}: {
+  checkoutSessionId?: string;
+  orderId?: string;
+  deliveryMethod?: string;
+}) {
+  return createCheckoutCompletionEvent({
+    status: "canceled",
+    checkoutSessionId,
+    orderId,
+    deliveryMethod,
+  });
+}
+
+function getAuthEntryStep(mode: AuthMode) {
+  return mode === "login" ? "login_entry" : "signup_entry";
+}
+
+function getAuthRequestStep(mode: AuthMode) {
+  return mode === "login" ? "login_request" : "signup_request";
+}
+
+export function createAuthEntryViewedEvent({
+  mode,
+  origin,
+  email,
+}: {
+  mode: AuthMode;
+  origin?: string;
+  email?: string;
+}) {
+  return createJourneyEvent({
+    journey: "auth",
+    step: getAuthEntryStep(mode),
+    status: "viewed",
+    context: {
+      entryOrigin: origin,
+      email,
+    },
+  });
+}
+
+export function createAuthRequestStartedEvent({
+  mode,
+  origin,
+  email,
+}: {
+  mode: AuthMode;
+  origin?: string;
+  email?: string;
+}) {
+  return createJourneyEvent({
+    journey: "auth",
+    step: getAuthRequestStep(mode),
+    status: "started",
+    context: {
+      entryOrigin: origin,
+      email,
+    },
+  });
+}
+
+export function createAuthVerificationViewedEvent({
+  email,
+}: {
+  email?: string;
+} = {}) {
+  return createJourneyEvent({
+    journey: "auth",
+    step: "auth_verification",
+    status: "viewed",
+    context: {
+      email,
+    },
+  });
+}
+
+export function createAuthVerificationSucceededEvent({
+  email,
+}: {
+  email?: string;
+} = {}) {
+  return createJourneyEvent({
+    journey: "auth",
+    step: "auth_verification",
+    status: "succeeded",
+    context: {
+      email,
+    },
+  });
+}

--- a/packages/storefront-webapp/src/routes/auth.verify.tsx
+++ b/packages/storefront-webapp/src/routes/auth.verify.tsx
@@ -28,12 +28,16 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { ArrowLeftIcon } from "@radix-ui/react-icons";
 import { useMutation } from "@tanstack/react-query";
 import { createFileRoute, Link, useSearch } from "@tanstack/react-router";
-import { useServerFn } from "@tanstack/start";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { set, z } from "zod";
 import { awardPointsForGuestOrders } from "@/api/rewards";
+import { useStorefrontObservability } from "@/hooks/useStorefrontObservability";
+import {
+  createAuthVerificationSucceededEvent,
+  createAuthVerificationViewedEvent,
+} from "@/lib/storefrontJourneyEvents";
 
 export const FormSchema = z.object({
   code: z.string().min(6, {
@@ -59,10 +63,12 @@ function InputOTPForm() {
   const [isVerifying, setIsVerifying] = useState(false);
   const [countdown, setCountdown] = useState<number>(WAIT_TIME); // 10 minutes in seconds
   const [showCountdown, setShowCountdown] = useState(true);
+  const hasTrackedVerificationView = useRef(false);
 
   const { email } = useSearch({ strict: false });
   const { store, userId } = useStoreContext();
   const { bag, savedBag } = useShoppingBag();
+  const { track } = useStorefrontObservability();
 
   const updateBagOwnerMutation = useMutation({
     mutationFn: updateBagOwner,
@@ -96,6 +102,20 @@ function InputOTPForm() {
       setShowCountdown(false);
     }
   }, [countdown, showCountdown]);
+
+  useEffect(() => {
+    if (hasTrackedVerificationView.current) return;
+
+    hasTrackedVerificationView.current = true;
+
+    void track(
+      createAuthVerificationViewedEvent({
+        email,
+      }),
+    ).catch((error) => {
+      console.error("Failed to track auth verification view:", error);
+    });
+  }, [email, track]);
 
   // Format countdown time
   const formatTime = (seconds: number) => {
@@ -155,6 +175,14 @@ function InputOTPForm() {
       }
 
       if (res.success) {
+        await track(
+          createAuthVerificationSucceededEvent({
+            email,
+          }),
+        ).catch((error) => {
+          console.error("Failed to track auth verification success:", error);
+        });
+
         await Promise.all([
           await updateBagOwnerMutation.mutateAsync({
             currentOwnerId: userId || "",

--- a/packages/storefront-webapp/src/routes/login.tsx
+++ b/packages/storefront-webapp/src/routes/login.tsx
@@ -26,7 +26,12 @@ import {
 import { ArrowRight } from "lucide-react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
+import { useStorefrontObservability } from "@/hooks/useStorefrontObservability";
+import {
+  createAuthEntryViewedEvent,
+  createAuthRequestStartedEvent,
+} from "@/lib/storefrontJourneyEvents";
 
 export const customerDetailsSchema = z.object({
   email: z
@@ -39,7 +44,7 @@ export const customerDetailsSchema = z.object({
 });
 
 export const Route = createFileRoute("/login")({
-  beforeLoad: async () => {
+  beforeLoad: async (): Promise<void> => {
     const id = localStorage.getItem(LOGGED_IN_USER_ID_KEY);
 
     const { storeId, organizationId } = getStoreDetails();
@@ -49,12 +54,12 @@ export const Route = createFileRoute("/login")({
         const user = await getActiveUser();
 
         if (user._id) {
-          return redirect({ to: "/account" });
+          throw redirect({ to: "/account" });
         }
       }
     } catch (e) {
       localStorage.removeItem(LOGGED_IN_USER_ID_KEY);
-      return redirect({ to: "/login" });
+      throw redirect({ to: "/login" });
     }
   },
 
@@ -70,14 +75,32 @@ const Login = () => {
   });
 
   const { origin, email } = useSearch({ strict: false });
+  const hasTrackedLoginEntry = useRef(false);
 
   const isFromGuestRewards = origin === "guest-rewards";
+  const { track } = useStorefrontObservability();
 
   useEffect(() => {
     if (isFromGuestRewards && email) {
       form.setValue("email", email);
     }
   }, [isFromGuestRewards, email]);
+
+  useEffect(() => {
+    if (hasTrackedLoginEntry.current) return;
+
+    hasTrackedLoginEntry.current = true;
+
+    void track(
+      createAuthEntryViewedEvent({
+        mode: "login",
+        origin,
+        email,
+      }),
+    ).catch((error) => {
+      console.error("Failed to track login entry:", error);
+    });
+  }, [email, origin, track]);
 
   const { store } = useStoreContext();
 
@@ -103,6 +126,16 @@ const Login = () => {
   if (!store) return <div className="h-screen" />;
 
   const onSubmit = async (data: z.infer<typeof customerDetailsSchema>) => {
+    void track(
+      createAuthRequestStartedEvent({
+        mode: "login",
+        origin,
+        email: data.email,
+      }),
+    ).catch((error) => {
+      console.error("Failed to track login request:", error);
+    });
+
     verifyMutation.mutate({
       email: data.email,
     });

--- a/packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/canceled.tsx
+++ b/packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/canceled.tsx
@@ -10,6 +10,9 @@ import { useCheckoutSessionQueries } from "@/lib/queries/checkout";
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link, useParams } from "@tanstack/react-router";
 import { AnimatePresence, motion } from "framer-motion";
+import { useEffect, useRef } from "react";
+import { useStorefrontObservability } from "@/hooks/useStorefrontObservability";
+import { createCheckoutCompletionCanceledEvent } from "@/lib/storefrontJourneyEvents";
 
 export const Route = createFileRoute("/shop/checkout/$sessionIdSlug/canceled")({
   component: () => <CheckoutCanceledView />,
@@ -17,6 +20,8 @@ export const Route = createFileRoute("/shop/checkout/$sessionIdSlug/canceled")({
 
 const CheckoutCanceledView = () => {
   const { sessionIdSlug } = useParams({ strict: false });
+  const { track } = useStorefrontObservability();
+  const hasTrackedCanceledCheckout = useRef(false);
 
   const checkoutSessionQueries = useCheckoutSessionQueries();
 
@@ -25,6 +30,23 @@ const CheckoutCanceledView = () => {
     isLoading,
     isRefetching,
   } = useQuery(checkoutSessionQueries.session(sessionIdSlug));
+
+  useEffect(() => {
+    if (!sessionData?.isPaymentRefunded || hasTrackedCanceledCheckout.current)
+      return;
+
+    hasTrackedCanceledCheckout.current = true;
+
+    void track(
+      createCheckoutCompletionCanceledEvent({
+        checkoutSessionId: sessionData._id,
+        orderId: sessionData.placedOrderId,
+        deliveryMethod: sessionData.deliveryMethod,
+      }),
+    ).catch((error) => {
+      console.error("Failed to track canceled checkout:", error);
+    });
+  }, [sessionData, track]);
 
   if ((!sessionData && isLoading) || isRefetching) return null;
 

--- a/packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/incomplete.tsx
+++ b/packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/incomplete.tsx
@@ -13,8 +13,10 @@ import {
   formatDeliveryAddress,
   getOrderAmount,
 } from "@/components/checkout/utils";
-import { useTrackEvent } from "@/hooks/useTrackEvent";
 import { CardTitle } from "@/components/ui/card";
+import { useStorefrontObservability } from "@/hooks/useStorefrontObservability";
+import { createCheckoutCompletionBlockedEvent } from "@/lib/storefrontJourneyEvents";
+import { useEffect, useRef } from "react";
 
 export const Route = createFileRoute(
   "/shop/checkout/$sessionIdSlug/incomplete"
@@ -25,6 +27,8 @@ export const Route = createFileRoute(
 function CheckoutIncompleteView() {
   const { onlineOrder } = useCheckout();
   const { formatter } = useStoreContext();
+  const { track } = useStorefrontObservability();
+  const hasTrackedIncompleteCheckout = useRef(false);
 
   const { amountCharged, amountPaid } = getOrderAmount({
     items: onlineOrder?.items || ([] as any),
@@ -37,13 +41,21 @@ function CheckoutIncompleteView() {
     onlineOrder?.deliveryDetails as Address
   );
 
-  useTrackEvent({
-    action: "viewed_checkout_incomplete_screen",
-    data: {
-      order_id: onlineOrder?._id,
-      checkout_session_id: onlineOrder?.checkoutSessionId,
-    },
-  });
+  useEffect(() => {
+    if (!onlineOrder || hasTrackedIncompleteCheckout.current) return;
+
+    hasTrackedIncompleteCheckout.current = true;
+
+    void track(
+      createCheckoutCompletionBlockedEvent({
+        checkoutSessionId: onlineOrder.checkoutSessionId,
+        orderId: onlineOrder._id,
+        deliveryMethod: onlineOrder.deliveryMethod,
+      }),
+    ).catch((error) => {
+      console.error("Failed to track incomplete checkout:", error);
+    });
+  }, [onlineOrder, track]);
 
   return (
     <AnimatePresence>

--- a/packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx
+++ b/packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx
@@ -16,7 +16,9 @@ import {
 } from "@tanstack/react-router";
 import { AnimatePresence, motion } from "framer-motion";
 import { AlertCircle } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { useStorefrontObservability } from "@/hooks/useStorefrontObservability";
+import { createOrderReviewViewedEvent } from "@/lib/storefrontJourneyEvents";
 
 export const Route = createFileRoute("/shop/checkout/$sessionIdSlug/")({
   component: () => <CheckoutSession />,
@@ -28,6 +30,7 @@ const CheckoutSession = () => {
   const [isPlacingOrder, setIsPlacingOrder] = useState(false);
   const [isCancelingOrder, setIsCancelingOrder] = useState(false);
   const [error, setError] = useState("");
+  const lastTrackedOrderReview = useRef<string | null>(null);
 
   const checkoutSessionQueries = useCheckoutSessionQueries();
 
@@ -42,6 +45,22 @@ const CheckoutSession = () => {
   );
 
   const queryClient = useQueryClient();
+  const { track } = useStorefrontObservability();
+
+  useEffect(() => {
+    if (!sessionData?._id) return;
+    if (lastTrackedOrderReview.current === sessionData._id) return;
+
+    lastTrackedOrderReview.current = sessionData._id;
+
+    void track(
+      createOrderReviewViewedEvent({
+        checkoutSessionId: sessionData._id,
+      }),
+    ).catch((error) => {
+      console.error("Failed to track order review view:", error);
+    });
+  }, [sessionData?._id, track]);
 
   const placeOrder = async () => {
     if (!sessionData || !sessionIdSlug) return;

--- a/packages/storefront-webapp/src/routes/shop/checkout/complete.index.tsx
+++ b/packages/storefront-webapp/src/routes/shop/checkout/complete.index.tsx
@@ -1,4 +1,3 @@
-import { postAnalytics } from "@/api/analytics";
 import { updateCheckoutSession } from "@/api/checkoutSession";
 import { BagSummaryItems } from "@/components/checkout/BagSummary";
 import { CheckoutProvider } from "@/components/checkout/CheckoutProvider";
@@ -18,6 +17,8 @@ import { useGetActiveCheckoutSession } from "@/hooks/useGetActiveCheckoutSession
 import { useShoppingBag } from "@/hooks/useShoppingBag";
 import { useBagQueries } from "@/lib/queries/bag";
 import { capitalizeFirstLetter } from "@/lib/utils";
+import { useStorefrontObservability } from "@/hooks/useStorefrontObservability";
+import { createCheckoutCompletionSucceededEvent } from "@/lib/storefrontJourneyEvents";
 import { useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { AnimatePresence, motion } from "framer-motion";
@@ -34,6 +35,7 @@ export const CheckoutComplete = () => {
   const { userId } = useAuth();
   const queryClient = useQueryClient();
   const bagQueries = useBagQueries();
+  const { track } = useStorefrontObservability();
 
   const [hasOrderError, setHasOrderError] = useState(false);
   const [isRetrying, setIsRetrying] = useState(false);
@@ -56,12 +58,13 @@ export const CheckoutComplete = () => {
             sessionId: activeSession._id,
             hasCompletedCheckoutSession: true,
           }),
-          postAnalytics({
-            action: "completed_checkout",
-            data: {
+          track(
+            createCheckoutCompletionSucceededEvent({
               checkoutSessionId: activeSession._id,
-            },
-          }),
+              orderId: onlineOrder?._id,
+              deliveryMethod: activeSession.deliveryMethod,
+            }),
+          ),
         ]);
 
         queryClient.invalidateQueries({ queryKey: bagQueries.activeBagKey() });
@@ -76,6 +79,9 @@ export const CheckoutComplete = () => {
     activeSession._id,
     activeSession.hasCompletedPayment,
     activeSession.hasVerifiedPayment,
+    activeSession.deliveryMethod,
+    onlineOrder?._id,
+    track,
   ]);
 
   const retryOrderCreation = async () => {

--- a/packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx
+++ b/packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx
@@ -3,7 +3,7 @@ import { Icons } from "@/components/ui/icons";
 import { useStoreContext } from "@/contexts/StoreContext";
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { motion } from "framer-motion";
 import { useGetActiveCheckoutSession } from "@/hooks/useGetActiveCheckoutSession";
 import {
@@ -11,6 +11,8 @@ import {
   UnableToVerifyCheckoutPayment,
 } from "@/components/states/checkout-expired/CheckoutExpired";
 import { CheckoutProvider } from "@/components/checkout/CheckoutProvider";
+import { useStorefrontObservability } from "@/hooks/useStorefrontObservability";
+import { createPaymentVerificationStartedEvent } from "@/lib/storefrontJourneyEvents";
 
 export const Route = createFileRoute("/shop/checkout/verify/")({
   component: () => <VerifyCheckoutSessionPayment />,
@@ -18,6 +20,8 @@ export const Route = createFileRoute("/shop/checkout/verify/")({
 
 const Verify = () => {
   const navigate = useNavigate();
+  const { track } = useStorefrontObservability();
+  const lastTrackedVerification = useRef<string | null>(null);
 
   const { data: session, isLoading } = useGetActiveCheckoutSession();
 
@@ -33,6 +37,24 @@ const Verify = () => {
       }),
     enabled: Boolean(externalReference),
   });
+
+  useEffect(() => {
+    const verificationKey = `${session?._id ?? "unknown"}:${externalReference ?? ""}`;
+
+    if (!externalReference || lastTrackedVerification.current === verificationKey)
+      return;
+
+    lastTrackedVerification.current = verificationKey;
+
+    void track(
+      createPaymentVerificationStartedEvent({
+        checkoutSessionId: session?._id,
+        externalReference,
+      }),
+    ).catch((error) => {
+      console.error("Failed to track checkout payment verification:", error);
+    });
+  }, [externalReference, session?._id, track]);
 
   useEffect(() => {
     if (

--- a/packages/storefront-webapp/src/routes/signup.tsx
+++ b/packages/storefront-webapp/src/routes/signup.tsx
@@ -27,7 +27,12 @@ import {
 import { ArrowRight } from "lucide-react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
+import { useStorefrontObservability } from "@/hooks/useStorefrontObservability";
+import {
+  createAuthEntryViewedEvent,
+  createAuthRequestStartedEvent,
+} from "@/lib/storefrontJourneyEvents";
 
 const nameRegex = /^[a-zA-Zà-öø-ÿÀ-ÖØ-ß\-'\.\s]+$/;
 
@@ -91,8 +96,10 @@ const Signup = () => {
   });
 
   const { origin, email } = useSearch({ strict: false });
+  const hasTrackedSignupEntry = useRef(false);
 
   const { store } = useStoreContext();
+  const { track } = useStorefrontObservability();
 
   const navigate = useNavigate();
 
@@ -101,6 +108,22 @@ const Signup = () => {
       form.setValue("email", email);
     }
   }, [origin, email]);
+
+  useEffect(() => {
+    if (hasTrackedSignupEntry.current) return;
+
+    hasTrackedSignupEntry.current = true;
+
+    void track(
+      createAuthEntryViewedEvent({
+        mode: "signup",
+        origin,
+        email,
+      }),
+    ).catch((error) => {
+      console.error("Failed to track signup entry:", error);
+    });
+  }, [email, origin, track]);
 
   const verifyMutation = useMutation({
     mutationFn: verifyUserAccount,
@@ -122,6 +145,16 @@ const Signup = () => {
   if (!store) return <div className="h-screen" />;
 
   const onSubmit = async (data: z.infer<typeof customerDetailsSchema>) => {
+    void track(
+      createAuthRequestStartedEvent({
+        mode: "signup",
+        origin,
+        email: data.email,
+      }),
+    ).catch((error) => {
+      console.error("Failed to track signup request:", error);
+    });
+
     verifyMutation.mutate({
       email: data.email,
       firstName: data.firstName,


### PR DESCRIPTION
## Summary
- add canonical storefront journey event builders for the forward-looking observability contract
- instrument the core shopper funnel across home, category browse, product detail, bag, checkout progression, checkout terminal states, and auth verification continuity
- replace the touched core-funnel ad hoc analytics calls with `useStorefrontObservability()`

## Why
- the storefront funnel needs consistent `journey`, `step`, and `status` telemetry so a single shopper path can be reconstructed end to end
- this keeps the migration aligned with `V26-180` by using the shared helper instead of adding more direct `postAnalytics(...)` calls
- the ticket stays scoped to success-path journey reconstruction and leaves promo/review/saved-bag side telemetry for follow-up work

## Validation
- `bun run test src/lib/storefrontObservability.test.ts src/lib/storefrontJourneyEvents.test.ts`
- `bun run test`
- `git diff --check`
- `bun run build` (Vite production build succeeds; trailing `tsc --noEmit` still fails on pre-existing package-wide type issues in `src/client.tsx`, checkout form/control typing, `src/server-actions/auth.ts`, and `src/ssr.tsx`)

https://linear.app/v26-labs/issue/V26-181/instrument-core-storefront-user-journeys-with-the-new-observability
