### PR TITLE
[V26-189]: add app harness docs and checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "athena",
   "private": true,
   "scripts": {
-    "pr:athena": "bun run --filter '@athena/webapp' audit:convex && bun run --filter '@athena/webapp' lint:convex:changed && bun run --filter '@athena/webapp' test && bun run --filter '@athena/storefront-webapp' test && bun run --filter '@athena/symphony-service' test",
+    "harness:check": "bun scripts/harness-check.ts",
+    "pr:athena": "bun run --filter '@athena/webapp' audit:convex && bun run --filter '@athena/webapp' lint:convex:changed && bun run --filter '@athena/webapp' test && bun run --filter '@athena/storefront-webapp' test && bun run harness:check",
     "symphony": "bun run --filter '@athena/symphony-service' start ../../WORKFLOW.md",
     "symphony:watch": "bun run --filter '@athena/symphony-service' start ../../WORKFLOW.md --watch",
     "test:symphony": "bun run --filter '@athena/symphony-service' test",

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -1,4 +1,10 @@
-# Athena Packages Agent Rules
+# Athena Packages Agent Router
+
+- For `packages/athena-webapp`, start with [athena-webapp/AGENTS.md](./athena-webapp/AGENTS.md).
+- For `packages/storefront-webapp`, start with [storefront-webapp/AGENTS.md](./storefront-webapp/AGENTS.md).
+- If a task spans both apps, read both harnesses first, keep docs in sync with code, and finish with `bun run harness:check`.
+
+## Shared Repo Rules
 
 ## Git Branching
 - After each merged checkpoint, start the next task from a new branch created from the latest `main`.

--- a/packages/athena-webapp/AGENTS.md
+++ b/packages/athena-webapp/AGENTS.md
@@ -1,0 +1,6 @@
+# Athena Webapp Agent Guide
+
+- Start with [docs/agent/index.md](./docs/agent/index.md).
+- Read [docs/agent/architecture.md](./docs/agent/architecture.md) before changing router, auth-shell, or Convex boundaries.
+- Use [docs/agent/testing.md](./docs/agent/testing.md) to choose the smallest honest validation set.
+- Use [docs/agent/code-map.md](./docs/agent/code-map.md) when tracing ownership across `src/` and `convex/`.

--- a/packages/athena-webapp/docs/agent/architecture.md
+++ b/packages/athena-webapp/docs/agent/architecture.md
@@ -1,0 +1,7 @@
+# Athena Webapp Architecture
+
+The app is a TanStack Router browser client in [src/main.tsx](../../src/main.tsx). The generated route tree in [src/routeTree.gen.ts](../../src/routeTree.gen.ts) fans into public/login routes plus the authenticated shell rooted at [src/routes/_authed.tsx](../../src/routes/_authed.tsx). Most user-facing work starts by figuring out whether the change belongs in route composition, a feature component under `src/components`, or a data hook under `src/hooks`.
+
+Backend and integration boundaries sit in Convex. The top-level HTTP entrypoint [convex/http.ts](../../convex/http.ts) mounts Hono routes for inventory, storefront, guest, checkout, rewards, and payment webhooks. Inventory-facing route composition is grouped in [convex/http/domains/inventory/routes/index.ts](../../convex/http/domains/inventory/routes/index.ts), while storefront-facing HTTP surfaces are grouped in [convex/http/domains/storeFront/routes/index.ts](../../convex/http/domains/storeFront/routes/index.ts). Shared persistence shape lives in [convex/schema.ts](../../convex/schema.ts).
+
+When you need to move logic across the browser/server boundary, prefer the Convex guidance in [convex/README.md](../../convex/README.md): keep public functions thin, treat Hono routes as explicit public boundaries, and push reusable server logic behind internal helpers instead of duplicating fetch-time behavior in React code.

--- a/packages/athena-webapp/docs/agent/code-map.md
+++ b/packages/athena-webapp/docs/agent/code-map.md
@@ -1,0 +1,7 @@
+# Athena Webapp Code Map
+
+- App bootstrap and routing: [src/main.tsx](../../src/main.tsx), [src/routes/index.tsx](../../src/routes/index.tsx), [src/routes/_authed.tsx](../../src/routes/_authed.tsx), [src/routeTree.gen.ts](../../src/routeTree.gen.ts)
+- Auth and shared frontend state: [src/hooks/useAuth.ts](../../src/hooks/useAuth.ts), [src/components/providers/currency-provider.tsx](../../src/components/providers/currency-provider.tsx)
+- Inventory backend surfaces: [convex/inventory/stores.ts](../../convex/inventory/stores.ts), [convex/http/domains/inventory/routes/stores.ts](../../convex/http/domains/inventory/routes/stores.ts), [convex/http/domains/inventory/routes/analytics.ts](../../convex/http/domains/inventory/routes/analytics.ts)
+- Storefront backend surfaces: [convex/storeFront/checkoutSession.ts](../../convex/storeFront/checkoutSession.ts), [convex/http/domains/storeFront/routes/checkout.ts](../../convex/http/domains/storeFront/routes/checkout.ts), [convex/http/domains/storeFront/routes/storefront.ts](../../convex/http/domains/storeFront/routes/storefront.ts)
+- Existing guardrail tests: [convex/http/routerComposition.test.ts](../../convex/http/routerComposition.test.ts), [convex/inventory/posQueryCleanup.test.ts](../../convex/inventory/posQueryCleanup.test.ts), [src/tests/pos/usePrint.test.ts](../../src/tests/pos/usePrint.test.ts)

--- a/packages/athena-webapp/docs/agent/index.md
+++ b/packages/athena-webapp/docs/agent/index.md
@@ -1,0 +1,21 @@
+# Athena Webapp Agent Docs
+
+- [Architecture](./architecture.md)
+- [Testing](./testing.md)
+- [Code map](./code-map.md)
+
+Use this harness when the task touches the authenticated dashboard shell in [src/main.tsx](../../src/main.tsx), route files under [src/routes/_authed.tsx](../../src/routes/_authed.tsx), or the Convex-backed HTTP surface in [convex/http.ts](../../convex/http.ts).
+
+Key boundaries to keep in mind:
+
+- Browser entry and generated TanStack Router state live in [src/main.tsx](../../src/main.tsx) and [src/routeTree.gen.ts](../../src/routeTree.gen.ts).
+- Inventory and storefront backend routes are composed in [convex/http.ts](../../convex/http.ts) over the schema in [convex/schema.ts](../../convex/schema.ts).
+- App-level auth and shell state usually fan out from [src/hooks/useAuth.ts](../../src/hooks/useAuth.ts) and the authenticated layout in [src/routes/_authed.tsx](../../src/routes/_authed.tsx).
+
+Common validation commands:
+
+- `bun run --filter '@athena/webapp' test`
+- `bun run --filter '@athena/webapp' audit:convex`
+- `bun run --filter '@athena/webapp' lint:convex:changed`
+- `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`
+- `bun run --filter '@athena/webapp' build`

--- a/packages/athena-webapp/docs/agent/testing.md
+++ b/packages/athena-webapp/docs/agent/testing.md
@@ -1,0 +1,12 @@
+# Athena Webapp Testing
+
+Start with the package suite in [vitest.config.ts](../../vitest.config.ts): `bun run --filter '@athena/webapp' test`. It covers both `src/**/*.test.{ts,tsx}` and `convex/**/*.test.{ts,tsx}`, so it is the default regression pass for mixed UI and backend changes.
+
+Escalate validation based on the surface you touched:
+
+- Convex HTTP composition or auth-route changes: run targeted tests like [convex/http/routerComposition.test.ts](../../convex/http/routerComposition.test.ts) and [convex/http/domains/storeFront/routes/security.test.ts](../../convex/http/domains/storeFront/routes/security.test.ts).
+- Inventory query or POS behavior changes: spot-check existing guards such as [convex/inventory/posQueryCleanup.test.ts](../../convex/inventory/posQueryCleanup.test.ts) and [src/tests/pos/usePrint.test.ts](../../src/tests/pos/usePrint.test.ts).
+- Any change under `convex/`: run `bun run --filter '@athena/webapp' audit:convex` and `bun run --filter '@athena/webapp' lint:convex:changed` before PR handoff.
+- Route, typing, or build-pipeline changes: run `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json` or `bun run --filter '@athena/webapp' build`.
+
+Avoid editing generated files like [src/routeTree.gen.ts](../../src/routeTree.gen.ts) or anything under `convex/_generated`; regenerate instead if a tool owns them.

--- a/packages/storefront-webapp/AGENTS.md
+++ b/packages/storefront-webapp/AGENTS.md
@@ -1,0 +1,6 @@
+# Storefront Webapp Agent Guide
+
+- Start with [docs/agent/index.md](./docs/agent/index.md).
+- Read [docs/agent/architecture.md](./docs/agent/architecture.md) before changing TanStack Start runtime, route layout, or API boundaries.
+- Use [docs/agent/testing.md](./docs/agent/testing.md) to choose the smallest honest validation set.
+- Use [docs/agent/code-map.md](./docs/agent/code-map.md) when tracing checkout, catalog, or observability code paths.

--- a/packages/storefront-webapp/docs/agent/architecture.md
+++ b/packages/storefront-webapp/docs/agent/architecture.md
@@ -1,0 +1,7 @@
+# Storefront Webapp Architecture
+
+This package is a TanStack Start app with separate browser and server entrypoints in [src/client.tsx](../../src/client.tsx) and [src/ssr.tsx](../../src/ssr.tsx). The router factory in [src/router.tsx](../../src/router.tsx) is shared between them, and the app shell plus global providers live in [src/routes/__root.tsx](../../src/routes/__root.tsx).
+
+Most data access flows through thin API wrappers rather than direct backend logic in components. Representative entrypoints are [src/api/storefront.ts](../../src/api/storefront.ts), [src/api/checkoutSession.ts](../../src/api/checkoutSession.ts), and the query helpers in [src/lib/queries/onlineOrder.ts](../../src/lib/queries/onlineOrder.ts). Those feed route-level UI and shared state through [src/contexts/StoreContext.tsx](../../src/contexts/StoreContext.tsx), [src/contexts/StorefrontObservabilityProvider.tsx](../../src/contexts/StorefrontObservabilityProvider.tsx), and checkout-specific state in [src/components/checkout/CheckoutProvider.tsx](../../src/components/checkout/CheckoutProvider.tsx).
+
+If a change affects routing, search params, or layout ownership, inspect the generated tree in [src/routeTree.gen.ts](../../src/routeTree.gen.ts) but avoid editing it directly. Change the route source files under `src/routes` and regenerate through the normal app tooling instead.

--- a/packages/storefront-webapp/docs/agent/code-map.md
+++ b/packages/storefront-webapp/docs/agent/code-map.md
@@ -1,0 +1,7 @@
+# Storefront Webapp Code Map
+
+- Runtime entrypoints: [src/client.tsx](../../src/client.tsx), [src/ssr.tsx](../../src/ssr.tsx), [src/router.tsx](../../src/router.tsx), [src/routes/__root.tsx](../../src/routes/__root.tsx)
+- Store and navigation context: [src/contexts/StoreContext.tsx](../../src/contexts/StoreContext.tsx), [src/contexts/NavigationBarProvider.tsx](../../src/contexts/NavigationBarProvider.tsx), [src/contexts/StorefrontObservabilityProvider.tsx](../../src/contexts/StorefrontObservabilityProvider.tsx)
+- Checkout flow: [src/components/checkout/CheckoutProvider.tsx](../../src/components/checkout/CheckoutProvider.tsx), [src/components/checkout/deliveryFees.ts](../../src/components/checkout/deliveryFees.ts), [src/components/checkout/BagSummary.tsx](../../src/components/checkout/BagSummary.tsx)
+- API and query layer: [src/api/storefront.ts](../../src/api/storefront.ts), [src/api/checkoutSession.ts](../../src/api/checkoutSession.ts), [src/lib/queries/onlineOrder.ts](../../src/lib/queries/onlineOrder.ts)
+- Observability and event helpers: [src/lib/storefrontObservability.ts](../../src/lib/storefrontObservability.ts), [src/lib/storefrontJourneyEvents.ts](../../src/lib/storefrontJourneyEvents.ts)

--- a/packages/storefront-webapp/docs/agent/index.md
+++ b/packages/storefront-webapp/docs/agent/index.md
@@ -1,0 +1,20 @@
+# Storefront Webapp Agent Docs
+
+- [Architecture](./architecture.md)
+- [Testing](./testing.md)
+- [Code map](./code-map.md)
+
+Use this harness when the task touches the TanStack Start runtime in [src/client.tsx](../../src/client.tsx) and [src/ssr.tsx](../../src/ssr.tsx), top-level layout composition in [src/routes/__root.tsx](../../src/routes/__root.tsx), or the browser-to-backend request layer in [src/api/storefront.ts](../../src/api/storefront.ts).
+
+Key boundaries to keep in mind:
+
+- Router runtime wiring lives in [src/router.tsx](../../src/router.tsx), [src/client.tsx](../../src/client.tsx), and [src/ssr.tsx](../../src/ssr.tsx).
+- Catalog, bag, and checkout state are coordinated through [src/contexts/StoreContext.tsx](../../src/contexts/StoreContext.tsx), [src/hooks/useShoppingBag.ts](../../src/hooks/useShoppingBag.ts), and [src/components/checkout/CheckoutProvider.tsx](../../src/components/checkout/CheckoutProvider.tsx).
+- Most backend calls are thin wrappers under `src/api`, including [src/api/storefront.ts](../../src/api/storefront.ts) and [src/api/checkoutSession.ts](../../src/api/checkoutSession.ts).
+
+Common validation commands:
+
+- `bun run --filter '@athena/storefront-webapp' test`
+- `bunx tsc --noEmit -p packages/storefront-webapp/tsconfig.json`
+- `bun run --filter '@athena/storefront-webapp' build`
+- `bun run --filter '@athena/storefront-webapp' test:e2e`

--- a/packages/storefront-webapp/docs/agent/testing.md
+++ b/packages/storefront-webapp/docs/agent/testing.md
@@ -1,0 +1,12 @@
+# Storefront Webapp Testing
+
+Start with the package suite in [vitest.config.ts](../../vitest.config.ts): `bun run --filter '@athena/storefront-webapp' test`. It is the default regression pass for API wrappers, route helpers, checkout state, and shared utility logic.
+
+Escalate validation based on the surface you touched:
+
+- Checkout flows: target [src/components/checkout/deliveryFees.test.ts](../../src/components/checkout/deliveryFees.test.ts), [src/components/checkout/deriveCheckoutState.test.ts](../../src/components/checkout/deriveCheckoutState.test.ts), and [src/api/checkoutSession.test.ts](../../src/api/checkoutSession.test.ts).
+- Store config or observability changes: target [src/lib/storeConfig.test.ts](../../src/lib/storeConfig.test.ts), [src/lib/storefrontObservability.test.ts](../../src/lib/storefrontObservability.test.ts), and [src/lib/storefrontJourneyEvents.test.ts](../../src/lib/storefrontJourneyEvents.test.ts).
+- Type or router changes: run `bunx tsc --noEmit -p packages/storefront-webapp/tsconfig.json` or `bun run --filter '@athena/storefront-webapp' build`.
+- Full browser journeys, navigation, or payment redirects: run `bun run --filter '@athena/storefront-webapp' test:e2e` with the setup in [playwright.config.ts](../../playwright.config.ts).
+
+This package does not expose a dedicated lint script in [package.json](../../package.json). If you need lint coverage for a risky refactor, run ESLint intentionally rather than assuming `pr:athena` will do it for you.

--- a/scripts/harness-check.test.ts
+++ b/scripts/harness-check.test.ts
@@ -1,0 +1,133 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { validateHarnessDocs } from "./harness-check";
+
+const REQUIRED_INDEX_LINKS = [
+  "./architecture.md",
+  "./testing.md",
+  "./code-map.md",
+];
+
+const tempRoots: string[] = [];
+
+async function write(relativePath: string, contents: string, rootDir: string) {
+  const filePath = path.join(rootDir, relativePath);
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, contents);
+}
+
+async function createFixtureRepo() {
+  const rootDir = await mkdtemp(path.join(tmpdir(), "athena-harness-check-"));
+  tempRoots.push(rootDir);
+
+  await write(
+    "packages/AGENTS.md",
+    [
+      "# Packages Agent Router",
+      "",
+      "- [Athena webapp](./athena-webapp/AGENTS.md)",
+      "- [Storefront webapp](./storefront-webapp/AGENTS.md)",
+    ].join("\n"),
+    rootDir
+  );
+
+  for (const appName of ["athena-webapp", "storefront-webapp"]) {
+    await write(
+      `packages/${appName}/AGENTS.md`,
+      [
+        `# ${appName}`,
+        "",
+        "- [Harness index](./docs/agent/index.md)",
+        "- [Architecture](./docs/agent/architecture.md)",
+        "- [Testing](./docs/agent/testing.md)",
+        "- [Code map](./docs/agent/code-map.md)",
+      ].join("\n"),
+      rootDir
+    );
+
+    await write(
+      `packages/${appName}/docs/agent/index.md`,
+      [
+        `# ${appName} agent docs`,
+        "",
+        ...REQUIRED_INDEX_LINKS.map((link) => `- [${link}](${link})`),
+      ].join("\n"),
+      rootDir
+    );
+
+    await write(
+      `packages/${appName}/docs/agent/architecture.md`,
+      "# Architecture\n\nSee [testing](./testing.md).\n",
+      rootDir
+    );
+    await write(
+      `packages/${appName}/docs/agent/testing.md`,
+      "# Testing\n\nUse the package test command.\n",
+      rootDir
+    );
+    await write(
+      `packages/${appName}/docs/agent/code-map.md`,
+      "# Code map\n\nStart from [architecture](./architecture.md).\n",
+      rootDir
+    );
+  }
+
+  return rootDir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((rootDir) => rm(rootDir, { recursive: true, force: true })));
+});
+
+describe("validateHarnessDocs", () => {
+  it("passes when every required harness file and relative link is present", async () => {
+    const rootDir = await createFixtureRepo();
+
+    await expect(validateHarnessDocs(rootDir)).resolves.toEqual([]);
+  });
+
+  it("reports missing required harness files", async () => {
+    const rootDir = await createFixtureRepo();
+    await rm(
+      path.join(rootDir, "packages/storefront-webapp/docs/agent/testing.md")
+    );
+
+    await expect(validateHarnessDocs(rootDir)).resolves.toContain(
+      "Missing required harness file: packages/storefront-webapp/docs/agent/testing.md"
+    );
+  });
+
+  it("reports broken relative markdown links in harness docs", async () => {
+    const rootDir = await createFixtureRepo();
+    await write(
+      "packages/athena-webapp/AGENTS.md",
+      "# athena-webapp\n\n- [Broken](./docs/agent/missing.md)\n",
+      rootDir
+    );
+
+    await expect(validateHarnessDocs(rootDir)).resolves.toContain(
+      "Broken markdown link in packages/athena-webapp/AGENTS.md: ./docs/agent/missing.md"
+    );
+  });
+
+  it("reports missing required core-doc links from an app index", async () => {
+    const rootDir = await createFixtureRepo();
+    await write(
+      "packages/storefront-webapp/docs/agent/index.md",
+      [
+        "# storefront-webapp agent docs",
+        "",
+        "- [architecture](./architecture.md)",
+        "- [code-map](./code-map.md)",
+      ].join("\n"),
+      rootDir
+    );
+
+    await expect(validateHarnessDocs(rootDir)).resolves.toContain(
+      "Missing required index link in packages/storefront-webapp/docs/agent/index.md: ./testing.md"
+    );
+  });
+});

