### PR TITLE
[V26-186]: add MTN MoMo collections foundation

### DIFF
--- a/packages/athena-webapp/convex/_generated/api.d.ts
+++ b/packages/athena-webapp/convex/_generated/api.d.ts
@@ -37,6 +37,8 @@ import type * as http_domains_inventory_routes_organizations from "../http/domai
 import type * as http_domains_inventory_routes_products from "../http/domains/inventory/routes/products.js";
 import type * as http_domains_inventory_routes_stores from "../http/domains/inventory/routes/stores.js";
 import type * as http_domains_inventory_routes_subcategories from "../http/domains/inventory/routes/subcategories.js";
+import type * as http_domains_payments_routes_index from "../http/domains/payments/routes/index.js";
+import type * as http_domains_payments_routes_mtnMomo from "../http/domains/payments/routes/mtnMomo.js";
 import type * as http_domains_storeFront_routes_bag from "../http/domains/storeFront/routes/bag.js";
 import type * as http_domains_storeFront_routes_checkout from "../http/domains/storeFront/routes/checkout.js";
 import type * as http_domains_storeFront_routes_guest from "../http/domains/storeFront/routes/guest.js";
@@ -98,6 +100,11 @@ import type * as llm_userInsights from "../llm/userInsights.js";
 import type * as llm_utils_analyticsUtils from "../llm/utils/analyticsUtils.js";
 import type * as mailersend_index from "../mailersend/index.js";
 import type * as migrations_migrateAmountsToPesewas from "../migrations/migrateAmountsToPesewas.js";
+import type * as mtn_client from "../mtn/client.js";
+import type * as mtn_collections from "../mtn/collections.js";
+import type * as mtn_config from "../mtn/config.js";
+import type * as mtn_normalize from "../mtn/normalize.js";
+import type * as mtn_types from "../mtn/types.js";
 import type * as otp_ResendOTP from "../otp/ResendOTP.js";
 import type * as otp_VerificationCodeEmail from "../otp/VerificationCodeEmail.js";
 import type * as paystack_index from "../paystack/index.js";
@@ -119,6 +126,7 @@ import type * as schemas_inventory_promoCode from "../schemas/inventory/promoCod
 import type * as schemas_inventory_redeemedPromoCode from "../schemas/inventory/redeemedPromoCode.js";
 import type * as schemas_inventory_store from "../schemas/inventory/store.js";
 import type * as schemas_inventory_subcategory from "../schemas/inventory/subcategory.js";
+import type * as schemas_payments_mtnCollections from "../schemas/payments/mtnCollections.js";
 import type * as schemas_pos_customer from "../schemas/pos/customer.js";
 import type * as schemas_pos_expenseSession from "../schemas/pos/expenseSession.js";
 import type * as schemas_pos_expenseSessionItem from "../schemas/pos/expenseSessionItem.js";
