### PR TITLE
[V26-184]: Migrate auxiliary storefront promo, review, and saved-item telemetry to the new observability model

### DIFF
--- a/packages/storefront-webapp/src/components/home/PromoAlert.tsx
+++ b/packages/storefront-webapp/src/components/home/PromoAlert.tsx
@@ -1,12 +1,16 @@
-import { Dispatch, SetStateAction, useRef } from "react";
+import { useEffect, useRef } from "react";
 import { X } from "lucide-react";
 import { usePromoCodesQueries } from "@/lib/queries/promoCode";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { AnimatedCard } from "../ui/AnimatedCard";
 import { Button } from "../ui/button";
-import { useTrackEvent } from "@/hooks/useTrackEvent";
-import { postAnalytics } from "@/api/analytics";
+import { useStorefrontObservability } from "@/hooks/useStorefrontObservability";
+import {
+  createPromoAlertViewedEvent,
+  createPromoAlertDismissedEvent,
+  createPromoAlertShopNowEvent,
+} from "@/lib/storefrontJourneyEvents";
 
 interface PromoAlertProps {
   isOpen: boolean;
@@ -56,49 +60,48 @@ export function PromoAlert({ isOpen, onClose }: PromoAlertProps) {
   const promoCodeQueries = usePromoCodesQueries();
   const { data: promoItems } = useQuery(promoCodeQueries.getAllItems());
   const promoItem = promoItems?.[0];
+  const { track } = useStorefrontObservability();
+  const hasTrackedView = useRef(false);
 
-  // Track when the alert is viewed
-  useTrackEvent({
-    action: "viewed_promo_alert",
-    data: {
-      promoCodeItemId: promoItem?._id,
-      productSku: promoItem?.productSku?.sku,
-      productImageUrl: promoItem?.productSku?.images[0],
-      product: promoItem?.productSku?.productId,
-    },
-    isReady: isOpen && !!promoItem && !!promoItem.productSku,
-  });
+  useEffect(() => {
+    if (isOpen && promoItem && promoItem.productSku && !hasTrackedView.current) {
+      hasTrackedView.current = true;
+      void track(
+        createPromoAlertViewedEvent({
+          promoCodeItemId: promoItem._id,
+          productSku: promoItem.productSku.sku,
+          productImageUrl: promoItem.productSku.images[0],
+          productId: promoItem.productSku.productId,
+        }),
+      );
+    }
+  }, [isOpen, promoItem, track]);
 
   const onPromoAlertClose = () => {
     onClose();
     if (promoItem && promoItem.productSku) {
-      postAnalytics({
-        action: "dismissed_promo_alert",
-        origin: "promo_alert",
-        data: {
+      void track(
+        createPromoAlertDismissedEvent({
           promoCodeItemId: promoItem._id,
           productSku: promoItem.productSku.sku,
           productImageUrl: promoItem.productSku.images[0],
-          product: promoItem.productSku.productId,
-        },
-      });
+          productId: promoItem.productSku.productId,
+        }),
+      );
     }
   };
 
-  // Track when the alert is actioned on
   const handleShopNow = () => {
     onClose();
     if (promoItem && promoItem.productSku) {
-      postAnalytics({
-        action: "clicked_shop_all_hair",
-        origin: "promo_alert",
-        data: {
+      void track(
+        createPromoAlertShopNowEvent({
           promoCodeItemId: promoItem._id,
           productSkuId: promoItem.productSku._id,
           quantity: promoItem.quantity,
           quantityClaimed: promoItem.quantityClaimed,
-        },
-      });
+        }),
+      );
     }
   };
 

--- a/packages/storefront-webapp/src/components/home/RewardsAlert.tsx
+++ b/packages/storefront-webapp/src/components/home/RewardsAlert.tsx
@@ -3,8 +3,11 @@ import { Link } from "@tanstack/react-router";
 import { X } from "lucide-react";
 import { AnimatedCard } from "../ui/AnimatedCard";
 import { Button } from "../ui/button";
-import { postAnalytics } from "@/api/analytics";
-import { useTrackEvent } from "@/hooks/useTrackEvent";
+import { useStorefrontObservability } from "@/hooks/useStorefrontObservability";
+import {
+  createRewardsAlertDismissedEvent,
+  createRewardsAlertShopNowEvent,
+} from "@/lib/storefrontJourneyEvents";
 
 interface RewardsAlertProps {
   isOpen: boolean;
@@ -12,24 +15,16 @@ interface RewardsAlertProps {
 }
 
 export function RewardsAlert({ isOpen, onClose }: RewardsAlertProps) {
+  const { track } = useStorefrontObservability();
+
   const onRewardsAlertClose = () => {
     onClose();
-
-    postAnalytics({
-      action: "dismissed_rewards_alert",
-      data: {},
-    });
+    void track(createRewardsAlertDismissedEvent());
   };
 
-  // Track when the alert is actioned on
   const handleShopNow = () => {
     onClose();
-
-    postAnalytics({
-      action: "clicked_shop_now",
-      origin: "rewards_alert",
-      data: {},
-    });
+    void track(createRewardsAlertShopNowEvent());
   };
 
   return (

--- a/packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx
+++ b/packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx
@@ -1,7 +1,7 @@
 import { useStoreContext } from "@/contexts/StoreContext";
 import { useOnlineOrderQueries } from "@/lib/queries/onlineOrder";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useParams, Link } from "@tanstack/react-router";
 import NotFound from "../states/not-found/NotFound";
 import { FadeIn } from "../common/FadeIn";
@@ -24,8 +24,11 @@ import { SuccessMessage } from "./SuccessMessage";
 import { ErrorMessage } from "./ErrorMessage";
 import { ExistingReviewMessage } from "./ExistingReviewMessage";
 import { ArrowRight, CheckCircle } from "lucide-react";
-import { useTrackEvent } from "@/hooks/useTrackEvent";
-import { postAnalytics } from "@/api/analytics";
+import { useStorefrontObservability } from "@/hooks/useStorefrontObservability";
+import {
+  createReviewEditorViewedEvent,
+  createReviewSubmittedEvent,
+} from "@/lib/storefrontJourneyEvents";
 import { cn } from "@/lib/utils";
 
 const PublishedReviewMessage = ({ productId }: { productId: string }) => {
@@ -87,15 +90,22 @@ export const ReviewEditor = () => {
 
   const item: any = data?.items?.find((item: any) => item._id == orderItemId);
 
-  useTrackEvent({
-    action: "navigated_to_product_review_editor",
-    data: {
-      orderId: orderId || "",
-      orderItemId: orderItemId || "",
-      product: item?.productId,
-      productImageUrl: item?.productImage,
-    },
-  });
+  const { track } = useStorefrontObservability();
+  const hasTrackedView = useRef(false);
+
+  useEffect(() => {
+    if (!hasTrackedView.current && item) {
+      hasTrackedView.current = true;
+      void track(
+        createReviewEditorViewedEvent({
+          orderId: orderId || "",
+          orderItemId: orderItemId || "",
+          productId: item?.productId,
+          productImageUrl: item?.productImage,
+        }),
+      );
+    }
+  }, [item, orderId, orderItemId, track]);
 
   // Check if review already exists for this order item
   const { data: existingReview, isLoading: isLoadingReview } = useQuery({
@@ -168,7 +178,7 @@ export const ReviewEditor = () => {
       setIsSubmitting(true);
 
       await Promise.all([
-        await createReview({
+        createReview({
           orderId: orderId as any,
           orderNumber: orderData?.orderNumber,
           orderItemId: orderItemId as any,
@@ -179,16 +189,15 @@ export const ReviewEditor = () => {
           ratings,
         }),
 
-        await postAnalytics({
-          action: "submitted_a_product_review",
-          data: {
+        track(
+          createReviewSubmittedEvent({
             orderId: orderId || "",
             orderItemId: orderItemId || "",
             productId: item.productId,
             productSkuId: item.productSkuId,
             productImageUrl: item.productImage,
-          },
-        }),
+          }),
+        ),
       ]);
 
       // Invalidate all review queries

--- a/packages/storefront-webapp/src/components/saved-items/SavedBag.tsx
+++ b/packages/storefront-webapp/src/components/saved-items/SavedBag.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { ShoppingBasket, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useStoreContext } from "@/contexts/StoreContext";
@@ -11,8 +11,12 @@ import { AnimatePresence, easeInOut, motion } from "framer-motion";
 import { EmptyState } from "../states/empty/empty-state";
 import { FadeIn } from "../common/FadeIn";
 import ImageWithFallback from "../ui/image-with-fallback";
-import { postAnalytics } from "@/api/analytics";
-import { useTrackEvent } from "@/hooks/useTrackEvent";
+import { useStorefrontObservability } from "@/hooks/useStorefrontObservability";
+import {
+  createSavedBagViewedEvent,
+  createSavedBagMoveToBagEvent,
+  createSavedBagRemoveEvent,
+} from "@/lib/storefrontJourneyEvents";
 import { getStoreFallbackImageUrl } from "@/lib/storeConfig";
 
 export default function SavedBag() {
@@ -26,13 +30,18 @@ export default function SavedBag() {
     isUpdatingSavedBag,
     moveItemFromSavedToBag,
   } = useShoppingBag();
+  const { track } = useStorefrontObservability();
 
   const { origin } = useSearch({ strict: false });
 
-  useTrackEvent({
-    action: "viewed_saved_bag",
-    origin,
-  });
+  const hasTrackedView = useRef(false);
+
+  useEffect(() => {
+    if (!hasTrackedView.current) {
+      hasTrackedView.current = true;
+      void track(createSavedBagViewedEvent());
+    }
+  }, [track]);
 
   const isSavedEmpty = savedBag?.items?.length === 0;
 
@@ -149,15 +158,13 @@ export default function SavedBag() {
                             setBagAction("moving-to-bag");
                             await Promise.all([
                               moveItemFromSavedToBag(item),
-                              postAnalytics({
-                                action: "added_product_to_bag",
-                                origin: "saved_bag",
-                                data: {
-                                  product: item.productId,
+                              track(
+                                createSavedBagMoveToBagEvent({
+                                  productId: item.productId,
                                   productSku: item.productSku,
                                   productImageUrl: item.productImage,
-                                },
-                              }),
+                                }),
+                              ),
                             ]);
                           }}
                         >
@@ -172,14 +179,13 @@ export default function SavedBag() {
                             setBagAction("deleting-from-saved-bag");
                             await Promise.all([
                               deleteItemFromSavedBag(item._id),
-                              postAnalytics({
-                                action: "removed_product_from_saved",
-                                data: {
-                                  product: item.productId,
+                              track(
+                                createSavedBagRemoveEvent({
+                                  productId: item.productId,
                                   productSku: item.productSku,
                                   productImageUrl: item.productImage,
-                                },
-                              }),
+                                }),
+                              ),
                             ]);
                           }}
                         >

--- a/packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx
+++ b/packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx
@@ -41,7 +41,10 @@ import ImageWithFallback from "../ui/image-with-fallback";
 import { useNavigationBarContext } from "@/contexts/NavigationBarProvider";
 import { useCheckoutSessionQueries } from "@/lib/queries/checkout";
 import { usePromoCodesQueries } from "@/lib/queries/promoCode";
-import { postAnalytics } from "@/api/analytics";
+import {
+  createBagMoveToSavedEvent,
+  createDiscountCodeTriggerEvent,
+} from "@/lib/storefrontJourneyEvents";
 import { useDiscountCodeAlert } from "@/hooks/useDiscountCodeAlert";
 import { WelcomeBackModal } from "../ui/modals/WelcomeBackModal";
 import { useProductDiscount } from "@/hooks/useProductDiscount";
@@ -499,13 +502,11 @@ export default function ShoppingBag() {
   const handleClickOnDiscountCode = async () => {
     openDiscountModal();
 
-    await postAnalytics({
-      action: "clicked_on_discount_code_trigger",
-      origin: "shopping_bag",
-      data: {
+    await track(
+      createDiscountCodeTriggerEvent({
         promoCodeId: storeConfig.promotions.homepageDiscountCodeModalPromoCode,
-      },
-    });
+      }),
+    );
   };
 
   const isSkuUnavailable = (skuId: string) => {
@@ -527,15 +528,13 @@ export default function ShoppingBag() {
     setBagAction("moving-to-saved-bag");
     await Promise.all([
       moveItemFromBagToSaved(item),
-      postAnalytics({
-        action: "added_product_to_saved",
-        origin: "shopping_bag",
-        data: {
-          product: item.productId,
+      track(
+        createBagMoveToSavedEvent({
+          productId: item.productId,
           productSku: item.productSku,
           productImageUrl: item.productImage,
-        },
-      }),
+        }),
+      ),
     ]);
   };
 

--- a/packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx
+++ b/packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx
@@ -504,7 +504,7 @@ export default function ShoppingBag() {
 
     await track(
       createDiscountCodeTriggerEvent({
-        promoCodeId: storeConfig.promotions.homepageDiscountCodeModalPromoCode,
+        promoCodeId: storeConfig.promotions.homepageDiscountCodeModalPromoCode?.promoCodeId,
       }),
     );
   };

--- a/packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx
+++ b/packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx
@@ -11,8 +11,11 @@ import {
   defaultBackgroundImageUrl,
   getModalConfig,
 } from "./config/leaveReviewModalConfig";
-import { useTrackEvent } from "@/hooks/useTrackEvent";
-import { postAnalytics } from "@/api/analytics";
+import { useStorefrontObservability } from "@/hooks/useStorefrontObservability";
+import {
+  createLeaveReviewModalViewedEvent,
+  createLeaveReviewModalDismissedEvent,
+} from "@/lib/storefrontJourneyEvents";
 import { useOnlineOrderQueries } from "@/lib/queries/onlineOrder";
 import { useQuery } from "@tanstack/react-query";
 import { PromoCode } from "./types";
@@ -44,28 +47,32 @@ export const LeaveAReviewModal: React.FC<LeaveAReviewModalProps> = ({
   );
 
   const incentiveType = promoCode ? "discount" : "points";
+  const { track } = useStorefrontObservability();
 
-  useTrackEvent({
-    action: `viewed_LEAVE_A_REVIEW_(${incentiveType})_modal`,
-    isReady: isOpen && !hasReviewed,
-    data: {
-      incentiveType,
-      promoCodeId: promoCode?.promoCodeId,
-    },
-  });
+  const hasTrackedView = React.useRef(false);
+
+  React.useEffect(() => {
+    if (isOpen && !hasReviewed && !hasTrackedView.current) {
+      hasTrackedView.current = true;
+      void track(
+        createLeaveReviewModalViewedEvent({
+          incentiveType,
+          promoCodeId: promoCode?.promoCodeId,
+        }),
+      );
+    }
+  }, [isOpen, hasReviewed, incentiveType, promoCode?.promoCodeId, track]);
 
   const handleClose = async (logAnalytics = true) => {
     onClose();
 
-    // Log analytics if needed
     if (logAnalytics) {
-      await postAnalytics({
-        action: `dismissed_LEAVE_A_REVIEW_(${incentiveType})_modal`,
-        data: {
+      await track(
+        createLeaveReviewModalDismissedEvent({
           incentiveType,
           promoCodeId: promoCode?.promoCodeId,
-        },
-      });
+        }),
+      );
     }
   };
 

--- a/packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx
+++ b/packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx
@@ -15,8 +15,12 @@ import {
   nextOrderConfigs,
   getModalConfig,
 } from "./config/welcomeBackModalConfig";
-import { useTrackEvent } from "@/hooks/useTrackEvent";
-import { postAnalytics } from "@/api/analytics";
+import { useStorefrontObservability } from "@/hooks/useStorefrontObservability";
+import {
+  createUpsellModalViewedEvent,
+  createUpsellModalDismissedEvent,
+  createUpsellModalSubmittedEvent,
+} from "@/lib/storefrontJourneyEvents";
 import { useOnlineOrderQueries } from "@/lib/queries/onlineOrder";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useUpsellsQueries } from "@/lib/queries/upsells";
@@ -53,6 +57,7 @@ export const UpsellModal: React.FC<UpsellModalProps> = ({ promoCode }) => {
     useState(false);
 
   const isNextOrder = onlineOrders && onlineOrders?.length > 1;
+  const { track } = useStorefrontObservability();
 
   useEffect(() => {
     // Don't add scroll listener until localStorage state is fully loaded
@@ -86,49 +91,51 @@ export const UpsellModal: React.FC<UpsellModalProps> = ({ promoCode }) => {
     isUpsellModalStateLoaded,
   ]);
 
-  useTrackEvent({
-    action: "viewed_upsell_product_modal",
-    isReady: isUpsellModalOpen,
-    data: {
-      isNextOrder,
-      promoCodeId: promoCode?.promoCodeId,
-      product: upsell?.productId,
-      productSku: upsell?.sku,
-      productImageUrl: upsell?.images[0],
-    },
-  });
+  const hasTrackedView = useRef(false);
+
+  useEffect(() => {
+    if (isUpsellModalOpen && !hasTrackedView.current) {
+      hasTrackedView.current = true;
+      void track(
+        createUpsellModalViewedEvent({
+          isNextOrder: !!isNextOrder,
+          promoCodeId: promoCode?.promoCodeId,
+          productId: upsell?.productId,
+          productSku: upsell?.sku,
+          productImageUrl: upsell?.images[0],
+        }),
+      );
+    }
+  }, [isUpsellModalOpen, isNextOrder, promoCode?.promoCodeId, upsell, track]);
 
   const handleClose = async (logAnalytics = true) => {
     handleCloseUpsellModal();
 
-    // Log analytics if needed
     if (logAnalytics) {
-      await postAnalytics({
-        action: "dismissed_upsell_product_modal",
-        data: {
-          isNextOrder,
+      await track(
+        createUpsellModalDismissedEvent({
+          isNextOrder: !!isNextOrder,
           promoCodeId: promoCode?.promoCodeId,
-          product: upsell?.productId,
+          productId: upsell?.productId,
           productSku: upsell?.sku,
           productImageUrl: upsell?.images[0],
-        },
-      });
+        }),
+      );
     }
   };
 
   const handleSuccess = async () => {
     completeUpsellModalFlow();
 
-    await postAnalytics({
-      action: "submitted_upsell_product_modal",
-      data: {
-        isNextOrder,
+    await track(
+      createUpsellModalSubmittedEvent({
+        isNextOrder: !!isNextOrder,
         promoCodeId: promoCode?.promoCodeId,
-        product: upsell?.productId,
+        productId: upsell?.productId,
         productSku: upsell?.sku,
         productImageUrl: upsell?.images[0],
-      },
-    });
+      }),
+    );
 
     setIsSuccess(true);
   };

--- a/packages/storefront-webapp/src/components/ui/modals/UpsellModalSuccess.tsx
+++ b/packages/storefront-webapp/src/components/ui/modals/UpsellModalSuccess.tsx
@@ -7,7 +7,8 @@ import {
 } from "./animations/welcomeBackModalAnimations";
 import { getProductName } from "@/lib/utils";
 import { useShoppingBag } from "@/hooks/useShoppingBag";
-import { postAnalytics } from "@/api/analytics";
+import { useStorefrontObservability } from "@/hooks/useStorefrontObservability";
+import { createUpsellModalAddToBagEvent } from "@/lib/storefrontJourneyEvents";
 import { useNavigate } from "@tanstack/react-router";
 
 interface UpsellModalSuccessProps {
@@ -20,6 +21,7 @@ export const UpsellModalSuccess: React.FC<UpsellModalSuccessProps> = ({
   upsell,
 }) => {
   const { addProductToBag, bag } = useShoppingBag();
+  const { track } = useStorefrontObservability();
   const [isAddingToBag, setIsAddingToBag] = useState(false);
 
   const navigate = useNavigate();
@@ -31,22 +33,20 @@ export const UpsellModalSuccess: React.FC<UpsellModalSuccessProps> = ({
 
     if (!isItemInBag) {
       await Promise.allSettled([
-        await addProductToBag({
+        addProductToBag({
           productId: upsell.productId,
           productSkuId: upsell._id,
           productSku: upsell.sku,
           quantity: 1,
         }),
 
-        await postAnalytics({
-          action: "added_product_to_bag",
-          origin: "homepage_upsell_modal",
-          data: {
-            product: upsell.productId,
+        track(
+          createUpsellModalAddToBagEvent({
+            productId: upsell.productId,
             productSku: upsell.sku,
             productImageUrl: upsell.images[0],
-          },
-        }),
+          }),
+        ),
       ]);
     }
 

--- a/packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx
+++ b/packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx
@@ -15,8 +15,12 @@ import {
   nextOrderConfigs,
   getModalConfig,
 } from "./config/welcomeBackModalConfig";
-import { useTrackEvent } from "@/hooks/useTrackEvent";
-import { postAnalytics } from "@/api/analytics";
+import { useStorefrontObservability } from "@/hooks/useStorefrontObservability";
+import {
+  createWelcomeBackModalViewedEvent,
+  createWelcomeBackModalDismissedEvent,
+  createWelcomeBackModalSubmittedEvent,
+} from "@/lib/storefrontJourneyEvents";
 import { useOnlineOrderQueries } from "@/lib/queries/onlineOrder";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { PromoCode } from "./types";
@@ -35,54 +39,52 @@ export const WelcomeBackModal: React.FC<WelcomeBackModalProps> = ({
   promoCode,
 }) => {
   const [isSuccess, setIsSuccess] = useState(false);
+  const { track } = useStorefrontObservability();
 
   const onlineOrderQueries = useOnlineOrderQueries();
   const { data: onlineOrders } = useQuery(onlineOrderQueries.list());
 
   const isNextOrder = onlineOrders && onlineOrders?.length > 1;
 
-  useTrackEvent({
-    action: "viewed_WELCOMEBACK25_modal",
-    isReady: isOpen,
-    data: {
-      isNextOrder,
-      promoCodeId: promoCode?.promoCodeId,
-    },
-  });
+  const hasTrackedView = React.useRef(false);
+
+  React.useEffect(() => {
+    if (isOpen && !hasTrackedView.current) {
+      hasTrackedView.current = true;
+      void track(
+        createWelcomeBackModalViewedEvent({
+          isNextOrder: !!isNextOrder,
+          promoCodeId: promoCode?.promoCodeId,
+        }),
+      );
+    }
+  }, [isOpen, isNextOrder, promoCode?.promoCodeId, track]);
 
   const handleClose = async (logAnalytics = true) => {
     onClose();
 
-    // Log analytics if needed
     if (logAnalytics) {
-      await postAnalytics({
-        action: "dismissed_WELCOMEBACK25_modal",
-        data: {
-          isNextOrder,
+      await track(
+        createWelcomeBackModalDismissedEvent({
+          isNextOrder: !!isNextOrder,
           promoCodeId: promoCode?.promoCodeId,
-        },
-      });
+        }),
+      );
     }
   };
 
   const handleSuccess = async () => {
     setIsSuccess(true);
-    // Call the onSuccess callback if provided
     if (onSuccess) {
       onSuccess();
     }
 
-    // await queryClient.invalidateQueries({
-    //   queryKey: ["userOffers", "redeemed"],
-    // });
-
-    await postAnalytics({
-      action: "submitted_WELCOMEBACK25_modal",
-      data: {
-        isNextOrder,
+    await track(
+      createWelcomeBackModalSubmittedEvent({
+        isNextOrder: !!isNextOrder,
         promoCodeId: promoCode?.promoCodeId,
-      },
-    });
+      }),
+    );
   };
 
   if (!promoCode || !isOpen) {

--- a/packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts
+++ b/packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts
@@ -381,3 +381,431 @@ export function createAuthVerificationSucceededEvent({
     },
   });
 }
+
+// --- Auxiliary engagement events (V26-184) ---
+
+export function createRewardsAlertViewedEvent() {
+  return createJourneyEvent({
+    journey: "browse",
+    step: "rewards_alert",
+    status: "viewed",
+  });
+}
+
+export function createRewardsAlertDismissedEvent() {
+  return createJourneyEvent({
+    journey: "browse",
+    step: "rewards_alert",
+    status: "canceled",
+  });
+}
+
+export function createRewardsAlertShopNowEvent() {
+  return createJourneyEvent({
+    journey: "browse",
+    step: "rewards_alert",
+    status: "succeeded",
+  });
+}
+
+export function createPromoAlertViewedEvent({
+  promoCodeItemId,
+  productSku,
+  productImageUrl,
+  productId,
+}: {
+  promoCodeItemId?: string;
+  productSku?: string;
+  productImageUrl?: string;
+  productId?: string;
+}) {
+  return createJourneyEvent({
+    journey: "browse",
+    step: "promo_alert",
+    status: "viewed",
+    context: {
+      promoCodeItemId,
+      productSku,
+      productImageUrl,
+      productId,
+    },
+  });
+}
+
+export function createPromoAlertDismissedEvent({
+  promoCodeItemId,
+  productSku,
+  productImageUrl,
+  productId,
+}: {
+  promoCodeItemId?: string;
+  productSku?: string;
+  productImageUrl?: string;
+  productId?: string;
+}) {
+  return createJourneyEvent({
+    journey: "browse",
+    step: "promo_alert",
+    status: "canceled",
+    context: {
+      promoCodeItemId,
+      productSku,
+      productImageUrl,
+      productId,
+    },
+  });
+}
+
+export function createPromoAlertShopNowEvent({
+  promoCodeItemId,
+  productSkuId,
+  quantity,
+  quantityClaimed,
+}: {
+  promoCodeItemId?: string;
+  productSkuId?: string;
+  quantity?: number;
+  quantityClaimed?: number;
+}) {
+  return createJourneyEvent({
+    journey: "browse",
+    step: "promo_alert",
+    status: "succeeded",
+    context: {
+      promoCodeItemId,
+      productSkuId,
+      quantity,
+      quantityClaimed,
+    },
+  });
+}
+
+export function createWelcomeBackModalViewedEvent({
+  isNextOrder,
+  promoCodeId,
+}: {
+  isNextOrder?: boolean;
+  promoCodeId?: string;
+}) {
+  return createJourneyEvent({
+    journey: "browse",
+    step: "welcome_back_modal",
+    status: "viewed",
+    context: {
+      isNextOrder,
+      promoCodeId,
+    },
+  });
+}
+
+export function createWelcomeBackModalDismissedEvent({
+  isNextOrder,
+  promoCodeId,
+}: {
+  isNextOrder?: boolean;
+  promoCodeId?: string;
+}) {
+  return createJourneyEvent({
+    journey: "browse",
+    step: "welcome_back_modal",
+    status: "canceled",
+    context: {
+      isNextOrder,
+      promoCodeId,
+    },
+  });
+}
+
+export function createWelcomeBackModalSubmittedEvent({
+  isNextOrder,
+  promoCodeId,
+}: {
+  isNextOrder?: boolean;
+  promoCodeId?: string;
+}) {
+  return createJourneyEvent({
+    journey: "browse",
+    step: "welcome_back_modal",
+    status: "succeeded",
+    context: {
+      isNextOrder,
+      promoCodeId,
+    },
+  });
+}
+
+export function createLeaveReviewModalViewedEvent({
+  incentiveType,
+  promoCodeId,
+}: {
+  incentiveType?: string;
+  promoCodeId?: string;
+}) {
+  return createJourneyEvent({
+    journey: "browse",
+    step: "leave_review_modal",
+    status: "viewed",
+    context: {
+      incentiveType,
+      promoCodeId,
+    },
+  });
+}
+
+export function createLeaveReviewModalDismissedEvent({
+  incentiveType,
+  promoCodeId,
+}: {
+  incentiveType?: string;
+  promoCodeId?: string;
+}) {
+  return createJourneyEvent({
+    journey: "browse",
+    step: "leave_review_modal",
+    status: "canceled",
+    context: {
+      incentiveType,
+      promoCodeId,
+    },
+  });
+}
+
+export function createUpsellModalViewedEvent({
+  isNextOrder,
+  promoCodeId,
+  productId,
+  productSku,
+  productImageUrl,
+}: {
+  isNextOrder?: boolean;
+  promoCodeId?: string;
+  productId?: string;
+  productSku?: string;
+  productImageUrl?: string;
+}) {
+  return createJourneyEvent({
+    journey: "browse",
+    step: "upsell_modal",
+    status: "viewed",
+    context: {
+      isNextOrder,
+      promoCodeId,
+      productId,
+      productSku,
+      productImageUrl,
+    },
+  });
+}
+
+export function createUpsellModalDismissedEvent({
+  isNextOrder,
+  promoCodeId,
+  productId,
+  productSku,
+  productImageUrl,
+}: {
+  isNextOrder?: boolean;
+  promoCodeId?: string;
+  productId?: string;
+  productSku?: string;
+  productImageUrl?: string;
+}) {
+  return createJourneyEvent({
+    journey: "browse",
+    step: "upsell_modal",
+    status: "canceled",
+    context: {
+      isNextOrder,
+      promoCodeId,
+      productId,
+      productSku,
+      productImageUrl,
+    },
+  });
+}
+
+export function createUpsellModalSubmittedEvent({
+  isNextOrder,
+  promoCodeId,
+  productId,
+  productSku,
+  productImageUrl,
+}: {
+  isNextOrder?: boolean;
+  promoCodeId?: string;
+  productId?: string;
+  productSku?: string;
+  productImageUrl?: string;
+}) {
+  return createJourneyEvent({
+    journey: "browse",
+    step: "upsell_modal",
+    status: "succeeded",
+    context: {
+      isNextOrder,
+      promoCodeId,
+      productId,
+      productSku,
+      productImageUrl,
+    },
+  });
+}
+
+export function createUpsellModalAddToBagEvent({
+  productId,
+  productSku,
+  productImageUrl,
+}: {
+  productId?: string;
+  productSku?: string;
+  productImageUrl?: string;
+}) {
+  return createJourneyEvent({
+    journey: "bag",
+    step: "bag_add",
+    status: "succeeded",
+    context: {
+      productId,
+      productSku,
+      productImageUrl,
+      entryOrigin: "homepage_upsell_modal",
+    },
+  });
+}
+
+export function createSavedBagViewedEvent() {
+  return createJourneyEvent({
+    journey: "bag",
+    step: "saved_bag_view",
+    status: "viewed",
+  });
+}
+
+export function createSavedBagMoveToBagEvent({
+  productId,
+  productSku,
+  productImageUrl,
+}: {
+  productId?: string;
+  productSku?: string;
+  productImageUrl?: string;
+}) {
+  return createJourneyEvent({
+    journey: "bag",
+    step: "saved_bag_move_to_bag",
+    status: "succeeded",
+    context: {
+      productId,
+      productSku,
+      productImageUrl,
+    },
+  });
+}
+
+export function createSavedBagRemoveEvent({
+  productId,
+  productSku,
+  productImageUrl,
+}: {
+  productId?: string;
+  productSku?: string;
+  productImageUrl?: string;
+}) {
+  return createJourneyEvent({
+    journey: "bag",
+    step: "saved_bag_remove",
+    status: "succeeded",
+    context: {
+      productId,
+      productSku,
+      productImageUrl,
+    },
+  });
+}
+
+export function createBagMoveToSavedEvent({
+  productId,
+  productSku,
+  productImageUrl,
+}: {
+  productId?: string;
+  productSku?: string;
+  productImageUrl?: string;
+}) {
+  return createJourneyEvent({
+    journey: "bag",
+    step: "bag_move_to_saved",
+    status: "succeeded",
+    context: {
+      productId,
+      productSku,
+      productImageUrl,
+    },
+  });
+}
+
+export function createDiscountCodeTriggerEvent({
+  promoCodeId,
+}: {
+  promoCodeId?: string;
+}) {
+  return createJourneyEvent({
+    journey: "bag",
+    step: "discount_code_trigger",
+    status: "started",
+    context: {
+      promoCodeId,
+    },
+  });
+}
+
+export function createReviewEditorViewedEvent({
+  orderId,
+  orderItemId,
+  productId,
+  productImageUrl,
+}: {
+  orderId?: string;
+  orderItemId?: string;
+  productId?: string;
+  productImageUrl?: string;
+}) {
+  return createJourneyEvent({
+    journey: "product_discovery",
+    step: "review_editor",
+    status: "viewed",
+    context: {
+      orderId,
+      orderItemId,
+      productId,
+      productImageUrl,
+    },
+  });
+}
+
+export function createReviewSubmittedEvent({
+  orderId,
+  orderItemId,
+  productId,
+  productSkuId,
+  productImageUrl,
+}: {
+  orderId?: string;
+  orderItemId?: string;
+  productId?: string;
+  productSkuId?: string;
+  productImageUrl?: string;
+}) {
+  return createJourneyEvent({
+    journey: "product_discovery",
+    step: "review_submission",
+    status: "succeeded",
+    context: {
+      orderId,
+      orderItemId,
+      productId,
+      productSkuId,
+      productImageUrl,
+    },
+  });
+}


### PR DESCRIPTION
## Summary

- Migrates all auxiliary storefront telemetry (promo alerts, rewards alerts, welcome-back/leave-a-review/upsell modals, saved bag interactions, product review flows, discount code trigger) from ad-hoc `postAnalytics()` calls to the canonical observability event contract via the shared helper
- Adds 22 new journey event factory functions to `storefrontJourneyEvents.ts` covering all auxiliary flows
- Fixes a pre-existing type bug where `PromoCodeConfig` object was passed where a `string` was expected in the discount code trigger

## Why

Auxiliary engagement events were still using scattered `postAnalytics()` calls with bespoke action names, making them inconsistent with the canonical observability model established in V26-180/V26-181. This migration ensures all storefront interaction telemetry uses consistent `journey`, `step`, `status` fields and flows through the shared observability provider with session/user context.

## Validation

- `tsc --noEmit` passes clean (zero errors)
- `git diff --check` passes (no whitespace issues)
- All migrated files confirmed free of `postAnalytics` imports
- Vite build fails due to pre-existing esbuild environment issue in worktree (unrelated to changes)

**Files changed (10):**
| File | Change |
|------|--------|
| `storefrontJourneyEvents.ts` | +22 new event factory functions |
| `RewardsAlert.tsx` | Migrated dismiss + shop-now |
| `PromoAlert.tsx` | Migrated view + dismiss + shop-now |
| `WelcomeBackModal.tsx` | Migrated view + dismiss + submit |
| `LeaveAReviewModal.tsx` | Migrated view + dismiss |
| `UpsellModal.tsx` | Migrated view + dismiss + submit |
| `UpsellModalSuccess.tsx` | Migrated add-to-bag |
| `SavedBag.tsx` | Migrated view + move-to-bag + remove |
| `ShoppingBag.tsx` | Migrated move-to-saved + discount trigger |
| `ReviewEditor.tsx` | Migrated view + submit |

https://linear.app/v26-labs/issue/V26-184/migrate-auxiliary-storefront-promo-review-and-saved-item-telemetry-to