--- a/scripts/harness-check.ts
+++ b/scripts/harness-check.ts
@@ -1,0 +1,142 @@
+import { access, readFile } from "node:fs/promises";
+import path from "node:path";
+
+const APP_NAMES = ["athena-webapp", "storefront-webapp"] as const;
+const REQUIRED_APP_FILES = [
+  "AGENTS.md",
+  "docs/agent/index.md",
+  "docs/agent/architecture.md",
+  "docs/agent/testing.md",
+  "docs/agent/code-map.md",
+] as const;
+const REQUIRED_INDEX_LINKS = [
+  "./architecture.md",
+  "./testing.md",
+  "./code-map.md",
+] as const;
+const MARKDOWN_LINK_PATTERN = /\[[^\]]+\]\(([^)]+)\)/g;
+
+function stripLinkDecorations(linkTarget: string) {
+  return linkTarget.split("#", 1)[0]?.split("?", 1)[0] ?? "";
+}
+
+function isRelativeLink(linkTarget: string) {
+  if (!linkTarget) {
+    return false;
+  }
+
+  return !/^(?:[a-z]+:|#|\/)/i.test(linkTarget);
+}
+
+async function fileExists(filePath: string) {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function collectMarkdownLinkErrors(rootDir: string, filePath: string) {
+  const contents = await readFile(path.join(rootDir, filePath), "utf8");
+  const errors: string[] = [];
+
+  for (const match of contents.matchAll(MARKDOWN_LINK_PATTERN)) {
+    const rawTarget = match[1]?.trim() ?? "";
+    const normalizedTarget = stripLinkDecorations(rawTarget);
+
+    if (!isRelativeLink(normalizedTarget)) {
+      continue;
+    }
+
+    const resolvedTarget = path.resolve(
+      rootDir,
+      path.dirname(filePath),
+      normalizedTarget
+    );
+
+    if (!(await fileExists(resolvedTarget))) {
+      errors.push(`Broken markdown link in ${filePath}: ${rawTarget}`);
+    }
+  }
+
+  return {
+    contents,
+    errors,
+  };
+}
+
+export async function validateHarnessDocs(rootDir: string) {
+  const errors: string[] = [];
+  const markdownFiles = ["packages/AGENTS.md"];
+
+  if (!(await fileExists(path.join(rootDir, "packages/AGENTS.md")))) {
+    errors.push("Missing required harness file: packages/AGENTS.md");
+    return errors;
+  }
+
+  for (const appName of APP_NAMES) {
+    for (const relativeFile of REQUIRED_APP_FILES) {
+      const repoRelativePath = path.posix.join("packages", appName, relativeFile);
+      if (!(await fileExists(path.join(rootDir, repoRelativePath)))) {
+        errors.push(`Missing required harness file: ${repoRelativePath}`);
+        continue;
+      }
+
+      if (repoRelativePath.endsWith(".md")) {
+        markdownFiles.push(repoRelativePath);
+      }
+    }
+  }
+
+  for (const markdownFile of markdownFiles) {
+    if (!(await fileExists(path.join(rootDir, markdownFile)))) {
+      continue;
+    }
+
+    const { contents, errors: linkErrors } = await collectMarkdownLinkErrors(
+      rootDir,
+      markdownFile
+    );
+    errors.push(...linkErrors);
+
+    if (!markdownFile.endsWith("/docs/agent/index.md")) {
+      continue;
+    }
+
+    const linkTargets = new Set(
+      [...contents.matchAll(MARKDOWN_LINK_PATTERN)]
+        .map((match) => stripLinkDecorations(match[1]?.trim() ?? ""))
+        .filter(Boolean)
+    );
+
+    for (const requiredLink of REQUIRED_INDEX_LINKS) {
+      if (!linkTargets.has(requiredLink)) {
+        errors.push(
+          `Missing required index link in ${markdownFile}: ${requiredLink}`
+        );
+      }
+    }
+  }
+
+  return errors;
+}
+
+export async function runHarnessCheck(rootDir: string) {
+  const errors = await validateHarnessDocs(rootDir);
+
+  if (errors.length === 0) {
+    console.log("Harness docs check passed.");
+    return;
+  }
+
+  for (const error of errors) {
+    console.error(`- ${error}`);
+  }
+
+  throw new Error(`Harness docs check failed with ${errors.length} issue(s).`);
+}
+
+if (import.meta.main) {
+  await runHarnessCheck(process.cwd());
+}


### PR DESCRIPTION
## Summary
- add a docs-first harness router for `packages/athena-webapp` and `packages/storefront-webapp`
- add app-local `AGENTS.md` files plus `docs/agent/{index,architecture,testing,code-map}.md` for both apps
- add `bun run harness:check`, cover it with fixture-backed tests, and wire it into `bun run pr:athena` while removing the stale `symphony-service` test dependency

## Why
This milestone makes the two web apps easier for coding agents to route, inspect, and validate without introducing heavier enforcement. It also aligns the PR-equivalent validation path with the current app scope instead of expecting `symphony-service`.

## Validation
- `bunx vitest run scripts/harness-check.test.ts`
- `bun run harness:check`
- `bun run pr:athena`
- `git diff --check`
- `python3 -c "from graphify.watch import _rebuild_code; from pathlib import Path; _rebuild_code(Path('.'))"` (fails locally: `ModuleNotFoundError: No module named `graphify``)

https://linear.app/v26-labs/issue/V26-189/land-a-docs-first-agent-harness-foundation-for-athena-webapp-and