@@ -218,6 +226,8 @@ declare const fullApi: ApiFromModules<{
   "http/domains/inventory/routes/products": typeof http_domains_inventory_routes_products;
   "http/domains/inventory/routes/stores": typeof http_domains_inventory_routes_stores;
   "http/domains/inventory/routes/subcategories": typeof http_domains_inventory_routes_subcategories;
+  "http/domains/payments/routes/index": typeof http_domains_payments_routes_index;
+  "http/domains/payments/routes/mtnMomo": typeof http_domains_payments_routes_mtnMomo;
   "http/domains/storeFront/routes/bag": typeof http_domains_storeFront_routes_bag;
   "http/domains/storeFront/routes/checkout": typeof http_domains_storeFront_routes_checkout;
   "http/domains/storeFront/routes/guest": typeof http_domains_storeFront_routes_guest;
@@ -279,6 +289,11 @@ declare const fullApi: ApiFromModules<{
   "llm/utils/analyticsUtils": typeof llm_utils_analyticsUtils;
   "mailersend/index": typeof mailersend_index;
   "migrations/migrateAmountsToPesewas": typeof migrations_migrateAmountsToPesewas;
+  "mtn/client": typeof mtn_client;
+  "mtn/collections": typeof mtn_collections;
+  "mtn/config": typeof mtn_config;
+  "mtn/normalize": typeof mtn_normalize;
+  "mtn/types": typeof mtn_types;
   "otp/ResendOTP": typeof otp_ResendOTP;
   "otp/VerificationCodeEmail": typeof otp_VerificationCodeEmail;
   "paystack/index": typeof paystack_index;
@@ -300,6 +315,7 @@ declare const fullApi: ApiFromModules<{
   "schemas/inventory/redeemedPromoCode": typeof schemas_inventory_redeemedPromoCode;
   "schemas/inventory/store": typeof schemas_inventory_store;
   "schemas/inventory/subcategory": typeof schemas_inventory_subcategory;
+  "schemas/payments/mtnCollections": typeof schemas_payments_mtnCollections;
   "schemas/pos/customer": typeof schemas_pos_customer;
   "schemas/pos/expenseSession": typeof schemas_pos_expenseSession;
   "schemas/pos/expenseSessionItem": typeof schemas_pos_expenseSessionItem;

--- a/packages/athena-webapp/convex/http.ts
+++ b/packages/athena-webapp/convex/http.ts
@@ -30,6 +30,7 @@ import {
 import { guestRoutes } from "./http/domains/storeFront/routes/guest";
 import { colorRoutes } from "./http/domains/inventory/routes/colors";
 import { savedBagRoutes } from "./http/domains/storeFront/routes/savedBag";
+import { mtnMomoRoutes } from "./http/domains/payments/routes";
 
 const app: HonoWithConvex<ActionCtx> = new Hono();
 
@@ -55,6 +56,7 @@ app.route("/stores", storeRoutes);
 app.route("/storefront", storefrontRoutes);
 
 app.route("/webhooks/paystack", paystackRoutes);
+app.route("/webhooks/mtn-momo", mtnMomoRoutes);
 
 app.route("/analytics", analyticsRoutes);
 

--- a/packages/athena-webapp/convex/http/domains/payments/routes/index.ts
+++ b/packages/athena-webapp/convex/http/domains/payments/routes/index.ts
@@ -1,0 +1,1 @@
+export * from "./mtnMomo";

--- a/packages/athena-webapp/convex/http/domains/payments/routes/mtnMomo.ts
+++ b/packages/athena-webapp/convex/http/domains/payments/routes/mtnMomo.ts
@@ -1,0 +1,44 @@
+import { Hono } from "hono";
+import { HonoWithConvex } from "convex-helpers/server/hono";
+import { ActionCtx } from "../../../../_generated/server";
+import { Id } from "../../../../_generated/dataModel";
+import { internal } from "../../../../_generated/api";
+import { parseCollectionsNotificationRequest } from "../../../../mtn/normalize";
+
+const mtnMomoRoutes: HonoWithConvex<ActionCtx> = new Hono();
+
+const handleCollectionNotification = async (c: any) => {
+  const rawBody = await c.req.text();
+  const parsed = parseCollectionsNotificationRequest({
+    rawBody,
+    headers: Object.fromEntries(c.req.raw.headers.entries()),
+    query: {
+      storeId: c.req.query("storeId"),
+      providerReference: c.req.query("providerReference"),
+    },
+    method: c.req.raw.method,
+  });
+
+  if (!parsed.ok) {
+    return c.json({ error: parsed.error }, parsed.statusCode);
+  }
+
+  const observedAt = Date.now();
+
+  await c.env.runMutation(internal.mtn.collections.ingestNotification, {
+    storeId: parsed.value.storeId as Id<"store">,
+    providerReference: parsed.value.providerReference,
+    statusPayload: parsed.value.payload as any,
+    observedAt,
+    callbackMetadata: {
+      ...parsed.value.callbackMetadata,
+      receivedAt: observedAt,
+    },
+  });
+
+  return c.json({ message: "OK" });
+};
+
+mtnMomoRoutes.on(["POST", "PUT"], "/collections", handleCollectionNotification);
+
+export { mtnMomoRoutes };

--- a/packages/athena-webapp/convex/mtn/client.test.ts
+++ b/packages/athena-webapp/convex/mtn/client.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createCollectionsAccessToken,
+  getRequestToPayStatus,
+  requestToPay,
+} from "./client";
+
+const baseConfig = {
+  subscriptionKey: "test-subscription-key",
+  apiUser: "test-user",
+  apiKey: "test-password",
+  targetEnvironment: "sandbox" as const,
+  baseUrl: "https://sandbox.momodeveloper.mtn.com",
+  callbackHost: "https://athena.example.com",
+  callbackPath: "/webhooks/mtn-momo/collections",
+};
+
+describe("MTN collections client", () => {
+  it("creates an access token with basic auth and the collections subscription key", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        access_token: "token-123",
+        token_type: "access_token",
+        expires_in: 3600,
+      }),
+    });
+
+    const result = await createCollectionsAccessToken(
+      baseConfig,
+      fetchMock as unknown as typeof fetch,
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://sandbox.momodeveloper.mtn.com/collection/token/",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: `Basic ${btoa("test-user:test-password")}`,
+          "Ocp-Apim-Subscription-Key": "test-subscription-key",
+        }),
+      }),
+    );
+    expect(result).toEqual({
+      accessToken: "token-123",
+      tokenType: "access_token",
+      expiresInSeconds: 3600,
+    });
+  });
+
+  it("submits request-to-pay calls with the callback url and generated reference", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 202,
+      text: async () => "",
+    });
+
+    const result = await requestToPay(
+      baseConfig,
+      "token-123",
+      {
+        providerReference: "provider-ref-123",
+        callbackUrl:
+          "https://athena.example.com/webhooks/mtn-momo/collections?storeId=store_123&providerReference=provider-ref-123",
+        amount: "1500",
+        currency: "EUR",
+        externalId: "order-001",
+        payer: {
+          partyIdType: "MSISDN",
+          partyId: "233555123456",
+        },
+        payerMessage: "Order Payment",
+        payeeNote: "Order Payment",
+      },
+      fetchMock as unknown as typeof fetch,
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://sandbox.momodeveloper.mtn.com/collection/v1_0/requesttopay",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer token-123",
+          "Ocp-Apim-Subscription-Key": "test-subscription-key",
+          "X-Reference-Id": "provider-ref-123",
+          "X-Callback-Url":
+            "https://athena.example.com/webhooks/mtn-momo/collections?storeId=store_123&providerReference=provider-ref-123",
+          "X-Target-Environment": "sandbox",
+        }),
+        body: JSON.stringify({
+          amount: "1500",
+          currency: "EUR",
+          externalId: "order-001",
+          payer: {
+            partyIdType: "MSISDN",
+            partyId: "233555123456",
+          },
+          payerMessage: "Order Payment",
+          payeeNote: "Order Payment",
+        }),
+      }),
+    );
+    expect(result).toEqual({
+      providerReference: "provider-ref-123",
+      accepted: true,
+      statusCode: 202,
+    });
+  });
+
+  it("retrieves request-to-pay status with the provider reference path", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        financialTransactionId: "fin-123",
+        externalId: "order-001",
+        amount: "1500",
+        currency: "EUR",
+        payer: {
+          partyIdType: "MSISDN",
+          partyId: "233555123456",
+        },
+        payerMessage: "Order Payment",
+        payeeNote: "Order Payment",
+        status: "SUCCESSFUL",
+      }),
+    });
+
+    const result = await getRequestToPayStatus(
+      baseConfig,
+      "token-123",
+      "provider-ref-123",
+      fetchMock as unknown as typeof fetch,
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://sandbox.momodeveloper.mtn.com/collection/v1_0/requesttopay/provider-ref-123",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          Authorization: "Bearer token-123",
+          "Ocp-Apim-Subscription-Key": "test-subscription-key",
+          "X-Target-Environment": "sandbox",
+        }),
+      }),
+    );
+    expect(result).toMatchObject({
+      financialTransactionId: "fin-123",
+      status: "SUCCESSFUL",
+      externalId: "order-001",
+    });
+  });
+});

