### PR TITLE
[V26-188]: add Athena PR preflight command

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "athena",
   "private": true,
   "scripts": {
+    "pr:athena": "bun run --filter '@athena/webapp' audit:convex && bun run --filter '@athena/webapp' lint:convex:changed && bun run --filter '@athena/webapp' test && bun run --filter '@athena/storefront-webapp' test && bun run --filter '@athena/symphony-service' test",
     "symphony": "bun run --filter '@athena/symphony-service' start ../../WORKFLOW.md",
     "symphony:watch": "bun run --filter '@athena/symphony-service' start ../../WORKFLOW.md --watch",
     "test:symphony": "bun run --filter '@athena/symphony-service' test",


### PR DESCRIPTION
## Summary
- add `bun run pr:athena` at the repo root as the local Athena PR gate command
- mirror the current Athena GitHub workflow by running webapp audit/lint/test plus storefront and symphony tests in order

## Why
- make Athena PR preflight explicit and repeatable from a single repo command
- reduce surprise in GitHub by running the same repo-side checks locally before opening or updating a PR

## Validation
- `bun run pr:athena`
- `git diff --check`

https://linear.app/v26-labs/issue/V26-188/add-athena-pr-preflight-command-for-repo-checks