--- a/packages/athena-webapp/convex/mtn/client.ts
+++ b/packages/athena-webapp/convex/mtn/client.ts
@@ -1,0 +1,134 @@
+import {
+  MtnCollectionsConfig,
+  MtnCollectionsStatusPayload,
+  MtnParty,
+} from "./types";
+
+type FetchLike = typeof fetch;
+
+const encodeBasicAuth = (value: string): string => {
+  return btoa(value);
+};
+
+const toError = async (response: Response): Promise<Error> => {
+  const body = await response.text();
+  return new Error(
+    `MTN collections request failed with ${response.status}: ${body || response.statusText}`,
+  );
+};
+
+const buildHeaders = (
+  config: MtnCollectionsConfig,
+  accessToken: string,
+): Record<string, string> => ({
+  Authorization: `Bearer ${accessToken}`,
+  "Content-Type": "application/json",
+  "Ocp-Apim-Subscription-Key": config.subscriptionKey,
+  "X-Target-Environment": config.targetEnvironment,
+});
+
+export async function createCollectionsAccessToken(
+  config: MtnCollectionsConfig,
+  fetchImpl: FetchLike = fetch,
+): Promise<{
+  accessToken: string;
+  tokenType: string;
+  expiresInSeconds: number;
+}> {
+  const response = await fetchImpl(`${config.baseUrl}/collection/token/`, {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${encodeBasicAuth(
+        `${config.apiUser}:${config.apiKey}`,
+      )}`,
+      "Ocp-Apim-Subscription-Key": config.subscriptionKey,
+    },
+  });
+
+  if (!response.ok) {
+    throw await toError(response);
+  }
+
+  const payload = (await response.json()) as {
+    access_token: string;
+    token_type: string;
+    expires_in: number;
+  };
+
+  return {
+    accessToken: payload.access_token,
+    tokenType: payload.token_type,
+    expiresInSeconds: payload.expires_in,
+  };
+}
+
+export async function requestToPay(
+  config: MtnCollectionsConfig,
+  accessToken: string,
+  input: {
+    providerReference: string;
+    callbackUrl: string;
+    amount: string;
+    currency: string;
+    externalId: string;
+    payer: MtnParty;
+    payerMessage: string;
+    payeeNote: string;
+  },
+  fetchImpl: FetchLike = fetch,
+): Promise<{
+  providerReference: string;
+  accepted: true;
+  statusCode: number;
+}> {
+  const response = await fetchImpl(
+    `${config.baseUrl}/collection/v1_0/requesttopay`,
+    {
+      method: "POST",
+      headers: {
+        ...buildHeaders(config, accessToken),
+        "X-Callback-Url": input.callbackUrl,
+        "X-Reference-Id": input.providerReference,
+      },
+      body: JSON.stringify({
+        amount: input.amount,
+        currency: input.currency,
+        externalId: input.externalId,
+        payer: input.payer,
+        payerMessage: input.payerMessage,
+        payeeNote: input.payeeNote,
+      }),
+    },
+  );
+
+  if (!response.ok) {
+    throw await toError(response);
+  }
+
+  return {
+    providerReference: input.providerReference,
+    accepted: true,
+    statusCode: response.status,
+  };
+}
+
+export async function getRequestToPayStatus(
+  config: MtnCollectionsConfig,
+  accessToken: string,
+  providerReference: string,
+  fetchImpl: FetchLike = fetch,
+): Promise<MtnCollectionsStatusPayload> {
+  const response = await fetchImpl(
+    `${config.baseUrl}/collection/v1_0/requesttopay/${providerReference}`,
+    {
+      method: "GET",
+      headers: buildHeaders(config, accessToken),
+    },
+  );
+
+  if (!response.ok) {
+    throw await toError(response);
+  }
+
+  return (await response.json()) as MtnCollectionsStatusPayload;
+}

--- a/packages/athena-webapp/convex/mtn/collections.ts
+++ b/packages/athena-webapp/convex/mtn/collections.ts
@@ -1,0 +1,443 @@
+import { v } from "convex/values";
+import {
+  ActionCtx,
+  internalAction,
+  internalMutation,
+  internalQuery,
+  MutationCtx,
+  QueryCtx,
+} from "../_generated/server";
+import { Doc, Id } from "../_generated/dataModel";
+import { internal } from "../_generated/api";
+import {
+  buildMtnCollectionsCallbackUrl,
+  resolveMtnCollectionsConfigFromEnv,
+} from "./config";
+import {
+  createCollectionsAccessToken,
+  getRequestToPayStatus,
+  requestToPay,
+} from "./client";
+import { normalizeCollectionsTransaction } from "./normalize";
+import { MtnCollectionsConfig } from "./types";
+
+const TOKEN_REFRESH_BUFFER_MS = 60_000;
+
+const getCachedTokenRecord = async (
+  ctx: ActionCtx,
+  storeId: Id<"store">,
+): Promise<Doc<"mtnCollectionsToken"> | null> => {
+  return await ctx.runQuery(internal.mtn.collections.getCachedToken, { storeId });
+};
+
+const resolveConfigForStore = async (
+  ctx: ActionCtx,
+  storeId: Id<"store">,
+): Promise<
+  | {
+      success: true;
+      store: Doc<"store">;
+      config: MtnCollectionsConfig;
+    }
+  | {
+      success: false;
+      reason: "store_not_found" | "not_configured";
+      missing?: string[];
+    }
+> => {
+  const store = await ctx.runQuery(internal.inventory.stores.findById, {
+    id: storeId,
+  });
+
+  if (!store) {
+    return {
+      success: false,
+      reason: "store_not_found",
+    };
+  }
+
+  const configResult = resolveMtnCollectionsConfigFromEnv({
+    storeId,
+    storeSlug: store.slug,
+  });
+
+  if (configResult.kind === "not_configured") {
+    return {
+      success: false,
+      reason: "not_configured",
+      missing: configResult.missing,
+    };
+  }
+
+  return {
+    success: true,
+    store,
+    config: configResult.config,
+  };
+};
+
+const resolveAccessTokenForStore = async (
+  ctx: ActionCtx,
+  storeId: Id<"store">,
+): Promise<
+  | {
+      success: true;
+      store: Doc<"store">;
+      config: MtnCollectionsConfig;
+      accessToken: string;
+      expiresAt: number;
+      cached: boolean;
+    }
+  | {
+      success: false;
+      reason: "store_not_found" | "not_configured";
+      missing?: string[];
+    }
+> => {
+  const configResult = await resolveConfigForStore(ctx, storeId);
+
+  if (!configResult.success) {
+    return configResult;
+  }
+
+  const cachedToken = await getCachedTokenRecord(ctx, storeId);
+  const now = Date.now();
+
+  if (cachedToken && cachedToken.expiresAt > now + TOKEN_REFRESH_BUFFER_MS) {
+    return {
+      success: true as const,
+      store: configResult.store,
+      config: configResult.config,
+      accessToken: cachedToken.accessToken,
+      expiresAt: cachedToken.expiresAt,
+      cached: true,
+    };
+  }
+
+  const token = await createCollectionsAccessToken(configResult.config);
+  const expiresAt = now + token.expiresInSeconds * 1000;
+
+  await ctx.runMutation(internal.mtn.collections.upsertCachedToken, {
+    storeId,
+    accessToken: token.accessToken,
+    expiresAt,
+  });
+
+  return {
+    success: true as const,
+    store: configResult.store,
+    config: configResult.config,
+    accessToken: token.accessToken,
+    expiresAt,
+    cached: false,
+  };
+};
+
+export const getCachedToken = internalQuery({
+  args: {
+    storeId: v.id("store"),
+  },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("mtnCollectionsToken")
+      .withIndex("by_storeId", (q) => q.eq("storeId", args.storeId))
+      .first();
+  },
+});
+
+export const upsertCachedToken = internalMutation({
+  args: {
+    storeId: v.id("store"),
+    accessToken: v.string(),
+    expiresAt: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("mtnCollectionsToken")
+      .withIndex("by_storeId", (q) => q.eq("storeId", args.storeId))
+      .first();
+
+    const patch = {
+      accessToken: args.accessToken,
+      expiresAt: args.expiresAt,
+      updatedAt: Date.now(),
+    };
+
+    if (existing) {
+      await ctx.db.patch("mtnCollectionsToken", existing._id, patch);
+      return existing._id;
+    }
+
+    return await ctx.db.insert("mtnCollectionsToken", {
+      storeId: args.storeId,
+      ...patch,
+    });
+  },
+});
+
+export const getAccessToken = internalAction({
+  args: {
+    storeId: v.id("store"),
+  },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<
+    | {
+        success: true;
+        accessToken: string;
+        expiresAt: number;
+        cached: boolean;
+        config: MtnCollectionsConfig;
+      }
+    | {
+        success: false;
+        reason: "store_not_found" | "not_configured";
+        missing?: string[];
+      }
+  > => {
+    const tokenResult = await resolveAccessTokenForStore(ctx, args.storeId);
+
+    if (!tokenResult.success) {
+      return tokenResult;
+    }
+
+    return {
+      success: true,
+      accessToken: tokenResult.accessToken,
+      expiresAt: tokenResult.expiresAt,
+      cached: tokenResult.cached,
+      config: tokenResult.config,
+    };
+  },
+});
+
+export const getTransactionByProviderReference = internalQuery({
+  args: {
+    providerReference: v.string(),
+  },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("mtnCollectionTransaction")
+      .withIndex("by_providerReference", (q) =>
+        q.eq("providerReference", args.providerReference),
+      )
+      .first();
+  },
+});
+
+export const listTransactions = internalQuery({
+  args: {
+    storeId: v.id("store"),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("mtnCollectionTransaction")
+      .withIndex("by_storeId_requestedAt", (q) =>
+        q.eq("storeId", args.storeId),
+      )
+      .order("desc")
+      .take(args.limit ?? 50);
+  },
+});
+
+export const upsertPendingTransaction = internalMutation({
+  args: {
+    storeId: v.id("store"),
+    providerReference: v.string(),
+    externalId: v.string(),
+    amount: v.number(),
+    currency: v.string(),
+    requestedAt: v.number(),
+    payerPartyIdType: v.string(),
+    payerIdentifierMasked: v.string(),
+    payerMessage: v.string(),
+    payeeNote: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("mtnCollectionTransaction")
+      .withIndex("by_providerReference", (q) =>
+        q.eq("providerReference", args.providerReference),
+      )
+      .first();
+
+    const patch = {
+      storeId: args.storeId,
+      providerReference: args.providerReference,
+      externalId: args.externalId,
+      status: existing?.status ?? "PENDING",
+      amount: args.amount,
+      currency: args.currency,
+      requestedAt: existing?.requestedAt ?? args.requestedAt,
+      payerPartyIdType: args.payerPartyIdType,
+      payerIdentifierMasked: args.payerIdentifierMasked,
+      payerMessage: args.payerMessage,
+      payeeNote: args.payeeNote,
+      callbackCount: existing?.callbackCount,
+      updatedAt: Date.now(),
+    };
+
+    if (existing) {
+      await ctx.db.patch("mtnCollectionTransaction", existing._id, patch);
+      return existing._id;
+    }
+
+    return await ctx.db.insert("mtnCollectionTransaction", patch as any);
+  },
+});
+
+export const ingestNotification = internalMutation({
+  args: {
+    storeId: v.id("store"),
+    providerReference: v.string(),
+    statusPayload: v.record(v.string(), v.any()),
+    observedAt: v.number(),
+    callbackMetadata: v.optional(v.record(v.string(), v.any())),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("mtnCollectionTransaction")
+      .withIndex("by_providerReference", (q) =>
+        q.eq("providerReference", args.providerReference),
+      )
+      .first();
+
+    const normalized = normalizeCollectionsTransaction({
+      storeId: args.storeId,
+      providerReference: args.providerReference,
+      requestedAt: existing?.requestedAt ?? args.observedAt,
+      statusPayload: args.statusPayload as any,
+      observedAt: args.observedAt,
+      callbackMetadata: args.callbackMetadata,
+    });
+
+    const patch: Record<string, any> = {
+      ...normalized,
+      amount: normalized.amount ?? existing?.amount ?? 0,
+      callbackCount: (existing?.callbackCount ?? 0) + 1,
+      providerPayload: args.statusPayload,
+      updatedAt: args.observedAt,
+    };
+
+    if (existing) {
+      await ctx.db.patch("mtnCollectionTransaction", existing._id, patch);
+      return existing._id;
+    }
+
+    return await ctx.db.insert("mtnCollectionTransaction", patch as any);
+  },
+});
+
+export const requestCollection = internalAction({
+  args: {
+    storeId: v.id("store"),
+    amount: v.number(),
+    currency: v.string(),
+    externalId: v.string(),
+    payer: v.object({
+      partyIdType: v.string(),
+      partyId: v.string(),
+    }),
+    payerMessage: v.string(),
+    payeeNote: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const tokenResult = await resolveAccessTokenForStore(ctx, args.storeId);
+
+    if (!tokenResult.success) {
+      return tokenResult;
+    }
+
+    const providerReference = crypto.randomUUID();
+    const requestedAt = Date.now();
+    const callbackUrl = buildMtnCollectionsCallbackUrl(tokenResult.config, {
+      storeId: args.storeId,
+      providerReference,
+    });
+
+    await ctx.runMutation(internal.mtn.collections.upsertPendingTransaction, {
+      storeId: args.storeId,
+      providerReference,
+      externalId: args.externalId,
+      amount: args.amount,
+      currency: args.currency,
+      requestedAt,
+      payerPartyIdType: args.payer.partyIdType,
+      payerIdentifierMasked: normalizeCollectionsTransaction({
+        storeId: args.storeId,
+        providerReference,
+        requestedAt,
+        statusPayload: {
+          amount: String(args.amount),
+          currency: args.currency,
+          externalId: args.externalId,
+          payer: args.payer,
+          payerMessage: args.payerMessage,
+          payeeNote: args.payeeNote,
+          status: "PENDING",
+        },
+        observedAt: requestedAt,
+      }).payerIdentifierMasked,
+      payerMessage: args.payerMessage,
+      payeeNote: args.payeeNote,
+    });
+
+    const response = await requestToPay(tokenResult.config, tokenResult.accessToken, {
+      providerReference,
+      callbackUrl,
+      amount: String(args.amount),
+      currency: args.currency,
+      externalId: args.externalId,
+      payer: args.payer,
+      payerMessage: args.payerMessage,
+      payeeNote: args.payeeNote,
+    });
+
+    return {
+      success: true,
+      providerReference: response.providerReference,
+      accepted: response.accepted,
+      callbackUrl,
+    };
+  },
+});
+
+export const getCollectionStatus = internalAction({
+  args: {
+    storeId: v.id("store"),
+    providerReference: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const tokenResult = await resolveAccessTokenForStore(ctx, args.storeId);
+
+    if (!tokenResult.success) {
+      return tokenResult;
+    }
+
+    const payload = await getRequestToPayStatus(
+      tokenResult.config,
+      tokenResult.accessToken,
+      args.providerReference,
+    );
+    const observedAt = Date.now();
+
+    await ctx.runMutation(internal.mtn.collections.ingestNotification, {
+      storeId: args.storeId,
+      providerReference: args.providerReference,
+      statusPayload: payload as any,
+      observedAt,
+      callbackMetadata: {
+        source: "status_poll",
+        receivedAt: observedAt,
+      },
+    });
+
+    return {
+      success: true,
+      providerReference: args.providerReference,
+      payload,
+    };
+  },
+});

--- a/packages/athena-webapp/convex/mtn/config.test.ts
+++ b/packages/athena-webapp/convex/mtn/config.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { resolveMtnCollectionsConfigFromEnv } from "./config";
+
+describe("resolveMtnCollectionsConfigFromEnv", () => {
+  it("returns an explicit not-configured result when store credentials are missing", () => {
+    const result = resolveMtnCollectionsConfigFromEnv(
+      {
+        storeId: "store_123",
+        storeSlug: "wig-club",
+      },
+      {},
+    );
+
+    expect(result).toEqual({
+      kind: "not_configured",
+      lookupPrefixes: [
+        "MTN_MOMO_COLLECTIONS_WIG_CLUB",
+        "MTN_MOMO_COLLECTIONS_STORE_123",
+      ],
+      missing: [
+        "MTN_MOMO_COLLECTIONS_WIG_CLUB_SUBSCRIPTION_KEY",
+        "MTN_MOMO_COLLECTIONS_WIG_CLUB_API_USER",
+        "MTN_MOMO_COLLECTIONS_WIG_CLUB_API_KEY",
+        "MTN_MOMO_COLLECTIONS_WIG_CLUB_TARGET_ENVIRONMENT",
+        "MTN_MOMO_COLLECTIONS_WIG_CLUB_CALLBACK_HOST",
+      ],
+    });
+  });
+
+  it("resolves store-scoped credentials and callback configuration from env", () => {
+    const result = resolveMtnCollectionsConfigFromEnv(
+      {
+        storeId: "store_123",
+        storeSlug: "wig-club",
+      },
+      {
+        MTN_MOMO_COLLECTIONS_WIG_CLUB_SUBSCRIPTION_KEY:
+          "test-subscription-key",
+        MTN_MOMO_COLLECTIONS_WIG_CLUB_API_USER: "test-user",
+        MTN_MOMO_COLLECTIONS_WIG_CLUB_API_KEY: "test-password",
+        MTN_MOMO_COLLECTIONS_WIG_CLUB_TARGET_ENVIRONMENT: "sandbox",
+        MTN_MOMO_COLLECTIONS_WIG_CLUB_CALLBACK_HOST:
+          "https://athena.example.com",
+        MTN_MOMO_COLLECTIONS_WIG_CLUB_CALLBACK_PATH:
+          "/webhooks/mtn-momo/collections",
+      },
+    );
+
+    expect(result).toEqual({
+      kind: "configured",
+      config: {
+        subscriptionKey: "test-subscription-key",
+        apiUser: "test-user",
+        apiKey: "test-password",
+        targetEnvironment: "sandbox",
+        baseUrl: "https://sandbox.momodeveloper.mtn.com",
+        callbackHost: "https://athena.example.com",
+        callbackPath: "/webhooks/mtn-momo/collections",
+      },
+      lookupPrefixes: [
+        "MTN_MOMO_COLLECTIONS_WIG_CLUB",
+        "MTN_MOMO_COLLECTIONS_STORE_123",
+      ],
+    });
+  });
+});

--- a/packages/athena-webapp/convex/mtn/config.ts
+++ b/packages/athena-webapp/convex/mtn/config.ts
@@ -1,0 +1,146 @@
+import {
+  MtnCollectionsConfig,
+  MtnCollectionsConfigResult,
+  MtnCollectionsTargetEnvironment,
+} from "./types";
+
+type StoreIdentity = {
+  storeId: string;
+  storeSlug?: string | null;
+};
+
+type EnvSource = Record<string, string | undefined>;
+
+const DEFAULT_CALLBACK_PATH = "/webhooks/mtn-momo/collections";
+
+const DEFAULT_BASE_URLS: Record<MtnCollectionsTargetEnvironment, string> = {
+  sandbox: "https://sandbox.momodeveloper.mtn.com",
+  production: "https://momodeveloper.mtn.com",
+};
+
+const REQUIRED_SUFFIXES = [
+  "SUBSCRIPTION_KEY",
+  "API_USER",
+  "API_KEY",
+  "TARGET_ENVIRONMENT",
+  "CALLBACK_HOST",
+] as const;
+
+const toEnvSegment = (value: string | null | undefined): string | undefined => {
+  if (!value) {
+    return undefined;
+  }
+
+  const normalized = value
+    .trim()
+    .replace(/[^a-zA-Z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .toUpperCase();
+
+  return normalized.length > 0 ? normalized : undefined;
+};
+
+export const buildMtnCollectionsLookupPrefixes = (
+  store: StoreIdentity,
+): string[] => {
+  const segments = [
+    toEnvSegment(store.storeSlug),
+    toEnvSegment(store.storeId),
+  ].filter((segment): segment is string => Boolean(segment));
+
+  return [...new Set(segments)].map(
+    (segment) => `MTN_MOMO_COLLECTIONS_${segment}`,
+  );
+};
+
+const readScopedValue = (
+  env: EnvSource,
+  prefix: string,
+  suffix: string,
+): string | undefined => {
+  const value = env[`${prefix}_${suffix}`];
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+};
+
+const isTargetEnvironment = (
+  value: string | undefined,
+): value is MtnCollectionsTargetEnvironment => {
+  return value === "sandbox" || value === "production";
+};
+
+const resolveConfigForPrefix = (
+  env: EnvSource,
+  prefix: string,
+): MtnCollectionsConfig | null => {
+  const subscriptionKey = readScopedValue(env, prefix, "SUBSCRIPTION_KEY");
+  const apiUser = readScopedValue(env, prefix, "API_USER");
+  const apiKey = readScopedValue(env, prefix, "API_KEY");
+  const targetEnvironment = readScopedValue(env, prefix, "TARGET_ENVIRONMENT");
+  const callbackHost = readScopedValue(env, prefix, "CALLBACK_HOST");
+
+  if (
+    !subscriptionKey ||
+    !apiUser ||
+    !apiKey ||
+    !targetEnvironment ||
+    !callbackHost ||
+    !isTargetEnvironment(targetEnvironment)
+  ) {
+    return null;
+  }
+
+  return {
+    subscriptionKey,
+    apiUser,
+    apiKey,
+    targetEnvironment,
+    baseUrl:
+      readScopedValue(env, prefix, "BASE_URL") ??
+      DEFAULT_BASE_URLS[targetEnvironment],
+    callbackHost,
+    callbackPath:
+      readScopedValue(env, prefix, "CALLBACK_PATH") ?? DEFAULT_CALLBACK_PATH,
+  };
+};
+
+export const resolveMtnCollectionsConfigFromEnv = (
+  store: StoreIdentity,
+  env: EnvSource = process.env,
+): MtnCollectionsConfigResult => {
+  const lookupPrefixes = buildMtnCollectionsLookupPrefixes(store);
+
+  for (const prefix of lookupPrefixes) {
+    const config = resolveConfigForPrefix(env, prefix);
+    if (config) {
+      return {
+        kind: "configured",
+        config,
+        lookupPrefixes,
+      };
+    }
+  }
+
+  const primaryPrefix =
+    lookupPrefixes[0] ?? "MTN_MOMO_COLLECTIONS_UNCONFIGURED_STORE";
+
+  return {
+    kind: "not_configured",
+    lookupPrefixes,
+    missing: REQUIRED_SUFFIXES.map((suffix) => `${primaryPrefix}_${suffix}`),
+  };
+};
+
+export const buildMtnCollectionsCallbackUrl = (
+  config: Pick<MtnCollectionsConfig, "callbackHost" | "callbackPath">,
+  params: {
+    storeId: string;
+    providerReference: string;
+  },
+): string => {
+  const base = new URL(config.callbackPath, config.callbackHost);
+  base.searchParams.set("storeId", params.storeId);
+  base.searchParams.set("providerReference", params.providerReference);
+  return base.toString();
+};

--- a/packages/athena-webapp/convex/mtn/foundation.test.ts
+++ b/packages/athena-webapp/convex/mtn/foundation.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const projectRoot = process.cwd();
+const readProjectFile = (...segments: string[]) =>
+  readFileSync(join(projectRoot, ...segments), "utf8");
+
+describe("MTN collections foundation", () => {
+  it("adds the transaction and token tables needed for store-scoped MTN state", () => {
+    const schemaSource = readProjectFile("convex", "schema.ts").replace(
+      /\s+/g,
+      " ",
+    );
+
+    expect(schemaSource).toContain(
+      'mtnCollectionsToken: defineTable(mtnCollectionsTokenSchema).index("by_storeId", ["storeId"])',
+    );
+    expect(schemaSource).toContain(
+      'mtnCollectionTransaction: defineTable(mtnCollectionTransactionSchema)',
+    );
+    expect(schemaSource).toContain(
+      '.index("by_providerReference", ["providerReference"])',
+    );
+    expect(schemaSource).toContain(
+      '.index("by_storeId_requestedAt", ["storeId", "requestedAt"])',
+    );
+  });
+
+  it("registers the MTN webhook route on the shared Hono router", () => {
+    const httpRouter = readProjectFile("convex", "http.ts");
+
+    expect(httpRouter).toContain('app.route("/webhooks/mtn-momo", mtnMomoRoutes);');
+  });
+});

--- a/packages/athena-webapp/convex/mtn/normalize.test.ts
+++ b/packages/athena-webapp/convex/mtn/normalize.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import {
+  maskMtnPartyId,
+  normalizeCollectionsTransaction,
+  parseCollectionsNotificationRequest,
+} from "./normalize";
+
+describe("MTN collections normalization", () => {
+  it("normalizes provider status payloads into store-scoped transaction records", () => {
+    const record = normalizeCollectionsTransaction({
+      storeId: "store_123",
+      providerReference: "provider-ref-123",
+      requestedAt: 1_712_345_678_000,
+      statusPayload: {
+        financialTransactionId: "fin-123",
+        externalId: "order-001",
+        amount: "1500",
+        currency: "EUR",
+        payer: {
+          partyIdType: "MSISDN",
+          partyId: "233555123456",
+        },
+        payerMessage: "Order Payment",
+        payeeNote: "Order Payment",
+        status: "SUCCESSFUL",
+      },
+      observedAt: 1_712_345_679_000,
+      callbackMetadata: {
+        method: "POST",
+        receivedAt: 1_712_345_679_000,
+      },
+    });
+
+    expect(record).toEqual({
+      storeId: "store_123",
+      providerReference: "provider-ref-123",
+      externalId: "order-001",
+      externalTransactionId: "fin-123",
+      status: "SUCCESSFUL",
+      amount: 1500,
+      currency: "EUR",
+      requestedAt: 1_712_345_678_000,
+      completedAt: 1_712_345_679_000,
+      payerPartyIdType: "MSISDN",
+      payerIdentifierMasked: "********3456",
+      payerMessage: "Order Payment",
+      payeeNote: "Order Payment",
+      callbackMetadata: {
+        method: "POST",
+        receivedAt: 1_712_345_679_000,
+      },
+    });
+  });
+
+  it("parses callback requests and rejects malformed payloads", () => {
+    expect(
+      parseCollectionsNotificationRequest({
+        rawBody: JSON.stringify({
+          financialTransactionId: "fin-123",
+          externalId: "order-001",
+          amount: "1500",
+          currency: "EUR",
+          payer: {
+            partyIdType: "MSISDN",
+            partyId: "233555123456",
+          },
+          payerMessage: "Order Payment",
+          payeeNote: "Order Payment",
+          status: "SUCCESSFUL",
+        }),
+        headers: {
+          "content-type": "application/json",
+        },
+        query: {
+          storeId: "store_123",
+          providerReference: "provider-ref-123",
+        },
+        method: "POST",
+      }),
+    ).toEqual({
+      ok: true,
+      value: {
+        storeId: "store_123",
+        providerReference: "provider-ref-123",
+        payload: {
+          financialTransactionId: "fin-123",
+          externalId: "order-001",
+          amount: "1500",
+          currency: "EUR",
+          payer: {
+            partyIdType: "MSISDN",
+            partyId: "233555123456",
+          },
+          payerMessage: "Order Payment",
+          payeeNote: "Order Payment",
+          status: "SUCCESSFUL",
+        },
+        callbackMetadata: {
+          contentType: "application/json",
+          method: "POST",
+          referenceIdHeader: undefined,
+        },
+      },
+    });
+
+    expect(
+      parseCollectionsNotificationRequest({
+        rawBody: JSON.stringify({ status: "SUCCESSFUL" }),
+        headers: {},
+        query: {
+          storeId: "store_123",
+        },
+        method: "POST",
+      }),
+    ).toEqual({
+      ok: false,
+      statusCode: 400,
+      error: "Missing provider reference",
+    });
+  });
+
+  it("masks payer identifiers for audit-safe storage", () => {
+    expect(maskMtnPartyId("233555123456")).toBe("********3456");
+    expect(maskMtnPartyId("1234")).toBe("1234");
+  });
+});

--- a/packages/athena-webapp/convex/mtn/normalize.ts
+++ b/packages/athena-webapp/convex/mtn/normalize.ts
@@ -1,0 +1,132 @@
+import { MtnCollectionsStatusPayload } from "./types";
+
+const FINAL_STATUSES = new Set([
+  "FAILED",
+  "REJECTED",
+  "SUCCESSFUL",
+  "TIMEOUT",
+]);
+
+export const maskMtnPartyId = (partyId: string): string => {
+  if (partyId.length <= 4) {
+    return partyId;
+  }
+
+  return `${"*".repeat(partyId.length - 4)}${partyId.slice(-4)}`;
+};
+
+export const normalizeCollectionsTransaction = (input: {
+  storeId: string;
+  providerReference: string;
+  requestedAt: number;
+  statusPayload: MtnCollectionsStatusPayload;
+  observedAt: number;
+  callbackMetadata?: Record<string, any>;
+}): Record<string, any> => {
+  const amount =
+    typeof input.statusPayload.amount === "string"
+      ? Number.parseInt(input.statusPayload.amount, 10)
+      : undefined;
+  const status = input.statusPayload.status;
+
+  return {
+    storeId: input.storeId,
+    providerReference: input.providerReference,
+    externalId: input.statusPayload.externalId,
+    externalTransactionId: input.statusPayload.financialTransactionId,
+    status,
+    amount,
+    currency: input.statusPayload.currency,
+    requestedAt: input.requestedAt,
+    completedAt: FINAL_STATUSES.has(status) ? input.observedAt : undefined,
+    payerPartyIdType: input.statusPayload.payer?.partyIdType,
+    payerIdentifierMasked: input.statusPayload.payer?.partyId
+      ? maskMtnPartyId(input.statusPayload.payer.partyId)
+      : undefined,
+    payerMessage: input.statusPayload.payerMessage,
+    payeeNote: input.statusPayload.payeeNote,
+    callbackMetadata: input.callbackMetadata,
+  };
+};
+
+export const parseCollectionsNotificationRequest = (input: {
+  rawBody: string;
+  headers: Record<string, string | undefined>;
+  query: {
+    storeId?: string;
+    providerReference?: string;
+  };
+  method: string;
+}):
+  | {
+      ok: true;
+      value: {
+        storeId: string;
+        providerReference: string;
+        payload: MtnCollectionsStatusPayload;
+        callbackMetadata: Record<string, any>;
+      };
+    }
+  | {
+      ok: false;
+      statusCode: 400;
+      error: string;
+    } => {
+  let payload: unknown;
+
+  try {
+    payload = JSON.parse(input.rawBody);
+  } catch {
+    return {
+      ok: false,
+      statusCode: 400,
+      error: "Invalid MTN callback payload",
+    };
+  }
+
+  if (!input.query.storeId) {
+    return {
+      ok: false,
+      statusCode: 400,
+      error: "Missing store identifier",
+    };
+  }
+
+  const payloadRecord =
+    payload && typeof payload === "object" && !Array.isArray(payload)
+      ? (payload as Record<string, any>)
+      : null;
+
+  if (!payloadRecord || typeof payloadRecord.status !== "string") {
+    return {
+      ok: false,
+      statusCode: 400,
+      error: "Malformed MTN callback payload",
+    };
+  }
+
+  const providerReference =
+    input.query.providerReference ?? input.headers["x-reference-id"];
+
+  if (!providerReference) {
+    return {
+      ok: false,
+      statusCode: 400,
+      error: "Missing provider reference",
+    };
+  }
+
+  return {
+    ok: true,
+    value: {
+      storeId: input.query.storeId,
+      providerReference,
+      payload: payloadRecord as MtnCollectionsStatusPayload,
+      callbackMetadata: {
+        contentType: input.headers["content-type"],
+        method: input.method,
+        referenceIdHeader: input.headers["x-reference-id"],
+      },
+    },
+  };
+};

--- a/packages/athena-webapp/convex/mtn/types.ts
+++ b/packages/athena-webapp/convex/mtn/types.ts
@@ -1,0 +1,40 @@
+export type MtnCollectionsTargetEnvironment = "sandbox" | "production";
+
+export type MtnCollectionsConfig = {
+  subscriptionKey: string;
+  apiUser: string;
+  apiKey: string;
+  targetEnvironment: MtnCollectionsTargetEnvironment;
+  baseUrl: string;
+  callbackHost: string;
+  callbackPath: string;
+};
+
+export type MtnCollectionsConfigResult =
+  | {
+      kind: "configured";
+      config: MtnCollectionsConfig;
+      lookupPrefixes: string[];
+    }
+  | {
+      kind: "not_configured";
+      missing: string[];
+      lookupPrefixes: string[];
+    };
+
+export type MtnParty = {
+  partyIdType: string;
+  partyId: string;
+};
+
+export type MtnCollectionsStatusPayload = {
+  financialTransactionId?: string;
+  externalId?: string;
+  amount?: string;
+  currency?: string;
+  payer?: MtnParty;
+  payerMessage?: string;
+  payeeNote?: string;
+  status: string;
+  reason?: string;
+};

--- a/packages/athena-webapp/convex/schema.ts
+++ b/packages/athena-webapp/convex/schema.ts
@@ -57,6 +57,10 @@ import {
   expenseTransactionItemSchema,
 } from "./schemas/pos";
 import { posSessionSchema } from "./schemas/pos/posSession";
+import {
+  mtnCollectionsTokenSchema,
+  mtnCollectionTransactionSchema,
+} from "./schemas/payments/mtnCollections";
 
 const schema = defineSchema({
   ...authTables,
@@ -116,6 +120,10 @@ const schema = defineSchema({
   onlineOrderItem: defineTable(onlineOrderItemSchema).index("by_orderId", [
     "orderId",
   ]),
+  mtnCollectionsToken: defineTable(mtnCollectionsTokenSchema).index("by_storeId", ["storeId"]),
+  mtnCollectionTransaction: defineTable(mtnCollectionTransactionSchema)
+    .index("by_providerReference", ["providerReference"])
+    .index("by_storeId_requestedAt", ["storeId", "requestedAt"]),
   organization: defineTable(organizationSchema),
   organizationMember: defineTable(organizationMemberSchema),
   posCustomer: defineTable(posCustomerSchema)

--- a/packages/athena-webapp/convex/schemas/payments/mtnCollections.ts
+++ b/packages/athena-webapp/convex/schemas/payments/mtnCollections.ts
@@ -1,0 +1,28 @@
+import { v } from "convex/values";
+
+export const mtnCollectionsTokenSchema = v.object({
+  storeId: v.id("store"),
+  accessToken: v.string(),
+  expiresAt: v.number(),
+  updatedAt: v.number(),
+});
+
+export const mtnCollectionTransactionSchema = v.object({
+  storeId: v.id("store"),
+  providerReference: v.string(),
+  externalId: v.optional(v.string()),
+  externalTransactionId: v.optional(v.string()),
+  status: v.string(),
+  amount: v.number(),
+  currency: v.optional(v.string()),
+  requestedAt: v.number(),
+  completedAt: v.optional(v.number()),
+  payerPartyIdType: v.optional(v.string()),
+  payerIdentifierMasked: v.optional(v.string()),
+  payerMessage: v.optional(v.string()),
+  payeeNote: v.optional(v.string()),
+  providerPayload: v.optional(v.record(v.string(), v.any())),
+  callbackMetadata: v.optional(v.record(v.string(), v.any())),
+  callbackCount: v.optional(v.number()),
+  updatedAt: v.number(),
+});

--- a/packages/athena-webapp/scripts/convex-lint-changed.sh
+++ b/packages/athena-webapp/scripts/convex-lint-changed.sh
@@ -33,6 +33,9 @@ MERGE_BASE="$(git -C "$REPO_ROOT" merge-base HEAD "$BASE_REF")"
 changed_files=()
 
 while IFS= read -r file; do
+  if [[ "$file" == packages/athena-webapp/convex/_generated/* ]]; then
+    continue
+  fi
   changed_files+=("${file#packages/athena-webapp/}")
 done < <(
   git -C "$REPO_ROOT" diff --name-only --diff-filter=ACMR "$MERGE_BASE"...HEAD -- packages/athena-webapp/convex \


### PR DESCRIPTION
## Summary
- add a backend-only MTN MoMo Collections foundation in Athena Convex
- resolve store-scoped MTN credentials from server env, cache tokens, and expose request-to-pay/status helpers
- add normalized MTN transaction persistence plus an idempotent webhook route keyed by provider reference

## Why
- Athena needs a reusable MTN Collections backend layer before POS and store configuration tickets can consume MTN payment data
- keeping credentials in server env avoids exposing MTN subscription/API secrets through store documents or browser-facing config surfaces
- persisting normalized transactions and deduping callbacks by provider reference gives later tickets a stable provider-agnostic payment record to build on

## Validation
- `bun run --filter '@athena/webapp' test convex/mtn/config.test.ts convex/mtn/client.test.ts convex/mtn/normalize.test.ts convex/mtn/foundation.test.ts`
- `bun run --filter '@athena/webapp' test`
- `git diff --check`
- `bun run --filter '@athena/webapp' build` currently hangs silently in the isolated repo-local worktree before Vite emits output; the same build command completes from the clean checkout, so this PR is opened as draft pending CI confirmation of the bundler path

https://linear.app/v26-labs/issue/V26-186/add-foundational-mtn-momo-collections-integration-to-athena
