### PR TITLE
[V26-194]: harden harness drift checks and graphify rebuild

### DIFF
--- a/.github/workflows/athena-pr-tests.yml
+++ b/.github/workflows/athena-pr-tests.yml
@@ -10,6 +10,31 @@ permissions:
   contents: read
 
 jobs:
+  harness-validation:
+    name: Harness and Architecture Validation
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Check harness docs
+        run: bun run harness:check
+
+      - name: Check architecture boundaries
+        run: bun run architecture:check
+
+      - name: Audit harness coverage
+        run: bun run harness:audit
+
   test-athena-webapp:
     name: Athena Webapp Validation
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,4 +6,4 @@ Rules:
 
 - Before answering architecture or codebase questions, read graphify-out/GRAPH_REPORT.md for god nodes and community structure
 - If graphify-out/wiki/index.md exists, navigate it instead of reading raw files
-- After modifying code files in this session, run `python3 -c "from graphify.watch import _rebuild_code; from pathlib import Path; _rebuild_code(Path('.'))"` to keep the graph current
+- After modifying code files in this session, run `bun run graphify:rebuild` to keep the graph current

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,25 +1,25 @@
-# Graph Report - .  (2026-04-09)
+# Graph Report - .  (2026-04-11)
 
 ## Corpus Check
-- 1203 files · ~0 words
+- 1170 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 2282 nodes · 5098 edges · 72 communities detected
-- Extraction: 91% EXTRACTED · 9% INFERRED · 0% AMBIGUOUS · INFERRED: 475 edges (avg confidence: 0.5)
+- 2102 nodes · 4792 edges · 72 communities detected
+- Extraction: 92% EXTRACTED · 8% INFERRED · 0% AMBIGUOUS · INFERRED: 401 edges (avg confidence: 0.5)
 - Token cost: 0 input · 0 output
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
-2. `CodexAppServerClient` - 23 edges
-3. `getStoreConfigV2()` - 16 edges
-4. `toV2Config()` - 13 edges
-5. `getBaseUrl()` - 12 edges
-6. `resolveEffectiveConfig()` - 10 edges
-7. `LinearTrackerClient` - 10 edges
-8. `usePOSSessionManager()` - 9 edges
-9. `getBaseUrl()` - 9 edges
-10. `handleRequest()` - 9 edges
+2. `getStoreConfigV2()` - 16 edges
+3. `toV2Config()` - 13 edges
+4. `getBaseUrl()` - 12 edges
+5. `usePOSSessionManager()` - 9 edges
+6. `getBaseUrl()` - 9 edges
+7. `Logger` - 8 edges
+8. `asRecord()` - 8 edges
+9. `buildTestIndex()` - 8 edges
+10. `collectAllPages()` - 7 edges
 
 ## Surprising Connections (you probably didn't know these)
 - `getAmountPaidForOrder()` --calls--> `getDiscountValue()`  [INFERRED]
@@ -37,19 +37,19 @@
 
 ### Community 0 - "Community 0"
 Cohesion: 0.01
-Nodes (16): AnalyticsCombinedUsers(), processAnalyticsToUsers(), AnalyticsTopUsers(), processAnalyticsToUsers(), isSkuReserved(), shouldDisable(), handleFileSelect(), validateFile() (+8 more)
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 1 - "Community 1"
 Cohesion: 0.01
-Nodes (15): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold(), handleKeyDown(), handleRedeemPromoCode(), getPromoAlertCopy() (+7 more)
+Nodes (9): handleKeyDown(), handleRedeemPromoCode(), getPromoAlertCopy(), PromoAlert(), getBaseUrl(), getPromoCodes(), redeemPromoCode(), clearFilters() (+1 more)
 
 ### Community 2 - "Community 2"
-Cohesion: 0.01
-Nodes (50): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory(), expectIndex(), getTableIndexes(), acquireInventoryHold(), acquireInventoryHoldsBatch() (+42 more)
+Cohesion: 0.02
+Nodes (44): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory(), getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore(), expectIndex() (+36 more)
 
 ### Community 3 - "Community 3"
 Cohesion: 0.02
-Nodes (84): asObject(), parseCliArgs(), parsePortArg(), parseWorkflowServerPort(), runCli(), runCliEntry(), SymphonyError, handleRequest() (+76 more)
+Nodes (19): AnalyticsCombinedUsers(), processAnalyticsToUsers(), AnalyticsTopUsers(), processAnalyticsToUsers(), handleSave(), hasReceivingAccountDetails(), normalizePrimaryAccounts(), toPatchReceivingAccounts() (+11 more)
 
 ### Community 4 - "Community 4"
 Cohesion: 0.02
@@ -57,95 +57,95 @@ Nodes (17): handleNewSession(), resetAutoSessionInitialized(), Logger, handleNew
 
 ### Community 5 - "Community 5"
 Cohesion: 0.03
-Nodes (12): getNonEmptyString(), isFailureStatus(), normalizeEvent(), handleSave(), hasReceivingAccountDetails(), normalizePrimaryAccounts(), toPatchReceivingAccounts(), trimToUndefined() (+4 more)
+Nodes (11): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold(), onSubmit(), saveStoreChanges(), getActiveUser() (+3 more)
 
 ### Community 6 - "Community 6"
 Cohesion: 0.03
-Nodes (12): createReview(), deleteReview(), getBaseUrl(), getReviewByOrderItem(), getReviewsByProductId(), getReviewsByProductSkuId(), getUserReviews(), getUserReviewsForProduct() (+4 more)
+Nodes (14): isSkuReserved(), shouldDisable(), createReview(), deleteReview(), getBaseUrl(), getReviewByOrderItem(), getReviewsByProductId(), getReviewsByProductSkuId() (+6 more)
 
 ### Community 7 - "Community 7"
-Cohesion: 0.03
-Nodes (9): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource(), modifyProduct(), onSubmit(), saveProduct(), onSubmit() (+1 more)
+Cohesion: 0.05
+Nodes (63): onSubmit(), reportAuthFailure(), resendVerificationCode(), addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), listBagItems() (+55 more)
 
 ### Community 8 - "Community 8"
-Cohesion: 0.05
-Nodes (26): buildApprovalResponse(), buildHeaders(), CodexAppServerClient, createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError() (+18 more)
+Cohesion: 0.03
+Nodes (5): modifyProduct(), onSubmit(), saveProduct(), onSubmit(), saveStoreChanges()
 
 ### Community 9 - "Community 9"
 Cohesion: 0.05
-Nodes (39): getAllColors(), getBaseUrl(), asInt(), asObject(), asPositiveInt(), asString(), asStringArray(), buildMtnCollectionsLookupPrefixes() (+31 more)
+Nodes (39): buildUsername(), normalizeNameSegment(), buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins(), getDeliveryAddress() (+31 more)
 
 ### Community 10 - "Community 10"
+Cohesion: 0.05
+Nodes (37): checkIfItemsHaveChanged(), CheckoutSessionError, createCheckoutSession(), createOnlineOrder(), defaultCheckoutActionMessage(), findBestValuePromoCode(), getActiveCheckoutSession(), getBaseUrl() (+29 more)
+
+### Community 11 - "Community 11"
 Cohesion: 0.03
 Nodes (4): cancelOrder(), getErrorMessage(), placeOrder(), ValkeyClient
 
-### Community 11 - "Community 11"
-Cohesion: 0.05
-Nodes (31): checkIfItemsHaveChanged(), CheckoutSessionError, createCheckoutSession(), createOnlineOrder(), defaultCheckoutActionMessage(), findBestValuePromoCode(), getActiveCheckoutSession(), getBaseUrl() (+23 more)
-
 ### Community 12 - "Community 12"
-Cohesion: 0.06
-Nodes (29): onSubmit(), reportAuthFailure(), resendVerificationCode(), addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), listBagItems() (+21 more)
+Cohesion: 0.05
+Nodes (21): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventoryHold(), releaseInventoryHold(), validateInventoryAvailability(), collectAllPages(), createTransactionFromSessionHandler(), listCompletedTransactionsForDay() (+13 more)
 
 ### Community 13 - "Community 13"
-Cohesion: 0.04
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.07
+Nodes (53): addGroupedError(), collectLiveSurfaceEntries(), fileExists(), formatGroupedErrors(), inferGroupFromError(), loadAuditTarget(), matchesPathPrefix(), normalizeRepoPath() (+45 more)
 
 ### Community 14 - "Community 14"
-Cohesion: 0.08
-Nodes (45): compactContext(), createAuthEntryViewedEvent(), createAuthRequestStartedEvent(), createAuthVerificationSucceededEvent(), createAuthVerificationViewedEvent(), createBagAddSucceededEvent(), createBagMoveToSavedEvent(), createBagRemoveSucceededEvent() (+37 more)
-
-### Community 15 - "Community 15"
-Cohesion: 0.1
-Nodes (28): asArray(), asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), assignOrDelete(), asString() (+20 more)
-
-### Community 16 - "Community 16"
-Cohesion: 0.1
-Nodes (26): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction(), asBoolean(), asMtnMomoSetupStatus() (+18 more)
-
-### Community 17 - "Community 17"
-Cohesion: 0.07
+Cohesion: 0.05
 Nodes (7): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile(), MockImage
 
+### Community 15 - "Community 15"
+Cohesion: 0.05
+Nodes (13): getAllColors(), getBaseUrl(), getNonEmptyString(), isFailureStatus(), normalizeEvent(), buildQueryString(), getAllProducts(), getBaseUrl() (+5 more)
+
+### Community 16 - "Community 16"
+Cohesion: 0.06
+Nodes (0): 
+
+### Community 17 - "Community 17"
+Cohesion: 0.12
+Nodes (26): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction(), asBoolean(), asMtnMomoSetupStatus() (+18 more)
+
 ### Community 18 - "Community 18"
-Cohesion: 0.11
-Nodes (27): collectMarkdownLinkErrors(), collectReferencedPathErrors(), collectTestingDocErrors(), collectTestSurfaceRoots(), extractInlineCode(), extractTestScriptFromCommand(), fileExists(), isLikelyPathReference() (+19 more)
+Cohesion: 0.14
+Nodes (12): collectScriptsForChangedFiles(), fileExists(), loadReviewTarget(), loadReviewTargets(), matchesPathPrefix(), normalizeRepoPath(), runHarnessReview(), createFixtureRepo() (+4 more)
 
 ### Community 19 - "Community 19"
+Cohesion: 0.22
+Nodes (9): awardPointsForGuestOrders(), awardPointsForPastOrder(), getBaseUrl(), getEligiblePastOrders(), getOrderRewardPoints(), getPointHistory(), getRewardTiers(), getUserPoints() (+1 more)
+
+### Community 20 - "Community 20"
 Cohesion: 0.17
 Nodes (0): 
 
-### Community 20 - "Community 20"
+### Community 21 - "Community 21"
 Cohesion: 0.18
 Nodes (0): 
 
-### Community 21 - "Community 21"
-Cohesion: 0.22
-Nodes (2): useBulkOperations(), validateOperationValue()
-
 ### Community 22 - "Community 22"
-Cohesion: 0.2
-Nodes (0): 
-
-### Community 23 - "Community 23"
 Cohesion: 0.24
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
+
+### Community 23 - "Community 23"
+Cohesion: 0.2
+Nodes (0): 
 
 ### Community 24 - "Community 24"
 Cohesion: 0.39
 Nodes (7): calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock(), validateRefund()
 
 ### Community 25 - "Community 25"
-Cohesion: 0.4
-Nodes (0): 
+Cohesion: 0.32
+Nodes (3): fileExists(), resolveGraphifyPython(), runGraphifyRebuild()
 
 ### Community 26 - "Community 26"
 Cohesion: 0.7
-Nodes (4): runTests(), testBasicOperations(), testClusterInfo(), testConnection()
+Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
 ### Community 27 - "Community 27"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 0.7
+Nodes (4): runTests(), testBasicOperations(), testClusterInfo(), testConnection()
 
 ### Community 28 - "Community 28"
 Cohesion: 1.0
@@ -422,9 +422,9 @@ _Questions this graph is uniquely positioned to answer:_
   _`toV2Config()` has 12 INFERRED edges - model-reasoned connections that need verification._
 - **Are the 11 inferred relationships involving `getBaseUrl()` (e.g. with `createReview()` and `getReviewByOrderItem()`) actually correct?**
   _`getBaseUrl()` has 11 INFERRED edges - model-reasoned connections that need verification._
+- **Are the 8 inferred relationships involving `usePOSSessionManager()` (e.g. with `usePOSSessionCreate()` and `usePOSSessionUpdate()`) actually correct?**
+  _`usePOSSessionManager()` has 8 INFERRED edges - model-reasoned connections that need verification._
 - **Should `Community 0` be split into smaller, more focused modules?**
   _Cohesion score 0.01 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**
-  _Cohesion score 0.01 - nodes in this community are weakly interconnected._
-- **Should `Community 2` be split into smaller, more focused modules?**
   _Cohesion score 0.01 - nodes in this community are weakly interconnected._

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -73,7 +73,7 @@
       "source_file": "packages/valkey-proxy-server/index.js",
       "source_location": "L1",
       "id": "index",
-      "community": 10
+      "community": 11
     },
     {
       "label": "ValkeyClient",
@@ -81,7 +81,7 @@
       "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L4",
       "id": "index_valkeyclient",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".constructor()",
@@ -89,7 +89,7 @@
       "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L11",
       "id": "index_valkeyclient_constructor",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".get()",
@@ -97,7 +97,7 @@
       "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L20",
       "id": "index_valkeyclient_get",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".set()",
@@ -105,7 +105,7 @@
       "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L48",
       "id": "index_valkeyclient_set",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".invalidate()",
@@ -113,7 +113,7 @@
       "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L75",
       "id": "index_valkeyclient_invalidate",
-      "community": 10
+      "community": 11
     },
     {
       "label": "r2.ts",
@@ -121,7 +121,7 @@
       "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
       "source_location": "L1",
       "id": "r2",
-      "community": 15
+      "community": 2
     },
     {
       "label": "uploadFileToR2()",
@@ -129,7 +129,7 @@
       "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
       "source_location": "L21",
       "id": "r2_uploadfiletor2",
-      "community": 15
+      "community": 2
     },
     {
       "label": "deleteFileInR2()",
@@ -137,7 +137,7 @@
       "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
       "source_location": "L40",
       "id": "r2_deletefileinr2",
-      "community": 15
+      "community": 2
     },
     {
       "label": "deleteDirectoryInR2()",
@@ -145,7 +145,7 @@
       "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
       "source_location": "L62",
       "id": "r2_deletedirectoryinr2",
-      "community": 15
+      "community": 2
     },
     {
       "label": "listItemsInR2Directory()",
@@ -153,7 +153,7 @@
       "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
       "source_location": "L106",
       "id": "r2_listitemsinr2directory",
-      "community": 15
+      "community": 2
     },
     {
       "label": "stream.ts",
@@ -177,7 +177,7 @@
       "source_file": "packages/storefront-webapp/src/lib/countries.ts",
       "source_location": "L1",
       "id": "countries",
-      "community": 1
+      "community": 5
     },
     {
       "label": "email.ts",
@@ -193,7 +193,7 @@
       "source_file": "packages/storefront-webapp/src/lib/ghana.ts",
       "source_location": "L1",
       "id": "ghana",
-      "community": 1
+      "community": 5
     },
     {
       "label": "payment.ts",
@@ -217,7 +217,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
       "source_location": "L1",
       "id": "discountcode",
-      "community": 10
+      "community": 11
     },
     {
       "label": "ProductCard()",
@@ -225,7 +225,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
       "source_location": "L33",
       "id": "discountcode_productcard",
-      "community": 10
+      "community": 11
     },
     {
       "label": "chunkProducts()",
@@ -233,7 +233,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
       "source_location": "L98",
       "id": "discountcode_chunkproducts",
-      "community": 10
+      "community": 11
     },
     {
       "label": "DiscountReminder.tsx",
@@ -241,7 +241,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
       "source_location": "L1",
       "id": "discountreminder",
-      "community": 10
+      "community": 11
     },
     {
       "label": "ProductCard()",
@@ -249,7 +249,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
       "source_location": "L31",
       "id": "discountreminder_productcard",
-      "community": 10
+      "community": 11
     },
     {
       "label": "chunkProducts()",
@@ -257,7 +257,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
       "source_location": "L85",
       "id": "discountreminder_chunkproducts",
-      "community": 10
+      "community": 11
     },
     {
       "label": "FeedbackRequest.tsx",
@@ -265,7 +265,7 @@
       "source_file": "packages/athena-webapp/convex/emails/FeedbackRequest.tsx",
       "source_location": "L1",
       "id": "feedbackrequest",
-      "community": 10
+      "community": 11
     },
     {
       "label": "NewOrderAdmin.tsx",
@@ -273,7 +273,7 @@
       "source_file": "packages/athena-webapp/convex/emails/NewOrderAdmin.tsx",
       "source_location": "L1",
       "id": "neworderadmin",
-      "community": 10
+      "community": 11
     },
     {
       "label": "OrderEmail.tsx",
@@ -281,7 +281,7 @@
       "source_file": "packages/athena-webapp/convex/emails/OrderEmail.tsx",
       "source_location": "L1",
       "id": "orderemail",
-      "community": 10
+      "community": 11
     },
     {
       "label": "PosReceiptEmail.tsx",
@@ -289,7 +289,7 @@
       "source_file": "packages/athena-webapp/convex/emails/PosReceiptEmail.tsx",
       "source_location": "L1",
       "id": "posreceiptemail",
-      "community": 1
+      "community": 4
     },
     {
       "label": "VerificationCode.tsx",
@@ -297,7 +297,7 @@
       "source_file": "packages/athena-webapp/convex/emails/VerificationCode.tsx",
       "source_location": "L1",
       "id": "verificationcode",
-      "community": 10
+      "community": 11
     },
     {
       "label": "VerificationCode()",
@@ -305,7 +305,7 @@
       "source_file": "packages/athena-webapp/convex/emails/VerificationCode.tsx",
       "source_location": "L18",
       "id": "verificationcode_verificationcode",
-      "community": 10
+      "community": 11
     },
     {
       "label": "env.ts",
@@ -313,7 +313,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
       "source_location": "L1",
       "id": "env",
-      "community": 23
+      "community": 22
     },
     {
       "label": "analytics.ts",
@@ -321,7 +321,7 @@
       "source_file": "packages/storefront-webapp/src/lib/mutations.ts/analytics.ts",
       "source_location": "L1",
       "id": "analytics",
-      "community": 6
+      "community": 15
     },
     {
       "label": "bannerMessage.ts",
@@ -369,7 +369,7 @@
       "source_file": "packages/storefront-webapp/src/api/stores.ts",
       "source_location": "L1",
       "id": "stores",
-      "community": 15
+      "community": 2
     },
     {
       "label": "subcategories.ts",
@@ -401,7 +401,7 @@
       "source_file": "packages/storefront-webapp/src/lib/schemas/bag.ts",
       "source_location": "L1",
       "id": "bag",
-      "community": 12
+      "community": 7
     },
     {
       "label": "checkout.ts",
@@ -457,7 +457,7 @@
       "source_file": "packages/storefront-webapp/src/api/offers.ts",
       "source_location": "L1",
       "id": "offers",
-      "community": 9
+      "community": 2
     },
     {
       "label": "onlineOrder.ts",
@@ -489,7 +489,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/rewards.ts",
       "source_location": "L1",
       "id": "rewards",
-      "community": 12
+      "community": 19
     },
     {
       "label": "SavedBag.tsx",
@@ -497,7 +497,7 @@
       "source_file": "packages/storefront-webapp/src/components/saved-items/SavedBag.tsx",
       "source_location": "L1",
       "id": "savedbag",
-      "community": 12
+      "community": 7
     },
     {
       "label": "security.test.ts",
@@ -585,7 +585,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/userOffers.ts",
       "source_location": "L1",
       "id": "useroffers",
-      "community": 9
+      "community": 2
     },
     {
       "label": "routerComposition.test.ts",
@@ -609,7 +609,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L1",
       "id": "utils",
-      "community": 0
+      "community": 3
     },
     {
       "label": "getStoreDataFromRequest()",
@@ -617,7 +617,7 @@
       "source_file": "packages/athena-webapp/convex/http/utils.ts",
       "source_location": "L5",
       "id": "utils_getstoredatafromrequest",
-      "community": 0
+      "community": 3
     },
     {
       "label": "getStorefrontUserFromRequest()",
@@ -625,7 +625,7 @@
       "source_file": "packages/athena-webapp/convex/http/utils.ts",
       "source_location": "L12",
       "id": "utils_getstorefrontuserfromrequest",
-      "community": 0
+      "community": 3
     },
     {
       "label": "http.ts",
@@ -681,7 +681,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessionItems.ts",
       "source_location": "L1",
       "id": "expensesessionitems",
-      "community": 2
+      "community": 12
     },
     {
       "label": "expenseSessions.ts",
@@ -689,7 +689,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
       "source_location": "L1",
       "id": "expensesessions",
-      "community": 2
+      "community": 12
     },
     {
       "label": "buildNextExpenseSessionNumber()",
@@ -697,7 +697,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
       "source_location": "L33",
       "id": "expensesessions_buildnextexpensesessionnumber",
-      "community": 2
+      "community": 12
     },
     {
       "label": "loadExpenseSessionItems()",
@@ -705,7 +705,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
       "source_location": "L41",
       "id": "expensesessions_loadexpensesessionitems",
-      "community": 2
+      "community": 12
     },
     {
       "label": "listExpenseSessionsByStatusBefore()",
@@ -713,7 +713,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
       "source_location": "L66",
       "id": "expensesessions_listexpensesessionsbystatusbefore",
-      "community": 2
+      "community": 12
     },
     {
       "label": "expenseTransactions.ts",
@@ -737,7 +737,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionExpiration.ts",
       "source_location": "L1",
       "id": "expensesessionexpiration",
-      "community": 2
+      "community": 12
     },
     {
       "label": "calculateExpenseSessionExpiration()",
@@ -745,7 +745,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionExpiration.ts",
       "source_location": "L21",
       "id": "expensesessionexpiration_calculateexpensesessionexpiration",
-      "community": 2
+      "community": 12
     },
     {
       "label": "getExpenseSessionExpiryDuration()",
@@ -753,7 +753,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionExpiration.ts",
       "source_location": "L35",
       "id": "expensesessionexpiration_getexpensesessionexpiryduration",
-      "community": 2
+      "community": 12
     },
     {
       "label": "getExpenseSessionExpiryDurationMinutes()",
@@ -761,7 +761,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionExpiration.ts",
       "source_location": "L45",
       "id": "expensesessionexpiration_getexpensesessionexpirydurationminutes",
-      "community": 2
+      "community": 12
     },
     {
       "label": "expenseSessionValidation.ts",
@@ -769,7 +769,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
       "source_location": "L1",
       "id": "expensesessionvalidation",
-      "community": 2
+      "community": 12
     },
     {
       "label": "validateExpenseSessionExists()",
@@ -777,7 +777,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
       "source_location": "L19",
       "id": "expensesessionvalidation_validateexpensesessionexists",
-      "community": 2
+      "community": 12
     },
     {
       "label": "validateExpenseSessionActive()",
@@ -785,7 +785,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
       "source_location": "L39",
       "id": "expensesessionvalidation_validateexpensesessionactive",
-      "community": 2
+      "community": 12
     },
     {
       "label": "validateExpenseSessionModifiable()",
@@ -793,7 +793,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
       "source_location": "L92",
       "id": "expensesessionvalidation_validateexpensesessionmodifiable",
-      "community": 2
+      "community": 12
     },
     {
       "label": "validateExpenseItemBelongsToSession()",
@@ -801,7 +801,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
       "source_location": "L135",
       "id": "expensesessionvalidation_validateexpenseitembelongstosession",
-      "community": 2
+      "community": 12
     },
     {
       "label": "inventoryHolds.ts",
@@ -809,7 +809,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
       "source_location": "L1",
       "id": "inventoryholds",
-      "community": 2
+      "community": 12
     },
     {
       "label": "validateInventoryAvailability()",
@@ -817,7 +817,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
       "source_location": "L20",
       "id": "inventoryholds_validateinventoryavailability",
-      "community": 2
+      "community": 12
     },
     {
       "label": "acquireInventoryHold()",
@@ -825,7 +825,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
       "source_location": "L76",
       "id": "inventoryholds_acquireinventoryhold",
-      "community": 2
+      "community": 12
     },
     {
       "label": "releaseInventoryHold()",
@@ -833,7 +833,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
       "source_location": "L114",
       "id": "inventoryholds_releaseinventoryhold",
-      "community": 2
+      "community": 12
     },
     {
       "label": "adjustInventoryHold()",
@@ -841,7 +841,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
       "source_location": "L161",
       "id": "inventoryholds_adjustinventoryhold",
-      "community": 2
+      "community": 12
     },
     {
       "label": "acquireInventoryHoldsBatch()",
@@ -849,7 +849,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
       "source_location": "L190",
       "id": "inventoryholds_acquireinventoryholdsbatch",
-      "community": 2
+      "community": 12
     },
     {
       "label": "releaseInventoryHoldsBatch()",
@@ -857,7 +857,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
       "source_location": "L239",
       "id": "inventoryholds_releaseinventoryholdsbatch",
-      "community": 2
+      "community": 12
     },
     {
       "label": "resultTypes.ts",
@@ -865,7 +865,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L1",
       "id": "resulttypes",
-      "community": 2
+      "community": 12
     },
     {
       "label": "success()",
@@ -873,7 +873,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L21",
       "id": "resulttypes_success",
-      "community": 2
+      "community": 12
     },
     {
       "label": "error()",
@@ -881,7 +881,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L28",
       "id": "resulttypes_error",
-      "community": 2
+      "community": 12
     },
     {
       "label": "itemSuccess()",
@@ -889,7 +889,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L140",
       "id": "resulttypes_itemsuccess",
-      "community": 2
+      "community": 12
     },
     {
       "label": "operationSuccess()",
@@ -897,7 +897,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L150",
       "id": "resulttypes_operationsuccess",
-      "community": 2
+      "community": 12
     },
     {
       "label": "sessionSuccess()",
@@ -905,7 +905,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L157",
       "id": "resulttypes_sessionsuccess",
-      "community": 2
+      "community": 12
     },
     {
       "label": "isSuccess()",
@@ -913,7 +913,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L167",
       "id": "resulttypes_issuccess",
-      "community": 2
+      "community": 12
     },
     {
       "label": "isError()",
@@ -921,7 +921,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L176",
       "id": "resulttypes_iserror",
-      "community": 2
+      "community": 12
     },
     {
       "label": "expenseItemSuccess()",
@@ -929,7 +929,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L276",
       "id": "resulttypes_expenseitemsuccess",
-      "community": 2
+      "community": 12
     },
     {
       "label": "expenseSessionSuccess()",
@@ -937,7 +937,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L286",
       "id": "resulttypes_expensesessionsuccess",
-      "community": 2
+      "community": 12
     },
     {
       "label": "sessionExpiration.ts",
@@ -945,7 +945,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
       "source_location": "L1",
       "id": "sessionexpiration",
-      "community": 2
+      "community": 12
     },
     {
       "label": "calculateSessionExpiration()",
@@ -953,7 +953,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
       "source_location": "L21",
       "id": "sessionexpiration_calculatesessionexpiration",
-      "community": 2
+      "community": 12
     },
     {
       "label": "getSessionExpiryDuration()",
@@ -961,7 +961,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
       "source_location": "L35",
       "id": "sessionexpiration_getsessionexpiryduration",
-      "community": 2
+      "community": 12
     },
     {
       "label": "getSessionExpiryDurationMinutes()",
@@ -969,7 +969,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
       "source_location": "L45",
       "id": "sessionexpiration_getsessionexpirydurationminutes",
-      "community": 2
+      "community": 12
     },
     {
       "label": "sessionValidation.ts",
@@ -977,7 +977,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L1",
       "id": "sessionvalidation",
-      "community": 2
+      "community": 12
     },
     {
       "label": "validateSessionExists()",
@@ -985,7 +985,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L19",
       "id": "sessionvalidation_validatesessionexists",
-      "community": 2
+      "community": 12
     },
     {
       "label": "validateSessionActive()",
@@ -993,7 +993,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L39",
       "id": "sessionvalidation_validatesessionactive",
-      "community": 2
+      "community": 12
     },
     {
       "label": "validateSessionModifiable()",
@@ -1001,7 +1001,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L95",
       "id": "sessionvalidation_validatesessionmodifiable",
-      "community": 2
+      "community": 12
     },
     {
       "label": "validateSessionOwnership()",
@@ -1009,7 +1009,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L140",
       "id": "sessionvalidation_validatesessionownership",
-      "community": 2
+      "community": 12
     },
     {
       "label": "validateCartItems()",
@@ -1017,7 +1017,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L188",
       "id": "sessionvalidation_validatecartitems",
-      "community": 2
+      "community": 12
     },
     {
       "label": "validateItemBelongsToSession()",
@@ -1025,7 +1025,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L245",
       "id": "sessionvalidation_validateitembelongstosession",
-      "community": 2
+      "community": 12
     },
     {
       "label": "validateCustomerInfo()",
@@ -1033,7 +1033,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L272",
       "id": "sessionvalidation_validatecustomerinfo",
-      "community": 2
+      "community": 12
     },
     {
       "label": "isValidEmail()",
@@ -1041,7 +1041,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L300",
       "id": "sessionvalidation_isvalidemail",
-      "community": 2
+      "community": 12
     },
     {
       "label": "validatePaymentDetails()",
@@ -1049,7 +1049,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L308",
       "id": "sessionvalidation_validatepaymentdetails",
-      "community": 2
+      "community": 12
     },
     {
       "label": "inviteCode.ts",
@@ -1073,7 +1073,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L1",
       "id": "pos",
-      "community": 2
+      "community": 12
     },
     {
       "label": "isConvexProductId()",
@@ -1081,7 +1081,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L15",
       "id": "pos_isconvexproductid",
-      "community": 2
+      "community": 12
     },
     {
       "label": "collectAllPages()",
@@ -1089,7 +1089,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L19",
       "id": "pos_collectallpages",
-      "community": 2
+      "community": 12
     },
     {
       "label": "listProductSkusByProductId()",
@@ -1097,7 +1097,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L41",
       "id": "pos_listproductskusbyproductid",
-      "community": 2
+      "community": 12
     },
     {
       "label": "listStoreProducts()",
@@ -1105,7 +1105,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L53",
       "id": "pos_liststoreproducts",
-      "community": 2
+      "community": 12
     },
     {
       "label": "listStoreSkus()",
@@ -1113,7 +1113,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L62",
       "id": "pos_liststoreskus",
-      "community": 2
+      "community": 12
     },
     {
       "label": "listTransactionItems()",
@@ -1121,7 +1121,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L71",
       "id": "pos_listtransactionitems",
-      "community": 2
+      "community": 12
     },
     {
       "label": "listSessionItems()",
@@ -1129,7 +1129,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L83",
       "id": "pos_listsessionitems",
-      "community": 2
+      "community": 12
     },
     {
       "label": "listCompletedTransactionsForDay()",
@@ -1137,7 +1137,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L92",
       "id": "pos_listcompletedtransactionsforday",
-      "community": 2
+      "community": 12
     },
     {
       "label": "createTransactionFromSessionHandler()",
@@ -1145,7 +1145,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L939",
       "id": "pos_createtransactionfromsessionhandler",
-      "community": 2
+      "community": 12
     },
     {
       "label": "posCustomers.ts",
@@ -1177,7 +1177,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posSessionItems.ts",
       "source_location": "L1",
       "id": "possessionitems",
-      "community": 2
+      "community": 12
     },
     {
       "label": "posSessions.ts",
@@ -1185,7 +1185,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
       "source_location": "L1",
       "id": "possessions",
-      "community": 2
+      "community": 12
     },
     {
       "label": "buildNextSessionNumber()",
@@ -1193,7 +1193,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
       "source_location": "L34",
       "id": "possessions_buildnextsessionnumber",
-      "community": 2
+      "community": 12
     },
     {
       "label": "loadPosSessionItems()",
@@ -1201,7 +1201,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
       "source_location": "L45",
       "id": "possessions_loadpossessionitems",
-      "community": 2
+      "community": 12
     },
     {
       "label": "listPosSessionsByStatusBefore()",
@@ -1209,7 +1209,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
       "source_location": "L67",
       "id": "possessions_listpossessionsbystatusbefore",
-      "community": 2
+      "community": 12
     },
     {
       "label": "listPosSessionsForStoreStatus()",
@@ -1217,7 +1217,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
       "source_location": "L93",
       "id": "possessions_listpossessionsforstorestatus",
-      "community": 2
+      "community": 12
     },
     {
       "label": "posTerminal.ts",
@@ -1233,7 +1233,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/productSku.ts",
       "source_location": "L1",
       "id": "productsku",
-      "community": 15
+      "community": 2
     },
     {
       "label": "productUtil.ts",
@@ -1313,7 +1313,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.test.ts",
       "source_location": "L1",
       "id": "storeconfigv2_test",
-      "community": 15
+      "community": 9
     },
     {
       "label": "storeConfigV2.ts",
@@ -1321,7 +1321,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L1",
       "id": "storeconfigv2",
-      "community": 15
+      "community": 9
     },
     {
       "label": "isPlainObject()",
@@ -1329,7 +1329,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L53",
       "id": "storeconfigv2_isplainobject",
-      "community": 15
+      "community": 9
     },
     {
       "label": "asRecord()",
@@ -1337,7 +1337,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L57",
       "id": "storeconfigv2_asrecord",
-      "community": 15
+      "community": 9
     },
     {
       "label": "asNumber()",
@@ -1345,7 +1345,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L61",
       "id": "storeconfigv2_asnumber",
-      "community": 15
+      "community": 9
     },
     {
       "label": "asString()",
@@ -1353,7 +1353,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L65",
       "id": "storeconfigv2_asstring",
-      "community": 15
+      "community": 9
     },
     {
       "label": "asBoolean()",
@@ -1361,7 +1361,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L69",
       "id": "storeconfigv2_asboolean",
-      "community": 15
+      "community": 9
     },
     {
       "label": "asArray()",
@@ -1369,7 +1369,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L77",
       "id": "storeconfigv2_asarray",
-      "community": 15
+      "community": 9
     },
     {
       "label": "asOptionalArray()",
@@ -1377,7 +1377,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L90",
       "id": "storeconfigv2_asoptionalarray",
-      "community": 15
+      "community": 9
     },
     {
       "label": "firstDefined()",
@@ -1385,7 +1385,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L101",
       "id": "storeconfigv2_firstdefined",
-      "community": 15
+      "community": 9
     },
     {
       "label": "mapPromotion()",
@@ -1393,7 +1393,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L111",
       "id": "storeconfigv2_mappromotion",
-      "community": 15
+      "community": 9
     },
     {
       "label": "mapStreamReel()",
@@ -1401,7 +1401,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L115",
       "id": "storeconfigv2_mapstreamreel",
-      "community": 15
+      "community": 9
     },
     {
       "label": "normalizeWaiveDeliveryFees()",
@@ -1409,7 +1409,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L135",
       "id": "storeconfigv2_normalizewaivedeliveryfees",
-      "community": 15
+      "community": 9
     },
     {
       "label": "cleanUndefined()",
@@ -1417,7 +1417,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L153",
       "id": "storeconfigv2_cleanundefined",
-      "community": 15
+      "community": 9
     },
     {
       "label": "asMtnMomoSetupStatus()",
@@ -1425,7 +1425,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L165",
       "id": "storeconfigv2_asmtnmomosetupstatus",
-      "community": 15
+      "community": 9
     },
     {
       "label": "hasMtnMomoReceivingAccountDetails()",
@@ -1433,7 +1433,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L178",
       "id": "storeconfigv2_hasmtnmomoreceivingaccountdetails",
-      "community": 15
+      "community": 9
     },
     {
       "label": "mapMtnMomoReceivingAccount()",
@@ -1441,7 +1441,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L191",
       "id": "storeconfigv2_mapmtnmomoreceivingaccount",
-      "community": 15
+      "community": 9
     },
     {
       "label": "normalizeMtnMomoReceivingAccounts()",
@@ -1449,7 +1449,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L214",
       "id": "storeconfigv2_normalizemtnmomoreceivingaccounts",
-      "community": 15
+      "community": 9
     },
     {
       "label": "toV2Config()",
@@ -1457,7 +1457,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L231",
       "id": "storeconfigv2_tov2config",
-      "community": 15
+      "community": 9
     },
     {
       "label": "normalizeStoreConfig()",
@@ -1465,7 +1465,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L474",
       "id": "storeconfigv2_normalizestoreconfig",
-      "community": 15
+      "community": 9
     },
     {
       "label": "deepMerge()",
@@ -1473,7 +1473,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L478",
       "id": "storeconfigv2_deepmerge",
-      "community": 15
+      "community": 9
     },
     {
       "label": "patchV2Config()",
@@ -1481,7 +1481,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L498",
       "id": "storeconfigv2_patchv2config",
-      "community": 15
+      "community": 9
     },
     {
       "label": "assignOrDelete()",
@@ -1489,7 +1489,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L507",
       "id": "storeconfigv2_assignordelete",
-      "community": 15
+      "community": 9
     },
     {
       "label": "mirrorLegacyKeys()",
@@ -1497,7 +1497,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L520",
       "id": "storeconfigv2_mirrorlegacykeys",
-      "community": 15
+      "community": 9
     },
     {
       "label": "getUnknownStoreConfigRootKeys()",
@@ -1505,7 +1505,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L591",
       "id": "storeconfigv2_getunknownstoreconfigrootkeys",
-      "community": 15
+      "community": 9
     },
     {
       "label": "isStoreCheckoutDisabled()",
@@ -1513,7 +1513,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L597",
       "id": "storeconfigv2_isstorecheckoutdisabled",
-      "community": 15
+      "community": 9
     },
     {
       "label": "removeLegacyRootKeysFromConfig()",
@@ -1521,7 +1521,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L606",
       "id": "storeconfigv2_removelegacyrootkeysfromconfig",
-      "community": 15
+      "community": 9
     },
     {
       "label": "isLegacyRootKey()",
@@ -1529,7 +1529,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L623",
       "id": "storeconfigv2_islegacyrootkey",
-      "community": 15
+      "community": 9
     },
     {
       "label": "isV2RootKey()",
@@ -1537,7 +1537,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L627",
       "id": "storeconfigv2_isv2rootkey",
-      "community": 15
+      "community": 9
     },
     {
       "label": "toV2OnlyConfig()",
@@ -1545,7 +1545,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/stores.ts",
       "source_location": "L27",
       "id": "stores_tov2onlyconfig",
-      "community": 15
+      "community": 2
     },
     {
       "label": "getDiscountValue()",
@@ -1553,7 +1553,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L17",
       "id": "utils_getdiscountvalue",
-      "community": 0
+      "community": 3
     },
     {
       "label": "getProductDiscountValue()",
@@ -1561,7 +1561,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
       "source_location": "L75",
       "id": "utils_getproductdiscountvalue",
-      "community": 0
+      "community": 3
     },
     {
       "label": "getOrderAmount()",
@@ -1569,7 +1569,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L51",
       "id": "utils_getorderamount",
-      "community": 0
+      "community": 3
     },
     {
       "label": "formatDeliveryAddress()",
@@ -1577,7 +1577,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L74",
       "id": "utils_formatdeliveryaddress",
-      "community": 0
+      "community": 3
     },
     {
       "label": "currency.test.ts",
@@ -1585,7 +1585,7 @@
       "source_file": "packages/athena-webapp/convex/lib/currency.test.ts",
       "source_location": "L1",
       "id": "currency_test",
-      "community": 1
+      "community": 9
     },
     {
       "label": "currency.ts",
@@ -1593,7 +1593,7 @@
       "source_file": "packages/storefront-webapp/src/lib/currency.ts",
       "source_location": "L1",
       "id": "currency",
-      "community": 1
+      "community": 9
     },
     {
       "label": "toPesewas()",
@@ -1601,7 +1601,7 @@
       "source_file": "packages/storefront-webapp/src/lib/currency.ts",
       "source_location": "L1",
       "id": "currency_topesewas",
-      "community": 1
+      "community": 9
     },
     {
       "label": "toDisplayAmount()",
@@ -1609,7 +1609,7 @@
       "source_file": "packages/storefront-webapp/src/lib/currency.ts",
       "source_location": "L5",
       "id": "currency_todisplayamount",
-      "community": 1
+      "community": 9
     },
     {
       "label": "callLlmProvider.ts",
@@ -1705,7 +1705,7 @@
       "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L3",
       "id": "index_sendverificationcode",
-      "community": 10
+      "community": 11
     },
     {
       "label": "sendOrderEmail()",
@@ -1713,7 +1713,7 @@
       "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L43",
       "id": "index_sendorderemail",
-      "community": 10
+      "community": 11
     },
     {
       "label": "sendNewOrderEmail()",
@@ -1721,7 +1721,7 @@
       "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L117",
       "id": "index_sendneworderemail",
-      "community": 10
+      "community": 11
     },
     {
       "label": "sendFeedbackRequestEmail()",
@@ -1729,7 +1729,7 @@
       "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L167",
       "id": "index_sendfeedbackrequestemail",
-      "community": 10
+      "community": 11
     },
     {
       "label": "sendDiscountCodeEmail()",
@@ -1737,7 +1737,7 @@
       "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L255",
       "id": "index_senddiscountcodeemail",
-      "community": 10
+      "community": 11
     },
     {
       "label": "sendDiscountReminderEmail()",
@@ -1745,7 +1745,7 @@
       "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L334",
       "id": "index_senddiscountreminderemail",
-      "community": 10
+      "community": 11
     },
     {
       "label": "migrateAmountsToPesewas.ts",
@@ -1753,7 +1753,7 @@
       "source_file": "packages/athena-webapp/convex/migrations/migrateAmountsToPesewas.ts",
       "source_location": "L1",
       "id": "migrateamountstopesewas",
-      "community": 1
+      "community": 9
     },
     {
       "label": "client.test.ts",
@@ -1761,15 +1761,15 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.test.ts",
       "source_location": "L1",
       "id": "client_test",
-      "community": 8
+      "community": 10
     },
     {
-      "label": "client.ts",
+      "label": "client.tsx",
       "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
+      "source_file": "packages/storefront-webapp/src/client.tsx",
       "source_location": "L1",
       "id": "client",
-      "community": 8
+      "community": 10
     },
     {
       "label": "encodeBasicAuth()",
@@ -1777,7 +1777,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L9",
       "id": "client_encodebasicauth",
-      "community": 8
+      "community": 10
     },
     {
       "label": "toError()",
@@ -1785,7 +1785,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L13",
       "id": "client_toerror",
-      "community": 8
+      "community": 10
     },
     {
       "label": "buildHeaders()",
@@ -1793,7 +1793,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L20",
       "id": "client_buildheaders",
-      "community": 8
+      "community": 10
     },
     {
       "label": "createCollectionsAccessToken()",
@@ -1801,7 +1801,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L30",
       "id": "client_createcollectionsaccesstoken",
-      "community": 8
+      "community": 10
     },
     {
       "label": "requestToPay()",
@@ -1809,7 +1809,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L65",
       "id": "client_requesttopay",
-      "community": 8
+      "community": 10
     },
     {
       "label": "getRequestToPayStatus()",
@@ -1817,7 +1817,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L115",
       "id": "client_getrequesttopaystatus",
-      "community": 8
+      "community": 10
     },
     {
       "label": "collections.ts",
@@ -1825,7 +1825,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
       "source_location": "L1",
       "id": "collections",
-      "community": 8
+      "community": 2
     },
     {
       "label": "getCachedTokenRecord()",
@@ -1833,7 +1833,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
       "source_location": "L26",
       "id": "collections_getcachedtokenrecord",
-      "community": 8
+      "community": 2
     },
     {
       "label": "resolveConfigForStore()",
@@ -1841,7 +1841,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
       "source_location": "L33",
       "id": "collections_resolveconfigforstore",
-      "community": 8
+      "community": 2
     },
     {
       "label": "resolveAccessTokenForStore()",
@@ -1849,23 +1849,23 @@
       "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
       "source_location": "L79",
       "id": "collections_resolveaccesstokenforstore",
-      "community": 8
+      "community": 2
     },
     {
       "label": "config.test.ts",
       "file_type": "code",
-      "source_file": "packages/symphony-service/tests/config.test.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/config.test.ts",
       "source_location": "L1",
       "id": "config_test",
-      "community": 3
+      "community": 2
     },
     {
       "label": "config.ts",
       "file_type": "code",
-      "source_file": "packages/symphony-service/src/config.ts",
+      "source_file": "packages/storefront-webapp/src/config.ts",
       "source_location": "L1",
       "id": "config",
-      "community": 9
+      "community": 2
     },
     {
       "label": "toEnvSegment()",
@@ -1873,7 +1873,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L29",
       "id": "config_toenvsegment",
-      "community": 9
+      "community": 2
     },
     {
       "label": "buildMtnCollectionsLookupPrefixes()",
@@ -1881,7 +1881,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L43",
       "id": "config_buildmtncollectionslookupprefixes",
-      "community": 9
+      "community": 2
     },
     {
       "label": "readScopedValue()",
@@ -1889,7 +1889,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L56",
       "id": "config_readscopedvalue",
-      "community": 9
+      "community": 2
     },
     {
       "label": "isTargetEnvironment()",
@@ -1897,7 +1897,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L67",
       "id": "config_istargetenvironment",
-      "community": 9
+      "community": 2
     },
     {
       "label": "resolveConfigForPrefix()",
@@ -1905,7 +1905,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L73",
       "id": "config_resolveconfigforprefix",
-      "community": 9
+      "community": 2
     },
     {
       "label": "resolveMtnCollectionsConfigFromEnv()",
@@ -1913,7 +1913,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L108",
       "id": "config_resolvemtncollectionsconfigfromenv",
-      "community": 9
+      "community": 2
     },
     {
       "label": "buildMtnCollectionsCallbackUrl()",
@@ -1921,7 +1921,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L135",
       "id": "config_buildmtncollectionscallbackurl",
-      "community": 9
+      "community": 2
     },
     {
       "label": "foundation.test.ts",
@@ -1945,7 +1945,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/normalize.test.ts",
       "source_location": "L1",
       "id": "normalize_test",
-      "community": 8
+      "community": 2
     },
     {
       "label": "normalize.ts",
@@ -1953,7 +1953,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
       "source_location": "L1",
       "id": "normalize",
-      "community": 8
+      "community": 2
     },
     {
       "label": "maskMtnPartyId()",
@@ -1961,7 +1961,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
       "source_location": "L10",
       "id": "normalize_maskmtnpartyid",
-      "community": 8
+      "community": 2
     },
     {
       "label": "normalizeCollectionsTransaction()",
@@ -1969,7 +1969,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
       "source_location": "L18",
       "id": "normalize_normalizecollectionstransaction",
-      "community": 8
+      "community": 2
     },
     {
       "label": "parseCollectionsNotificationRequest()",
@@ -1977,12 +1977,12 @@
       "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
       "source_location": "L52",
       "id": "normalize_parsecollectionsnotificationrequest",
-      "community": 8
+      "community": 2
     },
     {
       "label": "types.ts",
       "file_type": "code",
-      "source_file": "packages/symphony-service/src/types.ts",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/types.ts",
       "source_location": "L1",
       "id": "types",
       "community": 1
@@ -1993,7 +1993,7 @@
       "source_file": "packages/athena-webapp/convex/otp/ResendOTP.ts",
       "source_location": "L1",
       "id": "resendotp",
-      "community": 23
+      "community": 22
     },
     {
       "label": "VerificationCodeEmail.tsx",
@@ -2001,7 +2001,7 @@
       "source_file": "packages/athena-webapp/convex/otp/VerificationCodeEmail.tsx",
       "source_location": "L1",
       "id": "verificationcodeemail",
-      "community": 23
+      "community": 22
     },
     {
       "label": "VerificationCodeEmail()",
@@ -2009,7 +2009,7 @@
       "source_file": "packages/athena-webapp/convex/otp/VerificationCodeEmail.tsx",
       "source_location": "L11",
       "id": "verificationcodeemail_verificationcodeemail",
-      "community": 23
+      "community": 22
     },
     {
       "label": "listTransactions()",
@@ -2017,7 +2017,7 @@
       "source_file": "packages/athena-webapp/convex/paystack/index.ts",
       "source_location": "L7",
       "id": "index_listtransactions",
-      "community": 10
+      "community": 11
     },
     {
       "label": "verifyTransaction()",
@@ -2025,7 +2025,7 @@
       "source_file": "packages/athena-webapp/convex/paystack/index.ts",
       "source_location": "L109",
       "id": "index_verifytransaction",
-      "community": 10
+      "community": 11
     },
     {
       "label": "schema.ts",
@@ -2057,7 +2057,7 @@
       "source_file": "packages/storefront-webapp/src/api/color.ts",
       "source_location": "L1",
       "id": "color",
-      "community": 9
+      "community": 15
     },
     {
       "label": "organization.ts",
@@ -2065,7 +2065,7 @@
       "source_file": "packages/storefront-webapp/src/lib/schemas/organization.ts",
       "source_location": "L1",
       "id": "organization",
-      "community": 9
+      "community": 2
     },
     {
       "label": "organizationMember.ts",
@@ -2081,7 +2081,7 @@
       "source_file": "packages/storefront-webapp/src/lib/schemas/product.ts",
       "source_location": "L1",
       "id": "product",
-      "community": 9
+      "community": 15
     },
     {
       "label": "redeemedPromoCode.ts",
@@ -2105,7 +2105,7 @@
       "source_file": "packages/storefront-webapp/src/lib/schemas/subcategory.ts",
       "source_location": "L1",
       "id": "subcategory",
-      "community": 9
+      "community": 2
     },
     {
       "label": "mtnCollections.ts",
@@ -2193,7 +2193,7 @@
       "source_file": "packages/storefront-webapp/src/lib/schemas/bagItem.ts",
       "source_location": "L1",
       "id": "bagitem",
-      "community": 12
+      "community": 7
     },
     {
       "label": "checkoutSession.ts",
@@ -2201,7 +2201,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L1",
       "id": "checkoutsession",
-      "community": 11
+      "community": 10
     },
     {
       "label": "checkoutSessionItem.ts",
@@ -2257,7 +2257,7 @@
       "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
       "source_location": "L1",
       "id": "storefrontuser",
-      "community": 1
+      "community": 5
     },
     {
       "label": "storeFrontVerificationCode.ts",
@@ -2281,7 +2281,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L1",
       "id": "orderemailservice",
-      "community": 2
+      "community": 9
     },
     {
       "label": "shouldSendToAdmins()",
@@ -2289,7 +2289,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L42",
       "id": "orderemailservice_shouldsendtoadmins",
-      "community": 2
+      "community": 9
     },
     {
       "label": "buildOrderStatusMessage()",
@@ -2297,7 +2297,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L49",
       "id": "orderemailservice_buildorderstatusmessage",
-      "community": 2
+      "community": 9
     },
     {
       "label": "buildPickupDetails()",
@@ -2305,7 +2305,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L77",
       "id": "orderemailservice_buildpickupdetails",
-      "community": 2
+      "community": 9
     },
     {
       "label": "sendPODOrderEmails()",
@@ -2313,7 +2313,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L96",
       "id": "orderemailservice_sendpodorderemails",
-      "community": 2
+      "community": 9
     },
     {
       "label": "sendPaymentVerificationEmails()",
@@ -2321,7 +2321,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L217",
       "id": "orderemailservice_sendpaymentverificationemails",
-      "community": 2
+      "community": 9
     },
     {
       "label": "paystackService.ts",
@@ -2369,7 +2369,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L18",
       "id": "analytics_extractpromocodeid",
-      "community": 6
+      "community": 15
     },
     {
       "label": "getAnalyticsByStoreQuery()",
@@ -2377,7 +2377,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L28",
       "id": "analytics_getanalyticsbystorequery",
-      "community": 6
+      "community": 15
     },
     {
       "label": "getCompletedOrdersQuery()",
@@ -2385,7 +2385,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L59",
       "id": "analytics_getcompletedordersquery",
-      "community": 6
+      "community": 15
     },
     {
       "label": "getAnalyticsByStoreAndActionQuery()",
@@ -2393,7 +2393,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L97",
       "id": "analytics_getanalyticsbystoreandactionquery",
-      "community": 6
+      "community": 15
     },
     {
       "label": "getSkuMapForProducts()",
@@ -2401,7 +2401,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L132",
       "id": "analytics_getskumapforproducts",
-      "community": 6
+      "community": 15
     },
     {
       "label": "getStoreFrontActorById()",
@@ -2417,7 +2417,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L40",
       "id": "checkoutsession_listsessionitems",
-      "community": 11
+      "community": 10
     },
     {
       "label": "checkIfItemsHaveChanged()",
@@ -2425,7 +2425,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L50",
       "id": "checkoutsession_checkifitemshavechanged",
-      "community": 11
+      "community": 10
     },
     {
       "label": "createPatchObject()",
@@ -2433,7 +2433,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L651",
       "id": "checkoutsession_createpatchobject",
-      "community": 11
+      "community": 10
     },
     {
       "label": "handlePlaceOrder()",
@@ -2441,7 +2441,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L698",
       "id": "checkoutsession_handleplaceorder",
-      "community": 11
+      "community": 10
     },
     {
       "label": "handleOrderCreation()",
@@ -2449,7 +2449,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L734",
       "id": "checkoutsession_handleordercreation",
-      "community": 11
+      "community": 10
     },
     {
       "label": "createOnlineOrder()",
@@ -2457,7 +2457,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L765",
       "id": "checkoutsession_createonlineorder",
-      "community": 11
+      "community": 10
     },
     {
       "label": "retrieveActiveCheckoutSession()",
@@ -2465,7 +2465,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L951",
       "id": "checkoutsession_retrieveactivecheckoutsession",
-      "community": 11
+      "community": 10
     },
     {
       "label": "fetchProductSkus()",
@@ -2473,7 +2473,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L979",
       "id": "checkoutsession_fetchproductskus",
-      "community": 11
+      "community": 10
     },
     {
       "label": "checkAdjustedAvailability()",
@@ -2481,7 +2481,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L990",
       "id": "checkoutsession_checkadjustedavailability",
-      "community": 11
+      "community": 10
     },
     {
       "label": "updateExistingSession()",
@@ -2489,7 +2489,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1020",
       "id": "checkoutsession_updateexistingsession",
-      "community": 11
+      "community": 10
     },
     {
       "label": "createSessionItems()",
@@ -2497,7 +2497,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1102",
       "id": "checkoutsession_createsessionitems",
-      "community": 11
+      "community": 10
     },
     {
       "label": "updateProductAvailability()",
@@ -2505,7 +2505,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1123",
       "id": "checkoutsession_updateproductavailability",
-      "community": 11
+      "community": 10
     },
     {
       "label": "updateAvailability()",
@@ -2513,7 +2513,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1140",
       "id": "checkoutsession_updateavailability",
-      "community": 11
+      "community": 10
     },
     {
       "label": "handleExistingSession()",
@@ -2521,7 +2521,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1161",
       "id": "checkoutsession_handleexistingsession",
-      "community": 11
+      "community": 10
     },
     {
       "label": "validateExistingDiscount()",
@@ -2529,7 +2529,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1321",
       "id": "checkoutsession_validateexistingdiscount",
-      "community": 11
+      "community": 10
     },
     {
       "label": "calculatePromoCodeValue()",
@@ -2537,7 +2537,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1447",
       "id": "checkoutsession_calculatepromocodevalue",
-      "community": 11
+      "community": 10
     },
     {
       "label": "findBestValuePromoCode()",
@@ -2545,7 +2545,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1495",
       "id": "checkoutsession_findbestvaluepromocode",
-      "community": 11
+      "community": 10
     },
     {
       "label": "commerceQueryIndexes.test.ts",
@@ -2585,7 +2585,7 @@
       "source_file": "packages/athena-webapp/src/components/users/CustomerBehaviorTimeline.tsx",
       "source_location": "L1",
       "id": "customerbehaviortimeline",
-      "community": 5
+      "community": 3
     },
     {
       "label": "getTimeFilterForRange()",
@@ -2593,7 +2593,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
       "source_location": "L11",
       "id": "customerbehaviortimeline_gettimefilterforrange",
-      "community": 5
+      "community": 3
     },
     {
       "label": "getCustomerAnalyticsQuery()",
@@ -2601,7 +2601,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
       "source_location": "L26",
       "id": "customerbehaviortimeline_getcustomeranalyticsquery",
-      "community": 5
+      "community": 3
     },
     {
       "label": "getTimelineUserData()",
@@ -2609,7 +2609,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
       "source_location": "L42",
       "id": "customerbehaviortimeline_gettimelineuserdata",
-      "community": 5
+      "community": 3
     },
     {
       "label": "getProductInfoMaps()",
@@ -2617,7 +2617,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
       "source_location": "L66",
       "id": "customerbehaviortimeline_getproductinfomaps",
-      "community": 5
+      "community": 3
     },
     {
       "label": "customerObservabilityTimeline.test.ts",
@@ -2625,7 +2625,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimeline.test.ts",
       "source_location": "L1",
       "id": "customerobservabilitytimeline_test",
-      "community": 5
+      "community": 15
     },
     {
       "label": "createAnalyticsEvent()",
@@ -2633,7 +2633,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimeline.test.ts",
       "source_location": "L17",
       "id": "customerobservabilitytimeline_test_createanalyticsevent",
-      "community": 5
+      "community": 15
     },
     {
       "label": "customerObservabilityTimelineData.ts",
@@ -2641,7 +2641,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L1",
       "id": "customerobservabilitytimelinedata",
-      "community": 5
+      "community": 15
     },
     {
       "label": "getNonEmptyString()",
@@ -2649,7 +2649,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L64",
       "id": "customerobservabilitytimelinedata_getnonemptystring",
-      "community": 5
+      "community": 15
     },
     {
       "label": "isFailureStatus()",
@@ -2657,7 +2657,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L68",
       "id": "customerobservabilitytimelinedata_isfailurestatus",
-      "community": 5
+      "community": 15
     },
     {
       "label": "normalizeEvent()",
@@ -2665,7 +2665,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L72",
       "id": "customerobservabilitytimelinedata_normalizeevent",
-      "community": 5
+      "community": 15
     },
     {
       "label": "buildCustomerObservabilityTimeline()",
@@ -2673,7 +2673,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L118",
       "id": "customerobservabilitytimelinedata_buildcustomerobservabilitytimeline",
-      "community": 5
+      "community": 15
     },
     {
       "label": "helperOrchestration.test.ts",
@@ -2697,7 +2697,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/bag.ts",
       "source_location": "L7",
       "id": "bag_listbagitems",
-      "community": 12
+      "community": 7
     },
     {
       "label": "loadBagWithItems()",
@@ -2705,7 +2705,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/bag.ts",
       "source_location": "L14",
       "id": "bag_loadbagwithitems",
-      "community": 12
+      "community": 7
     },
     {
       "label": "generateOrderNumber()",
@@ -2753,7 +2753,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L1",
       "id": "orderupdateemails",
-      "community": 2
+      "community": 9
     },
     {
       "label": "getPickupLocation()",
@@ -2761,7 +2761,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L52",
       "id": "orderupdateemails_getpickuplocation",
-      "community": 2
+      "community": 9
     },
     {
       "label": "getDeliveryAddress()",
@@ -2769,7 +2769,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L55",
       "id": "orderupdateemails_getdeliveryaddress",
-      "community": 2
+      "community": 9
     },
     {
       "label": "getLocationDetails()",
@@ -2777,7 +2777,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L58",
       "id": "orderupdateemails_getlocationdetails",
-      "community": 2
+      "community": 9
     },
     {
       "label": "formatOrderItems()",
@@ -2785,7 +2785,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L64",
       "id": "orderupdateemails_formatorderitems",
-      "community": 2
+      "community": 9
     },
     {
       "label": "handleOrderStatusUpdate()",
@@ -2793,7 +2793,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L118",
       "id": "orderupdateemails_handleorderstatusupdate",
-      "community": 2
+      "community": 9
     },
     {
       "label": "processOrderUpdateEmail()",
@@ -2801,7 +2801,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L293",
       "id": "orderupdateemails_processorderupdateemail",
-      "community": 2
+      "community": 9
     },
     {
       "label": "paymentHelpers.ts",
@@ -2865,7 +2865,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
       "source_location": "L36",
       "id": "offers_isduplicate",
-      "community": 9
+      "community": 2
     },
     {
       "label": "updateStoreFrontActorEmail()",
@@ -2873,7 +2873,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
       "source_location": "L59",
       "id": "offers_updatestorefrontactoremail",
-      "community": 9
+      "community": 2
     },
     {
       "label": "createOffer()",
@@ -2881,7 +2881,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
       "source_location": "L88",
       "id": "offers_createoffer",
-      "community": 9
+      "community": 2
     },
     {
       "label": "getUpsellProducts()",
@@ -2889,7 +2889,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
       "source_location": "L685",
       "id": "offers_getupsellproducts",
-      "community": 9
+      "community": 2
     },
     {
       "label": "listOrderItems()",
@@ -2913,7 +2913,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderUtilFns.ts",
       "source_location": "L1",
       "id": "onlineorderutilfns",
-      "community": 2
+      "community": 9
     },
     {
       "label": "paystackActions.ts",
@@ -2937,7 +2937,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/savedBag.ts",
       "source_location": "L14",
       "id": "savedbag_listsavedbagitems",
-      "community": 12
+      "community": 7
     },
     {
       "label": "storefrontObservabilityReport.test.ts",
@@ -2945,7 +2945,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.test.ts",
       "source_location": "L1",
       "id": "storefrontobservabilityreport_test",
-      "community": 5
+      "community": 15
     },
     {
       "label": "createAnalyticsEvent()",
@@ -2953,7 +2953,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.test.ts",
       "source_location": "L7",
       "id": "storefrontobservabilityreport_test_createanalyticsevent",
-      "community": 5
+      "community": 15
     },
     {
       "label": "storefrontObservabilityReport.ts",
@@ -2961,7 +2961,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
       "source_location": "L1",
       "id": "storefrontobservabilityreport",
-      "community": 5
+      "community": 15
     },
     {
       "label": "getNonEmptyString()",
@@ -2969,7 +2969,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
       "source_location": "L59",
       "id": "storefrontobservabilityreport_getnonemptystring",
-      "community": 5
+      "community": 15
     },
     {
       "label": "normalizeStorefrontObservabilityEvent()",
@@ -2977,7 +2977,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
       "source_location": "L63",
       "id": "storefrontobservabilityreport_normalizestorefrontobservabilityevent",
-      "community": 5
+      "community": 15
     },
     {
       "label": "buildStorefrontObservabilityReport()",
@@ -2985,7 +2985,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
       "source_location": "L95",
       "id": "storefrontobservabilityreport_buildstorefrontobservabilityreport",
-      "community": 5
+      "community": 15
     },
     {
       "label": "timeQueryRefactors.test.ts",
@@ -3017,7 +3017,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/userOffers.ts",
       "source_location": "L30",
       "id": "useroffers_determineoffereligibility",
-      "community": 9
+      "community": 2
     },
     {
       "label": "users.ts",
@@ -3033,7 +3033,7 @@
       "source_file": "packages/athena-webapp/src/lib/utils.ts",
       "source_location": "L37",
       "id": "utils_toslug",
-      "community": 0
+      "community": 3
     },
     {
       "label": "getAddressString()",
@@ -3041,7 +3041,7 @@
       "source_file": "packages/athena-webapp/convex/utils.ts",
       "source_location": "L14",
       "id": "utils_getaddressstring",
-      "community": 0
+      "community": 3
     },
     {
       "label": "capitalizeWords()",
@@ -3049,7 +3049,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L23",
       "id": "utils_capitalizewords",
-      "community": 0
+      "community": 3
     },
     {
       "label": "currencyFormatter()",
@@ -3057,7 +3057,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L35",
       "id": "utils_currencyformatter",
-      "community": 0
+      "community": 3
     },
     {
       "label": "formatDate()",
@@ -3065,7 +3065,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L44",
       "id": "utils_formatdate",
-      "community": 0
+      "community": 3
     },
     {
       "label": "getProductName()",
@@ -3073,7 +3073,7 @@
       "source_file": "packages/athena-webapp/convex/utils.ts",
       "source_location": "L64",
       "id": "utils_getproductname",
-      "community": 0
+      "community": 3
     },
     {
       "label": "generateTransactionNumber()",
@@ -3081,7 +3081,7 @@
       "source_file": "packages/athena-webapp/convex/utils.ts",
       "source_location": "L77",
       "id": "utils_generatetransactionnumber",
-      "community": 0
+      "community": 3
     },
     {
       "label": "eslint.config.js",
@@ -3201,7 +3201,7 @@
       "source_file": "packages/athena-webapp/src/components/ProtectedRoute.tsx",
       "source_location": "L1",
       "id": "protectedroute",
-      "community": 7
+      "community": 8
     },
     {
       "label": "ProtectedRoute()",
@@ -3209,7 +3209,7 @@
       "source_file": "packages/athena-webapp/src/components/ProtectedRoute.tsx",
       "source_location": "L11",
       "id": "protectedroute_protectedroute",
-      "community": 7
+      "community": 8
     },
     {
       "label": "SettingsView.tsx",
@@ -3217,7 +3217,7 @@
       "source_file": "packages/athena-webapp/src/components/SettingsView.tsx",
       "source_location": "L1",
       "id": "settingsview",
-      "community": 10
+      "community": 11
     },
     {
       "label": "SettingsView()",
@@ -3225,7 +3225,7 @@
       "source_file": "packages/athena-webapp/src/components/SettingsView.tsx",
       "source_location": "L3",
       "id": "settingsview_settingsview",
-      "community": 10
+      "community": 11
     },
     {
       "label": "StoreAccordion.tsx",
@@ -3337,7 +3337,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
       "source_location": "L1",
       "id": "attributesmanager",
-      "community": 5
+      "community": 0
     },
     {
       "label": "Sidebar()",
@@ -3345,7 +3345,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
       "source_location": "L26",
       "id": "attributesmanager_sidebar",
-      "community": 5
+      "community": 0
     },
     {
       "label": "ColorManager()",
@@ -3353,7 +3353,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
       "source_location": "L45",
       "id": "attributesmanager_colormanager",
-      "community": 5
+      "community": 0
     },
     {
       "label": "AttributesManager()",
@@ -3361,7 +3361,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
       "source_location": "L228",
       "id": "attributesmanager_attributesmanager",
-      "community": 5
+      "community": 0
     },
     {
       "label": "AttributesTable.tsx",
@@ -3369,7 +3369,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
       "source_location": "L1",
       "id": "attributestable",
-      "community": 0
+      "community": 9
     },
     {
       "label": "handleChange()",
@@ -3377,7 +3377,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
       "source_location": "L32",
       "id": "attributestable_handlechange",
-      "community": 0
+      "community": 9
     },
     {
       "label": "getProductAttribute()",
@@ -3385,7 +3385,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
       "source_location": "L55",
       "id": "attributestable_getproductattribute",
-      "community": 0
+      "community": 9
     },
     {
       "label": "onSubmit()",
@@ -3393,7 +3393,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
       "source_location": "L210",
       "id": "attributestable_onsubmit",
-      "community": 0
+      "community": 9
     },
     {
       "label": "BarcodeQRViewer.tsx",
@@ -3449,7 +3449,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/DefaultAttributesToggleGroup.tsx",
       "source_location": "L1",
       "id": "defaultattributestogglegroup",
-      "community": 0
+      "community": 16
     },
     {
       "label": "ProcessingFees.tsx",
@@ -3497,7 +3497,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
       "source_location": "L1",
       "id": "productavailability",
-      "community": 0
+      "community": 16
     },
     {
       "label": "ProductAvailabilityView()",
@@ -3505,7 +3505,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
       "source_location": "L5",
       "id": "productavailability_productavailabilityview",
-      "community": 0
+      "community": 16
     },
     {
       "label": "ProductAvailability()",
@@ -3513,7 +3513,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
       "source_location": "L18",
       "id": "productavailability_productavailability",
-      "community": 0
+      "community": 16
     },
     {
       "label": "ProductAvailabilityToggleGroup.tsx",
@@ -3521,7 +3521,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailabilityToggleGroup.tsx",
       "source_location": "L1",
       "id": "productavailabilitytogglegroup",
-      "community": 0
+      "community": 16
     },
     {
       "label": "ProductAvailabilityToggleGroup()",
@@ -3529,7 +3529,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailabilityToggleGroup.tsx",
       "source_location": "L5",
       "id": "productavailabilitytogglegroup_productavailabilitytogglegroup",
-      "community": 0
+      "community": 16
     },
     {
       "label": "ProductCategorization.tsx",
@@ -3577,7 +3577,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
       "source_location": "L1",
       "id": "productdetails",
-      "community": 6
+      "community": 1
     },
     {
       "label": "handleNameChange()",
@@ -3585,7 +3585,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductDetails.tsx",
       "source_location": "L10",
       "id": "productdetails_handlenamechange",
-      "community": 6
+      "community": 1
     },
     {
       "label": "ProductImages.tsx",
@@ -3625,7 +3625,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
       "source_location": "L1",
       "id": "productstock",
-      "community": 0
+      "community": 6
     },
     {
       "label": "restock()",
@@ -3633,7 +3633,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L107",
       "id": "productstock_restock",
-      "community": 0
+      "community": 6
     },
     {
       "label": "isSkuReserved()",
@@ -3641,7 +3641,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L174",
       "id": "productstock_isskureserved",
-      "community": 0
+      "community": 6
     },
     {
       "label": "getReservationType()",
@@ -3649,7 +3649,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L178",
       "id": "productstock_getreservationtype",
-      "community": 0
+      "community": 6
     },
     {
       "label": "handleGenerateBarcode()",
@@ -3657,7 +3657,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L239",
       "id": "productstock_handlegeneratebarcode",
-      "community": 0
+      "community": 6
     },
     {
       "label": "handleSaveBarcode()",
@@ -3665,7 +3665,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L285",
       "id": "productstock_handlesavebarcode",
-      "community": 0
+      "community": 6
     },
     {
       "label": "handleViewBarcode()",
@@ -3673,7 +3673,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L300",
       "id": "productstock_handleviewbarcode",
-      "community": 0
+      "community": 6
     },
     {
       "label": "handleClearBarcodeClick()",
@@ -3681,7 +3681,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L308",
       "id": "productstock_handleclearbarcodeclick",
-      "community": 0
+      "community": 6
     },
     {
       "label": "handleClearBarcodeConfirm()",
@@ -3689,7 +3689,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L313",
       "id": "productstock_handleclearbarcodeconfirm",
-      "community": 0
+      "community": 6
     },
     {
       "label": "handleClearBarcodeCancel()",
@@ -3697,7 +3697,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L379",
       "id": "productstock_handleclearbarcodecancel",
-      "community": 0
+      "community": 6
     },
     {
       "label": "handleChange()",
@@ -3705,7 +3705,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L384",
       "id": "productstock_handlechange",
-      "community": 0
+      "community": 6
     },
     {
       "label": "addRow()",
@@ -3713,7 +3713,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L430",
       "id": "productstock_addrow",
-      "community": 0
+      "community": 6
     },
     {
       "label": "handleDeleteAction()",
@@ -3721,7 +3721,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L445",
       "id": "productstock_handledeleteaction",
-      "community": 0
+      "community": 6
     },
     {
       "label": "setOutOfStock()",
@@ -3729,7 +3729,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L462",
       "id": "productstock_setoutofstock",
-      "community": 0
+      "community": 6
     },
     {
       "label": "setVisibility()",
@@ -3737,7 +3737,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L472",
       "id": "productstock_setvisibility",
-      "community": 0
+      "community": 6
     },
     {
       "label": "isLastActiveVariant()",
@@ -3745,7 +3745,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L486",
       "id": "productstock_islastactivevariant",
-      "community": 0
+      "community": 6
     },
     {
       "label": "isLastVisibleVariant()",
@@ -3753,7 +3753,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L492",
       "id": "productstock_islastvisiblevariant",
-      "community": 0
+      "community": 6
     },
     {
       "label": "shouldDisable()",
@@ -3761,7 +3761,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L498",
       "id": "productstock_shoulddisable",
-      "community": 0
+      "community": 6
     },
     {
       "label": "hasQuantityError()",
@@ -3769,7 +3769,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L506",
       "id": "productstock_hasquantityerror",
-      "community": 0
+      "community": 6
     },
     {
       "label": "hasPriceError()",
@@ -3777,7 +3777,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L514",
       "id": "productstock_haspriceerror",
-      "community": 0
+      "community": 6
     },
     {
       "label": "ProductView.tsx",
@@ -3785,7 +3785,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L1",
       "id": "productview",
-      "community": 7
+      "community": 8
     },
     {
       "label": "deleteActiveProduct()",
@@ -3793,7 +3793,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L82",
       "id": "productview_deleteactiveproduct",
-      "community": 7
+      "community": 8
     },
     {
       "label": "saveProduct()",
@@ -3801,7 +3801,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L115",
       "id": "productview_saveproduct",
-      "community": 7
+      "community": 8
     },
     {
       "label": "modifyProduct()",
@@ -3809,7 +3809,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L170",
       "id": "productview_modifyproduct",
-      "community": 7
+      "community": 8
     },
     {
       "label": "createVariantSku()",
@@ -3817,7 +3817,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L245",
       "id": "productview_createvariantsku",
-      "community": 7
+      "community": 8
     },
     {
       "label": "updateVariantSku()",
@@ -3825,7 +3825,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L300",
       "id": "productview_updatevariantsku",
-      "community": 7
+      "community": 8
     },
     {
       "label": "onSubmit()",
@@ -3833,7 +3833,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L369",
       "id": "productview_onsubmit",
-      "community": 7
+      "community": 8
     },
     {
       "label": "handleKeyDown()",
@@ -3841,7 +3841,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L380",
       "id": "productview_handlekeydown",
-      "community": 7
+      "community": 8
     },
     {
       "label": "updateProductVisibility()",
@@ -3849,7 +3849,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L431",
       "id": "productview_updateproductvisibility",
-      "community": 7
+      "community": 8
     },
     {
       "label": "SheetProvider.tsx",
@@ -3905,7 +3905,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
       "source_location": "L1",
       "id": "copyimagesprovider",
-      "community": 0
+      "community": 6
     },
     {
       "label": "useCopyImages()",
@@ -3913,7 +3913,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
       "source_location": "L13",
       "id": "copyimagesprovider_usecopyimages",
-      "community": 0
+      "community": 6
     },
     {
       "label": "CopyImagesProvider()",
@@ -3921,7 +3921,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
       "source_location": "L21",
       "id": "copyimagesprovider_copyimagesprovider",
-      "community": 0
+      "community": 6
     },
     {
       "label": "CopyImagesView.tsx",
@@ -3953,7 +3953,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "data_table_column_header",
-      "community": 0
+      "community": 3
     },
     {
       "label": "DataTableColumnHeader()",
@@ -3961,7 +3961,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-column-header.tsx",
       "source_location": "L20",
       "id": "data_table_column_header_datatablecolumnheader",
-      "community": 0
+      "community": 3
     },
     {
       "label": "data-table-faceted-filter.tsx",
@@ -3969,7 +3969,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-faceted-filter.tsx",
       "source_location": "L1",
       "id": "data_table_faceted_filter",
-      "community": 13
+      "community": 0
     },
     {
       "label": "data-table-pagination.tsx",
@@ -3977,7 +3977,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "data_table_pagination",
-      "community": 0
+      "community": 3
     },
     {
       "label": "data-table-toolbar-provider.tsx",
@@ -3985,7 +3985,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
       "source_location": "L1",
       "id": "data_table_toolbar_provider",
-      "community": 13
+      "community": 0
     },
     {
       "label": "OrdersTableToolbarProvider()",
@@ -3993,7 +3993,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
       "source_location": "L16",
       "id": "data_table_toolbar_provider_orderstabletoolbarprovider",
-      "community": 13
+      "community": 0
     },
     {
       "label": "useOrdersTableToolbar()",
@@ -4001,7 +4001,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
       "source_location": "L46",
       "id": "data_table_toolbar_provider_useorderstabletoolbar",
-      "community": 13
+      "community": 0
     },
     {
       "label": "data-table-toolbar.tsx",
@@ -4009,7 +4009,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-toolbar.tsx",
       "source_location": "L1",
       "id": "data_table_toolbar",
-      "community": 13
+      "community": 0
     },
     {
       "label": "DataTableToolbar()",
@@ -4017,7 +4017,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
       "source_location": "L23",
       "id": "data_table_toolbar_datatabletoolbar",
-      "community": 13
+      "community": 0
     },
     {
       "label": "data-table-view-options.tsx",
@@ -4025,7 +4025,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
       "source_location": "L1",
       "id": "data_table_view_options",
-      "community": 13
+      "community": 0
     },
     {
       "label": "DataTableViewOptions()",
@@ -4033,7 +4033,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
       "source_location": "L18",
       "id": "data_table_view_options_datatableviewoptions",
-      "community": 13
+      "community": 0
     },
     {
       "label": "data-table.tsx",
@@ -4049,7 +4049,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
       "source_location": "L1",
       "id": "product_variant_columns",
-      "community": 0
+      "community": 6
     },
     {
       "label": "setSourceVariant()",
@@ -4057,7 +4057,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
       "source_location": "L47",
       "id": "product_variant_columns_setsourcevariant",
-      "community": 0
+      "community": 6
     },
     {
       "label": "ActivityTimeline.tsx",
@@ -4065,7 +4065,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/ActivityTimeline.tsx",
       "source_location": "L1",
       "id": "activitytimeline",
-      "community": 5
+      "community": 3
     },
     {
       "label": "capitalizeFirstLetter()",
@@ -4073,7 +4073,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/ActivityTimeline.tsx",
       "source_location": "L151",
       "id": "activitytimeline_capitalizefirstletter",
-      "community": 5
+      "community": 3
     },
     {
       "label": "AnalyticsCombinedUsers.tsx",
@@ -4081,7 +4081,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
       "source_location": "L1",
       "id": "analyticscombinedusers",
-      "community": 0
+      "community": 3
     },
     {
       "label": "processAnalyticsToUsers()",
@@ -4089,7 +4089,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
       "source_location": "L10",
       "id": "analyticscombinedusers_processanalyticstousers",
-      "community": 0
+      "community": 3
     },
     {
       "label": "AnalyticsCombinedUsers()",
@@ -4097,7 +4097,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
       "source_location": "L100",
       "id": "analyticscombinedusers_analyticscombinedusers",
-      "community": 0
+      "community": 3
     },
     {
       "label": "AnalyticsItems.tsx",
@@ -4137,7 +4137,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsTopUsers.tsx",
       "source_location": "L1",
       "id": "analyticstopusers",
-      "community": 0
+      "community": 3
     },
     {
       "label": "processAnalyticsToUsers()",
@@ -4145,7 +4145,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsTopUsers.tsx",
       "source_location": "L10",
       "id": "analyticstopusers_processanalyticstousers",
-      "community": 0
+      "community": 3
     },
     {
       "label": "AnalyticsTopUsers()",
@@ -4153,7 +4153,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsTopUsers.tsx",
       "source_location": "L100",
       "id": "analyticstopusers_analyticstopusers",
-      "community": 0
+      "community": 3
     },
     {
       "label": "AnalyticsUsers.tsx",
@@ -4209,7 +4209,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/ConversionFunnelChart.tsx",
       "source_location": "L1",
       "id": "conversionfunnelchart",
-      "community": 5
+      "community": 3
     },
     {
       "label": "EnhancedAnalyticsView.tsx",
@@ -4217,7 +4217,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/EnhancedAnalyticsView.tsx",
       "source_location": "L1",
       "id": "enhancedanalyticsview",
-      "community": 5
+      "community": 3
     },
     {
       "label": "getDateRangeMilliseconds()",
@@ -4225,7 +4225,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/EnhancedAnalyticsView.tsx",
       "source_location": "L42",
       "id": "enhancedanalyticsview_getdaterangemilliseconds",
-      "community": 5
+      "community": 3
     },
     {
       "label": "RevenueChart.tsx",
@@ -4233,7 +4233,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/RevenueChart.tsx",
       "source_location": "L1",
       "id": "revenuechart",
-      "community": 5
+      "community": 3
     },
     {
       "label": "getTrendIcon()",
@@ -4249,7 +4249,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
       "source_location": "L1",
       "id": "storefrontobservabilitypanel",
-      "community": 0
+      "community": 3
     },
     {
       "label": "formatLabel()",
@@ -4257,7 +4257,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
       "source_location": "L15",
       "id": "storefrontobservabilitypanel_formatlabel",
-      "community": 0
+      "community": 3
     },
     {
       "label": "SummaryCard()",
@@ -4265,7 +4265,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
       "source_location": "L19",
       "id": "storefrontobservabilitypanel_summarycard",
-      "community": 0
+      "community": 3
     },
     {
       "label": "VisitorChart.tsx",
@@ -4273,7 +4273,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/VisitorChart.tsx",
       "source_location": "L1",
       "id": "visitorchart",
-      "community": 5
+      "community": 3
     },
     {
       "label": "formatHour()",
@@ -4281,7 +4281,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/VisitorChart.tsx",
       "source_location": "L18",
       "id": "visitorchart_formathour",
-      "community": 5
+      "community": 3
     },
     {
       "label": "analytics-columns.tsx",
@@ -4297,7 +4297,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-row-actions.tsx",
       "source_location": "L1",
       "id": "data_table_row_actions",
-      "community": 1
+      "community": 0
     },
     {
       "label": "DataTableRowActions()",
@@ -4305,7 +4305,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-row-actions.tsx",
       "source_location": "L25",
       "id": "data_table_row_actions_datatablerowactions",
-      "community": 1
+      "community": 0
     },
     {
       "label": "selectable-data-provider.tsx",
@@ -4313,7 +4313,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
       "source_location": "L1",
       "id": "selectable_data_provider",
-      "community": 0
+      "community": 8
     },
     {
       "label": "SelectedProductsProvider()",
@@ -4321,7 +4321,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
       "source_location": "L16",
       "id": "selectable_data_provider_selectedproductsprovider",
-      "community": 0
+      "community": 8
     },
     {
       "label": "useSelectedProducts()",
@@ -4329,7 +4329,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
       "source_location": "L37",
       "id": "selectable_data_provider_useselectedproducts",
-      "community": 0
+      "community": 8
     },
     {
       "label": "columns.tsx",
@@ -4337,7 +4337,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/columns.tsx",
       "source_location": "L1",
       "id": "columns",
-      "community": 0
+      "community": 3
     },
     {
       "label": "chart.tsx",
@@ -4345,7 +4345,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/chart.tsx",
       "source_location": "L1",
       "id": "chart",
-      "community": 5
+      "community": 3
     },
     {
       "label": "data.ts",
@@ -4353,7 +4353,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data.ts",
       "source_location": "L1",
       "id": "data",
-      "community": 13
+      "community": 0
     },
     {
       "label": "groupAnalytics()",
@@ -4361,7 +4361,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
       "source_location": "L3",
       "id": "utils_groupanalytics",
-      "community": 0
+      "community": 3
     },
     {
       "label": "countGroupedAnalytics()",
@@ -4369,7 +4369,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
       "source_location": "L52",
       "id": "utils_countgroupedanalytics",
-      "community": 0
+      "community": 3
     },
     {
       "label": "groupProductViewsByDay()",
@@ -4377,7 +4377,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
       "source_location": "L90",
       "id": "utils_groupproductviewsbyday",
-      "community": 0
+      "community": 3
     },
     {
       "label": "LogItems.tsx",
@@ -4385,7 +4385,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/LogItems.tsx",
       "source_location": "L1",
       "id": "logitems",
-      "community": 0
+      "community": 3
     },
     {
       "label": "LogItems()",
@@ -4393,7 +4393,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/LogItems.tsx",
       "source_location": "L6",
       "id": "logitems_logitems",
-      "community": 0
+      "community": 3
     },
     {
       "label": "LogView.tsx",
@@ -4417,7 +4417,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
       "source_location": "L1",
       "id": "logsview",
-      "community": 0
+      "community": 3
     },
     {
       "label": "Navigation()",
@@ -4425,7 +4425,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
       "source_location": "L27",
       "id": "logsview_navigation",
-      "community": 0
+      "community": 3
     },
     {
       "label": "log-items-provider.tsx",
@@ -4433,7 +4433,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
       "source_location": "L1",
       "id": "log_items_provider",
-      "community": 0
+      "community": 3
     },
     {
       "label": "LogItemsProvider()",
@@ -4441,7 +4441,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
       "source_location": "L15",
       "id": "log_items_provider_logitemsprovider",
-      "community": 0
+      "community": 3
     },
     {
       "label": "useLogItems()",
@@ -4449,7 +4449,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
       "source_location": "L39",
       "id": "log_items_provider_uselogitems",
-      "community": 0
+      "community": 3
     },
     {
       "label": "useLoadLogItems.ts",
@@ -4489,7 +4489,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
       "source_location": "L42",
       "id": "index_header",
-      "community": 10
+      "community": 11
     },
     {
       "label": "FeesView()",
@@ -4497,7 +4497,7 @@
       "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
       "source_location": "L29",
       "id": "index_feesview",
-      "community": 10
+      "community": 11
     },
     {
       "label": "Auth()",
@@ -4513,7 +4513,7 @@
       "source_file": "packages/storefront-webapp/src/components/DefaultCatchBoundary.tsx",
       "source_location": "L1",
       "id": "defaultcatchboundary",
-      "community": 11
+      "community": 10
     },
     {
       "label": "InputOTP.tsx",
@@ -4521,7 +4521,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
       "source_location": "L1",
       "id": "inputotp",
-      "community": 1
+      "community": 11
     },
     {
       "label": "handlePinChange()",
@@ -4529,7 +4529,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
       "source_location": "L48",
       "id": "inputotp_handlepinchange",
-      "community": 1
+      "community": 11
     },
     {
       "label": "onSubmit()",
@@ -4537,7 +4537,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
       "source_location": "L56",
       "id": "inputotp_onsubmit",
-      "community": 1
+      "community": 11
     },
     {
       "label": "LoginForm.tsx",
@@ -4545,7 +4545,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Login/LoginForm.tsx",
       "source_location": "L1",
       "id": "loginform",
-      "community": 1
+      "community": 0
     },
     {
       "label": "Login()",
@@ -4553,7 +4553,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Login/index.tsx",
       "source_location": "L5",
       "id": "index_login",
-      "community": 10
+      "community": 11
     },
     {
       "label": "BulkOperationsFilters.tsx",
@@ -4561,7 +4561,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsFilters.tsx",
       "source_location": "L1",
       "id": "bulkoperationsfilters",
-      "community": 0
+      "community": 5
     },
     {
       "label": "handleLoadProducts()",
@@ -4569,7 +4569,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsFilters.tsx",
       "source_location": "L49",
       "id": "bulkoperationsfilters_handleloadproducts",
-      "community": 0
+      "community": 5
     },
     {
       "label": "BulkOperationsPage.tsx",
@@ -4585,7 +4585,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.test.tsx",
       "source_location": "L1",
       "id": "bulkoperationspreview_test",
-      "community": 21
+      "community": 9
     },
     {
       "label": "makeRow()",
@@ -4593,7 +4593,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.test.tsx",
       "source_location": "L23",
       "id": "bulkoperationspreview_test_makerow",
-      "community": 21
+      "community": 9
     },
     {
       "label": "BulkOperationsPreview.tsx",
@@ -4601,7 +4601,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.tsx",
       "source_location": "L1",
       "id": "bulkoperationspreview",
-      "community": 0
+      "community": 9
     },
     {
       "label": "formatPrice()",
@@ -4609,7 +4609,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.tsx",
       "source_location": "L50",
       "id": "bulkoperationspreview_formatprice",
-      "community": 0
+      "community": 9
     },
     {
       "label": "CashierManagement.tsx",
@@ -4617,7 +4617,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L1",
       "id": "cashiermanagement",
-      "community": 12
+      "community": 9
     },
     {
       "label": "normalizeNameSegment()",
@@ -4625,7 +4625,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L42",
       "id": "cashiermanagement_normalizenamesegment",
-      "community": 12
+      "community": 9
     },
     {
       "label": "buildUsername()",
@@ -4633,7 +4633,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L50",
       "id": "cashiermanagement_buildusername",
-      "community": 12
+      "community": 9
     },
     {
       "label": "handleSubmit()",
@@ -4641,7 +4641,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L109",
       "id": "cashiermanagement_handlesubmit",
-      "community": 12
+      "community": 9
     },
     {
       "label": "handlePinKeyDown()",
@@ -4649,7 +4649,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L169",
       "id": "cashiermanagement_handlepinkeydown",
-      "community": 12
+      "community": 9
     },
     {
       "label": "handleDelete()",
@@ -4657,7 +4657,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L320",
       "id": "cashiermanagement_handledelete",
-      "community": 12
+      "community": 9
     },
     {
       "label": "CheckoutSessionsTable.tsx",
@@ -4729,7 +4729,7 @@
       "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
       "source_location": "L1",
       "id": "dashboard",
-      "community": 5
+      "community": 3
     },
     {
       "label": "getPeriodRange()",
@@ -4737,7 +4737,7 @@
       "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
       "source_location": "L20",
       "id": "dashboard_getperiodrange",
-      "community": 5
+      "community": 3
     },
     {
       "label": "LoadingSection()",
@@ -4745,7 +4745,7 @@
       "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
       "source_location": "L50",
       "id": "dashboard_loadingsection",
-      "community": 5
+      "community": 3
     },
     {
       "label": "renderSalesSection()",
@@ -4753,7 +4753,7 @@
       "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
       "source_location": "L322",
       "id": "dashboard_rendersalessection",
-      "community": 5
+      "community": 3
     },
     {
       "label": "renderProductsSection()",
@@ -4761,7 +4761,7 @@
       "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
       "source_location": "L342",
       "id": "dashboard_renderproductssection",
-      "community": 5
+      "community": 3
     },
     {
       "label": "MetricCard.tsx",
@@ -4769,7 +4769,7 @@
       "source_file": "packages/athena-webapp/src/components/dashboard/MetricCard.tsx",
       "source_location": "L1",
       "id": "metriccard",
-      "community": 5
+      "community": 3
     },
     {
       "label": "ExpenseCompletion.tsx",
@@ -4985,7 +4985,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L1",
       "id": "heroheaderimageuploader",
-      "community": 17
+      "community": 14
     },
     {
       "label": "validateFile()",
@@ -4993,7 +4993,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L50",
       "id": "heroheaderimageuploader_validatefile",
-      "community": 17
+      "community": 14
     },
     {
       "label": "uploadImage()",
@@ -5001,7 +5001,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L67",
       "id": "heroheaderimageuploader_uploadimage",
-      "community": 17
+      "community": 14
     },
     {
       "label": "resetEditState()",
@@ -5009,7 +5009,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L95",
       "id": "heroheaderimageuploader_reseteditstate",
-      "community": 17
+      "community": 14
     },
     {
       "label": "handleEditClick()",
@@ -5017,7 +5017,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L108",
       "id": "heroheaderimageuploader_handleeditclick",
-      "community": 17
+      "community": 14
     },
     {
       "label": "handleFileSelect()",
@@ -5025,7 +5025,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L113",
       "id": "heroheaderimageuploader_handlefileselect",
-      "community": 17
+      "community": 14
     },
     {
       "label": "handleUpload()",
@@ -5033,7 +5033,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L127",
       "id": "heroheaderimageuploader_handleupload",
-      "community": 17
+      "community": 14
     },
     {
       "label": "handleRevert()",
@@ -5041,7 +5041,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L163",
       "id": "heroheaderimageuploader_handlerevert",
-      "community": 17
+      "community": 14
     },
     {
       "label": "EditModeButtons()",
@@ -5049,7 +5049,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L179",
       "id": "heroheaderimageuploader_editmodebuttons",
-      "community": 17
+      "community": 14
     },
     {
       "label": "ViewModeButton()",
@@ -5057,7 +5057,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L205",
       "id": "heroheaderimageuploader_viewmodebutton",
-      "community": 17
+      "community": 14
     },
     {
       "label": "HeroSectionTabs.tsx",
@@ -5273,7 +5273,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
       "source_location": "L1",
       "id": "videoplayer",
-      "community": 16
+      "community": 1
     },
     {
       "label": "VideoPlayer()",
@@ -5281,7 +5281,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
       "source_location": "L9",
       "id": "videoplayer_videoplayer",
-      "community": 16
+      "community": 1
     },
     {
       "label": "JoinTeam()",
@@ -5289,7 +5289,7 @@
       "source_file": "packages/athena-webapp/src/components/join-team/index.tsx",
       "source_location": "L11",
       "id": "index_jointeam",
-      "community": 10
+      "community": 11
     },
     {
       "label": "ActivityView.tsx",
@@ -5465,7 +5465,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderStatus.tsx",
       "source_location": "L1",
       "id": "orderstatus",
-      "community": 0
+      "community": 3
     },
     {
       "label": "OrderSummary.tsx",
@@ -5473,7 +5473,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/OrderSummary.tsx",
       "source_location": "L1",
       "id": "ordersummary",
-      "community": 1
+      "community": 4
     },
     {
       "label": "OrderView.tsx",
@@ -5505,7 +5505,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/Orders.tsx",
       "source_location": "L1",
       "id": "orders",
-      "community": 0
+      "community": 3
     },
     {
       "label": "OrdersView.tsx",
@@ -5513,7 +5513,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
       "source_location": "L1",
       "id": "ordersview",
-      "community": 7
+      "community": 8
     },
     {
       "label": "getTimeFilter()",
@@ -5521,7 +5521,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
       "source_location": "L35",
       "id": "ordersview_gettimefilter",
-      "community": 7
+      "community": 8
     },
     {
       "label": "PickupDetailsView.tsx",
@@ -5585,7 +5585,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar.tsx",
       "source_location": "L34",
       "id": "data_table_toolbar_handleclearfilters",
-      "community": 13
+      "community": 0
     },
     {
       "label": "orderColumns.tsx",
@@ -5593,7 +5593,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/orderColumns.tsx",
       "source_location": "L1",
       "id": "ordercolumns",
-      "community": 0
+      "community": 3
     },
     {
       "label": "if()",
@@ -5601,7 +5601,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/orderColumns.tsx",
       "source_location": "L89",
       "id": "ordercolumns_if",
-      "community": 0
+      "community": 3
     },
     {
       "label": "refundUtils.ts",
@@ -5681,7 +5681,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
       "source_location": "L1",
       "id": "utils_getorderstate",
-      "community": 0
+      "community": 3
     },
     {
       "label": "getAmountPaidForOrder()",
@@ -5689,7 +5689,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
       "source_location": "L108",
       "id": "utils_getamountpaidfororder",
-      "community": 0
+      "community": 3
     },
     {
       "label": "onSubmit()",
@@ -5697,7 +5697,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
       "source_location": "L105",
       "id": "index_onsubmit",
-      "community": 10
+      "community": 11
     },
     {
       "label": "inviteColumns.tsx",
@@ -5705,7 +5705,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/inviteColumns.tsx",
       "source_location": "L1",
       "id": "invitecolumns",
-      "community": 0
+      "community": 3
     },
     {
       "label": "membersColumns.tsx",
@@ -5713,7 +5713,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/membersColumns.tsx",
       "source_location": "L1",
       "id": "memberscolumns",
-      "community": 0
+      "community": 3
     },
     {
       "label": "organization-switcher.tsx",
@@ -5721,7 +5721,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-switcher.tsx",
       "source_location": "L1",
       "id": "organization_switcher",
-      "community": 13
+      "community": 16
     },
     {
       "label": "onOrganizationSelect()",
@@ -5729,7 +5729,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-switcher.tsx",
       "source_location": "L94",
       "id": "organization_switcher_onorganizationselect",
-      "community": 13
+      "community": 16
     },
     {
       "label": "handleSignOut()",
@@ -5737,7 +5737,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-switcher.tsx",
       "source_location": "L99",
       "id": "organization_switcher_handlesignout",
-      "community": 13
+      "community": 16
     },
     {
       "label": "CartItems.tsx",
@@ -5753,7 +5753,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx",
       "source_location": "L1",
       "id": "cashierauthdialog",
-      "community": 12
+      "community": 0
     },
     {
       "label": "CashierView.tsx",
@@ -5897,7 +5897,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
       "source_location": "L128",
       "id": "ordersummary_handlecompletetransaction",
-      "community": 1
+      "community": 4
     },
     {
       "label": "handleSelectedPaymentMethod()",
@@ -5905,7 +5905,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
       "source_location": "L150",
       "id": "ordersummary_handleselectedpaymentmethod",
-      "community": 1
+      "community": 4
     },
     {
       "label": "handleNewTransaction()",
@@ -5913,7 +5913,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
       "source_location": "L162",
       "id": "ordersummary_handlenewtransaction",
-      "community": 1
+      "community": 4
     },
     {
       "label": "POSRegisterView.tsx",
@@ -6073,7 +6073,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
       "source_location": "L1",
       "id": "pininput",
-      "community": 12
+      "community": 3
     },
     {
       "label": "PinInput()",
@@ -6081,7 +6081,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
       "source_location": "L13",
       "id": "pininput_pininput",
-      "community": 12
+      "community": 3
     },
     {
       "label": "PointOfSaleView.tsx",
@@ -6153,7 +6153,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/ProductLookup.tsx",
       "source_location": "L1",
       "id": "productlookup",
-      "community": 1
+      "community": 4
     },
     {
       "label": "QuickActionsBar.tsx",
@@ -6177,7 +6177,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/RegisterActions.tsx",
       "source_location": "L1",
       "id": "registeractions",
-      "community": 0
+      "community": 4
     },
     {
       "label": "SearchResultsSection.tsx",
@@ -6193,7 +6193,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionDemo.tsx",
       "source_location": "L1",
       "id": "sessiondemo",
-      "community": 5
+      "community": 3
     },
     {
       "label": "SessionDemo()",
@@ -6201,7 +6201,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionDemo.tsx",
       "source_location": "L15",
       "id": "sessiondemo_sessiondemo",
-      "community": 5
+      "community": 3
     },
     {
       "label": "SessionManager.tsx",
@@ -6249,7 +6249,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.tsx",
       "source_location": "L1",
       "id": "totalsdisplay",
-      "community": 1
+      "community": 4
     },
     {
       "label": "TotalsDisplay()",
@@ -6257,7 +6257,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.tsx",
       "source_location": "L12",
       "id": "totalsdisplay_totalsdisplay",
-      "community": 1
+      "community": 4
     },
     {
       "label": "ExpenseReportView.tsx",
@@ -6337,7 +6337,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/HoldSessionDialog.tsx",
       "source_location": "L1",
       "id": "holdsessiondialog",
-      "community": 1
+      "community": 5
     },
     {
       "label": "HoldSessionDialog()",
@@ -6345,7 +6345,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/HoldSessionDialog.tsx",
       "source_location": "L19",
       "id": "holdsessiondialog_holdsessiondialog",
-      "community": 1
+      "community": 5
     },
     {
       "label": "VoidSessionDialog.tsx",
@@ -6353,7 +6353,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/VoidSessionDialog.tsx",
       "source_location": "L1",
       "id": "voidsessiondialog",
-      "community": 1
+      "community": 3
     },
     {
       "label": "VoidSessionDialog()",
@@ -6361,7 +6361,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/VoidSessionDialog.tsx",
       "source_location": "L19",
       "id": "voidsessiondialog_voidsessiondialog",
-      "community": 1
+      "community": 3
     },
     {
       "label": "POSSettingsView.tsx",
@@ -6369,7 +6369,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
       "source_location": "L1",
       "id": "possettingsview",
-      "community": 7
+      "community": 0
     },
     {
       "label": "loadFingerprint()",
@@ -6377,7 +6377,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
       "source_location": "L166",
       "id": "possettingsview_loadfingerprint",
-      "community": 7
+      "community": 0
     },
     {
       "label": "handleRegisterTerminal()",
@@ -6385,7 +6385,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
       "source_location": "L247",
       "id": "possettingsview_handleregisterterminal",
-      "community": 7
+      "community": 0
     },
     {
       "label": "handleUpdateExistingTerminal()",
@@ -6393,7 +6393,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
       "source_location": "L284",
       "id": "possettingsview_handleupdateexistingterminal",
-      "community": 7
+      "community": 0
     },
     {
       "label": "TransactionView.tsx",
@@ -6529,7 +6529,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ProductStatus.tsx",
       "source_location": "L1",
       "id": "productstatus",
-      "community": 0
+      "community": 3
     },
     {
       "label": "ProductStockStatus()",
@@ -6537,7 +6537,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
       "source_location": "L4",
       "id": "productstock_productstockstatus",
-      "community": 0
+      "community": 6
     },
     {
       "label": "OutOfStockStatus()",
@@ -6545,7 +6545,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
       "source_location": "L38",
       "id": "productstock_outofstockstatus",
-      "community": 0
+      "community": 6
     },
     {
       "label": "LowStockStatus()",
@@ -6553,7 +6553,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
       "source_location": "L47",
       "id": "productstock_lowstockstatus",
-      "community": 0
+      "community": 6
     },
     {
       "label": "SKUSelector.tsx",
@@ -6777,7 +6777,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/complimentaryProductsColumn.tsx",
       "source_location": "L1",
       "id": "complimentaryproductscolumn",
-      "community": 0
+      "community": 3
     },
     {
       "label": "add-product-command.tsx",
@@ -6817,7 +6817,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeForm.tsx",
       "source_location": "L1",
       "id": "promocodeform",
-      "community": 1
+      "community": 16
     },
     {
       "label": "toggleDiscountType()",
@@ -6825,7 +6825,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeForm.tsx",
       "source_location": "L84",
       "id": "promocodeform_togglediscounttype",
-      "community": 1
+      "community": 16
     },
     {
       "label": "PromoCodeHeader.tsx",
@@ -6857,7 +6857,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
       "source_location": "L1",
       "id": "promocodeview",
-      "community": 0
+      "community": 8
     },
     {
       "label": "handleAddPromoCode()",
@@ -6865,7 +6865,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
       "source_location": "L146",
       "id": "promocodeview_handleaddpromocode",
-      "community": 0
+      "community": 8
     },
     {
       "label": "handleUpdatePromoCode()",
@@ -6873,7 +6873,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
       "source_location": "L213",
       "id": "promocodeview_handleupdatepromocode",
-      "community": 0
+      "community": 8
     },
     {
       "label": "updateHomepageDiscountCode()",
@@ -6881,7 +6881,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
       "source_location": "L299",
       "id": "promocodeview_updatehomepagediscountcode",
-      "community": 0
+      "community": 8
     },
     {
       "label": "updateLeaveAReviewDiscountCode()",
@@ -6889,7 +6889,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
       "source_location": "L351",
       "id": "promocodeview_updateleaveareviewdiscountcode",
-      "community": 0
+      "community": 8
     },
     {
       "label": "promoCodes.ts",
@@ -6897,7 +6897,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L1",
       "id": "promocodes",
-      "community": 9
+      "community": 1
     },
     {
       "label": "PromoCodesView.tsx",
@@ -6921,7 +6921,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/SelectableCategories.tsx",
       "source_location": "L1",
       "id": "selectablecategories",
-      "community": 0
+      "community": 5
     },
     {
       "label": "toggle()",
@@ -6929,7 +6929,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/SelectableCategories.tsx",
       "source_location": "L23",
       "id": "selectablecategories_toggle",
-      "community": 0
+      "community": 5
     },
     {
       "label": "DiscountTypeToggleGroup.tsx",
@@ -6937,7 +6937,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/DiscountTypeToggleGroup.tsx",
       "source_location": "L1",
       "id": "discounttypetogglegroup",
-      "community": 1
+      "community": 16
     },
     {
       "label": "DiscountTypeToggleGroup()",
@@ -6945,7 +6945,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/DiscountTypeToggleGroup.tsx",
       "source_location": "L5",
       "id": "discounttypetogglegroup_discounttypetogglegroup",
-      "community": 1
+      "community": 16
     },
     {
       "label": "PromoCodeSpanToggleGroup.tsx",
@@ -6953,7 +6953,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/PromoCodeSpanToggleGroup.tsx",
       "source_location": "L1",
       "id": "promocodespantogglegroup",
-      "community": 1
+      "community": 16
     },
     {
       "label": "PromoCodeSpanToggleGroup()",
@@ -6961,7 +6961,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/PromoCodeSpanToggleGroup.tsx",
       "source_location": "L4",
       "id": "promocodespantogglegroup_promocodespantogglegroup",
-      "community": 1
+      "community": 16
     },
     {
       "label": "PromoCodeAnalytics.tsx",
@@ -6993,7 +6993,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/captured/captured-emails-columns.tsx",
       "source_location": "L1",
       "id": "captured_emails_columns",
-      "community": 0
+      "community": 3
     },
     {
       "label": "color-picker.tsx",
@@ -7001,7 +7001,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
       "source_location": "L1",
       "id": "color_picker",
-      "community": 13
+      "community": 16
     },
     {
       "label": "handleInputChange()",
@@ -7009,7 +7009,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
       "source_location": "L20",
       "id": "color_picker_handleinputchange",
-      "community": 13
+      "community": 16
     },
     {
       "label": "handleBlur()",
@@ -7017,7 +7017,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
       "source_location": "L24",
       "id": "color_picker_handleblur",
-      "community": 13
+      "community": 16
     },
     {
       "label": "promo-code-modal.tsx",
@@ -7025,7 +7025,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/promo-code-modal.tsx",
       "source_location": "L1",
       "id": "promo_code_modal",
-      "community": 1
+      "community": 14
     },
     {
       "label": "PromoCodeModal()",
@@ -7033,7 +7033,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/promo-code-modal.tsx",
       "source_location": "L29",
       "id": "promo_code_modal_promocodemodal",
-      "community": 1
+      "community": 14
     },
     {
       "label": "welcome-offer-modal.tsx",
@@ -7041,7 +7041,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L1",
       "id": "welcome_offer_modal",
-      "community": 17
+      "community": 14
     },
     {
       "label": "handleChange()",
@@ -7049,7 +7049,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L76",
       "id": "welcome_offer_modal_handlechange",
-      "community": 17
+      "community": 14
     },
     {
       "label": "handleNumberChange()",
@@ -7057,7 +7057,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L83",
       "id": "welcome_offer_modal_handlenumberchange",
-      "community": 17
+      "community": 14
     },
     {
       "label": "handleSwitchChange()",
@@ -7065,7 +7065,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L88",
       "id": "welcome_offer_modal_handleswitchchange",
-      "community": 17
+      "community": 14
     },
     {
       "label": "handleColorChange()",
@@ -7073,7 +7073,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L92",
       "id": "welcome_offer_modal_handlecolorchange",
-      "community": 17
+      "community": 14
     },
     {
       "label": "handleSelectChange()",
@@ -7081,7 +7081,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L96",
       "id": "welcome_offer_modal_handleselectchange",
-      "community": 17
+      "community": 14
     },
     {
       "label": "updateImages()",
@@ -7089,7 +7089,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L100",
       "id": "welcome_offer_modal_updateimages",
-      "community": 17
+      "community": 14
     },
     {
       "label": "handleSubmit()",
@@ -7097,7 +7097,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L104",
       "id": "welcome_offer_modal_handlesubmit",
-      "community": 17
+      "community": 14
     },
     {
       "label": "welcome-offer-card.tsx",
@@ -7113,7 +7113,7 @@
       "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
       "source_location": "L1",
       "id": "currency_provider",
-      "community": 13
+      "community": 16
     },
     {
       "label": "useStoreCurrency()",
@@ -7121,7 +7121,7 @@
       "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
       "source_location": "L17",
       "id": "currency_provider_usestorecurrency",
-      "community": 13
+      "community": 16
     },
     {
       "label": "CurrencyProvider()",
@@ -7129,7 +7129,7 @@
       "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
       "source_location": "L25",
       "id": "currency_provider_currencyprovider",
-      "community": 13
+      "community": 16
     },
     {
       "label": "RatingStars.tsx",
@@ -7137,7 +7137,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/RatingStars.tsx",
       "source_location": "L1",
       "id": "ratingstars",
-      "community": 10
+      "community": 11
     },
     {
       "label": "ReviewActions.tsx",
@@ -7145,7 +7145,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewActions.tsx",
       "source_location": "L1",
       "id": "reviewactions",
-      "community": 1
+      "community": 11
     },
     {
       "label": "ReviewActions()",
@@ -7153,7 +7153,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewActions.tsx",
       "source_location": "L20",
       "id": "reviewactions_reviewactions",
-      "community": 1
+      "community": 11
     },
     {
       "label": "ReviewCard.tsx",
@@ -7161,7 +7161,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewCard.tsx",
       "source_location": "L1",
       "id": "reviewcard",
-      "community": 10
+      "community": 11
     },
     {
       "label": "ReviewMetadata.tsx",
@@ -7169,7 +7169,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewMetadata.tsx",
       "source_location": "L1",
       "id": "reviewmetadata",
-      "community": 10
+      "community": 11
     },
     {
       "label": "ReviewsView.tsx",
@@ -7177,7 +7177,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L1",
       "id": "reviewsview",
-      "community": 10
+      "community": 11
     },
     {
       "label": "Header()",
@@ -7185,7 +7185,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L13",
       "id": "reviewsview_header",
-      "community": 10
+      "community": 11
     },
     {
       "label": "handleApprove()",
@@ -7193,7 +7193,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L42",
       "id": "reviewsview_handleapprove",
-      "community": 10
+      "community": 11
     },
     {
       "label": "handleReject()",
@@ -7201,7 +7201,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L58",
       "id": "reviewsview_handlereject",
-      "community": 10
+      "community": 11
     },
     {
       "label": "handlePublish()",
@@ -7209,7 +7209,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L74",
       "id": "reviewsview_handlepublish",
-      "community": 10
+      "community": 11
     },
     {
       "label": "handleUnpublish()",
@@ -7217,7 +7217,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L90",
       "id": "reviewsview_handleunpublish",
-      "community": 10
+      "community": 11
     },
     {
       "label": "empty-state.tsx",
@@ -7257,7 +7257,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/error/index.tsx",
       "source_location": "L9",
       "id": "index_errorpage",
-      "community": 10
+      "community": 11
     },
     {
       "label": "app-skeleton.tsx",
@@ -7329,7 +7329,7 @@
       "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermission.tsx",
       "source_location": "L1",
       "id": "nopermission",
-      "community": 7
+      "community": 8
     },
     {
       "label": "NoPermission()",
@@ -7337,7 +7337,7 @@
       "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermission.tsx",
       "source_location": "L3",
       "id": "nopermission_nopermission",
-      "community": 7
+      "community": 8
     },
     {
       "label": "NoPermissionView.tsx",
@@ -7345,7 +7345,7 @@
       "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermissionView.tsx",
       "source_location": "L1",
       "id": "nopermissionview",
-      "community": 7
+      "community": 8
     },
     {
       "label": "NoPermissionView()",
@@ -7353,7 +7353,7 @@
       "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermissionView.tsx",
       "source_location": "L4",
       "id": "nopermissionview_nopermissionview",
-      "community": 7
+      "community": 8
     },
     {
       "label": "NotFound.tsx",
@@ -7377,7 +7377,7 @@
       "source_file": "packages/athena-webapp/src/components/states/not-found/NotFoundView.tsx",
       "source_location": "L1",
       "id": "notfoundview",
-      "community": 7
+      "community": 8
     },
     {
       "label": "NotFoundView()",
@@ -7385,7 +7385,7 @@
       "source_file": "packages/athena-webapp/src/components/states/not-found/NotFoundView.tsx",
       "source_location": "L4",
       "id": "notfoundview_notfoundview",
-      "community": 7
+      "community": 8
     },
     {
       "label": "ContactView.tsx",
@@ -7433,7 +7433,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L1",
       "id": "fulfillmentview",
-      "community": 16
+      "community": 17
     },
     {
       "label": "saveEnableStorePickupChanges()",
@@ -7441,7 +7441,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L43",
       "id": "fulfillmentview_saveenablestorepickupchanges",
-      "community": 16
+      "community": 17
     },
     {
       "label": "saveEnableDeliveryChanges()",
@@ -7449,7 +7449,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L75",
       "id": "fulfillmentview_saveenabledeliverychanges",
-      "community": 16
+      "community": 17
     },
     {
       "label": "savePickupRestriction()",
@@ -7457,7 +7457,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L107",
       "id": "fulfillmentview_savepickuprestriction",
-      "community": 16
+      "community": 17
     },
     {
       "label": "saveDeliveryRestriction()",
@@ -7465,7 +7465,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L132",
       "id": "fulfillmentview_savedeliveryrestriction",
-      "community": 16
+      "community": 17
     },
     {
       "label": "handlePickupRestrictionToggle()",
@@ -7473,7 +7473,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L157",
       "id": "fulfillmentview_handlepickuprestrictiontoggle",
-      "community": 16
+      "community": 17
     },
     {
       "label": "handleDeliveryRestrictionToggle()",
@@ -7481,7 +7481,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L196",
       "id": "fulfillmentview_handledeliveryrestrictiontoggle",
-      "community": 16
+      "community": 17
     },
     {
       "label": "handleSavePickupRestriction()",
@@ -7489,7 +7489,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L235",
       "id": "fulfillmentview_handlesavepickuprestriction",
-      "community": 16
+      "community": 17
     },
     {
       "label": "handleSaveDeliveryRestriction()",
@@ -7497,7 +7497,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L244",
       "id": "fulfillmentview_handlesavedeliveryrestriction",
-      "community": 16
+      "community": 17
     },
     {
       "label": "Header.tsx",
@@ -7505,7 +7505,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
       "source_location": "L1",
       "id": "header",
-      "community": 10
+      "community": 11
     },
     {
       "label": "Header()",
@@ -7513,7 +7513,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
       "source_location": "L1",
       "id": "header_header",
-      "community": 10
+      "community": 11
     },
     {
       "label": "MaintenanceView.tsx",
@@ -7537,7 +7537,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.test.tsx",
       "source_location": "L1",
       "id": "mtnmomoview_test",
-      "community": 5
+      "community": 3
     },
     {
       "label": "MtnMomoView.tsx",
@@ -7545,7 +7545,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L1",
       "id": "mtnmomoview",
-      "community": 5
+      "community": 3
     },
     {
       "label": "cloneReceivingAccount()",
@@ -7553,7 +7553,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L27",
       "id": "mtnmomoview_clonereceivingaccount",
-      "community": 5
+      "community": 3
     },
     {
       "label": "createEmptyReceivingAccount()",
@@ -7561,7 +7561,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L35",
       "id": "mtnmomoview_createemptyreceivingaccount",
-      "community": 5
+      "community": 3
     },
     {
       "label": "trimToUndefined()",
@@ -7569,7 +7569,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L47",
       "id": "mtnmomoview_trimtoundefined",
-      "community": 5
+      "community": 3
     },
     {
       "label": "cleanUndefinedFields()",
@@ -7577,7 +7577,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L52",
       "id": "mtnmomoview_cleanundefinedfields",
-      "community": 5
+      "community": 3
     },
     {
       "label": "hasReceivingAccountDetails()",
@@ -7585,7 +7585,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L64",
       "id": "mtnmomoview_hasreceivingaccountdetails",
-      "community": 5
+      "community": 3
     },
     {
       "label": "normalizePrimaryAccounts()",
@@ -7593,7 +7593,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L77",
       "id": "mtnmomoview_normalizeprimaryaccounts",
-      "community": 5
+      "community": 3
     },
     {
       "label": "toPatchReceivingAccounts()",
@@ -7601,7 +7601,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L93",
       "id": "mtnmomoview_topatchreceivingaccounts",
-      "community": 5
+      "community": 3
     },
     {
       "label": "getStatusBadgeVariant()",
@@ -7609,7 +7609,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L114",
       "id": "mtnmomoview_getstatusbadgevariant",
-      "community": 5
+      "community": 3
     },
     {
       "label": "updateAccount()",
@@ -7617,7 +7617,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L141",
       "id": "mtnmomoview_updateaccount",
-      "community": 5
+      "community": 3
     },
     {
       "label": "handleAddAccount()",
@@ -7625,7 +7625,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L152",
       "id": "mtnmomoview_handleaddaccount",
-      "community": 5
+      "community": 3
     },
     {
       "label": "handleMakePrimary()",
@@ -7633,7 +7633,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L159",
       "id": "mtnmomoview_handlemakeprimary",
-      "community": 5
+      "community": 3
     },
     {
       "label": "handleRemoveAccount()",
@@ -7641,7 +7641,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L168",
       "id": "mtnmomoview_handleremoveaccount",
-      "community": 5
+      "community": 3
     },
     {
       "label": "handleSave()",
@@ -7649,7 +7649,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L188",
       "id": "mtnmomoview_handlesave",
-      "community": 5
+      "community": 3
     },
     {
       "label": "TaxView.tsx",
@@ -7689,7 +7689,7 @@
       "source_file": "packages/athena-webapp/src/components/store-switcher.tsx",
       "source_location": "L1",
       "id": "store_switcher",
-      "community": 13
+      "community": 16
     },
     {
       "label": "onStoreSelect()",
@@ -7697,7 +7697,7 @@
       "source_file": "packages/athena-webapp/src/components/store-switcher.tsx",
       "source_location": "L63",
       "id": "store_switcher_onstoreselect",
-      "community": 13
+      "community": 16
     },
     {
       "label": "accordion.tsx",
@@ -7713,7 +7713,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/app-context-menu.tsx",
       "source_location": "L1",
       "id": "app_context_menu",
-      "community": 17
+      "community": 14
     },
     {
       "label": "AppContextMenu()",
@@ -7721,7 +7721,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/app-context-menu.tsx",
       "source_location": "L20",
       "id": "app_context_menu_appcontextmenu",
-      "community": 17
+      "community": 14
     },
     {
       "label": "badge.tsx",
@@ -7729,7 +7729,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/badge.tsx",
       "source_location": "L1",
       "id": "badge",
-      "community": 0
+      "community": 3
     },
     {
       "label": "Badge()",
@@ -7737,7 +7737,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/badge.tsx",
       "source_location": "L30",
       "id": "badge_badge",
-      "community": 0
+      "community": 3
     },
     {
       "label": "button.test.tsx",
@@ -7745,7 +7745,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/button.test.tsx",
       "source_location": "L1",
       "id": "button_test",
-      "community": 1
+      "community": 0
     },
     {
       "label": "button.tsx",
@@ -7753,7 +7753,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/button.tsx",
       "source_location": "L1",
       "id": "button",
-      "community": 1
+      "community": 0
     },
     {
       "label": "calendar.test.tsx",
@@ -7761,7 +7761,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/calendar.test.tsx",
       "source_location": "L1",
       "id": "calendar_test",
-      "community": 1
+      "community": 16
     },
     {
       "label": "calendar.tsx",
@@ -7769,7 +7769,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/calendar.tsx",
       "source_location": "L1",
       "id": "calendar",
-      "community": 1
+      "community": 16
     },
     {
       "label": "card.tsx",
@@ -7777,7 +7777,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/card.tsx",
       "source_location": "L1",
       "id": "card",
-      "community": 5
+      "community": 3
     },
     {
       "label": "useChart()",
@@ -7785,7 +7785,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/chart.tsx",
       "source_location": "L25",
       "id": "chart_usechart",
-      "community": 5
+      "community": 3
     },
     {
       "label": "checkbox.tsx",
@@ -7793,7 +7793,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/checkbox.tsx",
       "source_location": "L1",
       "id": "checkbox",
-      "community": 0
+      "community": 5
     },
     {
       "label": "collapsible.tsx",
@@ -7817,7 +7817,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/context-menu.tsx",
       "source_location": "L1",
       "id": "context_menu",
-      "community": 17
+      "community": 14
     },
     {
       "label": "copy-button.tsx",
@@ -7857,7 +7857,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/date-time-picker.tsx",
       "source_location": "L1",
       "id": "date_time_picker",
-      "community": 1
+      "community": 16
     },
     {
       "label": "DateTimePicker()",
@@ -7865,7 +7865,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/date-time-picker.tsx",
       "source_location": "L21",
       "id": "date_time_picker_datetimepicker",
-      "community": 1
+      "community": 16
     },
     {
       "label": "dialog.tsx",
@@ -7873,7 +7873,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/dialog.tsx",
       "source_location": "L1",
       "id": "dialog",
-      "community": 1
+      "community": 3
     },
     {
       "label": "dropdown-menu.tsx",
@@ -7889,7 +7889,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/form.tsx",
       "source_location": "L1",
       "id": "form",
-      "community": 1
+      "community": 5
     },
     {
       "label": "icons.tsx",
@@ -7905,7 +7905,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1",
       "id": "image_uploader",
-      "community": 17
+      "community": 14
     },
     {
       "label": "onDrop()",
@@ -7913,7 +7913,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L20",
       "id": "image_uploader_ondrop",
-      "community": 17
+      "community": 14
     },
     {
       "label": "removeImage()",
@@ -7921,7 +7921,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L31",
       "id": "image_uploader_removeimage",
-      "community": 17
+      "community": 14
     },
     {
       "label": "unmarkForDeletion()",
@@ -7929,7 +7929,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L46",
       "id": "image_uploader_unmarkfordeletion",
-      "community": 17
+      "community": 14
     },
     {
       "label": "onDragEnd()",
@@ -7937,7 +7937,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L100",
       "id": "image_uploader_ondragend",
-      "community": 17
+      "community": 14
     },
     {
       "label": "input-otp.tsx",
@@ -7945,7 +7945,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/input-otp.tsx",
       "source_location": "L1",
       "id": "input_otp",
-      "community": 12
+      "community": 3
     },
     {
       "label": "input.tsx",
@@ -7953,7 +7953,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/input.tsx",
       "source_location": "L1",
       "id": "input",
-      "community": 1
+      "community": 5
     },
     {
       "label": "label.tsx",
@@ -7977,7 +7977,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/loading-button.tsx",
       "source_location": "L1",
       "id": "loading_button",
-      "community": 1
+      "community": 0
     },
     {
       "label": "LoadingButton()",
@@ -7985,7 +7985,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/loading-button.tsx",
       "source_location": "L9",
       "id": "loading_button_loadingbutton",
-      "community": 1
+      "community": 0
     },
     {
       "label": "modal.tsx",
@@ -7993,7 +7993,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modal.tsx",
       "source_location": "L1",
       "id": "modal",
-      "community": 1
+      "community": 5
     },
     {
       "label": "onChange()",
@@ -8001,7 +8001,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modal.tsx",
       "source_location": "L38",
       "id": "modal_onchange",
-      "community": 1
+      "community": 5
     },
     {
       "label": "action-modal.tsx",
@@ -8009,7 +8009,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/action-modal.tsx",
       "source_location": "L1",
       "id": "action_modal",
-      "community": 1
+      "community": 0
     },
     {
       "label": "alert-modal.tsx",
@@ -8017,7 +8017,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/alert-modal.tsx",
       "source_location": "L1",
       "id": "alert_modal",
-      "community": 1
+      "community": 0
     },
     {
       "label": "AlertModal()",
@@ -8025,7 +8025,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/alert-modal.tsx",
       "source_location": "L20",
       "id": "alert_modal_alertmodal",
-      "community": 1
+      "community": 0
     },
     {
       "label": "custom-modal-example.tsx",
@@ -8033,7 +8033,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
       "source_location": "L1",
       "id": "custom_modal_example",
-      "community": 25
+      "community": 14
     },
     {
       "label": "BasicModalExample()",
@@ -8041,7 +8041,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
       "source_location": "L7",
       "id": "custom_modal_example_basicmodalexample",
-      "community": 25
+      "community": 14
     },
     {
       "label": "CustomPositionModalExample()",
@@ -8049,7 +8049,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
       "source_location": "L44",
       "id": "custom_modal_example_custompositionmodalexample",
-      "community": 25
+      "community": 14
     },
     {
       "label": "CustomCloseButtonExample()",
@@ -8057,7 +8057,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
       "source_location": "L69",
       "id": "custom_modal_example_customclosebuttonexample",
-      "community": 25
+      "community": 14
     },
     {
       "label": "FullScreenModalExample()",
@@ -8065,7 +8065,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
       "source_location": "L103",
       "id": "custom_modal_example_fullscreenmodalexample",
-      "community": 25
+      "community": 14
     },
     {
       "label": "custom-modal.tsx",
@@ -8073,7 +8073,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
       "source_location": "L1",
       "id": "custom_modal",
-      "community": 1
+      "community": 14
     },
     {
       "label": "CustomModal()",
@@ -8081,7 +8081,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
       "source_location": "L25",
       "id": "custom_modal_custommodal",
-      "community": 1
+      "community": 14
     },
     {
       "label": "organization-modal.tsx",
@@ -8089,7 +8089,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/organization-modal.tsx",
       "source_location": "L1",
       "id": "organization_modal",
-      "community": 1
+      "community": 5
     },
     {
       "label": "onSubmit()",
@@ -8097,7 +8097,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/organization-modal.tsx",
       "source_location": "L49",
       "id": "organization_modal_onsubmit",
-      "community": 1
+      "community": 5
     },
     {
       "label": "overlay-modal.tsx",
@@ -8105,7 +8105,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/overlay-modal.tsx",
       "source_location": "L1",
       "id": "overlay_modal",
-      "community": 13
+      "community": 16
     },
     {
       "label": "OverlayModal()",
@@ -8113,7 +8113,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/overlay-modal.tsx",
       "source_location": "L12",
       "id": "overlay_modal_overlaymodal",
-      "community": 13
+      "community": 16
     },
     {
       "label": "store-modal.tsx",
@@ -8121,7 +8121,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/store-modal.tsx",
       "source_location": "L1",
       "id": "store_modal",
-      "community": 1
+      "community": 5
     },
     {
       "label": "onSubmit()",
@@ -8129,7 +8129,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/store-modal.tsx",
       "source_location": "L63",
       "id": "store_modal_onsubmit",
-      "community": 1
+      "community": 5
     },
     {
       "label": "welcome-back-modal-example.tsx",
@@ -8137,7 +8137,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal-example.tsx",
       "source_location": "L1",
       "id": "welcome_back_modal_example",
-      "community": 1
+      "community": 14
     },
     {
       "label": "WelcomeBackModalExample()",
@@ -8145,7 +8145,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal-example.tsx",
       "source_location": "L5",
       "id": "welcome_back_modal_example_welcomebackmodalexample",
-      "community": 1
+      "community": 14
     },
     {
       "label": "welcome-back-modal.tsx",
@@ -8153,7 +8153,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal.tsx",
       "source_location": "L1",
       "id": "welcome_back_modal",
-      "community": 1
+      "community": 14
     },
     {
       "label": "WelcomeBackModal()",
@@ -8161,7 +8161,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal.tsx",
       "source_location": "L12",
       "id": "welcome_back_modal_welcomebackmodal",
-      "community": 1
+      "community": 14
     },
     {
       "label": "popover.tsx",
@@ -8169,7 +8169,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/popover.tsx",
       "source_location": "L1",
       "id": "popover",
-      "community": 13
+      "community": 16
     },
     {
       "label": "radio-group.tsx",
@@ -8177,7 +8177,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/radio-group.tsx",
       "source_location": "L1",
       "id": "radio_group",
-      "community": 0
+      "community": 5
     },
     {
       "label": "scroll-area.tsx",
@@ -8193,7 +8193,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/select-native.tsx",
       "source_location": "L1",
       "id": "select_native",
-      "community": 0
+      "community": 3
     },
     {
       "label": "cn()",
@@ -8201,7 +8201,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/select-native.tsx",
       "source_location": "L15",
       "id": "select_native_cn",
-      "community": 0
+      "community": 3
     },
     {
       "label": "select.tsx",
@@ -8217,7 +8217,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/separator.tsx",
       "source_location": "L1",
       "id": "separator",
-      "community": 13
+      "community": 5
     },
     {
       "label": "sheet.tsx",
@@ -8233,7 +8233,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L1",
       "id": "sidebar",
-      "community": 13
+      "community": 5
     },
     {
       "label": "useSidebar()",
@@ -8241,7 +8241,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L45",
       "id": "sidebar_usesidebar",
-      "community": 13
+      "community": 5
     },
     {
       "label": "handleKeyDown()",
@@ -8249,7 +8249,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L105",
       "id": "sidebar_handlekeydown",
-      "community": 13
+      "community": 5
     },
     {
       "label": "cn()",
@@ -8257,7 +8257,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L147",
       "id": "sidebar_cn",
-      "community": 13
+      "community": 5
     },
     {
       "label": "handleOnHover()",
@@ -8265,7 +8265,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L224",
       "id": "sidebar_handleonhover",
-      "community": 13
+      "community": 5
     },
     {
       "label": "handleOnMouseLeave()",
@@ -8273,7 +8273,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L228",
       "id": "sidebar_handleonmouseleave",
-      "community": 13
+      "community": 5
     },
     {
       "label": "skeleton.tsx",
@@ -8337,7 +8337,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/table.tsx",
       "source_location": "L1",
       "id": "table",
-      "community": 0
+      "community": 9
     },
     {
       "label": "tabs.tsx",
@@ -8353,7 +8353,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/textarea.tsx",
       "source_location": "L1",
       "id": "textarea",
-      "community": 1
+      "community": 3
     },
     {
       "label": "timeline-item.tsx",
@@ -8377,7 +8377,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/toggle-group.tsx",
       "source_location": "L1",
       "id": "toggle_group",
-      "community": 0
+      "community": 16
     },
     {
       "label": "toggle.tsx",
@@ -8385,7 +8385,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/toggle.tsx",
       "source_location": "L1",
       "id": "toggle",
-      "community": 0
+      "community": 16
     },
     {
       "label": "tooltip.tsx",
@@ -8417,7 +8417,7 @@
       "source_file": "packages/athena-webapp/src/components/upload-button.tsx",
       "source_location": "L1",
       "id": "upload_button",
-      "community": 10
+      "community": 11
     },
     {
       "label": "BagItems.tsx",
@@ -8465,7 +8465,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
       "source_location": "L1",
       "id": "bags",
-      "community": 0
+      "community": 3
     },
     {
       "label": "Bags()",
@@ -8473,7 +8473,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
       "source_location": "L4",
       "id": "bags_bags",
-      "community": 0
+      "community": 3
     },
     {
       "label": "bag-columns.tsx",
@@ -8481,7 +8481,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bag-columns.tsx",
       "source_location": "L1",
       "id": "bag_columns",
-      "community": 0
+      "community": 3
     },
     {
       "label": "bags-table.tsx",
@@ -8489,7 +8489,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bags-table.tsx",
       "source_location": "L1",
       "id": "bags_table",
-      "community": 0
+      "community": 3
     },
     {
       "label": "ActivitySummaryCards.tsx",
@@ -8497,7 +8497,7 @@
       "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
       "source_location": "L1",
       "id": "activitysummarycards",
-      "community": 5
+      "community": 3
     },
     {
       "label": "SummaryCard()",
@@ -8505,7 +8505,7 @@
       "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
       "source_location": "L19",
       "id": "activitysummarycards_summarycard",
-      "community": 5
+      "community": 3
     },
     {
       "label": "ActivitySummaryCards()",
@@ -8513,7 +8513,7 @@
       "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
       "source_location": "L44",
       "id": "activitysummarycards_activitysummarycards",
-      "community": 5
+      "community": 3
     },
     {
       "label": "String()",
@@ -8521,7 +8521,7 @@
       "source_file": "packages/athena-webapp/src/components/users/CustomerBehaviorTimeline.tsx",
       "source_location": "L110",
       "id": "customerbehaviortimeline_string",
-      "community": 5
+      "community": 3
     },
     {
       "label": "LinkedAccounts.tsx",
@@ -8537,7 +8537,7 @@
       "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.test.tsx",
       "source_location": "L1",
       "id": "timelineeventcard_test",
-      "community": 5
+      "community": 3
     },
     {
       "label": "TimelineEventCard.tsx",
@@ -8545,7 +8545,7 @@
       "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
       "source_location": "L1",
       "id": "timelineeventcard",
-      "community": 5
+      "community": 3
     },
     {
       "label": "formatObservabilityLabel()",
@@ -8553,7 +8553,7 @@
       "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
       "source_location": "L139",
       "id": "timelineeventcard_formatobservabilitylabel",
-      "community": 5
+      "community": 3
     },
     {
       "label": "loadMore()",
@@ -8561,7 +8561,7 @@
       "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
       "source_location": "L175",
       "id": "timelineeventcard_loadmore",
-      "community": 5
+      "community": 3
     },
     {
       "label": "UserActivity.tsx",
@@ -8657,7 +8657,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserStatus.tsx",
       "source_location": "L1",
       "id": "userstatus",
-      "community": 0
+      "community": 3
     },
     {
       "label": "UserStatus()",
@@ -8665,7 +8665,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserStatus.tsx",
       "source_location": "L7",
       "id": "userstatus_userstatus",
-      "community": 0
+      "community": 3
     },
     {
       "label": "UserView.tsx",
@@ -8689,7 +8689,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/CustomerJourneyStage.tsx",
       "source_location": "L1",
       "id": "customerjourneystage",
-      "community": 5
+      "community": 3
     },
     {
       "label": "CustomerJourneyStageCard()",
@@ -8697,7 +8697,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/CustomerJourneyStage.tsx",
       "source_location": "L13",
       "id": "customerjourneystage_customerjourneystagecard",
-      "community": 5
+      "community": 3
     },
     {
       "label": "EngagementMetrics.tsx",
@@ -8705,7 +8705,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
       "source_location": "L1",
       "id": "engagementmetrics",
-      "community": 5
+      "community": 3
     },
     {
       "label": "formatLastActivity()",
@@ -8713,7 +8713,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
       "source_location": "L75",
       "id": "engagementmetrics_formatlastactivity",
-      "community": 5
+      "community": 3
     },
     {
       "label": "getDeviceIcon()",
@@ -8721,7 +8721,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
       "source_location": "L82",
       "id": "engagementmetrics_getdeviceicon",
-      "community": 5
+      "community": 3
     },
     {
       "label": "getDeviceLabel()",
@@ -8729,7 +8729,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
       "source_location": "L93",
       "id": "engagementmetrics_getdevicelabel",
-      "community": 5
+      "community": 3
     },
     {
       "label": "RiskIndicators.tsx",
@@ -8737,7 +8737,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
       "source_location": "L1",
       "id": "riskindicators",
-      "community": 5
+      "community": 3
     },
     {
       "label": "getRiskIcon()",
@@ -8745,7 +8745,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
       "source_location": "L15",
       "id": "riskindicators_getriskicon",
-      "community": 5
+      "community": 3
     },
     {
       "label": "getRiskStyles()",
@@ -8753,7 +8753,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
       "source_location": "L28",
       "id": "riskindicators_getriskstyles",
-      "community": 5
+      "community": 3
     },
     {
       "label": "RiskIndicators()",
@@ -8761,7 +8761,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
       "source_location": "L54",
       "id": "riskindicators_riskindicators",
-      "community": 5
+      "community": 3
     },
     {
       "label": "UserBehaviorInsights.tsx",
@@ -8769,7 +8769,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/UserBehaviorInsights.tsx",
       "source_location": "L1",
       "id": "userbehaviorinsights",
-      "community": 5
+      "community": 3
     },
     {
       "label": "OnlineOrderContext.tsx",
@@ -8801,7 +8801,7 @@
       "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
       "source_location": "L1",
       "id": "permissionscontext",
-      "community": 13
+      "community": 1
     },
     {
       "label": "PermissionsProvider()",
@@ -8809,7 +8809,7 @@
       "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
       "source_location": "L23",
       "id": "permissionscontext_permissionsprovider",
-      "community": 13
+      "community": 1
     },
     {
       "label": "usePermissionsContext()",
@@ -8817,7 +8817,7 @@
       "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
       "source_location": "L51",
       "id": "permissionscontext_usepermissionscontext",
-      "community": 13
+      "community": 1
     },
     {
       "label": "ProductContext.tsx",
@@ -8857,7 +8857,7 @@
       "source_file": "packages/athena-webapp/src/contexts/UserContext.tsx",
       "source_location": "L1",
       "id": "usercontext",
-      "community": 13
+      "community": 16
     },
     {
       "label": "UserProvider()",
@@ -8865,7 +8865,7 @@
       "source_file": "packages/athena-webapp/src/contexts/UserContext.tsx",
       "source_location": "L12",
       "id": "usercontext_userprovider",
-      "community": 13
+      "community": 16
     },
     {
       "label": "useUserContext()",
@@ -8873,7 +8873,7 @@
       "source_file": "packages/athena-webapp/src/contexts/UserContext.tsx",
       "source_location": "L37",
       "id": "usercontext_useusercontext",
-      "community": 13
+      "community": 16
     },
     {
       "label": "use-image-upload.ts",
@@ -8881,7 +8881,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-image-upload.ts",
       "source_location": "L1",
       "id": "use_image_upload",
-      "community": 10
+      "community": 11
     },
     {
       "label": "useImageUpload()",
@@ -8889,7 +8889,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-image-upload.ts",
       "source_location": "L7",
       "id": "use_image_upload_useimageupload",
-      "community": 10
+      "community": 11
     },
     {
       "label": "use-mobile.tsx",
@@ -8897,7 +8897,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
       "source_location": "L1",
       "id": "use_mobile",
-      "community": 13
+      "community": 5
     },
     {
       "label": "useIsMobile()",
@@ -8905,7 +8905,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
       "source_location": "L5",
       "id": "use_mobile_useismobile",
-      "community": 13
+      "community": 5
     },
     {
       "label": "use-navigate-back.ts",
@@ -8969,7 +8969,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-table-keyboard-pagination.ts",
       "source_location": "L1",
       "id": "use_table_keyboard_pagination",
-      "community": 0
+      "community": 3
     },
     {
       "label": "useTableKeyboardPagination()",
@@ -8977,7 +8977,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-table-keyboard-pagination.ts",
       "source_location": "L6",
       "id": "use_table_keyboard_pagination_usetablekeyboardpagination",
-      "community": 0
+      "community": 3
     },
     {
       "label": "useAuth.ts",
@@ -9001,7 +9001,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.test.ts",
       "source_location": "L1",
       "id": "usebulkoperations_test",
-      "community": 21
+      "community": 9
     },
     {
       "label": "makeSku()",
@@ -9009,7 +9009,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.test.ts",
       "source_location": "L168",
       "id": "usebulkoperations_test_makesku",
-      "community": 21
+      "community": 9
     },
     {
       "label": "useBulkOperations.ts",
@@ -9017,7 +9017,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L1",
       "id": "usebulkoperations",
-      "community": 21
+      "community": 9
     },
     {
       "label": "applyOperation()",
@@ -9025,7 +9025,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L56",
       "id": "usebulkoperations_applyoperation",
-      "community": 21
+      "community": 9
     },
     {
       "label": "calculatePriceWithFee()",
@@ -9033,7 +9033,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L87",
       "id": "usebulkoperations_calculatepricewithfee",
-      "community": 21
+      "community": 9
     },
     {
       "label": "computePreview()",
@@ -9041,7 +9041,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L101",
       "id": "usebulkoperations_computepreview",
-      "community": 21
+      "community": 9
     },
     {
       "label": "validateOperationValue()",
@@ -9049,7 +9049,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L139",
       "id": "usebulkoperations_validateoperationvalue",
-      "community": 21
+      "community": 9
     },
     {
       "label": "useBulkOperations()",
@@ -9057,7 +9057,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L158",
       "id": "usebulkoperations_usebulkoperations",
-      "community": 21
+      "community": 9
     },
     {
       "label": "useCartOperations.ts",
@@ -9377,7 +9377,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetTerminal.ts",
       "source_location": "L1",
       "id": "usegetterminal",
-      "community": 4
+      "community": 0
     },
     {
       "label": "useGetTerminal()",
@@ -9385,7 +9385,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetTerminal.ts",
       "source_location": "L6",
       "id": "usegetterminal_usegetterminal",
-      "community": 4
+      "community": 0
     },
     {
       "label": "useNewOrderNotification.ts",
@@ -9409,7 +9409,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useOrganizationModal.tsx",
       "source_location": "L1",
       "id": "useorganizationmodal",
-      "community": 13
+      "community": 16
     },
     {
       "label": "usePOSCustomers.ts",
@@ -9633,7 +9633,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
       "source_location": "L1",
       "id": "useprint",
-      "community": 27
+      "community": 4
     },
     {
       "label": "usePrint()",
@@ -9641,7 +9641,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
       "source_location": "L3",
       "id": "useprint_useprint",
-      "community": 27
+      "community": 4
     },
     {
       "label": "useProductSearchResults.ts",
@@ -9785,7 +9785,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L1",
       "id": "behaviorutils",
-      "community": 5
+      "community": 3
     },
     {
       "label": "getCustomerJourneyStage()",
@@ -9793,7 +9793,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L36",
       "id": "behaviorutils_getcustomerjourneystage",
-      "community": 5
+      "community": 3
     },
     {
       "label": "calculateRiskIndicators()",
@@ -9801,7 +9801,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L71",
       "id": "behaviorutils_calculateriskindicators",
-      "community": 5
+      "community": 3
     },
     {
       "label": "calculateEngagementMetrics()",
@@ -9809,7 +9809,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L173",
       "id": "behaviorutils_calculateengagementmetrics",
-      "community": 5
+      "community": 3
     },
     {
       "label": "getActivityPriority()",
@@ -9817,7 +9817,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L251",
       "id": "behaviorutils_getactivitypriority",
-      "community": 5
+      "community": 3
     },
     {
       "label": "getJourneyStageInfo()",
@@ -9825,7 +9825,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L277",
       "id": "behaviorutils_getjourneystageinfo",
-      "community": 5
+      "community": 3
     },
     {
       "label": "browserFingerprint.ts",
@@ -9833,7 +9833,7 @@
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
       "source_location": "L1",
       "id": "browserfingerprint",
-      "community": 7
+      "community": 26
     },
     {
       "label": "bufferToHex()",
@@ -9841,7 +9841,7 @@
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
       "source_location": "L18",
       "id": "browserfingerprint_buffertohex",
-      "community": 7
+      "community": 26
     },
     {
       "label": "collectBrowserInfo()",
@@ -9849,7 +9849,7 @@
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
       "source_location": "L23",
       "id": "browserfingerprint_collectbrowserinfo",
-      "community": 7
+      "community": 26
     },
     {
       "label": "hashFingerprintSource()",
@@ -9857,7 +9857,7 @@
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
       "source_location": "L45",
       "id": "browserfingerprint_hashfingerprintsource",
-      "community": 7
+      "community": 26
     },
     {
       "label": "generateBrowserFingerprint()",
@@ -9865,7 +9865,7 @@
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
       "source_location": "L65",
       "id": "browserfingerprint_generatebrowserfingerprint",
-      "community": 7
+      "community": 26
     },
     {
       "label": "customerObservabilityTimeline.ts",
@@ -9873,7 +9873,7 @@
       "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
       "source_location": "L1",
       "id": "customerobservabilitytimeline",
-      "community": 5
+      "community": 3
     },
     {
       "label": "formatObservabilityLabel()",
@@ -9881,7 +9881,7 @@
       "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
       "source_location": "L59",
       "id": "customerobservabilitytimeline_formatobservabilitylabel",
-      "community": 5
+      "community": 3
     },
     {
       "label": "getObservabilityStatusStyles()",
@@ -9889,7 +9889,7 @@
       "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
       "source_location": "L67",
       "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
-      "community": 5
+      "community": 3
     },
     {
       "label": "getDeviceIcon()",
@@ -9897,7 +9897,7 @@
       "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
       "source_location": "L114",
       "id": "customerobservabilitytimeline_getdeviceicon",
-      "community": 5
+      "community": 3
     },
     {
       "label": "ghanaRegions.ts",
@@ -9905,7 +9905,7 @@
       "source_file": "packages/storefront-webapp/src/lib/ghanaRegions.ts",
       "source_location": "L1",
       "id": "ghanaregions",
-      "community": 1
+      "community": 5
     },
     {
       "label": "imageUtils.test.ts",
@@ -9913,7 +9913,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
       "source_location": "L1",
       "id": "imageutils_test",
-      "community": 17
+      "community": 14
     },
     {
       "label": "constructor()",
@@ -9921,7 +9921,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
       "source_location": "L74",
       "id": "imageutils_test_constructor",
-      "community": 17
+      "community": 14
     },
     {
       "label": "arrayBuffer()",
@@ -9929,7 +9929,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
       "source_location": "L78",
       "id": "imageutils_test_arraybuffer",
-      "community": 17
+      "community": 14
     },
     {
       "label": "MockImage",
@@ -9937,7 +9937,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
       "source_location": "L103",
       "id": "imageutils_test_mockimage",
-      "community": 17
+      "community": 14
     },
     {
       "label": ".src()",
@@ -9945,7 +9945,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
       "source_location": "L109",
       "id": "imageutils_test_mockimage_src",
-      "community": 17
+      "community": 14
     },
     {
       "label": "imageUtils.ts",
@@ -9953,7 +9953,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
       "source_location": "L1",
       "id": "imageutils",
-      "community": 17
+      "community": 14
     },
     {
       "label": "getUploadImagesData()",
@@ -9961,7 +9961,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
       "source_location": "L4",
       "id": "imageutils_getuploadimagesdata",
-      "community": 17
+      "community": 14
     },
     {
       "label": "convertImagesToWebp()",
@@ -9969,7 +9969,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
       "source_location": "L26",
       "id": "imageutils_convertimagestowebp",
-      "community": 17
+      "community": 14
     },
     {
       "label": "convertToJpg()",
@@ -9977,7 +9977,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
       "source_location": "L38",
       "id": "imageutils_converttojpg",
-      "community": 17
+      "community": 14
     },
     {
       "label": "convertImagesToJpg()",
@@ -9985,7 +9985,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
       "source_location": "L75",
       "id": "imageutils_convertimagestojpg",
-      "community": 17
+      "community": 14
     },
     {
       "label": "logger.ts",
@@ -10065,7 +10065,7 @@
       "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.ts",
       "source_location": "L1",
       "id": "maintenanceutils",
-      "community": 16
+      "community": 17
     },
     {
       "label": "isInMaintenanceMode()",
@@ -10073,7 +10073,7 @@
       "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.ts",
       "source_location": "L7",
       "id": "maintenanceutils_isinmaintenancemode",
-      "community": 16
+      "community": 17
     },
     {
       "label": "navigationUtils.ts",
@@ -10393,7 +10393,7 @@
       "source_file": "packages/athena-webapp/src/lib/productUtils.test.ts",
       "source_location": "L1",
       "id": "productutils_test",
-      "community": 6
+      "community": 1
     },
     {
       "label": "productUtils.ts",
@@ -10401,7 +10401,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L1",
       "id": "productutils",
-      "community": 6
+      "community": 1
     },
     {
       "label": "getProductName()",
@@ -10409,7 +10409,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L18",
       "id": "productutils_getproductname",
-      "community": 6
+      "community": 1
     },
     {
       "label": "sortProduct()",
@@ -10417,7 +10417,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L66",
       "id": "productutils_sortproduct",
-      "community": 6
+      "community": 1
     },
     {
       "label": "pinHash.ts",
@@ -10425,7 +10425,7 @@
       "source_file": "packages/athena-webapp/src/lib/security/pinHash.ts",
       "source_location": "L1",
       "id": "pinhash",
-      "community": 12
+      "community": 9
     },
     {
       "label": "hashPin()",
@@ -10433,7 +10433,7 @@
       "source_file": "packages/athena-webapp/src/lib/security/pinHash.ts",
       "source_location": "L12",
       "id": "pinhash_hashpin",
-      "community": 12
+      "community": 9
     },
     {
       "label": "storeConfig.test.ts",
@@ -10441,7 +10441,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.test.ts",
       "source_location": "L1",
       "id": "storeconfig_test",
-      "community": 16
+      "community": 17
     },
     {
       "label": "storeConfig.ts",
@@ -10449,7 +10449,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L1",
       "id": "storeconfig",
-      "community": 16
+      "community": 17
     },
     {
       "label": "asRecord()",
@@ -10457,7 +10457,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L103",
       "id": "storeconfig_asrecord",
-      "community": 16
+      "community": 17
     },
     {
       "label": "asString()",
@@ -10465,7 +10465,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L111",
       "id": "storeconfig_asstring",
-      "community": 16
+      "community": 17
     },
     {
       "label": "asNumber()",
@@ -10473,7 +10473,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L114",
       "id": "storeconfig_asnumber",
-      "community": 16
+      "community": 17
     },
     {
       "label": "asBoolean()",
@@ -10481,7 +10481,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L117",
       "id": "storeconfig_asboolean",
-      "community": 16
+      "community": 17
     },
     {
       "label": "asOptionalArray()",
@@ -10489,7 +10489,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L132",
       "id": "storeconfig_asoptionalarray",
-      "community": 16
+      "community": 17
     },
     {
       "label": "firstDefined()",
@@ -10497,7 +10497,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L120",
       "id": "storeconfig_firstdefined",
-      "community": 16
+      "community": 17
     },
     {
       "label": "cleanUndefined()",
@@ -10505,7 +10505,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L143",
       "id": "storeconfig_cleanundefined",
-      "community": 16
+      "community": 17
     },
     {
       "label": "asMtnMomoSetupStatus()",
@@ -10513,7 +10513,7 @@
       "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L80",
       "id": "storeconfig_asmtnmomosetupstatus",
-      "community": 16
+      "community": 17
     },
     {
       "label": "hasMtnMomoReceivingAccountDetails()",
@@ -10521,7 +10521,7 @@
       "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L93",
       "id": "storeconfig_hasmtnmomoreceivingaccountdetails",
-      "community": 16
+      "community": 17
     },
     {
       "label": "mapMtnMomoReceivingAccount()",
@@ -10529,7 +10529,7 @@
       "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L106",
       "id": "storeconfig_mapmtnmomoreceivingaccount",
-      "community": 16
+      "community": 17
     },
     {
       "label": "normalizeMtnMomoReceivingAccounts()",
@@ -10537,7 +10537,7 @@
       "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L126",
       "id": "storeconfig_normalizemtnmomoreceivingaccounts",
-      "community": 16
+      "community": 17
     },
     {
       "label": "getRawConfig()",
@@ -10545,7 +10545,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L196",
       "id": "storeconfig_getrawconfig",
-      "community": 16
+      "community": 17
     },
     {
       "label": "mapStreamReel()",
@@ -10553,7 +10553,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L155",
       "id": "storeconfig_mapstreamreel",
-      "community": 16
+      "community": 17
     },
     {
       "label": "mapPromotion()",
@@ -10561,7 +10561,7 @@
       "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L172",
       "id": "storeconfig_mappromotion",
-      "community": 16
+      "community": 17
     },
     {
       "label": "normalizeWaiveDeliveryFees()",
@@ -10569,7 +10569,7 @@
       "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L177",
       "id": "storeconfig_normalizewaivedeliveryfees",
-      "community": 16
+      "community": 17
     },
     {
       "label": "getStoreConfigV2()",
@@ -10577,7 +10577,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L208",
       "id": "storeconfig_getstoreconfigv2",
-      "community": 16
+      "community": 17
     },
     {
       "label": "timelineUtils.ts",
@@ -10585,7 +10585,7 @@
       "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
       "source_location": "L1",
       "id": "timelineutils",
-      "community": 5
+      "community": 3
     },
     {
       "label": "enrichTimelineEvent()",
@@ -10593,7 +10593,7 @@
       "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
       "source_location": "L184",
       "id": "timelineutils_enrichtimelineevent",
-      "community": 5
+      "community": 3
     },
     {
       "label": "enrichTimelineEvents()",
@@ -10601,7 +10601,7 @@
       "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
       "source_location": "L200",
       "id": "timelineutils_enrichtimelineevents",
-      "community": 5
+      "community": 3
     },
     {
       "label": "groupEventsByTimeframe()",
@@ -10609,7 +10609,7 @@
       "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
       "source_location": "L206",
       "id": "timelineutils_groupeventsbytimeframe",
-      "community": 5
+      "community": 3
     },
     {
       "label": "getTimeRangeLabel()",
@@ -10617,7 +10617,7 @@
       "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
       "source_location": "L244",
       "id": "timelineutils_gettimerangelabel",
-      "community": 5
+      "community": 3
     },
     {
       "label": "utils.test.ts",
@@ -10625,7 +10625,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.test.ts",
       "source_location": "L1",
       "id": "utils_test",
-      "community": 0
+      "community": 3
     },
     {
       "label": "cn()",
@@ -10633,7 +10633,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L9",
       "id": "utils_cn",
-      "community": 0
+      "community": 3
     },
     {
       "label": "getErrorForField()",
@@ -10641,7 +10641,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L14",
       "id": "utils_geterrorforfield",
-      "community": 0
+      "community": 3
     },
     {
       "label": "capitalizeFirstLetter()",
@@ -10649,7 +10649,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L18",
       "id": "utils_capitalizefirstletter",
-      "community": 0
+      "community": 3
     },
     {
       "label": "slugToWords()",
@@ -10657,7 +10657,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L31",
       "id": "utils_slugtowords",
-      "community": 0
+      "community": 3
     },
     {
       "label": "snakeCaseToWords()",
@@ -10665,7 +10665,7 @@
       "source_file": "packages/athena-webapp/src/lib/utils.ts",
       "source_location": "L50",
       "id": "utils_snakecasetowords",
-      "community": 0
+      "community": 3
     },
     {
       "label": "getRelativeTime()",
@@ -10673,7 +10673,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L67",
       "id": "utils_getrelativetime",
-      "community": 0
+      "community": 3
     },
     {
       "label": "getTimeRemaining()",
@@ -10681,7 +10681,7 @@
       "source_file": "packages/athena-webapp/src/lib/utils.ts",
       "source_location": "L71",
       "id": "utils_gettimeremaining",
-      "community": 0
+      "community": 3
     },
     {
       "label": "formatUserId()",
@@ -10689,7 +10689,7 @@
       "source_file": "packages/athena-webapp/src/lib/utils.ts",
       "source_location": "L91",
       "id": "utils_formatuserid",
-      "community": 0
+      "community": 3
     },
     {
       "label": "main.tsx",
@@ -10697,7 +10697,7 @@
       "source_file": "packages/storefront-webapp/src/main.tsx",
       "source_location": "L1",
       "id": "main",
-      "community": 8
+      "community": 10
     },
     {
       "label": "App()",
@@ -10705,7 +10705,7 @@
       "source_file": "packages/storefront-webapp/src/main.tsx",
       "source_location": "L38",
       "id": "main_app",
-      "community": 8
+      "community": 10
     },
     {
       "label": "routeTree.gen.ts",
@@ -10713,7 +10713,7 @@
       "source_file": "packages/storefront-webapp/src/routeTree.gen.ts",
       "source_location": "L1",
       "id": "routetree_gen",
-      "community": 7
+      "community": 8
     },
     {
       "label": "__root.tsx",
@@ -10729,7 +10729,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/stores/$storeUrlSlug.tsx",
       "source_location": "L1",
       "id": "storeurlslug",
-      "community": 7
+      "community": 8
     },
     {
       "label": "assets.index.tsx",
@@ -10737,7 +10737,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/assets.index.tsx",
       "source_location": "L1",
       "id": "assets_index",
-      "community": 7
+      "community": 8
     },
     {
       "label": "bags.$bagId.tsx",
@@ -10745,7 +10745,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.$bagId.tsx",
       "source_location": "L1",
       "id": "bags_bagid",
-      "community": 7
+      "community": 8
     },
     {
       "label": "bags.index.tsx",
@@ -10753,7 +10753,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.index.tsx",
       "source_location": "L1",
       "id": "bags_index",
-      "community": 7
+      "community": 8
     },
     {
       "label": "checkout-sessions.index.tsx",
@@ -10761,7 +10761,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/checkout-sessions.index.tsx",
       "source_location": "L1",
       "id": "checkout_sessions_index",
-      "community": 7
+      "community": 8
     },
     {
       "label": "configuration.index.tsx",
@@ -10769,7 +10769,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/configuration.index.tsx",
       "source_location": "L1",
       "id": "configuration_index",
-      "community": 7
+      "community": 8
     },
     {
       "label": "dashboard.index.tsx",
@@ -10777,7 +10777,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/dashboard.index.tsx",
       "source_location": "L1",
       "id": "dashboard_index",
-      "community": 5
+      "community": 3
     },
     {
       "label": "StoreRootRedirect()",
@@ -10785,7 +10785,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/index.tsx",
       "source_location": "L13",
       "id": "index_storerootredirect",
-      "community": 10
+      "community": 11
     },
     {
       "label": "logs.$logId.tsx",
@@ -10793,7 +10793,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.$logId.tsx",
       "source_location": "L1",
       "id": "logs_logid",
-      "community": 7
+      "community": 8
     },
     {
       "label": "logs.index.tsx",
@@ -10801,7 +10801,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.index.tsx",
       "source_location": "L1",
       "id": "logs_index",
-      "community": 7
+      "community": 3
     },
     {
       "label": "members.index.tsx",
@@ -10809,7 +10809,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/members.index.tsx",
       "source_location": "L1",
       "id": "members_index",
-      "community": 7
+      "community": 8
     },
     {
       "label": "all.index.tsx",
@@ -10817,7 +10817,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/all.index.tsx",
       "source_location": "L1",
       "id": "all_index",
-      "community": 7
+      "community": 8
     },
     {
       "label": "cancelled.index.tsx",
@@ -10825,7 +10825,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/cancelled.index.tsx",
       "source_location": "L1",
       "id": "cancelled_index",
-      "community": 7
+      "community": 8
     },
     {
       "label": "completed.index.tsx",
@@ -10833,7 +10833,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/completed.index.tsx",
       "source_location": "L1",
       "id": "completed_index",
-      "community": 7
+      "community": 8
     },
     {
       "label": "open.index.tsx",
@@ -10841,7 +10841,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/open.index.tsx",
       "source_location": "L1",
       "id": "open_index",
-      "community": 7
+      "community": 8
     },
     {
       "label": "out-for-delivery.index.tsx",
@@ -10849,7 +10849,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/out-for-delivery.index.tsx",
       "source_location": "L1",
       "id": "out_for_delivery_index",
-      "community": 7
+      "community": 8
     },
     {
       "label": "ready.index.tsx",
@@ -10857,7 +10857,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/ready.index.tsx",
       "source_location": "L1",
       "id": "ready_index",
-      "community": 7
+      "community": 8
     },
     {
       "label": "refunded.index.tsx",
@@ -10865,7 +10865,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/refunded.index.tsx",
       "source_location": "L1",
       "id": "refunded_index",
-      "community": 7
+      "community": 8
     },
     {
       "label": "$reportId.tsx",
@@ -10873,7 +10873,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports/$reportId.tsx",
       "source_location": "L1",
       "id": "reportid",
-      "community": 7
+      "community": 8
     },
     {
       "label": "expense-reports.index.tsx",
@@ -10881,7 +10881,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports.index.tsx",
       "source_location": "L1",
       "id": "expense_reports_index",
-      "community": 7
+      "community": 8
     },
     {
       "label": "expense.index.tsx",
@@ -10889,7 +10889,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense.index.tsx",
       "source_location": "L1",
       "id": "expense_index",
-      "community": 7
+      "community": 8
     },
     {
       "label": "register.index.tsx",
@@ -10897,7 +10897,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/register.index.tsx",
       "source_location": "L1",
       "id": "register_index",
-      "community": 7
+      "community": 8
     },
     {
       "label": "settings.index.tsx",
@@ -10905,7 +10905,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/settings.index.tsx",
       "source_location": "L1",
       "id": "settings_index",
-      "community": 7
+      "community": 8
     },
     {
       "label": "$transactionId.tsx",
@@ -10913,7 +10913,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId.tsx",
       "source_location": "L1",
       "id": "transactionid",
-      "community": 7
+      "community": 8
     },
     {
       "label": "transactions.index.tsx",
@@ -10921,7 +10921,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions.index.tsx",
       "source_location": "L1",
       "id": "transactions_index",
-      "community": 7
+      "community": 8
     },
     {
       "label": "edit.tsx",
@@ -10929,7 +10929,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/edit.tsx",
       "source_location": "L1",
       "id": "edit",
-      "community": 7
+      "community": 8
     },
     {
       "label": "new.tsx",
@@ -10937,7 +10937,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/new.tsx",
       "source_location": "L1",
       "id": "new",
-      "community": 0
+      "community": 8
     },
     {
       "label": "unresolved.tsx",
@@ -10945,7 +10945,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/unresolved.tsx",
       "source_location": "L1",
       "id": "unresolved",
-      "community": 7
+      "community": 8
     },
     {
       "label": "$promoCodeSlug.tsx",
@@ -10953,7 +10953,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/$promoCodeSlug.tsx",
       "source_location": "L1",
       "id": "promocodeslug",
-      "community": 0
+      "community": 8
     },
     {
       "label": "new.index.tsx",
@@ -10961,7 +10961,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/new.index.tsx",
       "source_location": "L1",
       "id": "new_index",
-      "community": 10
+      "community": 11
     },
     {
       "label": "published.index.tsx",
@@ -10969,7 +10969,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/published.index.tsx",
       "source_location": "L1",
       "id": "published_index",
-      "community": 7
+      "community": 8
     },
     {
       "label": "RouteComponent()",
@@ -10977,7 +10977,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/published.index.tsx",
       "source_location": "L9",
       "id": "published_index_routecomponent",
-      "community": 7
+      "community": 8
     },
     {
       "label": "users.$userId.tsx",
@@ -10985,7 +10985,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/users.$userId.tsx",
       "source_location": "L1",
       "id": "users_userid",
-      "community": 7
+      "community": 8
     },
     {
       "label": "_authed.tsx",
@@ -10993,7 +10993,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed.tsx",
       "source_location": "L1",
       "id": "authed",
-      "community": 13
+      "community": 5
     },
     {
       "label": "AuthedComponent()",
@@ -11001,7 +11001,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed.tsx",
       "source_location": "L18",
       "id": "authed_authedcomponent",
-      "community": 13
+      "community": 5
     },
     {
       "label": "Layout()",
@@ -11009,7 +11009,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed.tsx",
       "source_location": "L38",
       "id": "authed_layout",
-      "community": 13
+      "community": 5
     },
     {
       "label": "Index()",
@@ -11017,7 +11017,7 @@
       "source_file": "packages/athena-webapp/src/routes/index.tsx",
       "source_location": "L13",
       "id": "index_index",
-      "community": 10
+      "community": 11
     },
     {
       "label": "join-team.index.tsx",
@@ -11025,7 +11025,7 @@
       "source_file": "packages/athena-webapp/src/routes/join-team.index.tsx",
       "source_location": "L1",
       "id": "join_team_index",
-      "community": 7
+      "community": 8
     },
     {
       "label": "_layout.index.tsx",
@@ -11033,7 +11033,7 @@
       "source_file": "packages/athena-webapp/src/routes/login/_layout.index.tsx",
       "source_location": "L1",
       "id": "layout_index",
-      "community": 7
+      "community": 5
     },
     {
       "label": "_layout.tsx",
@@ -11041,7 +11041,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout.tsx",
       "source_location": "L1",
       "id": "layout",
-      "community": 7
+      "community": 1
     },
     {
       "label": "LoginLayout()",
@@ -11049,7 +11049,7 @@
       "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
       "source_location": "L36",
       "id": "layout_loginlayout",
-      "community": 7
+      "community": 1
     },
     {
       "label": "OrganizationSettingsView.tsx",
@@ -11057,7 +11057,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L1",
       "id": "organizationsettingsview",
-      "community": 13
+      "community": 5
     },
     {
       "label": "OrganizationSettings()",
@@ -11065,7 +11065,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L24",
       "id": "organizationsettingsview_organizationsettings",
-      "community": 13
+      "community": 5
     },
     {
       "label": "saveStoreChanges()",
@@ -11073,7 +11073,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L71",
       "id": "organizationsettingsview_savestorechanges",
-      "community": 13
+      "community": 5
     },
     {
       "label": "onSubmit()",
@@ -11081,7 +11081,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L105",
       "id": "organizationsettingsview_onsubmit",
-      "community": 13
+      "community": 5
     },
     {
       "label": "handleDeleteStore()",
@@ -11089,7 +11089,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L156",
       "id": "organizationsettingsview_handledeletestore",
-      "community": 13
+      "community": 5
     },
     {
       "label": "Navigation()",
@@ -11097,7 +11097,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L198",
       "id": "organizationsettingsview_navigation",
-      "community": 13
+      "community": 5
     },
     {
       "label": "OrganizationsSettingsAccordion.tsx",
@@ -11121,7 +11121,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L1",
       "id": "storesettingsview",
-      "community": 7
+      "community": 8
     },
     {
       "label": "StoreSettings()",
@@ -11129,7 +11129,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L28",
       "id": "storesettingsview_storesettings",
-      "community": 7
+      "community": 8
     },
     {
       "label": "saveStoreChanges()",
@@ -11137,7 +11137,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L82",
       "id": "storesettingsview_savestorechanges",
-      "community": 7
+      "community": 8
     },
     {
       "label": "onSubmit()",
@@ -11145,7 +11145,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L116",
       "id": "storesettingsview_onsubmit",
-      "community": 7
+      "community": 8
     },
     {
       "label": "handleDeleteStore()",
@@ -11153,7 +11153,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L167",
       "id": "storesettingsview_handledeletestore",
-      "community": 7
+      "community": 8
     },
     {
       "label": "handleDeleteAllProductsInStore()",
@@ -11161,7 +11161,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L232",
       "id": "storesettingsview_handledeleteallproductsinstore",
-      "community": 7
+      "community": 8
     },
     {
       "label": "StoresSettingsAccordion.tsx",
@@ -11201,7 +11201,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L1",
       "id": "backend_test",
-      "community": 20
+      "community": 21
     },
     {
       "label": "validateInventory()",
@@ -11209,7 +11209,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L58",
       "id": "backend_test_validateinventory",
-      "community": 20
+      "community": 21
     },
     {
       "label": "generateTransactionNumber()",
@@ -11217,7 +11217,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L374",
       "id": "backend_test_generatetransactionnumber",
-      "community": 20
+      "community": 21
     },
     {
       "label": "createTransaction()",
@@ -11225,7 +11225,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L391",
       "id": "backend_test_createtransaction",
-      "community": 20
+      "community": 21
     },
     {
       "label": "updateInventory()",
@@ -11233,7 +11233,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L422",
       "id": "backend_test_updateinventory",
-      "community": 20
+      "community": 21
     },
     {
       "label": "createTransactionItems()",
@@ -11241,7 +11241,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L467",
       "id": "backend_test_createtransactionitems",
-      "community": 20
+      "community": 21
     },
     {
       "label": "validateSession()",
@@ -11249,7 +11249,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L553",
       "id": "backend_test_validatesession",
-      "community": 20
+      "community": 21
     },
     {
       "label": "validateSessionInventory()",
@@ -11257,7 +11257,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L593",
       "id": "backend_test_validatesessioninventory",
-      "community": 20
+      "community": 21
     },
     {
       "label": "completeSession()",
@@ -11265,7 +11265,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L629",
       "id": "backend_test_completesession",
-      "community": 20
+      "community": 21
     },
     {
       "label": "handleDatabaseError()",
@@ -11273,7 +11273,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L671",
       "id": "backend_test_handledatabaseerror",
-      "community": 20
+      "community": 21
     },
     {
       "label": "rollbackInventory()",
@@ -11281,7 +11281,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L692",
       "id": "backend_test_rollbackinventory",
-      "community": 20
+      "community": 21
     },
     {
       "label": "inventoryValidationLogic.test.ts",
@@ -11313,7 +11313,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L1",
       "id": "simple_test",
-      "community": 22
+      "community": 23
     },
     {
       "label": "generateTransactionNumber()",
@@ -11321,7 +11321,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L38",
       "id": "simple_test_generatetransactionnumber",
-      "community": 22
+      "community": 23
     },
     {
       "label": "validateInventory()",
@@ -11329,7 +11329,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L77",
       "id": "simple_test_validateinventory",
-      "community": 22
+      "community": 23
     },
     {
       "label": "validateInventoryWithAggregation()",
@@ -11337,7 +11337,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L130",
       "id": "simple_test_validateinventorywithaggregation",
-      "community": 22
+      "community": 23
     },
     {
       "label": "formatCurrency()",
@@ -11345,7 +11345,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L173",
       "id": "simple_test_formatcurrency",
-      "community": 22
+      "community": 23
     },
     {
       "label": "formatPaymentMethod()",
@@ -11353,7 +11353,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L201",
       "id": "simple_test_formatpaymentmethod",
-      "community": 22
+      "community": 23
     },
     {
       "label": "formatReceiptDate()",
@@ -11361,7 +11361,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L225",
       "id": "simple_test_formatreceiptdate",
-      "community": 22
+      "community": 23
     },
     {
       "label": "addToCart()",
@@ -11369,7 +11369,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L249",
       "id": "simple_test_addtocart",
-      "community": 22
+      "community": 23
     },
     {
       "label": "removeFromCart()",
@@ -11377,7 +11377,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L288",
       "id": "simple_test_removefromcart",
-      "community": 22
+      "community": 23
     },
     {
       "label": "updateQuantity()",
@@ -11385,7 +11385,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L311",
       "id": "simple_test_updatequantity",
-      "community": 22
+      "community": 23
     },
     {
       "label": "usePrint.test.ts",
@@ -11393,7 +11393,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/usePrint.test.ts",
       "source_location": "L1",
       "id": "useprint_test",
-      "community": 27
+      "community": 4
     },
     {
       "label": "formatNumber.ts",
@@ -11401,7 +11401,7 @@
       "source_file": "packages/athena-webapp/src/utils/formatNumber.ts",
       "source_location": "L1",
       "id": "formatnumber",
-      "community": 5
+      "community": 3
     },
     {
       "label": "formatNumber()",
@@ -11409,7 +11409,7 @@
       "source_file": "packages/athena-webapp/src/utils/formatNumber.ts",
       "source_location": "L1",
       "id": "formatnumber_formatnumber",
-      "community": 5
+      "community": 3
     },
     {
       "label": "hashPassword()",
@@ -11417,7 +11417,7 @@
       "source_file": "packages/storefront-webapp/src/utils/index.ts",
       "source_location": "L1",
       "id": "index_hashpassword",
-      "community": 10
+      "community": 11
     },
     {
       "label": "session.ts",
@@ -11441,7 +11441,7 @@
       "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
       "source_location": "L1",
       "id": "versionchecker",
-      "community": 8
+      "community": 10
     },
     {
       "label": "createVersionChecker()",
@@ -11449,7 +11449,7 @@
       "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
       "source_location": "L16",
       "id": "versionchecker_createversionchecker",
-      "community": 8
+      "community": 10
     },
     {
       "label": "tailwind.config.js",
@@ -11465,7 +11465,7 @@
       "source_file": "packages/storefront-webapp/vite.config.ts",
       "source_location": "L1",
       "id": "vite_config",
-      "community": 9
+      "community": 2
     },
     {
       "label": "manualChunks()",
@@ -11473,15 +11473,15 @@
       "source_file": "packages/storefront-webapp/vite.config.ts",
       "source_location": "L19",
       "id": "vite_config_manualchunks",
-      "community": 9
+      "community": 2
     },
     {
       "label": "vitest.config.ts",
       "file_type": "code",
-      "source_file": "packages/symphony-service/vitest.config.ts",
+      "source_file": "packages/storefront-webapp/vitest.config.ts",
       "source_location": "L1",
       "id": "vitest_config",
-      "community": 9
+      "community": 2
     },
     {
       "label": "vitest.setup.ts",
@@ -11513,7 +11513,7 @@
       "source_file": "packages/storefront-webapp/src/api/analytics.ts",
       "source_location": "L3",
       "id": "analytics_postanalytics",
-      "community": 6
+      "community": 15
     },
     {
       "label": "updateAnalyticsOwner()",
@@ -11521,7 +11521,7 @@
       "source_file": "packages/storefront-webapp/src/api/analytics.ts",
       "source_location": "L32",
       "id": "analytics_updateanalyticsowner",
-      "community": 6
+      "community": 15
     },
     {
       "label": "logout()",
@@ -11529,7 +11529,7 @@
       "source_file": "packages/storefront-webapp/src/api/analytics.ts",
       "source_location": "L60",
       "id": "analytics_logout",
-      "community": 6
+      "community": 15
     },
     {
       "label": "getProductViewCount()",
@@ -11537,7 +11537,7 @@
       "source_file": "packages/storefront-webapp/src/api/analytics.ts",
       "source_location": "L78",
       "id": "analytics_getproductviewcount",
-      "community": 6
+      "community": 15
     },
     {
       "label": "verifyUserAccount()",
@@ -11561,7 +11561,7 @@
       "source_file": "packages/storefront-webapp/src/api/bag.ts",
       "source_location": "L10",
       "id": "bag_getbaseurl",
-      "community": 12
+      "community": 7
     },
     {
       "label": "getActiveBag()",
@@ -11569,7 +11569,7 @@
       "source_file": "packages/storefront-webapp/src/api/bag.ts",
       "source_location": "L12",
       "id": "bag_getactivebag",
-      "community": 12
+      "community": 7
     },
     {
       "label": "addItemToBag()",
@@ -11577,7 +11577,7 @@
       "source_file": "packages/storefront-webapp/src/api/bag.ts",
       "source_location": "L27",
       "id": "bag_additemtobag",
-      "community": 12
+      "community": 7
     },
     {
       "label": "updateBagItem()",
@@ -11585,7 +11585,7 @@
       "source_file": "packages/storefront-webapp/src/api/bag.ts",
       "source_location": "L63",
       "id": "bag_updatebagitem",
-      "community": 12
+      "community": 7
     },
     {
       "label": "removeItemFromBag()",
@@ -11593,7 +11593,7 @@
       "source_file": "packages/storefront-webapp/src/api/bag.ts",
       "source_location": "L90",
       "id": "bag_removeitemfrombag",
-      "community": 12
+      "community": 7
     },
     {
       "label": "clearBag()",
@@ -11601,7 +11601,7 @@
       "source_file": "packages/storefront-webapp/src/api/bag.ts",
       "source_location": "L106",
       "id": "bag_clearbag",
-      "community": 12
+      "community": 7
     },
     {
       "label": "updateBagOwner()",
@@ -11609,7 +11609,7 @@
       "source_file": "packages/storefront-webapp/src/api/bag.ts",
       "source_location": "L118",
       "id": "bag_updatebagowner",
-      "community": 12
+      "community": 7
     },
     {
       "label": "getBannerMessage()",
@@ -11657,7 +11657,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.test.ts",
       "source_location": "L1",
       "id": "checkoutsession_test",
-      "community": 11
+      "community": 10
     },
     {
       "label": "jsonResponse()",
@@ -11665,7 +11665,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.test.ts",
       "source_location": "L27",
       "id": "checkoutsession_test_jsonresponse",
-      "community": 11
+      "community": 10
     },
     {
       "label": "getBaseUrl()",
@@ -11673,7 +11673,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L5",
       "id": "checkoutsession_getbaseurl",
-      "community": 11
+      "community": 10
     },
     {
       "label": "CheckoutSessionError",
@@ -11681,7 +11681,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L64",
       "id": "checkoutsession_checkoutsessionerror",
-      "community": 11
+      "community": 10
     },
     {
       "label": ".constructor()",
@@ -11689,7 +11689,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L69",
       "id": "checkoutsession_checkoutsessionerror_constructor",
-      "community": 11
+      "community": 10
     },
     {
       "label": "isRecord()",
@@ -11697,7 +11697,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L78",
       "id": "checkoutsession_isrecord",
-      "community": 11
+      "community": 10
     },
     {
       "label": "parseJson()",
@@ -11705,7 +11705,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L81",
       "id": "checkoutsession_parsejson",
-      "community": 11
+      "community": 10
     },
     {
       "label": "getCheckoutErrorMessageFromPayload()",
@@ -11713,7 +11713,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L98",
       "id": "checkoutsession_getcheckouterrormessagefrompayload",
-      "community": 11
+      "community": 10
     },
     {
       "label": "parseCheckoutResponse()",
@@ -11721,7 +11721,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L115",
       "id": "checkoutsession_parsecheckoutresponse",
-      "community": 11
+      "community": 10
     },
     {
       "label": "defaultCheckoutActionMessage()",
@@ -11729,7 +11729,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L135",
       "id": "checkoutsession_defaultcheckoutactionmessage",
-      "community": 11
+      "community": 10
     },
     {
       "label": "getCheckoutActionErrorMessage()",
@@ -11737,7 +11737,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L147",
       "id": "checkoutsession_getcheckoutactionerrormessage",
-      "community": 11
+      "community": 10
     },
     {
       "label": "createCheckoutSession()",
@@ -11745,7 +11745,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L184",
       "id": "checkoutsession_createcheckoutsession",
-      "community": 11
+      "community": 10
     },
     {
       "label": "getActiveCheckoutSession()",
@@ -11753,7 +11753,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L204",
       "id": "checkoutsession_getactivecheckoutsession",
-      "community": 11
+      "community": 10
     },
     {
       "label": "getPendingCheckoutSessions()",
@@ -11761,7 +11761,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L215",
       "id": "checkoutsession_getpendingcheckoutsessions",
-      "community": 11
+      "community": 10
     },
     {
       "label": "getCheckoutSession()",
@@ -11769,7 +11769,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L226",
       "id": "checkoutsession_getcheckoutsession",
-      "community": 11
+      "community": 10
     },
     {
       "label": "updateCheckoutSession()",
@@ -11777,7 +11777,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L239",
       "id": "checkoutsession_updatecheckoutsession",
-      "community": 11
+      "community": 10
     },
     {
       "label": "verifyCheckoutSessionPayment()",
@@ -11785,7 +11785,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L274",
       "id": "checkoutsession_verifycheckoutsessionpayment",
-      "community": 11
+      "community": 10
     },
     {
       "label": "getBaseUrl()",
@@ -11793,7 +11793,7 @@
       "source_file": "packages/storefront-webapp/src/api/color.ts",
       "source_location": "L5",
       "id": "color_getbaseurl",
-      "community": 9
+      "community": 15
     },
     {
       "label": "getAllColors()",
@@ -11801,7 +11801,7 @@
       "source_file": "packages/storefront-webapp/src/api/color.ts",
       "source_location": "L7",
       "id": "color_getallcolors",
-      "community": 9
+      "community": 15
     },
     {
       "label": "updateGuest()",
@@ -11817,7 +11817,7 @@
       "source_file": "packages/storefront-webapp/src/api/offers.ts",
       "source_location": "L13",
       "id": "offers_getbaseurl",
-      "community": 9
+      "community": 2
     },
     {
       "label": "submitOffer()",
@@ -11825,7 +11825,7 @@
       "source_file": "packages/storefront-webapp/src/api/offers.ts",
       "source_location": "L21",
       "id": "offers_submitoffer",
-      "community": 9
+      "community": 2
     },
     {
       "label": "getUserRedeemedOffers()",
@@ -11833,7 +11833,7 @@
       "source_file": "packages/storefront-webapp/src/api/offers.ts",
       "source_location": "L46",
       "id": "offers_getuserredeemedoffers",
-      "community": 9
+      "community": 2
     },
     {
       "label": "getBaseUrl()",
@@ -11873,7 +11873,7 @@
       "source_file": "packages/storefront-webapp/src/api/organization.ts",
       "source_location": "L6",
       "id": "organization_getallorganizations",
-      "community": 9
+      "community": 2
     },
     {
       "label": "getOrganization()",
@@ -11881,7 +11881,7 @@
       "source_file": "packages/storefront-webapp/src/api/organization.ts",
       "source_location": "L18",
       "id": "organization_getorganization",
-      "community": 9
+      "community": 2
     },
     {
       "label": "buildQueryString()",
@@ -11889,7 +11889,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L5",
       "id": "product_buildquerystring",
-      "community": 9
+      "community": 15
     },
     {
       "label": "getBaseUrl()",
@@ -11897,7 +11897,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L18",
       "id": "product_getbaseurl",
-      "community": 9
+      "community": 15
     },
     {
       "label": "getAllProducts()",
@@ -11905,7 +11905,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L20",
       "id": "product_getallproducts",
-      "community": 9
+      "community": 15
     },
     {
       "label": "getProduct()",
@@ -11913,7 +11913,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L40",
       "id": "product_getproduct",
-      "community": 9
+      "community": 15
     },
     {
       "label": "getBestSellers()",
@@ -11921,7 +11921,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L59",
       "id": "product_getbestsellers",
-      "community": 9
+      "community": 15
     },
     {
       "label": "getFeatured()",
@@ -11929,7 +11929,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L73",
       "id": "product_getfeatured",
-      "community": 9
+      "community": 15
     },
     {
       "label": "getInventoryBySkuIds()",
@@ -11937,7 +11937,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L93",
       "id": "product_getinventorybyskuids",
-      "community": 9
+      "community": 15
     },
     {
       "label": "getBaseUrl()",
@@ -11945,7 +11945,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L4",
       "id": "promocodes_getbaseurl",
-      "community": 9
+      "community": 1
     },
     {
       "label": "redeemPromoCode()",
@@ -11953,7 +11953,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L6",
       "id": "promocodes_redeempromocode",
-      "community": 9
+      "community": 1
     },
     {
       "label": "getPromoCodes()",
@@ -11961,7 +11961,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L34",
       "id": "promocodes_getpromocodes",
-      "community": 9
+      "community": 1
     },
     {
       "label": "getPromoCodeItems()",
@@ -11969,7 +11969,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L49",
       "id": "promocodes_getpromocodeitems",
-      "community": 9
+      "community": 1
     },
     {
       "label": "getRedeemedPromoCodes()",
@@ -11977,7 +11977,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L74",
       "id": "promocodes_getredeemedpromocodes",
-      "community": 9
+      "community": 1
     },
     {
       "label": "getBaseUrl()",
@@ -12081,7 +12081,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L3",
       "id": "rewards_getbaseurl",
-      "community": 12
+      "community": 19
     },
     {
       "label": "getUserPoints()",
@@ -12089,7 +12089,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L54",
       "id": "rewards_getuserpoints",
-      "community": 12
+      "community": 19
     },
     {
       "label": "getPointHistory()",
@@ -12097,7 +12097,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L71",
       "id": "rewards_getpointhistory",
-      "community": 12
+      "community": 19
     },
     {
       "label": "getRewardTiers()",
@@ -12105,7 +12105,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L90",
       "id": "rewards_getrewardtiers",
-      "community": 12
+      "community": 19
     },
     {
       "label": "redeemRewardPoints()",
@@ -12113,7 +12113,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L107",
       "id": "rewards_redeemrewardpoints",
-      "community": 12
+      "community": 19
     },
     {
       "label": "getEligiblePastOrders()",
@@ -12121,7 +12121,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L129",
       "id": "rewards_geteligiblepastorders",
-      "community": 12
+      "community": 19
     },
     {
       "label": "awardPointsForPastOrder()",
@@ -12129,7 +12129,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L151",
       "id": "rewards_awardpointsforpastorder",
-      "community": 12
+      "community": 19
     },
     {
       "label": "getOrderRewardPoints()",
@@ -12137,7 +12137,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L175",
       "id": "rewards_getorderrewardpoints",
-      "community": 12
+      "community": 19
     },
     {
       "label": "awardPointsForGuestOrders()",
@@ -12145,7 +12145,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L198",
       "id": "rewards_awardpointsforguestorders",
-      "community": 12
+      "community": 19
     },
     {
       "label": "getBaseUrl()",
@@ -12153,7 +12153,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L8",
       "id": "savedbag_getbaseurl",
-      "community": 12
+      "community": 7
     },
     {
       "label": "getActiveSavedBag()",
@@ -12161,7 +12161,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L10",
       "id": "savedbag_getactivesavedbag",
-      "community": 12
+      "community": 7
     },
     {
       "label": "addItemToSavedBag()",
@@ -12169,7 +12169,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L25",
       "id": "savedbag_additemtosavedbag",
-      "community": 12
+      "community": 7
     },
     {
       "label": "updateSavedBagItem()",
@@ -12177,7 +12177,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L61",
       "id": "savedbag_updatesavedbagitem",
-      "community": 12
+      "community": 7
     },
     {
       "label": "removeItemFromSavedBag()",
@@ -12185,7 +12185,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L91",
       "id": "savedbag_removeitemfromsavedbag",
-      "community": 12
+      "community": 7
     },
     {
       "label": "updateSavedBagOwner()",
@@ -12193,7 +12193,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L109",
       "id": "savedbag_updatesavedbagowner",
-      "community": 12
+      "community": 7
     },
     {
       "label": "getBaseUrl()",
@@ -12201,7 +12201,7 @@
       "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
       "source_location": "L5",
       "id": "storefrontuser_getbaseurl",
-      "community": 1
+      "community": 5
     },
     {
       "label": "getGuest()",
@@ -12209,7 +12209,7 @@
       "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
       "source_location": "L7",
       "id": "storefrontuser_getguest",
-      "community": 1
+      "community": 5
     },
     {
       "label": "getActiveUser()",
@@ -12217,7 +12217,7 @@
       "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
       "source_location": "L28",
       "id": "storefrontuser_getactiveuser",
-      "community": 1
+      "community": 5
     },
     {
       "label": "updateUser()",
@@ -12225,7 +12225,7 @@
       "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
       "source_location": "L46",
       "id": "storefrontuser_updateuser",
-      "community": 1
+      "community": 5
     },
     {
       "label": "getStore()",
@@ -12241,7 +12241,7 @@
       "source_file": "packages/storefront-webapp/src/api/stores.ts",
       "source_location": "L5",
       "id": "stores_getbaseurl",
-      "community": 15
+      "community": 2
     },
     {
       "label": "getAllStores()",
@@ -12249,7 +12249,7 @@
       "source_file": "packages/storefront-webapp/src/api/stores.ts",
       "source_location": "L8",
       "id": "stores_getallstores",
-      "community": 15
+      "community": 2
     },
     {
       "label": "getStore()",
@@ -12257,7 +12257,7 @@
       "source_file": "packages/storefront-webapp/src/api/stores.ts",
       "source_location": "L20",
       "id": "stores_getstore",
-      "community": 15
+      "community": 2
     },
     {
       "label": "getBaseUrl()",
@@ -12265,7 +12265,7 @@
       "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
       "source_location": "L9",
       "id": "subcategory_getbaseurl",
-      "community": 9
+      "community": 2
     },
     {
       "label": "getAllSubcategories()",
@@ -12273,7 +12273,7 @@
       "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
       "source_location": "L11",
       "id": "subcategory_getallsubcategories",
-      "community": 9
+      "community": 2
     },
     {
       "label": "getSubategory()",
@@ -12281,7 +12281,7 @@
       "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
       "source_location": "L25",
       "id": "subcategory_getsubategory",
-      "community": 9
+      "community": 2
     },
     {
       "label": "getBaseUrl()",
@@ -12305,7 +12305,7 @@
       "source_file": "packages/storefront-webapp/src/api/userOffers.ts",
       "source_location": "L18",
       "id": "useroffers_getbaseurl",
-      "community": 9
+      "community": 2
     },
     {
       "label": "getUserOffersEligibility()",
@@ -12313,7 +12313,7 @@
       "source_file": "packages/storefront-webapp/src/api/userOffers.ts",
       "source_location": "L23",
       "id": "useroffers_getuserofferseligibility",
-      "community": 9
+      "community": 2
     },
     {
       "label": "HeartIconFilled.tsx",
@@ -12329,7 +12329,7 @@
       "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
       "source_location": "L1",
       "id": "entitypage",
-      "community": 9
+      "community": 15
     },
     {
       "label": "EntityPage()",
@@ -12337,7 +12337,7 @@
       "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
       "source_location": "L10",
       "id": "entitypage_entitypage",
-      "community": 9
+      "community": 15
     },
     {
       "label": "HomePage.tsx",
@@ -12377,7 +12377,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
       "source_location": "L1",
       "id": "productactionbar",
-      "community": 6
+      "community": 1
     },
     {
       "label": "checkScroll()",
@@ -12385,7 +12385,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
       "source_location": "L50",
       "id": "productactionbar_checkscroll",
-      "community": 6
+      "community": 1
     },
     {
       "label": "handleDismiss()",
@@ -12393,7 +12393,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
       "source_location": "L74",
       "id": "productactionbar_handledismiss",
-      "community": 6
+      "community": 1
     },
     {
       "label": "handleAction()",
@@ -12401,7 +12401,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
       "source_location": "L92",
       "id": "productactionbar_handleaction",
-      "community": 6
+      "community": 1
     },
     {
       "label": "ProductReminderBar.tsx",
@@ -12409,7 +12409,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
       "source_location": "L1",
       "id": "productreminderbar",
-      "community": 6
+      "community": 1
     },
     {
       "label": "checkScroll()",
@@ -12417,7 +12417,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
       "source_location": "L62",
       "id": "productreminderbar_checkscroll",
-      "community": 6
+      "community": 1
     },
     {
       "label": "handleAddToBag()",
@@ -12425,7 +12425,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
       "source_location": "L109",
       "id": "productreminderbar_handleaddtobag",
-      "community": 6
+      "community": 1
     },
     {
       "label": "handleDismiss()",
@@ -12433,7 +12433,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
       "source_location": "L177",
       "id": "productreminderbar_handledismiss",
-      "community": 6
+      "community": 1
     },
     {
       "label": "ProductsPage.tsx",
@@ -12457,7 +12457,7 @@
       "source_file": "packages/storefront-webapp/src/components/Upsell.tsx",
       "source_location": "L1",
       "id": "upsell",
-      "community": 1
+      "community": 3
     },
     {
       "label": "AuthComponent()",
@@ -12489,7 +12489,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L1",
       "id": "billingdetails",
-      "community": 1
+      "community": 5
     },
     {
       "label": "EnteredBillingAddressDetails()",
@@ -12497,7 +12497,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L102",
       "id": "billingdetails_enteredbillingaddressdetails",
-      "community": 1
+      "community": 5
     },
     {
       "label": "onSubmit()",
@@ -12505,7 +12505,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L150",
       "id": "billingdetails_onsubmit",
-      "community": 1
+      "community": 5
     },
     {
       "label": "toggleSameAsDelivery()",
@@ -12513,7 +12513,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L155",
       "id": "billingdetails_togglesameasdelivery",
-      "community": 1
+      "community": 5
     },
     {
       "label": "clearForm()",
@@ -12521,7 +12521,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L173",
       "id": "billingdetails_clearform",
-      "community": 1
+      "community": 5
     },
     {
       "label": "handleUseBillingAddressOnFile()",
@@ -12529,7 +12529,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L201",
       "id": "billingdetails_handleusebillingaddressonfile",
-      "community": 1
+      "community": 5
     },
     {
       "label": "BillingDetailsSection.tsx",
@@ -12537,7 +12537,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
       "source_location": "L1",
       "id": "billingdetailssection",
-      "community": 1
+      "community": 5
     },
     {
       "label": "clearForm()",
@@ -12545,7 +12545,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
       "source_location": "L18",
       "id": "billingdetailssection_clearform",
-      "community": 1
+      "community": 5
     },
     {
       "label": "handleUseBillingAddressOnFile()",
@@ -12553,7 +12553,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
       "source_location": "L52",
       "id": "billingdetailssection_handleusebillingaddressonfile",
-      "community": 1
+      "community": 5
     },
     {
       "label": "toggleSameAsDelivery()",
@@ -12561,7 +12561,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
       "source_location": "L68",
       "id": "billingdetailssection_togglesameasdelivery",
-      "community": 1
+      "community": 5
     },
     {
       "label": "CheckoutForm.tsx",
@@ -12569,7 +12569,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/CheckoutForm.tsx",
       "source_location": "L1",
       "id": "checkoutform",
-      "community": 1
+      "community": 5
     },
     {
       "label": "CheckoutForm()",
@@ -12577,7 +12577,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/CheckoutForm.tsx",
       "source_location": "L18",
       "id": "checkoutform_checkoutform",
-      "community": 1
+      "community": 5
     },
     {
       "label": "CheckoutProvider.tsx",
@@ -12601,7 +12601,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/CustomerDetails.tsx",
       "source_location": "L1",
       "id": "customerdetails",
-      "community": 1
+      "community": 5
     },
     {
       "label": "EnteredCustomerDetails()",
@@ -12609,7 +12609,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/CustomerDetails.tsx",
       "source_location": "L22",
       "id": "customerdetails_enteredcustomerdetails",
-      "community": 1
+      "community": 5
     },
     {
       "label": "onSubmit()",
@@ -12617,7 +12617,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/CustomerDetails.tsx",
       "source_location": "L55",
       "id": "customerdetails_onsubmit",
-      "community": 1
+      "community": 5
     },
     {
       "label": "CustomerInfoSection.tsx",
@@ -12625,7 +12625,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/CustomerInfoSection.tsx",
       "source_location": "L1",
       "id": "customerinfosection",
-      "community": 1
+      "community": 5
     },
     {
       "label": "DeliveryOptionsSelector.tsx",
@@ -12633,7 +12633,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
       "source_location": "L1",
       "id": "deliveryoptionsselector",
-      "community": 1
+      "community": 5
     },
     {
       "label": "StoreSelector()",
@@ -12641,7 +12641,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
       "source_location": "L11",
       "id": "deliveryoptionsselector_storeselector",
-      "community": 1
+      "community": 5
     },
     {
       "label": "handleChange()",
@@ -12649,7 +12649,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
       "source_location": "L77",
       "id": "deliveryoptionsselector_handlechange",
-      "community": 1
+      "community": 5
     },
     {
       "label": "DeliverySection.tsx",
@@ -12657,7 +12657,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
       "source_location": "L1",
       "id": "deliverysection",
-      "community": 1
+      "community": 5
     },
     {
       "label": "DeliveryDetails()",
@@ -12665,7 +12665,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
       "source_location": "L11",
       "id": "deliverysection_deliverydetails",
-      "community": 1
+      "community": 5
     },
     {
       "label": "DeliveryOptions()",
@@ -12673,7 +12673,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
       "source_location": "L22",
       "id": "deliverysection_deliveryoptions",
-      "community": 1
+      "community": 5
     },
     {
       "label": "PickupOptions.tsx",
@@ -12681,7 +12681,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/PickupOptions.tsx",
       "source_location": "L1",
       "id": "pickupoptions",
-      "community": 1
+      "community": 5
     },
     {
       "label": "isWithinRestrictionTime()",
@@ -12689,7 +12689,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/PickupOptions.tsx",
       "source_location": "L12",
       "id": "pickupoptions_iswithinrestrictiontime",
-      "community": 1
+      "community": 5
     },
     {
       "label": "DeliveryDetailsSection.tsx",
@@ -12697,7 +12697,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetailsSection.tsx",
       "source_location": "L1",
       "id": "deliverydetailssection",
-      "community": 1
+      "community": 5
     },
     {
       "label": "EnteredBillingAddressDetails.tsx",
@@ -12705,7 +12705,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/EnteredBillingAddressDetails.tsx",
       "source_location": "L1",
       "id": "enteredbillingaddressdetails",
-      "community": 1
+      "community": 5
     },
     {
       "label": "EnteredBillingAddressDetails()",
@@ -12713,7 +12713,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/EnteredBillingAddressDetails.tsx",
       "source_location": "L6",
       "id": "enteredbillingaddressdetails_enteredbillingaddressdetails",
-      "community": 1
+      "community": 5
     },
     {
       "label": "MobileBagSummary.tsx",
@@ -12745,7 +12745,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/OrderSummary.tsx",
       "source_location": "L18",
       "id": "ordersummary_ordersummary",
-      "community": 1
+      "community": 4
     },
     {
       "label": "PickupDetails()",
@@ -12753,7 +12753,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/index.tsx",
       "source_location": "L10",
       "id": "index_pickupdetails",
-      "community": 10
+      "community": 11
     },
     {
       "label": "PaymentMethodSection.tsx",
@@ -12761,7 +12761,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/PaymentMethodSection.tsx",
       "source_location": "L1",
       "id": "paymentmethodsection",
-      "community": 1
+      "community": 5
     },
     {
       "label": "PaymentMethodSection()",
@@ -12769,7 +12769,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/PaymentMethodSection.tsx",
       "source_location": "L8",
       "id": "paymentmethodsection_paymentmethodsection",
-      "community": 1
+      "community": 5
     },
     {
       "label": "PaymentSection.tsx",
@@ -12777,7 +12777,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/PaymentSection.tsx",
       "source_location": "L1",
       "id": "paymentsection",
-      "community": 1
+      "community": 5
     },
     {
       "label": "PaymentSection()",
@@ -12785,7 +12785,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/PaymentSection.tsx",
       "source_location": "L27",
       "id": "paymentsection_paymentsection",
-      "community": 1
+      "community": 5
     },
     {
       "label": "checkoutStorage.test.ts",
@@ -12873,7 +12873,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/billingDetailsSchema.ts",
       "source_location": "L1",
       "id": "billingdetailsschema",
-      "community": 1
+      "community": 5
     },
     {
       "label": "checkoutFormSchema.ts",
@@ -12881,7 +12881,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutFormSchema.ts",
       "source_location": "L1",
       "id": "checkoutformschema",
-      "community": 1
+      "community": 5
     },
     {
       "label": "checkoutSchemas.test.ts",
@@ -12889,7 +12889,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutSchemas.test.ts",
       "source_location": "L1",
       "id": "checkoutschemas_test",
-      "community": 1
+      "community": 5
     },
     {
       "label": "getIssueMap()",
@@ -12897,7 +12897,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutSchemas.test.ts",
       "source_location": "L8",
       "id": "checkoutschemas_test_getissuemap",
-      "community": 1
+      "community": 5
     },
     {
       "label": "customerDetailsSchema.ts",
@@ -12905,7 +12905,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/customerDetailsSchema.ts",
       "source_location": "L1",
       "id": "customerdetailsschema",
-      "community": 1
+      "community": 5
     },
     {
       "label": "deliveryDetailsSchema.ts",
@@ -12913,7 +12913,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/deliveryDetailsSchema.ts",
       "source_location": "L1",
       "id": "deliverydetailsschema",
-      "community": 1
+      "community": 5
     },
     {
       "label": "webOrderSchema.test.ts",
@@ -12921,7 +12921,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.test.ts",
       "source_location": "L1",
       "id": "weborderschema_test",
-      "community": 1
+      "community": 5
     },
     {
       "label": "getIssueMap()",
@@ -12929,7 +12929,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.test.ts",
       "source_location": "L12",
       "id": "weborderschema_test_getissuemap",
-      "community": 1
+      "community": 5
     },
     {
       "label": "webOrderSchema.ts",
@@ -12937,7 +12937,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.ts",
       "source_location": "L1",
       "id": "weborderschema",
-      "community": 1
+      "community": 5
     },
     {
       "label": "getPotentialPoints()",
@@ -12945,7 +12945,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L107",
       "id": "utils_getpotentialpoints",
-      "community": 0
+      "community": 3
     },
     {
       "label": "CustomerDetailsForm.tsx",
@@ -12953,7 +12953,7 @@
       "source_file": "packages/storefront-webapp/src/components/common/forms/CustomerDetailsForm.tsx",
       "source_location": "L1",
       "id": "customerdetailsform",
-      "community": 1
+      "community": 5
     },
     {
       "label": "onSubmit()",
@@ -12961,7 +12961,7 @@
       "source_file": "packages/storefront-webapp/src/components/common/forms/CustomerDetailsForm.tsx",
       "source_location": "L77",
       "id": "customerdetailsform_onsubmit",
-      "community": 1
+      "community": 5
     },
     {
       "label": "DeliveryDetailsForm.tsx",
@@ -12969,7 +12969,7 @@
       "source_file": "packages/storefront-webapp/src/components/common/forms/DeliveryDetailsForm.tsx",
       "source_location": "L1",
       "id": "deliverydetailsform",
-      "community": 1
+      "community": 5
     },
     {
       "label": "onSubmit()",
@@ -12977,7 +12977,7 @@
       "source_file": "packages/storefront-webapp/src/components/common/forms/DeliveryDetailsForm.tsx",
       "source_location": "L161",
       "id": "deliverydetailsform_onsubmit",
-      "community": 1
+      "community": 5
     },
     {
       "label": "useCountdown()",
@@ -13009,7 +13009,7 @@
       "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
       "source_location": "L1",
       "id": "productfilter",
-      "community": 13
+      "community": 5
     },
     {
       "label": "ProductFilter()",
@@ -13017,7 +13017,7 @@
       "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
       "source_location": "L14",
       "id": "productfilter_productfilter",
-      "community": 13
+      "community": 5
     },
     {
       "label": "ProductFilterBar.tsx",
@@ -13033,7 +13033,7 @@
       "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
       "source_location": "L1",
       "id": "filter",
-      "community": 13
+      "community": 5
     },
     {
       "label": "handleCheckboxChange()",
@@ -13041,7 +13041,7 @@
       "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
       "source_location": "L27",
       "id": "filter_handlecheckboxchange",
-      "community": 13
+      "community": 5
     },
     {
       "label": "Footer.tsx",
@@ -13105,7 +13105,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/HomeHero.tsx",
       "source_location": "L1",
       "id": "homehero",
-      "community": 16
+      "community": 1
     },
     {
       "label": "HomeHeroSection.tsx",
@@ -13265,7 +13265,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarConstants.ts",
       "source_location": "L1",
       "id": "navbarconstants",
-      "community": 19
+      "community": 20
     },
     {
       "label": "navBarStyles.ts",
@@ -13273,7 +13273,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L1",
       "id": "navbarstyles",
-      "community": 19
+      "community": 20
     },
     {
       "label": "getMainWrapperClass()",
@@ -13281,7 +13281,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L28",
       "id": "navbarstyles_getmainwrapperclass",
-      "community": 19
+      "community": 20
     },
     {
       "label": "getNavBGClass()",
@@ -13289,7 +13289,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L43",
       "id": "navbarstyles_getnavbgclass",
-      "community": 19
+      "community": 20
     },
     {
       "label": "getHoverClass()",
@@ -13297,7 +13297,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L76",
       "id": "navbarstyles_gethoverclass",
-      "community": 19
+      "community": 20
     },
     {
       "label": "getSubmenuBGClass()",
@@ -13305,7 +13305,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L93",
       "id": "navbarstyles_getsubmenubgclass",
-      "community": 19
+      "community": 20
     },
     {
       "label": "getBannerTextClass()",
@@ -13313,7 +13313,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L119",
       "id": "navbarstyles_getbannertextclass",
-      "community": 19
+      "community": 20
     },
     {
       "label": "getBannerBGClass()",
@@ -13321,7 +13321,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L136",
       "id": "navbarstyles_getbannerbgclass",
-      "community": 19
+      "community": 20
     },
     {
       "label": "getBannerAnimationDelay()",
@@ -13329,7 +13329,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L152",
       "id": "navbarstyles_getbanneranimationdelay",
-      "community": 19
+      "community": 20
     },
     {
       "label": "getNavBarWrapperClass()",
@@ -13337,7 +13337,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L163",
       "id": "navbarstyles_getnavbarwrapperclass",
-      "community": 19
+      "community": 20
     },
     {
       "label": "getNavBarAnimationDelay()",
@@ -13345,7 +13345,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L174",
       "id": "navbarstyles_getnavbaranimationdelay",
-      "community": 19
+      "community": 20
     },
     {
       "label": "getOverlayClass()",
@@ -13353,7 +13353,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L184",
       "id": "navbarstyles_getoverlayclass",
-      "community": 19
+      "community": 20
     },
     {
       "label": "NotificationPill.tsx",
@@ -13497,7 +13497,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.tsx",
       "source_location": "L1",
       "id": "productactions",
-      "community": 1
+      "community": 6
     },
     {
       "label": "ProductActions()",
@@ -13505,7 +13505,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.tsx",
       "source_location": "L17",
       "id": "productactions_productactions",
-      "community": 1
+      "community": 6
     },
     {
       "label": "ProductAttribute.tsx",
@@ -13545,7 +13545,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
       "source_location": "L13",
       "id": "productdetails_pickupdetails",
-      "community": 6
+      "community": 1
     },
     {
       "label": "BagProduct()",
@@ -13553,7 +13553,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
       "source_location": "L43",
       "id": "productdetails_bagproduct",
-      "community": 6
+      "community": 1
     },
     {
       "label": "ShippingPolicy()",
@@ -13561,7 +13561,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
       "source_location": "L88",
       "id": "productdetails_shippingpolicy",
-      "community": 6
+      "community": 1
     },
     {
       "label": "ProductInfo.tsx",
@@ -13609,7 +13609,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductsNavigationBar.tsx",
       "source_location": "L1",
       "id": "productsnavigationbar",
-      "community": 10
+      "community": 3
     },
     {
       "label": "ReviewSummary.tsx",
@@ -13737,7 +13737,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
       "source_location": "L1",
       "id": "orderpointsdisplay",
-      "community": 12
+      "community": 19
     },
     {
       "label": "OrderPointsDisplay()",
@@ -13745,7 +13745,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
       "source_location": "L11",
       "id": "orderpointsdisplay_orderpointsdisplay",
-      "community": 12
+      "community": 19
     },
     {
       "label": "PastOrdersRewards.tsx",
@@ -13753,7 +13753,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/PastOrdersRewards.tsx",
       "source_location": "L1",
       "id": "pastordersrewards",
-      "community": 1
+      "community": 19
     },
     {
       "label": "handleClaimPoints()",
@@ -13761,7 +13761,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/PastOrdersRewards.tsx",
       "source_location": "L59",
       "id": "pastordersrewards_handleclaimpoints",
-      "community": 1
+      "community": 19
     },
     {
       "label": "RewardsPanel.tsx",
@@ -13769,7 +13769,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/RewardsPanel.tsx",
       "source_location": "L1",
       "id": "rewardspanel",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleRedeemReward()",
@@ -13777,7 +13777,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/RewardsPanel.tsx",
       "source_location": "L33",
       "id": "rewardspanel_handleredeemreward",
-      "community": 1
+      "community": 0
     },
     {
       "label": "SavedIcon.tsx",
@@ -13793,7 +13793,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/BagItem.tsx",
       "source_location": "L19",
       "id": "bagitem_bagitem",
-      "community": 12
+      "community": 7
     },
     {
       "label": "CartIcon.tsx",
@@ -13961,7 +13961,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/ScrollDownButton.tsx",
       "source_location": "L1",
       "id": "scrolldownbutton",
-      "community": 16
+      "community": 15
     },
     {
       "label": "ScrollDownButton()",
@@ -13969,7 +13969,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/ScrollDownButton.tsx",
       "source_location": "L11",
       "id": "scrolldownbutton_scrolldownbutton",
-      "community": 16
+      "community": 15
     },
     {
       "label": "alert.tsx",
@@ -13977,7 +13977,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/alert.tsx",
       "source_location": "L1",
       "id": "alert",
-      "community": 0
+      "community": 3
     },
     {
       "label": "breadcrumb.tsx",
@@ -13985,7 +13985,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/breadcrumb.tsx",
       "source_location": "L1",
       "id": "breadcrumb",
-      "community": 10
+      "community": 3
     },
     {
       "label": "country-select.tsx",
@@ -13993,7 +13993,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/country-select.tsx",
       "source_location": "L1",
       "id": "country_select",
-      "community": 1
+      "community": 5
     },
     {
       "label": "CountrySelect()",
@@ -14001,7 +14001,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/country-select.tsx",
       "source_location": "L3",
       "id": "country_select_countryselect",
-      "community": 1
+      "community": 5
     },
     {
       "label": "ghana-region-select.tsx",
@@ -14009,7 +14009,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/ghana-region-select.tsx",
       "source_location": "L1",
       "id": "ghana_region_select",
-      "community": 1
+      "community": 5
     },
     {
       "label": "GhanaRegionSelect()",
@@ -14017,7 +14017,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/ghana-region-select.tsx",
       "source_location": "L3",
       "id": "ghana_region_select_ghanaregionselect",
-      "community": 1
+      "community": 5
     },
     {
       "label": "ghost-button.tsx",
@@ -14025,7 +14025,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/ghost-button.tsx",
       "source_location": "L1",
       "id": "ghost_button",
-      "community": 1
+      "community": 5
     },
     {
       "label": "GhostButton()",
@@ -14033,7 +14033,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/ghost-button.tsx",
       "source_location": "L9",
       "id": "ghost_button_ghostbutton",
-      "community": 1
+      "community": 5
     },
     {
       "label": "image-with-fallback.tsx",
@@ -14257,7 +14257,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/navigation-menu.tsx",
       "source_location": "L1",
       "id": "navigation_menu",
-      "community": 0
+      "community": 3
     },
     {
       "label": "webp-jpg.tsx",
@@ -14345,7 +14345,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
       "source_location": "L1",
       "id": "storefrontobservabilityprovider",
-      "community": 11
+      "community": 1
     },
     {
       "label": "StorefrontObservabilityProvider()",
@@ -14353,7 +14353,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
       "source_location": "L20",
       "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
-      "community": 11
+      "community": 1
     },
     {
       "label": "useStorefrontObservability()",
@@ -14361,7 +14361,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
       "source_location": "L55",
       "id": "storefrontobservabilityprovider_usestorefrontobservability",
-      "community": 11
+      "community": 1
     },
     {
       "label": "useCheckout.ts",
@@ -14369,7 +14369,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useCheckout.ts",
       "source_location": "L1",
       "id": "usecheckout",
-      "community": 1
+      "community": 5
     },
     {
       "label": "useCheckout()",
@@ -14377,7 +14377,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useCheckout.ts",
       "source_location": "L5",
       "id": "usecheckout_usecheckout",
-      "community": 1
+      "community": 5
     },
     {
       "label": "useDiscountCodeAlert.tsx",
@@ -14401,7 +14401,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useEnhancedTracking.ts",
       "source_location": "L1",
       "id": "useenhancedtracking",
-      "community": 6
+      "community": 15
     },
     {
       "label": "useEnhancedTracking()",
@@ -14409,7 +14409,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useEnhancedTracking.ts",
       "source_location": "L29",
       "id": "useenhancedtracking_useenhancedtracking",
-      "community": 6
+      "community": 15
     },
     {
       "label": "useGetActiveCheckoutSession.tsx",
@@ -14497,7 +14497,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useInventoryStatus.ts",
       "source_location": "L1",
       "id": "useinventorystatus",
-      "community": 9
+      "community": 15
     },
     {
       "label": "useInventoryStatus()",
@@ -14505,7 +14505,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useInventoryStatus.ts",
       "source_location": "L9",
       "id": "useinventorystatus_useinventorystatus",
-      "community": 9
+      "community": 15
     },
     {
       "label": "useLeaveAReviewModal.tsx",
@@ -14665,7 +14665,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useScrollToTop.ts",
       "source_location": "L1",
       "id": "usescrolltotop",
-      "community": 7
+      "community": 8
     },
     {
       "label": "useScrollToTop()",
@@ -14673,7 +14673,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useScrollToTop.ts",
       "source_location": "L3",
       "id": "usescrolltotop_usescrolltotop",
-      "community": 7
+      "community": 8
     },
     {
       "label": "useShoppingBag.ts",
@@ -14713,7 +14713,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useTrackAction.ts",
       "source_location": "L1",
       "id": "usetrackaction",
-      "community": 6
+      "community": 15
     },
     {
       "label": "useTrackAction()",
@@ -14721,7 +14721,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useTrackAction.ts",
       "source_location": "L5",
       "id": "usetrackaction_usetrackaction",
-      "community": 6
+      "community": 15
     },
     {
       "label": "useTrackEvent.ts",
@@ -14729,7 +14729,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useTrackEvent.ts",
       "source_location": "L1",
       "id": "usetrackevent",
-      "community": 6
+      "community": 1
     },
     {
       "label": "useTrackEvent()",
@@ -14737,7 +14737,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useTrackEvent.ts",
       "source_location": "L5",
       "id": "usetrackevent_usetrackevent",
-      "community": 6
+      "community": 1
     },
     {
       "label": "useUpsellModal.tsx",
@@ -14745,7 +14745,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useUpsellModal.tsx",
       "source_location": "L1",
       "id": "useupsellmodal",
-      "community": 9
+      "community": 1
     },
     {
       "label": "useUpsellModal()",
@@ -14753,7 +14753,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useUpsellModal.tsx",
       "source_location": "L14",
       "id": "useupsellmodal_useupsellmodal",
-      "community": 9
+      "community": 1
     },
     {
       "label": "feeUtils.test.ts",
@@ -14761,7 +14761,7 @@
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.test.ts",
       "source_location": "L1",
       "id": "feeutils_test",
-      "community": 1
+      "community": 5
     },
     {
       "label": "feeUtils.ts",
@@ -14769,7 +14769,7 @@
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L1",
       "id": "feeutils",
-      "community": 1
+      "community": 5
     },
     {
       "label": "meetsThreshold()",
@@ -14777,7 +14777,7 @@
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L17",
       "id": "feeutils_meetsthreshold",
-      "community": 1
+      "community": 5
     },
     {
       "label": "isFeeWaived()",
@@ -14785,7 +14785,7 @@
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L34",
       "id": "feeutils_isfeewaived",
-      "community": 1
+      "community": 5
     },
     {
       "label": "isAnyFeeWaived()",
@@ -14793,7 +14793,7 @@
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L74",
       "id": "feeutils_isanyfeewaived",
-      "community": 1
+      "community": 5
     },
     {
       "label": "hasWaiverConfigured()",
@@ -14801,7 +14801,7 @@
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L100",
       "id": "feeutils_haswaiverconfigured",
-      "community": 1
+      "community": 5
     },
     {
       "label": "getRemainingForFreeDelivery()",
@@ -14809,7 +14809,7 @@
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L138",
       "id": "feeutils_getremainingforfreedelivery",
-      "community": 1
+      "community": 5
     },
     {
       "label": "maintenanceUtils.test.ts",
@@ -14817,7 +14817,7 @@
       "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.test.ts",
       "source_location": "L1",
       "id": "maintenanceutils_test",
-      "community": 16
+      "community": 17
     },
     {
       "label": "usePostAnalytics()",
@@ -14825,7 +14825,7 @@
       "source_file": "packages/storefront-webapp/src/lib/mutations.ts/analytics.ts",
       "source_location": "L4",
       "id": "analytics_usepostanalytics",
-      "community": 6
+      "community": 15
     },
     {
       "label": "isSoldOut()",
@@ -14833,7 +14833,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L45",
       "id": "productutils_issoldout",
-      "community": 6
+      "community": 1
     },
     {
       "label": "hasLowStock()",
@@ -14841,7 +14841,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L52",
       "id": "productutils_haslowstock",
-      "community": 6
+      "community": 1
     },
     {
       "label": "sortSkusByLength()",
@@ -14849,7 +14849,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L62",
       "id": "productutils_sortskusbylength",
-      "community": 6
+      "community": 1
     },
     {
       "label": "useBagQueries()",
@@ -14857,7 +14857,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/bag.ts",
       "source_location": "L7",
       "id": "bag_usebagqueries",
-      "community": 12
+      "community": 7
     },
     {
       "label": "useBannerMessageQueries()",
@@ -14905,7 +14905,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/product.ts",
       "source_location": "L14",
       "id": "product_useproductqueries",
-      "community": 9
+      "community": 15
     },
     {
       "label": "usePromoCodesQueries()",
@@ -14929,7 +14929,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/rewards.ts",
       "source_location": "L11",
       "id": "rewards_userewardsqueries",
-      "community": 12
+      "community": 19
     },
     {
       "label": "useUpsellsQueries()",
@@ -14953,7 +14953,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/userOffers.ts",
       "source_location": "L6",
       "id": "useroffers_useuseroffersqueries",
-      "community": 9
+      "community": 2
     },
     {
       "label": "states.ts",
@@ -14961,7 +14961,7 @@
       "source_file": "packages/storefront-webapp/src/lib/states.ts",
       "source_location": "L1",
       "id": "states",
-      "community": 1
+      "community": 5
     },
     {
       "label": "buildV2Config()",
@@ -14969,7 +14969,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.test.ts",
       "source_location": "L10",
       "id": "storeconfig_test_buildv2config",
-      "community": 16
+      "community": 17
     },
     {
       "label": "mapPromo()",
@@ -14977,7 +14977,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L172",
       "id": "storeconfig_mappromo",
-      "community": 16
+      "community": 17
     },
     {
       "label": "isStoreReadOnlyMode()",
@@ -14985,7 +14985,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L461",
       "id": "storeconfig_isstorereadonlymode",
-      "community": 16
+      "community": 17
     },
     {
       "label": "isStoreMaintenanceMode()",
@@ -14993,7 +14993,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L465",
       "id": "storeconfig_isstoremaintenancemode",
-      "community": 16
+      "community": 17
     },
     {
       "label": "getStoreFallbackImageUrl()",
@@ -15001,7 +15001,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L479",
       "id": "storeconfig_getstorefallbackimageurl",
-      "community": 16
+      "community": 17
     },
     {
       "label": "storefrontFailureObservability.test.ts",
@@ -15009,7 +15009,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.test.ts",
       "source_location": "L1",
       "id": "storefrontfailureobservability_test",
-      "community": 11
+      "community": 10
     },
     {
       "label": "storefrontFailureObservability.ts",
@@ -15017,7 +15017,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
       "source_location": "L1",
       "id": "storefrontfailureobservability",
-      "community": 11
+      "community": 10
     },
     {
       "label": "inferStorefrontJourneyFromRoute()",
@@ -15025,7 +15025,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
       "source_location": "L25",
       "id": "storefrontfailureobservability_inferstorefrontjourneyfromroute",
-      "community": 11
+      "community": 10
     },
     {
       "label": "normalizeStorefrontError()",
@@ -15033,7 +15033,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
       "source_location": "L47",
       "id": "storefrontfailureobservability_normalizestorefronterror",
-      "community": 11
+      "community": 10
     },
     {
       "label": "createStorefrontFailureEvent()",
@@ -15041,7 +15041,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
       "source_location": "L136",
       "id": "storefrontfailureobservability_createstorefrontfailureevent",
-      "community": 11
+      "community": 10
     },
     {
       "label": "emitStorefrontFailure()",
@@ -15049,7 +15049,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
       "source_location": "L154",
       "id": "storefrontfailureobservability_emitstorefrontfailure",
-      "community": 11
+      "community": 10
     },
     {
       "label": "storefrontJourneyEvents.test.ts",
@@ -15057,7 +15057,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.test.ts",
       "source_location": "L1",
       "id": "storefrontjourneyevents_test",
-      "community": 14
+      "community": 7
     },
     {
       "label": "storefrontJourneyEvents.ts",
@@ -15065,7 +15065,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L1",
       "id": "storefrontjourneyevents",
-      "community": 14
+      "community": 7
     },
     {
       "label": "compactContext()",
@@ -15073,7 +15073,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L7",
       "id": "storefrontjourneyevents_compactcontext",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createJourneyEvent()",
@@ -15081,7 +15081,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L19",
       "id": "storefrontjourneyevents_createjourneyevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createLandingPageViewedEvent()",
@@ -15089,7 +15089,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L33",
       "id": "storefrontjourneyevents_createlandingpageviewedevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createCategoryBrowseViewedEvent()",
@@ -15097,7 +15097,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L41",
       "id": "storefrontjourneyevents_createcategorybrowseviewedevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createProductDetailViewedEvent()",
@@ -15105,7 +15105,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L59",
       "id": "storefrontjourneyevents_createproductdetailviewedevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createBagViewedEvent()",
@@ -15113,7 +15113,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L83",
       "id": "storefrontjourneyevents_createbagviewedevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createBagAddSucceededEvent()",
@@ -15121,7 +15121,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L101",
       "id": "storefrontjourneyevents_createbagaddsucceededevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createBagRemoveSucceededEvent()",
@@ -15129,7 +15129,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L122",
       "id": "storefrontjourneyevents_createbagremovesucceededevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createCheckoutStartEvent()",
@@ -15137,7 +15137,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L143",
       "id": "storefrontjourneyevents_createcheckoutstartevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createCheckoutDetailsViewedEvent()",
@@ -15145,7 +15145,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L164",
       "id": "storefrontjourneyevents_createcheckoutdetailsviewedevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createOrderReviewViewedEvent()",
@@ -15153,7 +15153,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L179",
       "id": "storefrontjourneyevents_createorderreviewviewedevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createPaymentSubmissionStartedEvent()",
@@ -15161,7 +15161,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L194",
       "id": "storefrontjourneyevents_createpaymentsubmissionstartedevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createPaymentVerificationStartedEvent()",
@@ -15169,7 +15169,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L215",
       "id": "storefrontjourneyevents_createpaymentverificationstartedevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createCheckoutCompletionEvent()",
@@ -15177,7 +15177,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L233",
       "id": "storefrontjourneyevents_createcheckoutcompletionevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createCheckoutCompletionSucceededEvent()",
@@ -15185,7 +15185,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L256",
       "id": "storefrontjourneyevents_createcheckoutcompletionsucceededevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createCheckoutCompletionBlockedEvent()",
@@ -15193,7 +15193,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L273",
       "id": "storefrontjourneyevents_createcheckoutcompletionblockedevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createCheckoutCompletionCanceledEvent()",
@@ -15201,7 +15201,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L290",
       "id": "storefrontjourneyevents_createcheckoutcompletioncanceledevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "getAuthEntryStep()",
@@ -15209,7 +15209,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L307",
       "id": "storefrontjourneyevents_getauthentrystep",
-      "community": 14
+      "community": 7
     },
     {
       "label": "getAuthRequestStep()",
@@ -15217,7 +15217,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L311",
       "id": "storefrontjourneyevents_getauthrequeststep",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createAuthEntryViewedEvent()",
@@ -15225,7 +15225,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L315",
       "id": "storefrontjourneyevents_createauthentryviewedevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createAuthRequestStartedEvent()",
@@ -15233,7 +15233,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L335",
       "id": "storefrontjourneyevents_createauthrequeststartedevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createAuthVerificationViewedEvent()",
@@ -15241,7 +15241,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L355",
       "id": "storefrontjourneyevents_createauthverificationviewedevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createAuthVerificationSucceededEvent()",
@@ -15249,7 +15249,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L370",
       "id": "storefrontjourneyevents_createauthverificationsucceededevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createRewardsAlertViewedEvent()",
@@ -15257,7 +15257,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L387",
       "id": "storefrontjourneyevents_createrewardsalertviewedevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createRewardsAlertDismissedEvent()",
@@ -15265,7 +15265,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L395",
       "id": "storefrontjourneyevents_createrewardsalertdismissedevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createRewardsAlertShopNowEvent()",
@@ -15273,7 +15273,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L403",
       "id": "storefrontjourneyevents_createrewardsalertshopnowevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createPromoAlertViewedEvent()",
@@ -15281,7 +15281,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L411",
       "id": "storefrontjourneyevents_createpromoalertviewedevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createPromoAlertDismissedEvent()",
@@ -15289,7 +15289,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L435",
       "id": "storefrontjourneyevents_createpromoalertdismissedevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createPromoAlertShopNowEvent()",
@@ -15297,7 +15297,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L459",
       "id": "storefrontjourneyevents_createpromoalertshopnowevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createWelcomeBackModalViewedEvent()",
@@ -15305,7 +15305,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L483",
       "id": "storefrontjourneyevents_createwelcomebackmodalviewedevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createWelcomeBackModalDismissedEvent()",
@@ -15313,7 +15313,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L501",
       "id": "storefrontjourneyevents_createwelcomebackmodaldismissedevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createWelcomeBackModalSubmittedEvent()",
@@ -15321,7 +15321,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L519",
       "id": "storefrontjourneyevents_createwelcomebackmodalsubmittedevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createLeaveReviewModalViewedEvent()",
@@ -15329,7 +15329,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L537",
       "id": "storefrontjourneyevents_createleavereviewmodalviewedevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createLeaveReviewModalDismissedEvent()",
@@ -15337,7 +15337,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L555",
       "id": "storefrontjourneyevents_createleavereviewmodaldismissedevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createUpsellModalViewedEvent()",
@@ -15345,7 +15345,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L573",
       "id": "storefrontjourneyevents_createupsellmodalviewedevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createUpsellModalDismissedEvent()",
@@ -15353,7 +15353,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L600",
       "id": "storefrontjourneyevents_createupsellmodaldismissedevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createUpsellModalSubmittedEvent()",
@@ -15361,7 +15361,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L627",
       "id": "storefrontjourneyevents_createupsellmodalsubmittedevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createUpsellModalAddToBagEvent()",
@@ -15369,7 +15369,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L654",
       "id": "storefrontjourneyevents_createupsellmodaladdtobagevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createSavedBagViewedEvent()",
@@ -15377,7 +15377,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L676",
       "id": "storefrontjourneyevents_createsavedbagviewedevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createSavedBagMoveToBagEvent()",
@@ -15385,7 +15385,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L684",
       "id": "storefrontjourneyevents_createsavedbagmovetobagevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createSavedBagRemoveEvent()",
@@ -15393,7 +15393,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L705",
       "id": "storefrontjourneyevents_createsavedbagremoveevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createBagMoveToSavedEvent()",
@@ -15401,7 +15401,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L726",
       "id": "storefrontjourneyevents_createbagmovetosavedevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createDiscountCodeTriggerEvent()",
@@ -15409,7 +15409,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L747",
       "id": "storefrontjourneyevents_creatediscountcodetriggerevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createReviewEditorViewedEvent()",
@@ -15417,7 +15417,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L762",
       "id": "storefrontjourneyevents_createrevieweditorviewedevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "createReviewSubmittedEvent()",
@@ -15425,7 +15425,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L786",
       "id": "storefrontjourneyevents_createreviewsubmittedevent",
-      "community": 14
+      "community": 7
     },
     {
       "label": "storefrontObservability.test.ts",
@@ -15433,7 +15433,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.test.ts",
       "source_location": "L1",
       "id": "storefrontobservability_test",
-      "community": 11
+      "community": 10
     },
     {
       "label": "createMemoryStorage()",
@@ -15441,7 +15441,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.test.ts",
       "source_location": "L12",
       "id": "storefrontobservability_test_creatememorystorage",
-      "community": 11
+      "community": 10
     },
     {
       "label": "storefrontObservability.ts",
@@ -15449,7 +15449,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L1",
       "id": "storefrontobservability",
-      "community": 11
+      "community": 10
     },
     {
       "label": "getOrCreateStorefrontObservabilitySessionId()",
@@ -15457,7 +15457,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L109",
       "id": "storefrontobservability_getorcreatestorefrontobservabilitysessionid",
-      "community": 11
+      "community": 10
     },
     {
       "label": "createStorefrontObservabilityContext()",
@@ -15465,7 +15465,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L134",
       "id": "storefrontobservability_createstorefrontobservabilitycontext",
-      "community": 11
+      "community": 10
     },
     {
       "label": "createStorefrontObservabilityPayload()",
@@ -15473,7 +15473,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L157",
       "id": "storefrontobservability_createstorefrontobservabilitypayload",
-      "community": 11
+      "community": 10
     },
     {
       "label": "trackStorefrontEvent()",
@@ -15481,7 +15481,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L193",
       "id": "storefrontobservability_trackstorefrontevent",
-      "community": 11
+      "community": 10
     },
     {
       "label": "getStoreDetails()",
@@ -15489,7 +15489,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L53",
       "id": "utils_getstoredetails",
-      "community": 0
+      "community": 3
     },
     {
       "label": "enableQuery()",
@@ -15497,7 +15497,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L60",
       "id": "utils_enablequery",
-      "community": 0
+      "community": 3
     },
     {
       "label": "validateEmail()",
@@ -15513,7 +15513,7 @@
       "source_file": "packages/storefront-webapp/src/router.tsx",
       "source_location": "L1",
       "id": "router",
-      "community": 11
+      "community": 10
     },
     {
       "label": "createRouter()",
@@ -15521,7 +15521,7 @@
       "source_file": "packages/storefront-webapp/src/router.tsx",
       "source_location": "L5",
       "id": "router_createrouter",
-      "community": 11
+      "community": 10
     },
     {
       "label": "$orderItemId.review.tsx",
@@ -15537,7 +15537,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
       "source_location": "L102",
       "id": "index_getpaymenttext",
-      "community": 10
+      "community": 11
     },
     {
       "label": "getOrderMessage()",
@@ -15545,7 +15545,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
       "source_location": "L429",
       "id": "index_getordermessage",
-      "community": 10
+      "community": 11
     },
     {
       "label": "OrderNavigation()",
@@ -15569,7 +15569,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout.tsx",
       "source_location": "L1",
       "id": "orderslayout",
-      "community": 7
+      "community": 8
     },
     {
       "label": "LayoutComponent()",
@@ -15577,7 +15577,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout.tsx",
       "source_location": "L8",
       "id": "orderslayout_layoutcomponent",
-      "community": 7
+      "community": 8
     },
     {
       "label": "$subcategorySlug.tsx",
@@ -15585,7 +15585,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout/shop/$categorySlug/$subcategorySlug.tsx",
       "source_location": "L1",
       "id": "subcategoryslug",
-      "community": 9
+      "community": 15
     },
     {
       "label": "_shopLayout.tsx",
@@ -15625,7 +15625,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
       "source_location": "L1",
       "id": "account",
-      "community": 1
+      "community": 5
     },
     {
       "label": "accountBeforeLoad()",
@@ -15633,7 +15633,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
       "source_location": "L17",
       "id": "account_accountbeforeload",
-      "community": 1
+      "community": 5
     },
     {
       "label": "handleOnSubmitForm()",
@@ -15641,7 +15641,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
       "source_location": "L63",
       "id": "account_handleonsubmitform",
-      "community": 1
+      "community": 5
     },
     {
       "label": "contact-us.tsx",
@@ -15665,7 +15665,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/delivery-returns-exchanges.index.tsx",
       "source_location": "L1",
       "id": "delivery_returns_exchanges_index",
-      "community": 7
+      "community": 8
     },
     {
       "label": "OnlineOrderPolicy()",
@@ -15673,7 +15673,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/delivery-returns-exchanges.index.tsx",
       "source_location": "L13",
       "id": "delivery_returns_exchanges_index_onlineorderpolicy",
-      "community": 7
+      "community": 8
     },
     {
       "label": "privacy.index.tsx",
@@ -15681,7 +15681,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/privacy.index.tsx",
       "source_location": "L1",
       "id": "privacy_index",
-      "community": 7
+      "community": 8
     },
     {
       "label": "PrivacyPolicy()",
@@ -15689,7 +15689,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/privacy.index.tsx",
       "source_location": "L9",
       "id": "privacy_index_privacypolicy",
-      "community": 7
+      "community": 8
     },
     {
       "label": "tos.index.tsx",
@@ -15697,7 +15697,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
       "source_location": "L1",
       "id": "tos_index",
-      "community": 7
+      "community": 8
     },
     {
       "label": "TosSection()",
@@ -15705,7 +15705,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
       "source_location": "L15",
       "id": "tos_index_tossection",
-      "community": 7
+      "community": 8
     },
     {
       "label": "rewards.index.tsx",
@@ -15713,7 +15713,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/rewards.index.tsx",
       "source_location": "L1",
       "id": "rewards_index",
-      "community": 1
+      "community": 0
     },
     {
       "label": "shop.product.$productSlug.tsx",
@@ -15721,7 +15721,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/shop.product.$productSlug.tsx",
       "source_location": "L1",
       "id": "shop_product_productslug",
-      "community": 10
+      "community": 6
     },
     {
       "label": "Component()",
@@ -15729,7 +15729,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/shop.product.$productSlug.tsx",
       "source_location": "L16",
       "id": "shop_product_productslug_component",
-      "community": 10
+      "community": 6
     },
     {
       "label": "shop.saved.index.tsx",
@@ -15737,7 +15737,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/shop.saved.index.tsx",
       "source_location": "L1",
       "id": "shop_saved_index",
-      "community": 12
+      "community": 7
     },
     {
       "label": "LayoutComponent()",
@@ -15745,7 +15745,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout.tsx",
       "source_location": "L6",
       "id": "layout_layoutcomponent",
-      "community": 7
+      "community": 1
     },
     {
       "label": "auth.verify.tsx",
@@ -15753,7 +15753,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L1",
       "id": "auth_verify",
-      "community": 12
+      "community": 7
     },
     {
       "label": "reportAuthFailure()",
@@ -15761,7 +15761,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L93",
       "id": "auth_verify_reportauthfailure",
-      "community": 12
+      "community": 7
     },
     {
       "label": "formatTime()",
@@ -15769,7 +15769,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L149",
       "id": "auth_verify_formattime",
-      "community": 12
+      "community": 7
     },
     {
       "label": "handleCodeChange()",
@@ -15777,7 +15777,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L156",
       "id": "auth_verify_handlecodechange",
-      "community": 12
+      "community": 7
     },
     {
       "label": "onSubmit()",
@@ -15785,7 +15785,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L201",
       "id": "auth_verify_onsubmit",
-      "community": 12
+      "community": 7
     },
     {
       "label": "resendVerificationCode()",
@@ -15793,7 +15793,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L282",
       "id": "auth_verify_resendverificationcode",
-      "community": 12
+      "community": 7
     },
     {
       "label": "login.tsx",
@@ -15801,7 +15801,7 @@
       "source_file": "packages/storefront-webapp/src/routes/login.tsx",
       "source_location": "L1",
       "id": "login",
-      "community": 1
+      "community": 5
     },
     {
       "label": "loginBeforeLoad()",
@@ -15809,7 +15809,7 @@
       "source_file": "packages/storefront-webapp/src/routes/login.tsx",
       "source_location": "L47",
       "id": "login_loginbeforeload",
-      "community": 1
+      "community": 5
     },
     {
       "label": "onSubmit()",
@@ -15817,7 +15817,7 @@
       "source_file": "packages/storefront-webapp/src/routes/login.tsx",
       "source_location": "L141",
       "id": "login_onsubmit",
-      "community": 1
+      "community": 5
     },
     {
       "label": "bag.index.tsx",
@@ -15825,7 +15825,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/bag.index.tsx",
       "source_location": "L1",
       "id": "bag_index",
-      "community": 1
+      "community": 8
     },
     {
       "label": "canceled.tsx",
@@ -15865,7 +15865,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
       "source_location": "L26",
       "id": "index_geterrormessage",
-      "community": 10
+      "community": 11
     },
     {
       "label": "placeOrder()",
@@ -15873,7 +15873,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
       "source_location": "L71",
       "id": "index_placeorder",
-      "community": 10
+      "community": 11
     },
     {
       "label": "cancelOrder()",
@@ -15881,7 +15881,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
       "source_location": "L121",
       "id": "index_cancelorder",
-      "community": 10
+      "community": 11
     },
     {
       "label": "complete.index.tsx",
@@ -15953,7 +15953,7 @@
       "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
       "source_location": "L1",
       "id": "signup",
-      "community": 1
+      "community": 5
     },
     {
       "label": "signupBeforeLoad()",
@@ -15961,7 +15961,7 @@
       "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
       "source_location": "L66",
       "id": "signup_signupbeforeload",
-      "community": 1
+      "community": 5
     },
     {
       "label": "onSubmit()",
@@ -15969,7 +15969,7 @@
       "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
       "source_location": "L161",
       "id": "signup_onsubmit",
-      "community": 1
+      "community": 5
     },
     {
       "label": "ssr.tsx",
@@ -15977,7 +15977,7 @@
       "source_file": "packages/storefront-webapp/src/ssr.tsx",
       "source_location": "L1",
       "id": "ssr",
-      "community": 11
+      "community": 10
     },
     {
       "label": "bootstrap.ts",
@@ -15985,7 +15985,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
       "source_location": "L1",
       "id": "bootstrap",
-      "community": 23
+      "community": 22
     },
     {
       "label": "createMarker()",
@@ -15993,7 +15993,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
       "source_location": "L20",
       "id": "bootstrap_createmarker",
-      "community": 23
+      "community": 22
     },
     {
       "label": "createBootstrapToken()",
@@ -16001,7 +16001,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
       "source_location": "L24",
       "id": "bootstrap_createbootstraptoken",
-      "community": 23
+      "community": 22
     },
     {
       "label": "bootstrapCheckout()",
@@ -16009,7 +16009,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
       "source_location": "L46",
       "id": "bootstrap_bootstrapcheckout",
-      "community": 23
+      "community": 22
     },
     {
       "label": "requireEnv()",
@@ -16017,7 +16017,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
       "source_location": "L1",
       "id": "env_requireenv",
-      "community": 23
+      "community": 22
     },
     {
       "label": "optionalNumberEnv()",
@@ -16025,1879 +16025,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
       "source_location": "L11",
       "id": "env_optionalnumberenv",
-      "community": 23
-    },
-    {
-      "label": "realIntegrationSmoke.ts",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/scripts/realIntegrationSmoke.ts",
-      "source_location": "L1",
-      "id": "realintegrationsmoke",
-      "community": 3
-    },
-    {
-      "label": "main()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/scripts/realIntegrationSmoke.ts",
-      "source_location": "L9",
-      "id": "realintegrationsmoke_main",
-      "community": 3
-    },
-    {
-      "label": "parseArgs()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/scripts/realIntegrationSmoke.ts",
-      "source_location": "L44",
-      "id": "realintegrationsmoke_parseargs",
-      "community": 3
-    },
-    {
-      "label": "resolveWorkflowPath()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/scripts/realIntegrationSmoke.ts",
-      "source_location": "L76",
-      "id": "realintegrationsmoke_resolveworkflowpath",
-      "community": 3
-    },
-    {
-      "label": "parseBooleanFlag()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/scripts/realIntegrationSmoke.ts",
-      "source_location": "L90",
-      "id": "realintegrationsmoke_parsebooleanflag",
-      "community": 3
-    },
-    {
-      "label": "smokeLaunchCodex()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/scripts/realIntegrationSmoke.ts",
-      "source_location": "L103",
-      "id": "realintegrationsmoke_smokelaunchcodex",
-      "community": 3
-    },
-    {
-      "label": "cli.ts",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/cli.ts",
-      "source_location": "L1",
-      "id": "cli",
-      "community": 3
-    },
-    {
-      "label": "parseCliArgs()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/cli.ts",
-      "source_location": "L60",
-      "id": "cli_parsecliargs",
-      "community": 3
-    },
-    {
-      "label": "runCli()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/cli.ts",
-      "source_location": "L107",
-      "id": "cli_runcli",
-      "community": 3
-    },
-    {
-      "label": "runCliEntry()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/cli.ts",
-      "source_location": "L177",
-      "id": "cli_runclientry",
-      "community": 3
-    },
-    {
-      "label": "parsePortArg()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/cli.ts",
-      "source_location": "L193",
-      "id": "cli_parseportarg",
-      "community": 3
-    },
-    {
-      "label": "parseWorkflowServerPort()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/cli.ts",
-      "source_location": "L206",
-      "id": "cli_parseworkflowserverport",
-      "community": 3
-    },
-    {
-      "label": "asObject()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/cli.ts",
-      "source_location": "L224",
-      "id": "cli_asobject",
-      "community": 3
-    },
-    {
-      "label": "CodexAppServerClient",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L71",
-      "id": "client_codexappserverclient",
-      "community": 8
-    },
-    {
-      "label": ".constructor()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L81",
-      "id": "client_codexappserverclient_constructor",
-      "community": 8
-    },
-    {
-      "label": ".startSession()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L86",
-      "id": "client_codexappserverclient_startsession",
-      "community": 8
-    },
-    {
-      "label": ".runTurn()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L113",
-      "id": "client_codexappserverclient_runturn",
-      "community": 8
-    },
-    {
-      "label": ".stop()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L150",
-      "id": "client_codexappserverclient_stop",
-      "community": 8
-    },
-    {
-      "label": ".ensureProcess()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L158",
-      "id": "client_codexappserverclient_ensureprocess",
-      "community": 8
-    },
-    {
-      "label": ".initializeProtocol()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L211",
-      "id": "client_codexappserverclient_initializeprotocol",
-      "community": 8
-    },
-    {
-      "label": ".sendRequest()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L222",
-      "id": "client_codexappserverclient_sendrequest",
-      "community": 8
-    },
-    {
-      "label": ".sendNotification()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L259",
-      "id": "client_codexappserverclient_sendnotification",
-      "community": 8
-    },
-    {
-      "label": ".handleStdoutLine()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L268",
-      "id": "client_codexappserverclient_handlestdoutline",
-      "community": 8
-    },
-    {
-      "label": ".resolvePendingRequest()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L289",
-      "id": "client_codexappserverclient_resolvependingrequest",
-      "community": 8
-    },
-    {
-      "label": ".handleIncomingMessage()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L315",
-      "id": "client_codexappserverclient_handleincomingmessage",
-      "community": 8
-    },
-    {
-      "label": ".sendRequestResult()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L365",
-      "id": "client_codexappserverclient_sendrequestresult",
-      "community": 8
-    },
-    {
-      "label": ".waitForTurnOutcome()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L378",
-      "id": "client_codexappserverclient_waitforturnoutcome",
-      "community": 8
-    },
-    {
-      "label": ".resolveTurnOutcome()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L399",
-      "id": "client_codexappserverclient_resolveturnoutcome",
-      "community": 8
-    },
-    {
-      "label": ".rejectAllPending()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L411",
-      "id": "client_codexappserverclient_rejectallpending",
-      "community": 8
-    },
-    {
-      "label": ".teardown()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L419",
-      "id": "client_codexappserverclient_teardown",
-      "community": 8
-    },
-    {
-      "label": ".emit()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L431",
-      "id": "client_codexappserverclient_emit",
-      "community": 8
-    },
-    {
-      "label": ".allocateRequestId()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L439",
-      "id": "client_codexappserverclient_allocaterequestid",
-      "community": 8
-    },
-    {
-      "label": ".assertAbsoluteCwd()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L445",
-      "id": "client_codexappserverclient_assertabsolutecwd",
-      "community": 8
-    },
-    {
-      "label": ".recordStderr()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L452",
-      "id": "client_codexappserverclient_recordstderr",
-      "community": 8
-    },
-    {
-      "label": ".mapExitError()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L459",
-      "id": "client_codexappserverclient_mapexiterror",
-      "community": 8
-    },
-    {
-      "label": ".looksLikeCommandNotFound()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L473",
-      "id": "client_codexappserverclient_lookslikecommandnotfound",
-      "community": 8
-    },
-    {
-      "label": "buildApprovalResponse()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L483",
-      "id": "client_buildapprovalresponse",
-      "community": 8
-    },
-    {
-      "label": "protocol.ts",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L1",
-      "id": "protocol",
-      "community": 8
-    },
-    {
-      "label": "createInitializeRequest()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L17",
-      "id": "protocol_createinitializerequest",
-      "community": 8
-    },
-    {
-      "label": "createInitializedNotification()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L35",
-      "id": "protocol_createinitializednotification",
-      "community": 8
-    },
-    {
-      "label": "createThreadStartRequest()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L42",
-      "id": "protocol_createthreadstartrequest",
-      "community": 8
-    },
-    {
-      "label": "createTurnStartRequest()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L61",
-      "id": "protocol_createturnstartrequest",
-      "community": 8
-    },
-    {
-      "label": "parseProtocolLine()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L86",
-      "id": "protocol_parseprotocolline",
-      "community": 8
-    },
-    {
-      "label": "extractThreadId()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L112",
-      "id": "protocol_extractthreadid",
-      "community": 8
-    },
-    {
-      "label": "extractTurnId()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L124",
-      "id": "protocol_extractturnid",
-      "community": 8
-    },
-    {
-      "label": "getMethodName()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L136",
-      "id": "protocol_getmethodname",
-      "community": 8
-    },
-    {
-      "label": "getTurnTerminalState()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L140",
-      "id": "protocol_getturnterminalstate",
-      "community": 8
-    },
-    {
-      "label": "isApprovalRequest()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L156",
-      "id": "protocol_isapprovalrequest",
-      "community": 8
-    },
-    {
-      "label": "isUnsupportedToolCallRequest()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L161",
-      "id": "protocol_isunsupportedtoolcallrequest",
-      "community": 8
-    },
-    {
-      "label": "isUserInputRequired()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L166",
-      "id": "protocol_isuserinputrequired",
-      "community": 8
-    },
-    {
-      "label": "extractUsage()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L184",
-      "id": "protocol_extractusage",
-      "community": 8
-    },
-    {
-      "label": "extractRateLimits()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L233",
-      "id": "protocol_extractratelimits",
-      "community": 8
-    },
-    {
-      "label": "hasRequestId()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L241",
-      "id": "protocol_hasrequestid",
-      "community": 8
-    },
-    {
-      "label": "asObject()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L246",
-      "id": "protocol_asobject",
-      "community": 8
-    },
-    {
-      "label": "firstObject()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L254",
-      "id": "protocol_firstobject",
-      "community": 8
-    },
-    {
-      "label": "asString()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L265",
-      "id": "protocol_asstring",
-      "community": 8
-    },
-    {
-      "label": "asNumber()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L273",
-      "id": "protocol_asnumber",
-      "community": 8
-    },
-    {
-      "label": "resolveEffectiveConfig()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/config.ts",
-      "source_location": "L8",
-      "id": "config_resolveeffectiveconfig",
-      "community": 9
-    },
-    {
-      "label": "resolveWorkspaceRoot()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/config.ts",
-      "source_location": "L77",
-      "id": "config_resolveworkspaceroot",
-      "community": 9
-    },
-    {
-      "label": "expandPathLike()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/config.ts",
-      "source_location": "L85",
-      "id": "config_expandpathlike",
-      "community": 9
-    },
-    {
-      "label": "resolveEnvReference()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/config.ts",
-      "source_location": "L99",
-      "id": "config_resolveenvreference",
-      "community": 9
-    },
-    {
-      "label": "resolveConfigString()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/config.ts",
-      "source_location": "L111",
-      "id": "config_resolveconfigstring",
-      "community": 9
-    },
-    {
-      "label": "normalizeStateLimits()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/config.ts",
-      "source_location": "L115",
-      "id": "config_normalizestatelimits",
-      "community": 9
-    },
-    {
-      "label": "asObject()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/config.ts",
-      "source_location": "L131",
-      "id": "config_asobject",
-      "community": 9
-    },
-    {
-      "label": "asString()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/config.ts",
-      "source_location": "L139",
-      "id": "config_asstring",
-      "community": 9
-    },
-    {
-      "label": "asStringArray()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/config.ts",
-      "source_location": "L147",
-      "id": "config_asstringarray",
-      "community": 9
-    },
-    {
-      "label": "asPositiveInt()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/config.ts",
-      "source_location": "L156",
-      "id": "config_aspositiveint",
-      "community": 9
-    },
-    {
-      "label": "asInt()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/config.ts",
-      "source_location": "L161",
-      "id": "config_asint",
-      "community": 9
-    },
-    {
-      "label": "errors.ts",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/errors.ts",
-      "source_location": "L1",
-      "id": "errors",
-      "community": 3
-    },
-    {
-      "label": "SymphonyError",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/errors.ts",
-      "source_location": "L28",
-      "id": "errors_symphonyerror",
-      "community": 3
-    },
-    {
-      "label": ".constructor()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/errors.ts",
-      "source_location": "L32",
-      "id": "errors_symphonyerror_constructor",
-      "community": 3
-    },
-    {
-      "label": "toErrorMessage()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/errors.ts",
-      "source_location": "L40",
-      "id": "errors_toerrormessage",
-      "community": 3
-    },
-    {
-      "label": "httpServer.ts",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L1",
-      "id": "httpserver",
-      "community": 3
-    },
-    {
-      "label": "startStatusServer()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L69",
-      "id": "httpserver_startstatusserver",
-      "community": 3
-    },
-    {
-      "label": "handleRequest()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L97",
-      "id": "httpserver_handlerequest",
-      "community": 3
-    },
-    {
-      "label": "queueRefresh()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L177",
-      "id": "httpserver_queuerefresh",
-      "community": 3
-    },
-    {
-      "label": "drainRefreshQueue()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L188",
-      "id": "httpserver_drainrefreshqueue",
-      "community": 3
-    },
-    {
-      "label": "toStateResponse()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L210",
-      "id": "httpserver_tostateresponse",
-      "community": 3
-    },
-    {
-      "label": "toIssueResponse()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L255",
-      "id": "httpserver_toissueresponse",
-      "community": 3
-    },
-    {
-      "label": "renderDashboardHtml()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L307",
-      "id": "httpserver_renderdashboardhtml",
-      "community": 3
-    },
-    {
-      "label": "safeJsonForScript()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L842",
-      "id": "httpserver_safejsonforscript",
-      "community": 3
-    },
-    {
-      "label": "toIso()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L849",
-      "id": "httpserver_toiso",
-      "community": 3
-    },
-    {
-      "label": "toIsoNullable()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L853",
-      "id": "httpserver_toisonullable",
-      "community": 3
-    },
-    {
-      "label": "sendJson()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L860",
-      "id": "httpserver_sendjson",
-      "community": 3
-    },
-    {
-      "label": "sendJsonError()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L867",
-      "id": "httpserver_sendjsonerror",
-      "community": 3
-    },
-    {
-      "label": "sendText()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L876",
-      "id": "httpserver_sendtext",
-      "community": 3
-    },
-    {
-      "label": "sendMethodNotAllowed()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L882",
-      "id": "httpserver_sendmethodnotallowed",
-      "community": 3
-    },
-    {
-      "label": "listen()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L888",
-      "id": "httpserver_listen",
-      "community": 3
-    },
-    {
-      "label": "closeServer()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L898",
-      "id": "httpserver_closeserver",
-      "community": 3
-    },
-    {
-      "label": "issue.ts",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/issue.ts",
-      "source_location": "L1",
-      "id": "issue",
-      "community": 3
-    },
-    {
-      "label": "orchestrator.ts",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/orchestrator.ts",
-      "source_location": "L1",
-      "id": "orchestrator",
-      "community": 3
-    },
-    {
-      "label": "createOrchestratorState()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/orchestrator.ts",
-      "source_location": "L45",
-      "id": "orchestrator_createorchestratorstate",
-      "community": 3
-    },
-    {
-      "label": "markIssueRunning()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/orchestrator.ts",
-      "source_location": "L54",
-      "id": "orchestrator_markissuerunning",
-      "community": 3
-    },
-    {
-      "label": "getAvailableGlobalSlots()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/orchestrator.ts",
-      "source_location": "L71",
-      "id": "orchestrator_getavailableglobalslots",
-      "community": 3
-    },
-    {
-      "label": "getRunningCountByState()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/orchestrator.ts",
-      "source_location": "L75",
-      "id": "orchestrator_getrunningcountbystate",
-      "community": 3
-    },
-    {
-      "label": "selectDispatchCandidates()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/orchestrator.ts",
-      "source_location": "L86",
-      "id": "orchestrator_selectdispatchcandidates",
-      "community": 3
-    },
-    {
-      "label": "scheduleRetry()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/orchestrator.ts",
-      "source_location": "L143",
-      "id": "orchestrator_scheduleretry",
-      "community": 3
-    },
-    {
-      "label": "onWorkerExit()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/orchestrator.ts",
-      "source_location": "L161",
-      "id": "orchestrator_onworkerexit",
-      "community": 3
-    },
-    {
-      "label": "getStalledIssueIds()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/orchestrator.ts",
-      "source_location": "L212",
-      "id": "orchestrator_getstalledissueids",
-      "community": 3
-    },
-    {
-      "label": "reconcileRunningIssueStates()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/orchestrator.ts",
-      "source_location": "L236",
-      "id": "orchestrator_reconcilerunningissuestates",
-      "community": 3
-    },
-    {
-      "label": "normalizeRetryAttempt()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/orchestrator.ts",
-      "source_location": "L289",
-      "id": "orchestrator_normalizeretryattempt",
-      "community": 3
-    },
-    {
-      "label": "retry.ts",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/retry.ts",
-      "source_location": "L1",
-      "id": "retry",
-      "community": 3
-    },
-    {
-      "label": "calculateFailureRetryDelay()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/retry.ts",
-      "source_location": "L1",
-      "id": "retry_calculatefailureretrydelay",
-      "community": 3
-    },
-    {
-      "label": "calculateContinuationDelay()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/retry.ts",
-      "source_location": "L7",
-      "id": "retry_calculatecontinuationdelay",
-      "community": 3
-    },
-    {
-      "label": "runtime.ts",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/runtime.ts",
-      "source_location": "L1",
-      "id": "runtime",
-      "community": 3
-    },
-    {
-      "label": "runOrchestratorTick()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/runtime.ts",
-      "source_location": "L58",
-      "id": "runtime_runorchestratortick",
-      "community": 3
-    },
-    {
-      "label": "isGuardrailBlockedError()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/runtime.ts",
-      "source_location": "L155",
-      "id": "runtime_isguardrailblockederror",
-      "community": 3
-    },
-    {
-      "label": "reconcileRunningIssues()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/runtime.ts",
-      "source_location": "L163",
-      "id": "runtime_reconcilerunningissues",
-      "community": 3
-    },
-    {
-      "label": "normalizeDispatchAttempt()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/runtime.ts",
-      "source_location": "L188",
-      "id": "runtime_normalizedispatchattempt",
-      "community": 3
-    },
-    {
-      "label": "nextRetryAttempt()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/runtime.ts",
-      "source_location": "L196",
-      "id": "runtime_nextretryattempt",
-      "community": 3
-    },
-    {
-      "label": "processDueRetries()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/runtime.ts",
-      "source_location": "L204",
-      "id": "runtime_processdueretries",
-      "community": 3
-    },
-    {
-      "label": "canDispatchRetryIssue()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/runtime.ts",
-      "source_location": "L304",
-      "id": "runtime_candispatchretryissue",
-      "community": 3
-    },
-    {
-      "label": "requeueRetryEntry()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/runtime.ts",
-      "source_location": "L326",
-      "id": "runtime_requeueretryentry",
-      "community": 3
-    },
-    {
-      "label": "scheduler.ts",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/scheduler.ts",
-      "source_location": "L1",
-      "id": "scheduler",
-      "community": 3
-    },
-    {
-      "label": "sortIssuesForDispatch()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/scheduler.ts",
-      "source_location": "L3",
-      "id": "scheduler_sortissuesfordispatch",
-      "community": 3
-    },
-    {
-      "label": "isIssueDispatchEligible()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/scheduler.ts",
-      "source_location": "L22",
-      "id": "scheduler_isissuedispatcheligible",
-      "community": 3
-    },
-    {
-      "label": "normalizePriority()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/scheduler.ts",
-      "source_location": "L57",
-      "id": "scheduler_normalizepriority",
-      "community": 3
-    },
-    {
-      "label": "service.ts",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L1",
-      "id": "service",
-      "community": 3
-    },
-    {
-      "label": "formatServiceLogLine()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L191",
-      "id": "service_formatservicelogline",
-      "community": 3
-    },
-    {
-      "label": "createSymphonyService()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L206",
-      "id": "service_createsymphonyservice",
-      "community": 3
-    },
-    {
-      "label": "resolveDependencies()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L1412",
-      "id": "service_resolvedependencies",
-      "community": 3
-    },
-    {
-      "label": "hasRecognizedPackageLabel()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L1464",
-      "id": "service_hasrecognizedpackagelabel",
-      "community": 3
-    },
-    {
-      "label": "isDoneSignalState()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L1483",
-      "id": "service_isdonesignalstate",
-      "community": 3
-    },
-    {
-      "label": "buildRunCommentBody()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L1496",
-      "id": "service_buildruncommentbody",
-      "community": 3
-    },
-    {
-      "label": "normalizeCodexEventKind()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L1524",
-      "id": "service_normalizecodexeventkind",
-      "community": 3
-    },
-    {
-      "label": "formatCodexEventMessage()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L1528",
-      "id": "service_formatcodexeventmessage",
-      "community": 3
-    },
-    {
-      "label": "extractCodexMethod()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L1541",
-      "id": "service_extractcodexmethod",
-      "community": 3
-    },
-    {
-      "label": "normalizeUsage()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L1550",
-      "id": "service_normalizeusage",
-      "community": 3
-    },
-    {
-      "label": "normalizeRateLimits()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L1570",
-      "id": "service_normalizeratelimits",
-      "community": 3
-    },
-    {
-      "label": "formatLogValue()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L1578",
-      "id": "service_formatlogvalue",
-      "community": 3
-    },
-    {
-      "label": "asString()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L1594",
-      "id": "service_asstring",
-      "community": 3
-    },
-    {
-      "label": "asNumber()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L1598",
-      "id": "service_asnumber",
-      "community": 3
-    },
-    {
-      "label": "startup.ts",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/startup.ts",
-      "source_location": "L1",
-      "id": "startup",
-      "community": 3
-    },
-    {
-      "label": "cleanupTerminalIssueWorkspaces()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/startup.ts",
-      "source_location": "L24",
-      "id": "startup_cleanupterminalissueworkspaces",
-      "community": 3
-    },
-    {
-      "label": "template.ts",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/template.ts",
-      "source_location": "L1",
-      "id": "template",
-      "community": 3
-    },
-    {
-      "label": "renderPromptTemplate()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/template.ts",
-      "source_location": "L10",
-      "id": "template_renderprompttemplate",
-      "community": 3
-    },
-    {
-      "label": "buildIssuePrompt()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/template.ts",
-      "source_location": "L25",
-      "id": "template_buildissueprompt",
-      "community": 3
-    },
-    {
-      "label": "linear.ts",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L1",
-      "id": "linear",
-      "community": 3
-    },
-    {
-      "label": "LinearTrackerClient",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L159",
-      "id": "linear_lineartrackerclient",
-      "community": 3
-    },
-    {
-      "label": ".constructor()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L169",
-      "id": "linear_lineartrackerclient_constructor",
-      "community": 3
-    },
-    {
-      "label": ".fetchCandidateIssues()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L179",
-      "id": "linear_lineartrackerclient_fetchcandidateissues",
-      "community": 3
-    },
-    {
-      "label": ".fetchIssuesByStates()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L186",
-      "id": "linear_lineartrackerclient_fetchissuesbystates",
-      "community": 3
-    },
-    {
-      "label": ".fetchIssueStatesByIds()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L197",
-      "id": "linear_lineartrackerclient_fetchissuestatesbyids",
-      "community": 3
-    },
-    {
-      "label": ".createIssueComment()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L214",
-      "id": "linear_lineartrackerclient_createissuecomment",
-      "community": 3
-    },
-    {
-      "label": ".updateIssueStateByName()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L225",
-      "id": "linear_lineartrackerclient_updateissuestatebyname",
-      "community": 3
-    },
-    {
-      "label": ".fetchPaginatedIssues()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L248",
-      "id": "linear_lineartrackerclient_fetchpaginatedissues",
-      "community": 3
-    },
-    {
-      "label": ".resolveWorkflowStateIdByName()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L288",
-      "id": "linear_lineartrackerclient_resolveworkflowstateidbyname",
-      "community": 3
-    },
-    {
-      "label": ".graphqlRequest()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L314",
-      "id": "linear_lineartrackerclient_graphqlrequest",
-      "community": 3
-    },
-    {
-      "label": "normalizeIssue()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L360",
-      "id": "linear_normalizeissue",
-      "community": 3
-    },
-    {
-      "label": "asString()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L392",
-      "id": "linear_asstring",
-      "community": 3
-    },
-    {
-      "label": "normalizePriority()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L396",
-      "id": "linear_normalizepriority",
-      "community": 3
-    },
-    {
-      "label": "normalizeIso()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L404",
-      "id": "linear_normalizeiso",
-      "community": 3
-    },
-    {
-      "label": "normalizeLabels()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L417",
-      "id": "linear_normalizelabels",
-      "community": 3
-    },
-    {
-      "label": "normalizeBlockedBy()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L428",
-      "id": "linear_normalizeblockedby",
-      "community": 3
-    },
-    {
-      "label": "validate.ts",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/validate.ts",
-      "source_location": "L1",
-      "id": "validate",
-      "community": 3
-    },
-    {
-      "label": "validateDispatchPreflight()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/validate.ts",
-      "source_location": "L4",
-      "id": "validate_validatedispatchpreflight",
-      "community": 3
-    },
-    {
-      "label": "worker.ts",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/worker.ts",
-      "source_location": "L1",
-      "id": "worker",
-      "community": 3
-    },
-    {
-      "label": "runIssueAttempt()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/worker.ts",
-      "source_location": "L42",
-      "id": "worker_runissueattempt",
-      "community": 3
-    },
-    {
-      "label": "shouldContinueTurns()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/worker.ts",
-      "source_location": "L254",
-      "id": "worker_shouldcontinueturns",
-      "community": 3
-    },
-    {
-      "label": "getWorkspaceFingerprint()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/worker.ts",
-      "source_location": "L262",
-      "id": "worker_getworkspacefingerprint",
-      "community": 3
-    },
-    {
-      "label": "toWorkspaceConfig()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/worker.ts",
-      "source_location": "L274",
-      "id": "worker_toworkspaceconfig",
-      "community": 3
-    },
-    {
-      "label": "toTemplateIssue()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/worker.ts",
-      "source_location": "L287",
-      "id": "worker_totemplateissue",
-      "community": 3
-    },
-    {
-      "label": "asNumber()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/worker.ts",
-      "source_location": "L301",
-      "id": "worker_asnumber",
-      "community": 3
-    },
-    {
-      "label": "workflow.ts",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/workflow.ts",
-      "source_location": "L1",
-      "id": "workflow",
-      "community": 3
-    },
-    {
-      "label": "loadWorkflowFile()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/workflow.ts",
-      "source_location": "L10",
-      "id": "workflow_loadworkflowfile",
-      "community": 3
-    },
-    {
-      "label": "parseWorkflowContent()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/workflow.ts",
-      "source_location": "L32",
-      "id": "workflow_parseworkflowcontent",
-      "community": 3
-    },
-    {
-      "label": "parseFrontMatter()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/workflow.ts",
-      "source_location": "L71",
-      "id": "workflow_parsefrontmatter",
-      "community": 3
-    },
-    {
-      "label": "watchWorkflowFile()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/workflow.ts",
-      "source_location": "L97",
-      "id": "workflow_watchworkflowfile",
-      "community": 3
-    },
-    {
-      "label": "workspace.ts",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/workspace.ts",
-      "source_location": "L1",
-      "id": "workspace",
-      "community": 3
-    },
-    {
-      "label": "ensureWorkspaceForIssue()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/workspace.ts",
-      "source_location": "L25",
-      "id": "workspace_ensureworkspaceforissue",
-      "community": 3
-    },
-    {
-      "label": "runBeforeRunHook()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/workspace.ts",
-      "source_location": "L47",
-      "id": "workspace_runbeforerunhook",
-      "community": 3
-    },
-    {
-      "label": "runAfterRunHook()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/workspace.ts",
-      "source_location": "L55",
-      "id": "workspace_runafterrunhook",
-      "community": 3
-    },
-    {
-      "label": "removeWorkspace()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/workspace.ts",
-      "source_location": "L63",
-      "id": "workspace_removeworkspace",
-      "community": 3
-    },
-    {
-      "label": "resolveWorkspaceLocation()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/workspace.ts",
-      "source_location": "L73",
-      "id": "workspace_resolveworkspacelocation",
-      "community": 3
-    },
-    {
-      "label": "sanitizeWorkspaceKey()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/workspace.ts",
-      "source_location": "L87",
-      "id": "workspace_sanitizeworkspacekey",
-      "community": 3
-    },
-    {
-      "label": "assertWorkspacePathSafety()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/workspace.ts",
-      "source_location": "L98",
-      "id": "workspace_assertworkspacepathsafety",
-      "community": 3
-    },
-    {
-      "label": "runRequiredHook()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/workspace.ts",
-      "source_location": "L117",
-      "id": "workspace_runrequiredhook",
-      "community": 3
-    },
-    {
-      "label": "runBestEffortHook()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/workspace.ts",
-      "source_location": "L127",
-      "id": "workspace_runbestefforthook",
-      "community": 3
-    },
-    {
-      "label": "runHookScript()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/workspace.ts",
-      "source_location": "L142",
-      "id": "workspace_runhookscript",
-      "community": 3
-    },
-    {
-      "label": "pathExists()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/workspace.ts",
-      "source_location": "L219",
-      "id": "workspace_pathexists",
-      "community": 3
-    },
-    {
-      "label": "isMissingPathError()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/src/workspace.ts",
-      "source_location": "L232",
-      "id": "workspace_ismissingpatherror",
-      "community": 3
-    },
-    {
-      "label": "cli.test.ts",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/cli.test.ts",
-      "source_location": "L1",
-      "id": "cli_test",
-      "community": 3
-    },
-    {
-      "label": "makeService()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/cli.test.ts",
-      "source_location": "L5",
-      "id": "cli_test_makeservice",
-      "community": 3
-    },
-    {
-      "label": "codexClient.test.ts",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/codexClient.test.ts",
-      "source_location": "L1",
-      "id": "codexclient_test",
-      "community": 8
-    },
-    {
-      "label": "writeMockServer()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/codexClient.test.ts",
-      "source_location": "L350",
-      "id": "codexclient_test_writemockserver",
-      "community": 8
-    },
-    {
-      "label": "codexProtocol.test.ts",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/codexProtocol.test.ts",
-      "source_location": "L1",
-      "id": "codexprotocol_test",
-      "community": 8
-    },
-    {
-      "label": "httpServer.test.ts",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/httpServer.test.ts",
-      "source_location": "L1",
-      "id": "httpserver_test",
-      "community": 3
-    },
-    {
-      "label": "makeService()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/httpServer.test.ts",
-      "source_location": "L5",
-      "id": "httpserver_test_makeservice",
-      "community": 3
-    },
-    {
-      "label": "linearTracker.test.ts",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/linearTracker.test.ts",
-      "source_location": "L1",
-      "id": "lineartracker_test",
-      "community": 3
-    },
-    {
-      "label": "makeFetch()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/linearTracker.test.ts",
-      "source_location": "L5",
-      "id": "lineartracker_test_makefetch",
-      "community": 3
-    },
-    {
-      "label": "clientWith()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/linearTracker.test.ts",
-      "source_location": "L28",
-      "id": "lineartracker_test_clientwith",
-      "community": 3
-    },
-    {
-      "label": "orchestrator.test.ts",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/orchestrator.test.ts",
-      "source_location": "L1",
-      "id": "orchestrator_test",
-      "community": 3
-    },
-    {
-      "label": "issue()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/orchestrator.test.ts",
-      "source_location": "L14",
-      "id": "orchestrator_test_issue",
-      "community": 3
-    },
-    {
-      "label": "retry.test.ts",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/retry.test.ts",
-      "source_location": "L1",
-      "id": "retry_test",
-      "community": 3
-    },
-    {
-      "label": "runtime.test.ts",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/runtime.test.ts",
-      "source_location": "L1",
-      "id": "runtime_test",
-      "community": 3
-    },
-    {
-      "label": "issue()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/runtime.test.ts",
-      "source_location": "L7",
-      "id": "runtime_test_issue",
-      "community": 3
-    },
-    {
-      "label": "FakeTracker",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/runtime.test.ts",
-      "source_location": "L21",
-      "id": "runtime_test_faketracker",
-      "community": 3
-    },
-    {
-      "label": ".constructor()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/runtime.test.ts",
-      "source_location": "L22",
-      "id": "runtime_test_faketracker_constructor",
-      "community": 3
-    },
-    {
-      "label": ".fetchCandidateIssues()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/runtime.test.ts",
-      "source_location": "L27",
-      "id": "runtime_test_faketracker_fetchcandidateissues",
-      "community": 3
-    },
-    {
-      "label": ".fetchIssuesByStates()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/runtime.test.ts",
-      "source_location": "L31",
-      "id": "runtime_test_faketracker_fetchissuesbystates",
-      "community": 3
-    },
-    {
-      "label": ".fetchIssueStatesByIds()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/runtime.test.ts",
-      "source_location": "L35",
-      "id": "runtime_test_faketracker_fetchissuestatesbyids",
-      "community": 3
-    },
-    {
-      "label": "config()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/runtime.test.ts",
-      "source_location": "L40",
-      "id": "runtime_test_config",
-      "community": 3
-    },
-    {
-      "label": "scheduler.test.ts",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/scheduler.test.ts",
-      "source_location": "L1",
-      "id": "scheduler_test",
-      "community": 3
-    },
-    {
-      "label": "makeIssue()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/scheduler.test.ts",
-      "source_location": "L5",
-      "id": "scheduler_test_makeissue",
-      "community": 3
-    },
-    {
-      "label": "service.test.ts",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/service.test.ts",
-      "source_location": "L1",
-      "id": "service_test",
-      "community": 3
-    },
-    {
-      "label": "FakeTracker",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/service.test.ts",
-      "source_location": "L7",
-      "id": "service_test_faketracker",
-      "community": 3
-    },
-    {
-      "label": ".fetchCandidateIssues()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/service.test.ts",
-      "source_location": "L8",
-      "id": "service_test_faketracker_fetchcandidateissues",
-      "community": 3
-    },
-    {
-      "label": ".fetchIssuesByStates()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/service.test.ts",
-      "source_location": "L12",
-      "id": "service_test_faketracker_fetchissuesbystates",
-      "community": 3
-    },
-    {
-      "label": ".fetchIssueStatesByIds()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/service.test.ts",
-      "source_location": "L16",
-      "id": "service_test_faketracker_fetchissuestatesbyids",
-      "community": 3
-    },
-    {
-      "label": "issue()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/service.test.ts",
-      "source_location": "L21",
-      "id": "service_test_issue",
-      "community": 3
-    },
-    {
-      "label": "workflow()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/service.test.ts",
-      "source_location": "L38",
-      "id": "service_test_workflow",
-      "community": 3
-    },
-    {
-      "label": "startup.test.ts",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/startup.test.ts",
-      "source_location": "L1",
-      "id": "startup_test",
-      "community": 3
-    },
-    {
-      "label": "issue()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/startup.test.ts",
-      "source_location": "L9",
-      "id": "startup_test_issue",
-      "community": 3
-    },
-    {
-      "label": "FakeTracker",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/startup.test.ts",
-      "source_location": "L23",
-      "id": "startup_test_faketracker",
-      "community": 3
-    },
-    {
-      "label": ".constructor()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/startup.test.ts",
-      "source_location": "L24",
-      "id": "startup_test_faketracker_constructor",
-      "community": 3
-    },
-    {
-      "label": ".fetchCandidateIssues()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/startup.test.ts",
-      "source_location": "L29",
-      "id": "startup_test_faketracker_fetchcandidateissues",
-      "community": 3
-    },
-    {
-      "label": ".fetchIssuesByStates()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/startup.test.ts",
-      "source_location": "L33",
-      "id": "startup_test_faketracker_fetchissuesbystates",
-      "community": 3
-    },
-    {
-      "label": ".fetchIssueStatesByIds()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/startup.test.ts",
-      "source_location": "L41",
-      "id": "startup_test_faketracker_fetchissuestatesbyids",
-      "community": 3
-    },
-    {
-      "label": "template.test.ts",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/template.test.ts",
-      "source_location": "L1",
-      "id": "template_test",
-      "community": 3
-    },
-    {
-      "label": "worker.test.ts",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/worker.test.ts",
-      "source_location": "L1",
-      "id": "worker_test",
-      "community": 3
-    },
-    {
-      "label": "issue()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/worker.test.ts",
-      "source_location": "L10",
-      "id": "worker_test_issue",
-      "community": 3
-    },
-    {
-      "label": "FakeTracker",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/worker.test.ts",
-      "source_location": "L24",
-      "id": "worker_test_faketracker",
-      "community": 3
-    },
-    {
-      "label": ".constructor()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/worker.test.ts",
-      "source_location": "L25",
-      "id": "worker_test_faketracker_constructor",
-      "community": 3
-    },
-    {
-      "label": ".fetchCandidateIssues()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/worker.test.ts",
-      "source_location": "L29",
-      "id": "worker_test_faketracker_fetchcandidateissues",
-      "community": 3
-    },
-    {
-      "label": ".fetchIssuesByStates()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/worker.test.ts",
-      "source_location": "L33",
-      "id": "worker_test_faketracker_fetchissuesbystates",
-      "community": 3
-    },
-    {
-      "label": ".fetchIssueStatesByIds()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/worker.test.ts",
-      "source_location": "L37",
-      "id": "worker_test_faketracker_fetchissuestatesbyids",
-      "community": 3
-    },
-    {
-      "label": "FakeCodex",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/worker.test.ts",
-      "source_location": "L42",
-      "id": "worker_test_fakecodex",
-      "community": 3
-    },
-    {
-      "label": ".constructor()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/worker.test.ts",
-      "source_location": "L48",
-      "id": "worker_test_fakecodex_constructor",
-      "community": 3
-    },
-    {
-      "label": ".startSession()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/worker.test.ts",
-      "source_location": "L53",
-      "id": "worker_test_fakecodex_startsession",
-      "community": 3
-    },
-    {
-      "label": ".runTurn()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/worker.test.ts",
-      "source_location": "L58",
-      "id": "worker_test_fakecodex_runturn",
-      "community": 3
-    },
-    {
-      "label": ".stop()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/worker.test.ts",
-      "source_location": "L86",
-      "id": "worker_test_fakecodex_stop",
-      "community": 3
-    },
-    {
-      "label": "config()",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/worker.test.ts",
-      "source_location": "L91",
-      "id": "worker_test_config",
-      "community": 3
-    },
-    {
-      "label": "workflow.test.ts",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/workflow.test.ts",
-      "source_location": "L1",
-      "id": "workflow_test",
-      "community": 3
-    },
-    {
-      "label": "workspace.test.ts",
-      "file_type": "code",
-      "source_file": "packages/symphony-service/tests/workspace.test.ts",
-      "source_location": "L1",
-      "id": "workspace_test",
-      "community": 3
+      "community": 22
     },
     {
       "label": "test-connection.js",
@@ -17905,7 +16033,7 @@
       "source_file": "packages/valkey-proxy-server/test-connection.js",
       "source_location": "L1",
       "id": "test_connection",
-      "community": 26
+      "community": 27
     },
     {
       "label": "testConnection()",
@@ -17913,7 +16041,7 @@
       "source_file": "packages/valkey-proxy-server/test-connection.js",
       "source_location": "L40",
       "id": "test_connection_testconnection",
-      "community": 26
+      "community": 27
     },
     {
       "label": "testClusterInfo()",
@@ -17921,7 +16049,7 @@
       "source_file": "packages/valkey-proxy-server/test-connection.js",
       "source_location": "L52",
       "id": "test_connection_testclusterinfo",
-      "community": 26
+      "community": 27
     },
     {
       "label": "testBasicOperations()",
@@ -17929,7 +16057,7 @@
       "source_file": "packages/valkey-proxy-server/test-connection.js",
       "source_location": "L64",
       "id": "test_connection_testbasicoperations",
-      "community": 26
+      "community": 27
     },
     {
       "label": "runTests()",
@@ -17937,7 +16065,7 @@
       "source_file": "packages/valkey-proxy-server/test-connection.js",
       "source_location": "L89",
       "id": "test_connection_runtests",
-      "community": 26
+      "community": 27
     },
     {
       "label": "architecture-boundaries.test.ts",
@@ -17972,28 +16100,220 @@
       "community": 44
     },
     {
+      "label": "graphify-rebuild.test.ts",
+      "file_type": "code",
+      "source_file": "scripts/graphify-rebuild.test.ts",
+      "source_location": "L1",
+      "id": "graphify_rebuild_test",
+      "community": 25
+    },
+    {
+      "label": "write()",
+      "file_type": "code",
+      "source_file": "scripts/graphify-rebuild.test.ts",
+      "source_location": "L10",
+      "id": "graphify_rebuild_test_write",
+      "community": 25
+    },
+    {
+      "label": "createFixtureRoot()",
+      "file_type": "code",
+      "source_file": "scripts/graphify-rebuild.test.ts",
+      "source_location": "L16",
+      "id": "graphify_rebuild_test_createfixtureroot",
+      "community": 25
+    },
+    {
+      "label": "spawn()",
+      "file_type": "code",
+      "source_file": "scripts/graphify-rebuild.test.ts",
+      "source_location": "L38",
+      "id": "graphify_rebuild_test_spawn",
+      "community": 25
+    },
+    {
+      "label": "graphify-rebuild.ts",
+      "file_type": "code",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L1",
+      "id": "graphify_rebuild",
+      "community": 25
+    },
+    {
+      "label": "fileExists()",
+      "file_type": "code",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L67",
+      "id": "graphify_rebuild_fileexists",
+      "community": 25
+    },
+    {
+      "label": "resolveGraphifyPython()",
+      "file_type": "code",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L76",
+      "id": "graphify_rebuild_resolvegraphifypython",
+      "community": 25
+    },
+    {
+      "label": "runGraphifyRebuild()",
+      "file_type": "code",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L86",
+      "id": "graphify_rebuild_rungraphifyrebuild",
+      "community": 25
+    },
+    {
+      "label": "harness-audit.test.ts",
+      "file_type": "code",
+      "source_file": "scripts/harness-audit.test.ts",
+      "source_location": "L1",
+      "id": "harness_audit_test",
+      "community": 13
+    },
+    {
+      "label": "write()",
+      "file_type": "code",
+      "source_file": "scripts/harness-audit.test.ts",
+      "source_location": "L11",
+      "id": "harness_audit_test_write",
+      "community": 13
+    },
+    {
+      "label": "createFixtureRepo()",
+      "file_type": "code",
+      "source_file": "scripts/harness-audit.test.ts",
+      "source_location": "L17",
+      "id": "harness_audit_test_createfixturerepo",
+      "community": 13
+    },
+    {
+      "label": "harness-audit.ts",
+      "file_type": "code",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L1",
+      "id": "harness_audit",
+      "community": 13
+    },
+    {
+      "label": "normalizeRepoPath()",
+      "file_type": "code",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L48",
+      "id": "harness_audit_normalizerepopath",
+      "community": 13
+    },
+    {
+      "label": "matchesPathPrefix()",
+      "file_type": "code",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L52",
+      "id": "harness_audit_matchespathprefix",
+      "community": 13
+    },
+    {
+      "label": "fileExists()",
+      "file_type": "code",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L66",
+      "id": "harness_audit_fileexists",
+      "community": 13
+    },
+    {
+      "label": "readJsonFile()",
+      "file_type": "code",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L75",
+      "id": "harness_audit_readjsonfile",
+      "community": 13
+    },
+    {
+      "label": "toValidationSurfaces()",
+      "file_type": "code",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L79",
+      "id": "harness_audit_tovalidationsurfaces",
+      "community": 13
+    },
+    {
+      "label": "addGroupedError()",
+      "file_type": "code",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L91",
+      "id": "harness_audit_addgroupederror",
+      "community": 13
+    },
+    {
+      "label": "inferGroupFromError()",
+      "file_type": "code",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L105",
+      "id": "harness_audit_infergroupfromerror",
+      "community": 13
+    },
+    {
+      "label": "shouldSkipSurfaceEntry()",
+      "file_type": "code",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L110",
+      "id": "harness_audit_shouldskipsurfaceentry",
+      "community": 13
+    },
+    {
+      "label": "collectLiveSurfaceEntries()",
+      "file_type": "code",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L121",
+      "id": "harness_audit_collectlivesurfaceentries",
+      "community": 13
+    },
+    {
+      "label": "loadAuditTarget()",
+      "file_type": "code",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L150",
+      "id": "harness_audit_loadaudittarget",
+      "community": 13
+    },
+    {
+      "label": "formatGroupedErrors()",
+      "file_type": "code",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L278",
+      "id": "harness_audit_formatgroupederrors",
+      "community": 13
+    },
+    {
+      "label": "runHarnessAudit()",
+      "file_type": "code",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L293",
+      "id": "harness_audit_runharnessaudit",
+      "community": 13
+    },
+    {
       "label": "harness-check.test.ts",
       "file_type": "code",
       "source_file": "scripts/harness-check.test.ts",
       "source_location": "L1",
       "id": "harness_check_test",
-      "community": 18
+      "community": 13
     },
     {
       "label": "write()",
       "file_type": "code",
       "source_file": "scripts/harness-check.test.ts",
-      "source_location": "L16",
+      "source_location": "L29",
       "id": "harness_check_test_write",
-      "community": 18
+      "community": 13
     },
     {
       "label": "createFixtureRepo()",
       "file_type": "code",
       "source_file": "scripts/harness-check.test.ts",
-      "source_location": "L22",
+      "source_location": "L35",
       "id": "harness_check_test_createfixturerepo",
-      "community": 18
+      "community": 13
     },
     {
       "label": "harness-check.ts",
@@ -18001,135 +16321,335 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L1",
       "id": "harness_check",
-      "community": 18
+      "community": 13
     },
     {
       "label": "stripLinkDecorations()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L29",
+      "source_location": "L44",
       "id": "harness_check_striplinkdecorations",
-      "community": 18
+      "community": 13
     },
     {
       "label": "isRelativeLink()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L33",
+      "source_location": "L48",
       "id": "harness_check_isrelativelink",
-      "community": 18
+      "community": 13
     },
     {
       "label": "fileExists()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L41",
+      "source_location": "L56",
       "id": "harness_check_fileexists",
-      "community": 18
+      "community": 13
     },
     {
       "label": "collectMarkdownLinkErrors()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L50",
+      "source_location": "L65",
       "id": "harness_check_collectmarkdownlinkerrors",
-      "community": 18
+      "community": 13
     },
     {
       "label": "extractInlineCode()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L79",
+      "source_location": "L94",
       "id": "harness_check_extractinlinecode",
-      "community": 18
+      "community": 13
     },
     {
       "label": "normalizePathReference()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L85",
+      "source_location": "L100",
       "id": "harness_check_normalizepathreference",
-      "community": 18
+      "community": 13
     },
     {
       "label": "isLikelyPathReference()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L98",
+      "source_location": "L113",
       "id": "harness_check_islikelypathreference",
-      "community": 18
+      "community": 13
     },
     {
       "label": "resolvePathReference()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L123",
+      "source_location": "L138",
       "id": "harness_check_resolvepathreference",
-      "community": 18
+      "community": 13
     },
     {
       "label": "collectReferencedPathErrors()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L149",
+      "source_location": "L164",
       "id": "harness_check_collectreferencedpatherrors",
-      "community": 18
+      "community": 13
     },
     {
       "label": "readPackageConfig()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L184",
+      "source_location": "L199",
       "id": "harness_check_readpackageconfig",
-      "community": 18
+      "community": 13
     },
     {
       "label": "extractTestScriptFromCommand()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L209",
+      "source_location": "L224",
       "id": "harness_check_extracttestscriptfromcommand",
-      "community": 18
+      "community": 13
     },
     {
       "label": "walkFiles()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L241",
+      "source_location": "L256",
       "id": "harness_check_walkfiles",
-      "community": 18
+      "community": 13
     },
     {
       "label": "collectTestSurfaceRoots()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L261",
+      "source_location": "L276",
       "id": "harness_check_collecttestsurfaceroots",
-      "community": 18
+      "community": 13
     },
     {
       "label": "collectTestingDocErrors()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L303",
+      "source_location": "L318",
       "id": "harness_check_collecttestingdocerrors",
-      "community": 18
+      "community": 13
     },
     {
       "label": "validateHarnessDocs()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L348",
+      "source_location": "L363",
       "id": "harness_check_validateharnessdocs",
-      "community": 18
+      "community": 13
     },
     {
       "label": "runHarnessCheck()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L446",
+      "source_location": "L496",
       "id": "harness_check_runharnesscheck",
-      "community": 18
+      "community": 13
+    },
+    {
+      "label": "harness-generate.test.ts",
+      "file_type": "code",
+      "source_file": "scripts/harness-generate.test.ts",
+      "source_location": "L1",
+      "id": "harness_generate_test",
+      "community": 13
+    },
+    {
+      "label": "write()",
+      "file_type": "code",
+      "source_file": "scripts/harness-generate.test.ts",
+      "source_location": "L10",
+      "id": "harness_generate_test_write",
+      "community": 13
+    },
+    {
+      "label": "createFixtureRepo()",
+      "file_type": "code",
+      "source_file": "scripts/harness-generate.test.ts",
+      "source_location": "L16",
+      "id": "harness_generate_test_createfixturerepo",
+      "community": 13
+    },
+    {
+      "label": "harness-generate.ts",
+      "file_type": "code",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L1",
+      "id": "harness_generate",
+      "community": 13
+    },
+    {
+      "label": "normalizeRepoPath()",
+      "file_type": "code",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L250",
+      "id": "harness_generate_normalizerepopath",
+      "community": 13
+    },
+    {
+      "label": "shouldSkipGeneratedEntry()",
+      "file_type": "code",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L254",
+      "id": "harness_generate_shouldskipgeneratedentry",
+      "community": 13
+    },
+    {
+      "label": "fileExists()",
+      "file_type": "code",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L258",
+      "id": "harness_generate_fileexists",
+      "community": 13
+    },
+    {
+      "label": "walkFiles()",
+      "file_type": "code",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L267",
+      "id": "harness_generate_walkfiles",
+      "community": 13
+    },
+    {
+      "label": "readPackageConfig()",
+      "file_type": "code",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L289",
+      "id": "harness_generate_readpackageconfig",
+      "community": 13
+    },
+    {
+      "label": "toDocPath()",
+      "file_type": "code",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L307",
+      "id": "harness_generate_todocpath",
+      "community": 13
+    },
+    {
+      "label": "formatMarkdownLink()",
+      "file_type": "code",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L311",
+      "id": "harness_generate_formatmarkdownlink",
+      "community": 13
+    },
+    {
+      "label": "headingFromSegment()",
+      "file_type": "code",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L315",
+      "id": "harness_generate_headingfromsegment",
+      "community": 13
+    },
+    {
+      "label": "summarizeChildren()",
+      "file_type": "code",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L323",
+      "id": "harness_generate_summarizechildren",
+      "community": 13
+    },
+    {
+      "label": "collectRouteGroups()",
+      "file_type": "code",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L331",
+      "id": "harness_generate_collectroutegroups",
+      "community": 13
+    },
+    {
+      "label": "collectTestFiles()",
+      "file_type": "code",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L357",
+      "id": "harness_generate_collecttestfiles",
+      "community": 13
+    },
+    {
+      "label": "collectTestSurfaceRoots()",
+      "file_type": "code",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L387",
+      "id": "harness_generate_collecttestsurfaceroots",
+      "community": 13
+    },
+    {
+      "label": "collectFolderFacts()",
+      "file_type": "code",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L429",
+      "id": "harness_generate_collectfolderfacts",
+      "community": 13
+    },
+    {
+      "label": "formatScriptCommand()",
+      "file_type": "code",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L452",
+      "id": "harness_generate_formatscriptcommand",
+      "community": 13
+    },
+    {
+      "label": "buildGeneratedDoc()",
+      "file_type": "code",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L462",
+      "id": "harness_generate_buildgenerateddoc",
+      "community": 13
+    },
+    {
+      "label": "buildRouteIndex()",
+      "file_type": "code",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L472",
+      "id": "harness_generate_buildrouteindex",
+      "community": 13
+    },
+    {
+      "label": "buildTestIndex()",
+      "file_type": "code",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L499",
+      "id": "harness_generate_buildtestindex",
+      "community": 13
+    },
+    {
+      "label": "buildKeyFolderIndex()",
+      "file_type": "code",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L544",
+      "id": "harness_generate_buildkeyfolderindex",
+      "community": 13
+    },
+    {
+      "label": "buildValidationGuide()",
+      "file_type": "code",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L577",
+      "id": "harness_generate_buildvalidationguide",
+      "community": 13
+    },
+    {
+      "label": "generateHarnessDocs()",
+      "file_type": "code",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L616",
+      "id": "harness_generate_generateharnessdocs",
+      "community": 13
+    },
+    {
+      "label": "writeGeneratedHarnessDocs()",
+      "file_type": "code",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L642",
+      "id": "harness_generate_writegeneratedharnessdocs",
+      "community": 13
     },
     {
       "label": "harness-review.test.ts",
@@ -18183,7 +16703,7 @@
       "label": "normalizeRepoPath()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L44",
+      "source_location": "L51",
       "id": "harness_review_normalizerepopath",
       "community": 18
     },
@@ -18191,7 +16711,7 @@
       "label": "matchesPathPrefix()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L48",
+      "source_location": "L55",
       "id": "harness_review_matchespathprefix",
       "community": 18
     },
@@ -18199,7 +16719,7 @@
       "label": "fileExists()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L62",
+      "source_location": "L69",
       "id": "harness_review_fileexists",
       "community": 18
     },
@@ -18207,15 +16727,23 @@
       "label": "readJsonFile()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L71",
+      "source_location": "L78",
       "id": "harness_review_readjsonfile",
+      "community": 18
+    },
+    {
+      "label": "toValidationRules()",
+      "file_type": "code",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L82",
+      "id": "harness_review_tovalidationrules",
       "community": 18
     },
     {
       "label": "loadReviewTarget()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L75",
+      "source_location": "L95",
       "id": "harness_review_loadreviewtarget",
       "community": 18
     },
@@ -18223,7 +16751,7 @@
       "label": "loadReviewTargets()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L145",
+      "source_location": "L167",
       "id": "harness_review_loadreviewtargets",
       "community": 18
     },
@@ -18231,7 +16759,7 @@
       "label": "collectScriptsForChangedFiles()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L161",
+      "source_location": "L183",
       "id": "harness_review_collectscriptsforchangedfiles",
       "community": 18
     },
@@ -18239,7 +16767,7 @@
       "label": "getChangedFilesFromGit()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L216",
+      "source_location": "L238",
       "id": "harness_review_getchangedfilesfromgit",
       "community": 18
     },
@@ -18247,7 +16775,7 @@
       "label": "runPackageScript()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L254",
+      "source_location": "L276",
       "id": "harness_review_runpackagescript",
       "community": 18
     },
@@ -18255,8 +16783,40 @@
       "label": "runHarnessReview()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L268",
+      "source_location": "L290",
       "id": "harness_review_runharnessreview",
+      "community": 18
+    },
+    {
+      "label": "pre-push-review.ts",
+      "file_type": "code",
+      "source_file": "scripts/pre-push-review.ts",
+      "source_location": "L1",
+      "id": "pre_push_review",
+      "community": 18
+    },
+    {
+      "label": "getChangedFilesVsOriginMain()",
+      "file_type": "code",
+      "source_file": "scripts/pre-push-review.ts",
+      "source_location": "L6",
+      "id": "pre_push_review_getchangedfilesvsoriginmain",
+      "community": 18
+    },
+    {
+      "label": "runArchitectureCheck()",
+      "file_type": "code",
+      "source_file": "scripts/pre-push-review.ts",
+      "source_location": "L44",
+      "id": "pre_push_review_runarchitecturecheck",
+      "community": 18
+    },
+    {
+      "label": "main()",
+      "file_type": "code",
+      "source_file": "scripts/pre-push-review.ts",
+      "source_location": "L56",
+      "id": "pre_push_review_main",
       "community": 18
     }
   ],
@@ -31726,102 +30286,6 @@
       "confidence_score": 1.0
     },
     {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L4",
-      "weight": 1.0,
-      "_src": "client",
-      "_tgt": "errors",
-      "source": "client",
-      "target": "errors",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L5",
-      "weight": 1.0,
-      "_src": "client",
-      "_tgt": "protocol",
-      "source": "client",
-      "target": "protocol",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L71",
-      "weight": 1.0,
-      "_src": "client",
-      "_tgt": "client_codexappserverclient",
-      "source": "client",
-      "target": "client_codexappserverclient",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L483",
-      "weight": 1.0,
-      "_src": "client",
-      "_tgt": "client_buildapprovalresponse",
-      "source": "client",
-      "target": "client_buildapprovalresponse",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L3",
-      "weight": 1.0,
-      "_src": "service",
-      "_tgt": "client",
-      "source": "client",
-      "target": "service",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/worker.ts",
-      "source_location": "L3",
-      "weight": 1.0,
-      "_src": "worker",
-      "_tgt": "client",
-      "source": "client",
-      "target": "worker",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/codexClient.test.ts",
-      "source_location": "L5",
-      "weight": 1.0,
-      "_src": "codexclient_test",
-      "_tgt": "client",
-      "source": "client",
-      "target": "codexclient_test",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/worker.test.ts",
-      "source_location": "L5",
-      "weight": 1.0,
-      "_src": "worker_test",
-      "_tgt": "client",
-      "source": "client",
-      "target": "worker_test",
-      "confidence_score": 1.0
-    },
-    {
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "packages/athena-webapp/convex/mtn/client.ts",
@@ -31992,7 +30456,7 @@
     {
       "relation": "imports_from",
       "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/config.test.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/config.test.ts",
       "source_location": "L2",
       "weight": 1.0,
       "_src": "config_test",
@@ -32004,32 +30468,8 @@
     {
       "relation": "imports_from",
       "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/config.test.ts",
-      "source_location": "L3",
-      "weight": 1.0,
-      "_src": "config_test",
-      "_tgt": "errors",
-      "source": "config_test",
-      "target": "errors",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/config.test.ts",
-      "source_location": "L4",
-      "weight": 1.0,
-      "_src": "config_test",
-      "_tgt": "validate",
-      "source": "config_test",
-      "target": "validate",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/config.ts",
-      "source_location": "L3",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L1",
       "weight": 1.0,
       "_src": "config",
       "_tgt": "types",
@@ -32196,7 +30636,7 @@
     {
       "relation": "imports_from",
       "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/vitest.config.ts",
+      "source_file": "packages/storefront-webapp/vitest.config.ts",
       "source_location": "L1",
       "weight": 1.0,
       "_src": "vitest_config",
@@ -32311,162 +30751,6 @@
       "_tgt": "config",
       "source": "config",
       "target": "homehero",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/scripts/realIntegrationSmoke.ts",
-      "source_location": "L4",
-      "weight": 1.0,
-      "_src": "realintegrationsmoke",
-      "_tgt": "config",
-      "source": "config",
-      "target": "realintegrationsmoke",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/config.ts",
-      "source_location": "L8",
-      "weight": 1.0,
-      "_src": "config",
-      "_tgt": "config_resolveeffectiveconfig",
-      "source": "config",
-      "target": "config_resolveeffectiveconfig",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/config.ts",
-      "source_location": "L77",
-      "weight": 1.0,
-      "_src": "config",
-      "_tgt": "config_resolveworkspaceroot",
-      "source": "config",
-      "target": "config_resolveworkspaceroot",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/config.ts",
-      "source_location": "L85",
-      "weight": 1.0,
-      "_src": "config",
-      "_tgt": "config_expandpathlike",
-      "source": "config",
-      "target": "config_expandpathlike",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/config.ts",
-      "source_location": "L99",
-      "weight": 1.0,
-      "_src": "config",
-      "_tgt": "config_resolveenvreference",
-      "source": "config",
-      "target": "config_resolveenvreference",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/config.ts",
-      "source_location": "L111",
-      "weight": 1.0,
-      "_src": "config",
-      "_tgt": "config_resolveconfigstring",
-      "source": "config",
-      "target": "config_resolveconfigstring",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/config.ts",
-      "source_location": "L115",
-      "weight": 1.0,
-      "_src": "config",
-      "_tgt": "config_normalizestatelimits",
-      "source": "config",
-      "target": "config_normalizestatelimits",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/config.ts",
-      "source_location": "L131",
-      "weight": 1.0,
-      "_src": "config",
-      "_tgt": "config_asobject",
-      "source": "config",
-      "target": "config_asobject",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/config.ts",
-      "source_location": "L139",
-      "weight": 1.0,
-      "_src": "config",
-      "_tgt": "config_asstring",
-      "source": "config",
-      "target": "config_asstring",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/config.ts",
-      "source_location": "L147",
-      "weight": 1.0,
-      "_src": "config",
-      "_tgt": "config_asstringarray",
-      "source": "config",
-      "target": "config_asstringarray",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/config.ts",
-      "source_location": "L156",
-      "weight": 1.0,
-      "_src": "config",
-      "_tgt": "config_aspositiveint",
-      "source": "config",
-      "target": "config_aspositiveint",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/config.ts",
-      "source_location": "L161",
-      "weight": 1.0,
-      "_src": "config",
-      "_tgt": "config_asint",
-      "source": "config",
-      "target": "config_asint",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L2",
-      "weight": 1.0,
-      "_src": "service",
-      "_tgt": "config",
-      "source": "config",
-      "target": "service",
       "confidence_score": 1.0
     },
     {
@@ -34171,114 +32455,6 @@
       "_tgt": "types",
       "source": "types",
       "target": "pod_confirmation",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/runtime.ts",
-      "source_location": "L14",
-      "weight": 1.0,
-      "_src": "runtime",
-      "_tgt": "types",
-      "source": "types",
-      "target": "runtime",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L10",
-      "weight": 1.0,
-      "_src": "service",
-      "_tgt": "types",
-      "source": "types",
-      "target": "service",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/template.ts",
-      "source_location": "L3",
-      "weight": 1.0,
-      "_src": "template",
-      "_tgt": "types",
-      "source": "types",
-      "target": "template",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/validate.ts",
-      "source_location": "L2",
-      "weight": 1.0,
-      "_src": "validate",
-      "_tgt": "types",
-      "source": "types",
-      "target": "validate",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/worker.ts",
-      "source_location": "L7",
-      "weight": 1.0,
-      "_src": "worker",
-      "_tgt": "types",
-      "source": "types",
-      "target": "worker",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/workflow.ts",
-      "source_location": "L6",
-      "weight": 1.0,
-      "_src": "workflow",
-      "_tgt": "types",
-      "source": "types",
-      "target": "workflow",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/runtime.test.ts",
-      "source_location": "L2",
-      "weight": 1.0,
-      "_src": "runtime_test",
-      "_tgt": "types",
-      "source": "types",
-      "target": "runtime_test",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/service.test.ts",
-      "source_location": "L3",
-      "weight": 1.0,
-      "_src": "service_test",
-      "_tgt": "types",
-      "source": "types",
-      "target": "service_test",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/worker.test.ts",
-      "source_location": "L7",
-      "weight": 1.0,
-      "_src": "worker_test",
-      "_tgt": "types",
-      "source": "types",
-      "target": "worker_test",
       "confidence_score": 1.0
     },
     {
@@ -73978,4554 +72154,6 @@
       "confidence_score": 0.5
     },
     {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/scripts/realIntegrationSmoke.ts",
-      "source_location": "L5",
-      "weight": 1.0,
-      "_src": "realintegrationsmoke",
-      "_tgt": "linear",
-      "source": "realintegrationsmoke",
-      "target": "linear",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/scripts/realIntegrationSmoke.ts",
-      "source_location": "L6",
-      "weight": 1.0,
-      "_src": "realintegrationsmoke",
-      "_tgt": "validate",
-      "source": "realintegrationsmoke",
-      "target": "validate",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/scripts/realIntegrationSmoke.ts",
-      "source_location": "L7",
-      "weight": 1.0,
-      "_src": "realintegrationsmoke",
-      "_tgt": "workflow",
-      "source": "realintegrationsmoke",
-      "target": "workflow",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/scripts/realIntegrationSmoke.ts",
-      "source_location": "L9",
-      "weight": 1.0,
-      "_src": "realintegrationsmoke",
-      "_tgt": "realintegrationsmoke_main",
-      "source": "realintegrationsmoke",
-      "target": "realintegrationsmoke_main",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/scripts/realIntegrationSmoke.ts",
-      "source_location": "L44",
-      "weight": 1.0,
-      "_src": "realintegrationsmoke",
-      "_tgt": "realintegrationsmoke_parseargs",
-      "source": "realintegrationsmoke",
-      "target": "realintegrationsmoke_parseargs",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/scripts/realIntegrationSmoke.ts",
-      "source_location": "L76",
-      "weight": 1.0,
-      "_src": "realintegrationsmoke",
-      "_tgt": "realintegrationsmoke_resolveworkflowpath",
-      "source": "realintegrationsmoke",
-      "target": "realintegrationsmoke_resolveworkflowpath",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/scripts/realIntegrationSmoke.ts",
-      "source_location": "L90",
-      "weight": 1.0,
-      "_src": "realintegrationsmoke",
-      "_tgt": "realintegrationsmoke_parsebooleanflag",
-      "source": "realintegrationsmoke",
-      "target": "realintegrationsmoke_parsebooleanflag",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/scripts/realIntegrationSmoke.ts",
-      "source_location": "L103",
-      "weight": 1.0,
-      "_src": "realintegrationsmoke",
-      "_tgt": "realintegrationsmoke_smokelaunchcodex",
-      "source": "realintegrationsmoke",
-      "target": "realintegrationsmoke_smokelaunchcodex",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/scripts/realIntegrationSmoke.ts",
-      "source_location": "L10",
-      "weight": 0.8,
-      "_src": "realintegrationsmoke_main",
-      "_tgt": "realintegrationsmoke_parseargs",
-      "source": "realintegrationsmoke_main",
-      "target": "realintegrationsmoke_parseargs",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/scripts/realIntegrationSmoke.ts",
-      "source_location": "L37",
-      "weight": 0.8,
-      "_src": "realintegrationsmoke_main",
-      "_tgt": "realintegrationsmoke_smokelaunchcodex",
-      "source": "realintegrationsmoke_main",
-      "target": "realintegrationsmoke_smokelaunchcodex",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/scripts/realIntegrationSmoke.ts",
-      "source_location": "L55",
-      "weight": 0.8,
-      "_src": "realintegrationsmoke_parseargs",
-      "_tgt": "realintegrationsmoke_parsebooleanflag",
-      "source": "realintegrationsmoke_parseargs",
-      "target": "realintegrationsmoke_parsebooleanflag",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/scripts/realIntegrationSmoke.ts",
-      "source_location": "L70",
-      "weight": 0.8,
-      "_src": "realintegrationsmoke_parseargs",
-      "_tgt": "realintegrationsmoke_resolveworkflowpath",
-      "source": "realintegrationsmoke_parseargs",
-      "target": "realintegrationsmoke_resolveworkflowpath",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/cli.ts",
-      "source_location": "L2",
-      "weight": 1.0,
-      "_src": "cli",
-      "_tgt": "errors",
-      "source": "cli",
-      "target": "errors",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/cli.ts",
-      "source_location": "L3",
-      "weight": 1.0,
-      "_src": "cli",
-      "_tgt": "httpserver",
-      "source": "cli",
-      "target": "httpserver",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/cli.ts",
-      "source_location": "L4",
-      "weight": 1.0,
-      "_src": "cli",
-      "_tgt": "service",
-      "source": "cli",
-      "target": "service",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/cli.ts",
-      "source_location": "L5",
-      "weight": 1.0,
-      "_src": "cli",
-      "_tgt": "workflow",
-      "source": "cli",
-      "target": "workflow",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/cli.ts",
-      "source_location": "L60",
-      "weight": 1.0,
-      "_src": "cli",
-      "_tgt": "cli_parsecliargs",
-      "source": "cli",
-      "target": "cli_parsecliargs",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/cli.ts",
-      "source_location": "L107",
-      "weight": 1.0,
-      "_src": "cli",
-      "_tgt": "cli_runcli",
-      "source": "cli",
-      "target": "cli_runcli",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/cli.ts",
-      "source_location": "L177",
-      "weight": 1.0,
-      "_src": "cli",
-      "_tgt": "cli_runclientry",
-      "source": "cli",
-      "target": "cli_runclientry",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/cli.ts",
-      "source_location": "L193",
-      "weight": 1.0,
-      "_src": "cli",
-      "_tgt": "cli_parseportarg",
-      "source": "cli",
-      "target": "cli_parseportarg",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/cli.ts",
-      "source_location": "L206",
-      "weight": 1.0,
-      "_src": "cli",
-      "_tgt": "cli_parseworkflowserverport",
-      "source": "cli",
-      "target": "cli_parseworkflowserverport",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/cli.ts",
-      "source_location": "L224",
-      "weight": 1.0,
-      "_src": "cli",
-      "_tgt": "cli_asobject",
-      "source": "cli",
-      "target": "cli_asobject",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/cli.test.ts",
-      "source_location": "L3",
-      "weight": 1.0,
-      "_src": "cli_test",
-      "_tgt": "cli",
-      "source": "cli",
-      "target": "cli_test",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/cli.ts",
-      "source_location": "L84",
-      "weight": 0.8,
-      "_src": "cli_parsecliargs",
-      "_tgt": "cli_parseportarg",
-      "source": "cli_parsecliargs",
-      "target": "cli_parseportarg",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/cli.ts",
-      "source_location": "L111",
-      "weight": 0.8,
-      "_src": "cli_runcli",
-      "_tgt": "cli_parsecliargs",
-      "source": "cli_parsecliargs",
-      "target": "cli_runcli",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/cli.ts",
-      "source_location": "L182",
-      "weight": 0.8,
-      "_src": "cli_runclientry",
-      "_tgt": "cli_runcli",
-      "source": "cli_runcli",
-      "target": "cli_runclientry",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/cli.ts",
-      "source_location": "L218",
-      "weight": 0.8,
-      "_src": "cli_parseworkflowserverport",
-      "_tgt": "cli_parseportarg",
-      "source": "cli_parseportarg",
-      "target": "cli_parseworkflowserverport",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/cli.ts",
-      "source_location": "L207",
-      "weight": 0.8,
-      "_src": "cli_parseworkflowserverport",
-      "_tgt": "cli_asobject",
-      "source": "cli_parseworkflowserverport",
-      "target": "cli_asobject",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L81",
-      "weight": 1.0,
-      "_src": "client_codexappserverclient",
-      "_tgt": "client_codexappserverclient_constructor",
-      "source": "client_codexappserverclient",
-      "target": "client_codexappserverclient_constructor",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L86",
-      "weight": 1.0,
-      "_src": "client_codexappserverclient",
-      "_tgt": "client_codexappserverclient_startsession",
-      "source": "client_codexappserverclient",
-      "target": "client_codexappserverclient_startsession",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L113",
-      "weight": 1.0,
-      "_src": "client_codexappserverclient",
-      "_tgt": "client_codexappserverclient_runturn",
-      "source": "client_codexappserverclient",
-      "target": "client_codexappserverclient_runturn",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L150",
-      "weight": 1.0,
-      "_src": "client_codexappserverclient",
-      "_tgt": "client_codexappserverclient_stop",
-      "source": "client_codexappserverclient",
-      "target": "client_codexappserverclient_stop",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L158",
-      "weight": 1.0,
-      "_src": "client_codexappserverclient",
-      "_tgt": "client_codexappserverclient_ensureprocess",
-      "source": "client_codexappserverclient",
-      "target": "client_codexappserverclient_ensureprocess",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L211",
-      "weight": 1.0,
-      "_src": "client_codexappserverclient",
-      "_tgt": "client_codexappserverclient_initializeprotocol",
-      "source": "client_codexappserverclient",
-      "target": "client_codexappserverclient_initializeprotocol",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L222",
-      "weight": 1.0,
-      "_src": "client_codexappserverclient",
-      "_tgt": "client_codexappserverclient_sendrequest",
-      "source": "client_codexappserverclient",
-      "target": "client_codexappserverclient_sendrequest",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L259",
-      "weight": 1.0,
-      "_src": "client_codexappserverclient",
-      "_tgt": "client_codexappserverclient_sendnotification",
-      "source": "client_codexappserverclient",
-      "target": "client_codexappserverclient_sendnotification",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L268",
-      "weight": 1.0,
-      "_src": "client_codexappserverclient",
-      "_tgt": "client_codexappserverclient_handlestdoutline",
-      "source": "client_codexappserverclient",
-      "target": "client_codexappserverclient_handlestdoutline",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L289",
-      "weight": 1.0,
-      "_src": "client_codexappserverclient",
-      "_tgt": "client_codexappserverclient_resolvependingrequest",
-      "source": "client_codexappserverclient",
-      "target": "client_codexappserverclient_resolvependingrequest",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L315",
-      "weight": 1.0,
-      "_src": "client_codexappserverclient",
-      "_tgt": "client_codexappserverclient_handleincomingmessage",
-      "source": "client_codexappserverclient",
-      "target": "client_codexappserverclient_handleincomingmessage",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L365",
-      "weight": 1.0,
-      "_src": "client_codexappserverclient",
-      "_tgt": "client_codexappserverclient_sendrequestresult",
-      "source": "client_codexappserverclient",
-      "target": "client_codexappserverclient_sendrequestresult",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L378",
-      "weight": 1.0,
-      "_src": "client_codexappserverclient",
-      "_tgt": "client_codexappserverclient_waitforturnoutcome",
-      "source": "client_codexappserverclient",
-      "target": "client_codexappserverclient_waitforturnoutcome",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L399",
-      "weight": 1.0,
-      "_src": "client_codexappserverclient",
-      "_tgt": "client_codexappserverclient_resolveturnoutcome",
-      "source": "client_codexappserverclient",
-      "target": "client_codexappserverclient_resolveturnoutcome",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L411",
-      "weight": 1.0,
-      "_src": "client_codexappserverclient",
-      "_tgt": "client_codexappserverclient_rejectallpending",
-      "source": "client_codexappserverclient",
-      "target": "client_codexappserverclient_rejectallpending",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L419",
-      "weight": 1.0,
-      "_src": "client_codexappserverclient",
-      "_tgt": "client_codexappserverclient_teardown",
-      "source": "client_codexappserverclient",
-      "target": "client_codexappserverclient_teardown",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L431",
-      "weight": 1.0,
-      "_src": "client_codexappserverclient",
-      "_tgt": "client_codexappserverclient_emit",
-      "source": "client_codexappserverclient",
-      "target": "client_codexappserverclient_emit",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L439",
-      "weight": 1.0,
-      "_src": "client_codexappserverclient",
-      "_tgt": "client_codexappserverclient_allocaterequestid",
-      "source": "client_codexappserverclient",
-      "target": "client_codexappserverclient_allocaterequestid",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L445",
-      "weight": 1.0,
-      "_src": "client_codexappserverclient",
-      "_tgt": "client_codexappserverclient_assertabsolutecwd",
-      "source": "client_codexappserverclient",
-      "target": "client_codexappserverclient_assertabsolutecwd",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L452",
-      "weight": 1.0,
-      "_src": "client_codexappserverclient",
-      "_tgt": "client_codexappserverclient_recordstderr",
-      "source": "client_codexappserverclient",
-      "target": "client_codexappserverclient_recordstderr",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L459",
-      "weight": 1.0,
-      "_src": "client_codexappserverclient",
-      "_tgt": "client_codexappserverclient_mapexiterror",
-      "source": "client_codexappserverclient",
-      "target": "client_codexappserverclient_mapexiterror",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L473",
-      "weight": 1.0,
-      "_src": "client_codexappserverclient",
-      "_tgt": "client_codexappserverclient_lookslikecommandnotfound",
-      "source": "client_codexappserverclient",
-      "target": "client_codexappserverclient_lookslikecommandnotfound",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L87",
-      "weight": 0.8,
-      "_src": "client_codexappserverclient_startsession",
-      "_tgt": "client_codexappserverclient_assertabsolutecwd",
-      "source": "client_codexappserverclient_startsession",
-      "target": "client_codexappserverclient_assertabsolutecwd",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L88",
-      "weight": 0.8,
-      "_src": "client_codexappserverclient_startsession",
-      "_tgt": "client_codexappserverclient_ensureprocess",
-      "source": "client_codexappserverclient_startsession",
-      "target": "client_codexappserverclient_ensureprocess",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L91",
-      "weight": 0.8,
-      "_src": "client_codexappserverclient_startsession",
-      "_tgt": "client_codexappserverclient_initializeprotocol",
-      "source": "client_codexappserverclient_startsession",
-      "target": "client_codexappserverclient_initializeprotocol",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L95",
-      "weight": 0.8,
-      "_src": "client_codexappserverclient_startsession",
-      "_tgt": "client_codexappserverclient_sendrequest",
-      "source": "client_codexappserverclient_startsession",
-      "target": "client_codexappserverclient_sendrequest",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L96",
-      "weight": 0.8,
-      "_src": "client_codexappserverclient_startsession",
-      "_tgt": "client_codexappserverclient_allocaterequestid",
-      "source": "client_codexappserverclient_startsession",
-      "target": "client_codexappserverclient_allocaterequestid",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L119",
-      "weight": 0.8,
-      "_src": "client_codexappserverclient_runturn",
-      "_tgt": "client_codexappserverclient_assertabsolutecwd",
-      "source": "client_codexappserverclient_runturn",
-      "target": "client_codexappserverclient_assertabsolutecwd",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L125",
-      "weight": 0.8,
-      "_src": "client_codexappserverclient_runturn",
-      "_tgt": "client_codexappserverclient_sendrequest",
-      "source": "client_codexappserverclient_runturn",
-      "target": "client_codexappserverclient_sendrequest",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L126",
-      "weight": 0.8,
-      "_src": "client_codexappserverclient_runturn",
-      "_tgt": "client_codexappserverclient_allocaterequestid",
-      "source": "client_codexappserverclient_runturn",
-      "target": "client_codexappserverclient_allocaterequestid",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L144",
-      "weight": 0.8,
-      "_src": "client_codexappserverclient_runturn",
-      "_tgt": "client_codexappserverclient_emit",
-      "source": "client_codexappserverclient_runturn",
-      "target": "client_codexappserverclient_emit",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L146",
-      "weight": 0.8,
-      "_src": "client_codexappserverclient_runturn",
-      "_tgt": "client_codexappserverclient_waitforturnoutcome",
-      "source": "client_codexappserverclient_runturn",
-      "target": "client_codexappserverclient_waitforturnoutcome",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L155",
-      "weight": 0.8,
-      "_src": "client_codexappserverclient_stop",
-      "_tgt": "client_codexappserverclient_teardown",
-      "source": "client_codexappserverclient_stop",
-      "target": "client_codexappserverclient_teardown",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L212",
-      "weight": 0.8,
-      "_src": "client_codexappserverclient_initializeprotocol",
-      "_tgt": "client_codexappserverclient_sendrequest",
-      "source": "client_codexappserverclient_initializeprotocol",
-      "target": "client_codexappserverclient_sendrequest",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L213",
-      "weight": 0.8,
-      "_src": "client_codexappserverclient_initializeprotocol",
-      "_tgt": "client_codexappserverclient_allocaterequestid",
-      "source": "client_codexappserverclient_initializeprotocol",
-      "target": "client_codexappserverclient_allocaterequestid",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L219",
-      "weight": 0.8,
-      "_src": "client_codexappserverclient_initializeprotocol",
-      "_tgt": "client_codexappserverclient_sendnotification",
-      "source": "client_codexappserverclient_initializeprotocol",
-      "target": "client_codexappserverclient_sendnotification",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L272",
-      "weight": 0.8,
-      "_src": "client_codexappserverclient_handlestdoutline",
-      "_tgt": "client_codexappserverclient_emit",
-      "source": "client_codexappserverclient_handlestdoutline",
-      "target": "client_codexappserverclient_emit",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L282",
-      "weight": 0.8,
-      "_src": "client_codexappserverclient_handlestdoutline",
-      "_tgt": "client_codexappserverclient_resolvependingrequest",
-      "source": "client_codexappserverclient_handlestdoutline",
-      "target": "client_codexappserverclient_resolvependingrequest",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L286",
-      "weight": 0.8,
-      "_src": "client_codexappserverclient_handlestdoutline",
-      "_tgt": "client_codexappserverclient_handleincomingmessage",
-      "source": "client_codexappserverclient_handlestdoutline",
-      "target": "client_codexappserverclient_handleincomingmessage",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L321",
-      "weight": 0.8,
-      "_src": "client_codexappserverclient_handleincomingmessage",
-      "_tgt": "client_codexappserverclient_sendrequestresult",
-      "source": "client_codexappserverclient_handleincomingmessage",
-      "target": "client_codexappserverclient_sendrequestresult",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L321",
-      "weight": 0.8,
-      "_src": "client_codexappserverclient_handleincomingmessage",
-      "_tgt": "client_buildapprovalresponse",
-      "source": "client_codexappserverclient_handleincomingmessage",
-      "target": "client_buildapprovalresponse",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L322",
-      "weight": 0.8,
-      "_src": "client_codexappserverclient_handleincomingmessage",
-      "_tgt": "client_codexappserverclient_emit",
-      "source": "client_codexappserverclient_handleincomingmessage",
-      "target": "client_codexappserverclient_emit",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L334",
-      "weight": 0.8,
-      "_src": "client_codexappserverclient_handleincomingmessage",
-      "_tgt": "client_codexappserverclient_resolveturnoutcome",
-      "source": "client_codexappserverclient_handleincomingmessage",
-      "target": "client_codexappserverclient_resolveturnoutcome",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/codex/client.ts",
-      "source_location": "L460",
-      "weight": 0.8,
-      "_src": "client_codexappserverclient_mapexiterror",
-      "_tgt": "client_codexappserverclient_lookslikecommandnotfound",
-      "source": "client_codexappserverclient_mapexiterror",
-      "target": "client_codexappserverclient_lookslikecommandnotfound",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L17",
-      "weight": 1.0,
-      "_src": "protocol",
-      "_tgt": "protocol_createinitializerequest",
-      "source": "protocol",
-      "target": "protocol_createinitializerequest",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L35",
-      "weight": 1.0,
-      "_src": "protocol",
-      "_tgt": "protocol_createinitializednotification",
-      "source": "protocol",
-      "target": "protocol_createinitializednotification",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L42",
-      "weight": 1.0,
-      "_src": "protocol",
-      "_tgt": "protocol_createthreadstartrequest",
-      "source": "protocol",
-      "target": "protocol_createthreadstartrequest",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L61",
-      "weight": 1.0,
-      "_src": "protocol",
-      "_tgt": "protocol_createturnstartrequest",
-      "source": "protocol",
-      "target": "protocol_createturnstartrequest",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L86",
-      "weight": 1.0,
-      "_src": "protocol",
-      "_tgt": "protocol_parseprotocolline",
-      "source": "protocol",
-      "target": "protocol_parseprotocolline",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L112",
-      "weight": 1.0,
-      "_src": "protocol",
-      "_tgt": "protocol_extractthreadid",
-      "source": "protocol",
-      "target": "protocol_extractthreadid",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L124",
-      "weight": 1.0,
-      "_src": "protocol",
-      "_tgt": "protocol_extractturnid",
-      "source": "protocol",
-      "target": "protocol_extractturnid",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L136",
-      "weight": 1.0,
-      "_src": "protocol",
-      "_tgt": "protocol_getmethodname",
-      "source": "protocol",
-      "target": "protocol_getmethodname",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L140",
-      "weight": 1.0,
-      "_src": "protocol",
-      "_tgt": "protocol_getturnterminalstate",
-      "source": "protocol",
-      "target": "protocol_getturnterminalstate",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L156",
-      "weight": 1.0,
-      "_src": "protocol",
-      "_tgt": "protocol_isapprovalrequest",
-      "source": "protocol",
-      "target": "protocol_isapprovalrequest",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L161",
-      "weight": 1.0,
-      "_src": "protocol",
-      "_tgt": "protocol_isunsupportedtoolcallrequest",
-      "source": "protocol",
-      "target": "protocol_isunsupportedtoolcallrequest",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L166",
-      "weight": 1.0,
-      "_src": "protocol",
-      "_tgt": "protocol_isuserinputrequired",
-      "source": "protocol",
-      "target": "protocol_isuserinputrequired",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L184",
-      "weight": 1.0,
-      "_src": "protocol",
-      "_tgt": "protocol_extractusage",
-      "source": "protocol",
-      "target": "protocol_extractusage",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L233",
-      "weight": 1.0,
-      "_src": "protocol",
-      "_tgt": "protocol_extractratelimits",
-      "source": "protocol",
-      "target": "protocol_extractratelimits",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L241",
-      "weight": 1.0,
-      "_src": "protocol",
-      "_tgt": "protocol_hasrequestid",
-      "source": "protocol",
-      "target": "protocol_hasrequestid",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L246",
-      "weight": 1.0,
-      "_src": "protocol",
-      "_tgt": "protocol_asobject",
-      "source": "protocol",
-      "target": "protocol_asobject",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L254",
-      "weight": 1.0,
-      "_src": "protocol",
-      "_tgt": "protocol_firstobject",
-      "source": "protocol",
-      "target": "protocol_firstobject",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L265",
-      "weight": 1.0,
-      "_src": "protocol",
-      "_tgt": "protocol_asstring",
-      "source": "protocol",
-      "target": "protocol_asstring",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L273",
-      "weight": 1.0,
-      "_src": "protocol",
-      "_tgt": "protocol_asnumber",
-      "source": "protocol",
-      "target": "protocol_asnumber",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/codexProtocol.test.ts",
-      "source_location": "L2",
-      "weight": 1.0,
-      "_src": "codexprotocol_test",
-      "_tgt": "protocol",
-      "source": "protocol",
-      "target": "codexprotocol_test",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L113",
-      "weight": 0.8,
-      "_src": "protocol_extractthreadid",
-      "_tgt": "protocol_asobject",
-      "source": "protocol_extractthreadid",
-      "target": "protocol_asobject",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L116",
-      "weight": 0.8,
-      "_src": "protocol_extractthreadid",
-      "_tgt": "protocol_asstring",
-      "source": "protocol_extractthreadid",
-      "target": "protocol_asstring",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L125",
-      "weight": 0.8,
-      "_src": "protocol_extractturnid",
-      "_tgt": "protocol_asobject",
-      "source": "protocol_extractturnid",
-      "target": "protocol_asobject",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L128",
-      "weight": 0.8,
-      "_src": "protocol_extractturnid",
-      "_tgt": "protocol_asstring",
-      "source": "protocol_extractturnid",
-      "target": "protocol_asstring",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L137",
-      "weight": 0.8,
-      "_src": "protocol_getmethodname",
-      "_tgt": "protocol_asstring",
-      "source": "protocol_getmethodname",
-      "target": "protocol_asstring",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L157",
-      "weight": 0.8,
-      "_src": "protocol_isapprovalrequest",
-      "_tgt": "protocol_getmethodname",
-      "source": "protocol_getmethodname",
-      "target": "protocol_isapprovalrequest",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L162",
-      "weight": 0.8,
-      "_src": "protocol_isunsupportedtoolcallrequest",
-      "_tgt": "protocol_getmethodname",
-      "source": "protocol_getmethodname",
-      "target": "protocol_isunsupportedtoolcallrequest",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L167",
-      "weight": 0.8,
-      "_src": "protocol_isuserinputrequired",
-      "_tgt": "protocol_getmethodname",
-      "source": "protocol_getmethodname",
-      "target": "protocol_isuserinputrequired",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L158",
-      "weight": 0.8,
-      "_src": "protocol_isapprovalrequest",
-      "_tgt": "protocol_hasrequestid",
-      "source": "protocol_isapprovalrequest",
-      "target": "protocol_hasrequestid",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L163",
-      "weight": 0.8,
-      "_src": "protocol_isunsupportedtoolcallrequest",
-      "_tgt": "protocol_hasrequestid",
-      "source": "protocol_isunsupportedtoolcallrequest",
-      "target": "protocol_hasrequestid",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L172",
-      "weight": 0.8,
-      "_src": "protocol_isuserinputrequired",
-      "_tgt": "protocol_asobject",
-      "source": "protocol_isuserinputrequired",
-      "target": "protocol_asobject",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L185",
-      "weight": 0.8,
-      "_src": "protocol_extractusage",
-      "_tgt": "protocol_asobject",
-      "source": "protocol_extractusage",
-      "target": "protocol_asobject",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L190",
-      "weight": 0.8,
-      "_src": "protocol_extractusage",
-      "_tgt": "protocol_firstobject",
-      "source": "protocol_extractusage",
-      "target": "protocol_firstobject",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L211",
-      "weight": 0.8,
-      "_src": "protocol_extractusage",
-      "_tgt": "protocol_asnumber",
-      "source": "protocol_extractusage",
-      "target": "protocol_asnumber",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L234",
-      "weight": 0.8,
-      "_src": "protocol_extractratelimits",
-      "_tgt": "protocol_asobject",
-      "source": "protocol_extractratelimits",
-      "target": "protocol_asobject",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L237",
-      "weight": 0.8,
-      "_src": "protocol_extractratelimits",
-      "_tgt": "protocol_firstobject",
-      "source": "protocol_extractratelimits",
-      "target": "protocol_firstobject",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/codex/protocol.ts",
-      "source_location": "L256",
-      "weight": 0.8,
-      "_src": "protocol_firstobject",
-      "_tgt": "protocol_asobject",
-      "source": "protocol_asobject",
-      "target": "protocol_firstobject",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/config.ts",
-      "source_location": "L9",
-      "weight": 0.8,
-      "_src": "config_resolveeffectiveconfig",
-      "_tgt": "config_asobject",
-      "source": "config_resolveeffectiveconfig",
-      "target": "config_asobject",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/config.ts",
-      "source_location": "L16",
-      "weight": 0.8,
-      "_src": "config_resolveeffectiveconfig",
-      "_tgt": "config_asstring",
-      "source": "config_resolveeffectiveconfig",
-      "target": "config_asstring",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/config.ts",
-      "source_location": "L21",
-      "weight": 0.8,
-      "_src": "config_resolveeffectiveconfig",
-      "_tgt": "config_resolveenvreference",
-      "source": "config_resolveeffectiveconfig",
-      "target": "config_resolveenvreference",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/config.ts",
-      "source_location": "L32",
-      "weight": 0.8,
-      "_src": "config_resolveeffectiveconfig",
-      "_tgt": "config_asstringarray",
-      "source": "config_resolveeffectiveconfig",
-      "target": "config_asstringarray",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/config.ts",
-      "source_location": "L36",
-      "weight": 0.8,
-      "_src": "config_resolveeffectiveconfig",
-      "_tgt": "config_aspositiveint",
-      "source": "config_resolveeffectiveconfig",
-      "target": "config_aspositiveint",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/config.ts",
-      "source_location": "L39",
-      "weight": 0.8,
-      "_src": "config_resolveeffectiveconfig",
-      "_tgt": "config_resolveworkspaceroot",
-      "source": "config_resolveeffectiveconfig",
-      "target": "config_resolveworkspaceroot",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/config.ts",
-      "source_location": "L56",
-      "weight": 0.8,
-      "_src": "config_resolveeffectiveconfig",
-      "_tgt": "config_normalizestatelimits",
-      "source": "config_resolveeffectiveconfig",
-      "target": "config_normalizestatelimits",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/config.ts",
-      "source_location": "L60",
-      "weight": 0.8,
-      "_src": "config_resolveeffectiveconfig",
-      "_tgt": "config_resolveconfigstring",
-      "source": "config_resolveeffectiveconfig",
-      "target": "config_resolveconfigstring",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/config.ts",
-      "source_location": "L72",
-      "weight": 0.8,
-      "_src": "config_resolveeffectiveconfig",
-      "_tgt": "config_asint",
-      "source": "config_resolveeffectiveconfig",
-      "target": "config_asint",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/config.ts",
-      "source_location": "L82",
-      "weight": 0.8,
-      "_src": "config_resolveworkspaceroot",
-      "_tgt": "config_expandpathlike",
-      "source": "config_resolveworkspaceroot",
-      "target": "config_expandpathlike",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/config.ts",
-      "source_location": "L112",
-      "weight": 0.8,
-      "_src": "config_resolveconfigstring",
-      "_tgt": "config_resolveenvreference",
-      "source": "config_resolveenvreference",
-      "target": "config_resolveconfigstring",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/config.ts",
-      "source_location": "L112",
-      "weight": 0.8,
-      "_src": "config_resolveconfigstring",
-      "_tgt": "config_asstring",
-      "source": "config_resolveconfigstring",
-      "target": "config_asstring",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/config.ts",
-      "source_location": "L122",
-      "weight": 0.8,
-      "_src": "config_normalizestatelimits",
-      "_tgt": "config_aspositiveint",
-      "source": "config_normalizestatelimits",
-      "target": "config_aspositiveint",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/config.ts",
-      "source_location": "L157",
-      "weight": 0.8,
-      "_src": "config_aspositiveint",
-      "_tgt": "config_asint",
-      "source": "config_aspositiveint",
-      "target": "config_asint",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/errors.ts",
-      "source_location": "L28",
-      "weight": 1.0,
-      "_src": "errors",
-      "_tgt": "errors_symphonyerror",
-      "source": "errors",
-      "target": "errors_symphonyerror",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/errors.ts",
-      "source_location": "L40",
-      "weight": 1.0,
-      "_src": "errors",
-      "_tgt": "errors_toerrormessage",
-      "source": "errors",
-      "target": "errors_toerrormessage",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/runtime.ts",
-      "source_location": "L1",
-      "weight": 1.0,
-      "_src": "runtime",
-      "_tgt": "errors",
-      "source": "errors",
-      "target": "runtime",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L4",
-      "weight": 1.0,
-      "_src": "service",
-      "_tgt": "errors",
-      "source": "errors",
-      "target": "service",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/startup.ts",
-      "source_location": "L2",
-      "weight": 1.0,
-      "_src": "startup",
-      "_tgt": "errors",
-      "source": "errors",
-      "target": "startup",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/template.ts",
-      "source_location": "L2",
-      "weight": 1.0,
-      "_src": "template",
-      "_tgt": "errors",
-      "source": "errors",
-      "target": "template",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L1",
-      "weight": 1.0,
-      "_src": "linear",
-      "_tgt": "errors",
-      "source": "errors",
-      "target": "linear",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/validate.ts",
-      "source_location": "L1",
-      "weight": 1.0,
-      "_src": "validate",
-      "_tgt": "errors",
-      "source": "errors",
-      "target": "validate",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/worker.ts",
-      "source_location": "L4",
-      "weight": 1.0,
-      "_src": "worker",
-      "_tgt": "errors",
-      "source": "errors",
-      "target": "worker",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/workflow.ts",
-      "source_location": "L5",
-      "weight": 1.0,
-      "_src": "workflow",
-      "_tgt": "errors",
-      "source": "errors",
-      "target": "workflow",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/workspace.ts",
-      "source_location": "L4",
-      "weight": 1.0,
-      "_src": "workspace",
-      "_tgt": "errors",
-      "source": "errors",
-      "target": "workspace",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/linearTracker.test.ts",
-      "source_location": "L2",
-      "weight": 1.0,
-      "_src": "lineartracker_test",
-      "_tgt": "errors",
-      "source": "errors",
-      "target": "lineartracker_test",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/template.test.ts",
-      "source_location": "L2",
-      "weight": 1.0,
-      "_src": "template_test",
-      "_tgt": "errors",
-      "source": "errors",
-      "target": "template_test",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/workflow.test.ts",
-      "source_location": "L5",
-      "weight": 1.0,
-      "_src": "workflow_test",
-      "_tgt": "errors",
-      "source": "errors",
-      "target": "workflow_test",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/workspace.test.ts",
-      "source_location": "L5",
-      "weight": 1.0,
-      "_src": "workspace_test",
-      "_tgt": "errors",
-      "source": "errors",
-      "target": "workspace_test",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/errors.ts",
-      "source_location": "L32",
-      "weight": 1.0,
-      "_src": "errors_symphonyerror",
-      "_tgt": "errors_symphonyerror_constructor",
-      "source": "errors_symphonyerror",
-      "target": "errors_symphonyerror_constructor",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L3",
-      "weight": 1.0,
-      "_src": "httpserver",
-      "_tgt": "service",
-      "source": "httpserver",
-      "target": "service",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L69",
-      "weight": 1.0,
-      "_src": "httpserver",
-      "_tgt": "httpserver_startstatusserver",
-      "source": "httpserver",
-      "target": "httpserver_startstatusserver",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L97",
-      "weight": 1.0,
-      "_src": "httpserver",
-      "_tgt": "httpserver_handlerequest",
-      "source": "httpserver",
-      "target": "httpserver_handlerequest",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L177",
-      "weight": 1.0,
-      "_src": "httpserver",
-      "_tgt": "httpserver_queuerefresh",
-      "source": "httpserver",
-      "target": "httpserver_queuerefresh",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L188",
-      "weight": 1.0,
-      "_src": "httpserver",
-      "_tgt": "httpserver_drainrefreshqueue",
-      "source": "httpserver",
-      "target": "httpserver_drainrefreshqueue",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L210",
-      "weight": 1.0,
-      "_src": "httpserver",
-      "_tgt": "httpserver_tostateresponse",
-      "source": "httpserver",
-      "target": "httpserver_tostateresponse",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L255",
-      "weight": 1.0,
-      "_src": "httpserver",
-      "_tgt": "httpserver_toissueresponse",
-      "source": "httpserver",
-      "target": "httpserver_toissueresponse",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L307",
-      "weight": 1.0,
-      "_src": "httpserver",
-      "_tgt": "httpserver_renderdashboardhtml",
-      "source": "httpserver",
-      "target": "httpserver_renderdashboardhtml",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L842",
-      "weight": 1.0,
-      "_src": "httpserver",
-      "_tgt": "httpserver_safejsonforscript",
-      "source": "httpserver",
-      "target": "httpserver_safejsonforscript",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L849",
-      "weight": 1.0,
-      "_src": "httpserver",
-      "_tgt": "httpserver_toiso",
-      "source": "httpserver",
-      "target": "httpserver_toiso",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L853",
-      "weight": 1.0,
-      "_src": "httpserver",
-      "_tgt": "httpserver_toisonullable",
-      "source": "httpserver",
-      "target": "httpserver_toisonullable",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L860",
-      "weight": 1.0,
-      "_src": "httpserver",
-      "_tgt": "httpserver_sendjson",
-      "source": "httpserver",
-      "target": "httpserver_sendjson",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L867",
-      "weight": 1.0,
-      "_src": "httpserver",
-      "_tgt": "httpserver_sendjsonerror",
-      "source": "httpserver",
-      "target": "httpserver_sendjsonerror",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L876",
-      "weight": 1.0,
-      "_src": "httpserver",
-      "_tgt": "httpserver_sendtext",
-      "source": "httpserver",
-      "target": "httpserver_sendtext",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L882",
-      "weight": 1.0,
-      "_src": "httpserver",
-      "_tgt": "httpserver_sendmethodnotallowed",
-      "source": "httpserver",
-      "target": "httpserver_sendmethodnotallowed",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L888",
-      "weight": 1.0,
-      "_src": "httpserver",
-      "_tgt": "httpserver_listen",
-      "source": "httpserver",
-      "target": "httpserver_listen",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L898",
-      "weight": 1.0,
-      "_src": "httpserver",
-      "_tgt": "httpserver_closeserver",
-      "source": "httpserver",
-      "target": "httpserver_closeserver",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/httpServer.test.ts",
-      "source_location": "L3",
-      "weight": 1.0,
-      "_src": "httpserver_test",
-      "_tgt": "httpserver",
-      "source": "httpserver",
-      "target": "httpserver_test",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L80",
-      "weight": 0.8,
-      "_src": "httpserver_startstatusserver",
-      "_tgt": "httpserver_listen",
-      "source": "httpserver_startstatusserver",
-      "target": "httpserver_listen",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L109",
-      "weight": 0.8,
-      "_src": "httpserver_handlerequest",
-      "_tgt": "httpserver_sendmethodnotallowed",
-      "source": "httpserver_handlerequest",
-      "target": "httpserver_sendmethodnotallowed",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L113",
-      "weight": 0.8,
-      "_src": "httpserver_handlerequest",
-      "_tgt": "httpserver_tostateresponse",
-      "source": "httpserver_handlerequest",
-      "target": "httpserver_tostateresponse",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L114",
-      "weight": 0.8,
-      "_src": "httpserver_handlerequest",
-      "_tgt": "httpserver_renderdashboardhtml",
-      "source": "httpserver_handlerequest",
-      "target": "httpserver_renderdashboardhtml",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L115",
-      "weight": 0.8,
-      "_src": "httpserver_handlerequest",
-      "_tgt": "httpserver_sendtext",
-      "source": "httpserver_handlerequest",
-      "target": "httpserver_sendtext",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L125",
-      "weight": 0.8,
-      "_src": "httpserver_handlerequest",
-      "_tgt": "httpserver_sendjson",
-      "source": "httpserver_handlerequest",
-      "target": "httpserver_sendjson",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L136",
-      "weight": 0.8,
-      "_src": "httpserver_handlerequest",
-      "_tgt": "httpserver_queuerefresh",
-      "source": "httpserver_handlerequest",
-      "target": "httpserver_queuerefresh",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L150",
-      "weight": 0.8,
-      "_src": "httpserver_handlerequest",
-      "_tgt": "httpserver_sendjsonerror",
-      "source": "httpserver_handlerequest",
-      "target": "httpserver_sendjsonerror",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L159",
-      "weight": 0.8,
-      "_src": "httpserver_handlerequest",
-      "_tgt": "httpserver_toissueresponse",
-      "source": "httpserver_handlerequest",
-      "target": "httpserver_toissueresponse",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L274",
-      "weight": 0.8,
-      "_src": "httpserver_toissueresponse",
-      "_tgt": "httpserver_toiso",
-      "source": "httpserver_toissueresponse",
-      "target": "httpserver_toiso",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L275",
-      "weight": 0.8,
-      "_src": "httpserver_toissueresponse",
-      "_tgt": "httpserver_toisonullable",
-      "source": "httpserver_toissueresponse",
-      "target": "httpserver_toisonullable",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L308",
-      "weight": 0.8,
-      "_src": "httpserver_renderdashboardhtml",
-      "_tgt": "httpserver_safejsonforscript",
-      "source": "httpserver_renderdashboardhtml",
-      "target": "httpserver_safejsonforscript",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L857",
-      "weight": 0.8,
-      "_src": "httpserver_toisonullable",
-      "_tgt": "httpserver_toiso",
-      "source": "httpserver_toiso",
-      "target": "httpserver_toisonullable",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L868",
-      "weight": 0.8,
-      "_src": "httpserver_sendjsonerror",
-      "_tgt": "httpserver_sendjson",
-      "source": "httpserver_sendjson",
-      "target": "httpserver_sendjsonerror",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/httpServer.ts",
-      "source_location": "L885",
-      "weight": 0.8,
-      "_src": "httpserver_sendmethodnotallowed",
-      "_tgt": "httpserver_sendjsonerror",
-      "source": "httpserver_sendjsonerror",
-      "target": "httpserver_sendmethodnotallowed",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/orchestrator.ts",
-      "source_location": "L1",
-      "weight": 1.0,
-      "_src": "orchestrator",
-      "_tgt": "issue",
-      "source": "issue",
-      "target": "orchestrator",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/runtime.ts",
-      "source_location": "L2",
-      "weight": 1.0,
-      "_src": "runtime",
-      "_tgt": "issue",
-      "source": "issue",
-      "target": "runtime",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/scheduler.ts",
-      "source_location": "L1",
-      "weight": 1.0,
-      "_src": "scheduler",
-      "_tgt": "issue",
-      "source": "issue",
-      "target": "scheduler",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L5",
-      "weight": 1.0,
-      "_src": "service",
-      "_tgt": "issue",
-      "source": "issue",
-      "target": "service",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/startup.ts",
-      "source_location": "L1",
-      "weight": 1.0,
-      "_src": "startup",
-      "_tgt": "issue",
-      "source": "issue",
-      "target": "startup",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L2",
-      "weight": 1.0,
-      "_src": "linear",
-      "_tgt": "issue",
-      "source": "issue",
-      "target": "linear",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/worker.ts",
-      "source_location": "L5",
-      "weight": 1.0,
-      "_src": "worker",
-      "_tgt": "issue",
-      "source": "issue",
-      "target": "worker",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/orchestrator.test.ts",
-      "source_location": "L2",
-      "weight": 1.0,
-      "_src": "orchestrator_test",
-      "_tgt": "issue",
-      "source": "issue",
-      "target": "orchestrator_test",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/runtime.test.ts",
-      "source_location": "L3",
-      "weight": 1.0,
-      "_src": "runtime_test",
-      "_tgt": "issue",
-      "source": "issue",
-      "target": "runtime_test",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/scheduler.test.ts",
-      "source_location": "L3",
-      "weight": 1.0,
-      "_src": "scheduler_test",
-      "_tgt": "issue",
-      "source": "issue",
-      "target": "scheduler_test",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/service.test.ts",
-      "source_location": "L4",
-      "weight": 1.0,
-      "_src": "service_test",
-      "_tgt": "issue",
-      "source": "issue",
-      "target": "service_test",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/startup.test.ts",
-      "source_location": "L5",
-      "weight": 1.0,
-      "_src": "startup_test",
-      "_tgt": "issue",
-      "source": "issue",
-      "target": "startup_test",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/worker.test.ts",
-      "source_location": "L6",
-      "weight": 1.0,
-      "_src": "worker_test",
-      "_tgt": "issue",
-      "source": "issue",
-      "target": "worker_test",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/orchestrator.ts",
-      "source_location": "L2",
-      "weight": 1.0,
-      "_src": "orchestrator",
-      "_tgt": "retry",
-      "source": "orchestrator",
-      "target": "retry",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/orchestrator.ts",
-      "source_location": "L3",
-      "weight": 1.0,
-      "_src": "orchestrator",
-      "_tgt": "scheduler",
-      "source": "orchestrator",
-      "target": "scheduler",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/orchestrator.ts",
-      "source_location": "L45",
-      "weight": 1.0,
-      "_src": "orchestrator",
-      "_tgt": "orchestrator_createorchestratorstate",
-      "source": "orchestrator",
-      "target": "orchestrator_createorchestratorstate",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/orchestrator.ts",
-      "source_location": "L54",
-      "weight": 1.0,
-      "_src": "orchestrator",
-      "_tgt": "orchestrator_markissuerunning",
-      "source": "orchestrator",
-      "target": "orchestrator_markissuerunning",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/orchestrator.ts",
-      "source_location": "L71",
-      "weight": 1.0,
-      "_src": "orchestrator",
-      "_tgt": "orchestrator_getavailableglobalslots",
-      "source": "orchestrator",
-      "target": "orchestrator_getavailableglobalslots",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/orchestrator.ts",
-      "source_location": "L75",
-      "weight": 1.0,
-      "_src": "orchestrator",
-      "_tgt": "orchestrator_getrunningcountbystate",
-      "source": "orchestrator",
-      "target": "orchestrator_getrunningcountbystate",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/orchestrator.ts",
-      "source_location": "L86",
-      "weight": 1.0,
-      "_src": "orchestrator",
-      "_tgt": "orchestrator_selectdispatchcandidates",
-      "source": "orchestrator",
-      "target": "orchestrator_selectdispatchcandidates",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/orchestrator.ts",
-      "source_location": "L143",
-      "weight": 1.0,
-      "_src": "orchestrator",
-      "_tgt": "orchestrator_scheduleretry",
-      "source": "orchestrator",
-      "target": "orchestrator_scheduleretry",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/orchestrator.ts",
-      "source_location": "L161",
-      "weight": 1.0,
-      "_src": "orchestrator",
-      "_tgt": "orchestrator_onworkerexit",
-      "source": "orchestrator",
-      "target": "orchestrator_onworkerexit",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/orchestrator.ts",
-      "source_location": "L212",
-      "weight": 1.0,
-      "_src": "orchestrator",
-      "_tgt": "orchestrator_getstalledissueids",
-      "source": "orchestrator",
-      "target": "orchestrator_getstalledissueids",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/orchestrator.ts",
-      "source_location": "L236",
-      "weight": 1.0,
-      "_src": "orchestrator",
-      "_tgt": "orchestrator_reconcilerunningissuestates",
-      "source": "orchestrator",
-      "target": "orchestrator_reconcilerunningissuestates",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/orchestrator.ts",
-      "source_location": "L289",
-      "weight": 1.0,
-      "_src": "orchestrator",
-      "_tgt": "orchestrator_normalizeretryattempt",
-      "source": "orchestrator",
-      "target": "orchestrator_normalizeretryattempt",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/runtime.ts",
-      "source_location": "L3",
-      "weight": 1.0,
-      "_src": "runtime",
-      "_tgt": "orchestrator",
-      "source": "orchestrator",
-      "target": "runtime",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L6",
-      "weight": 1.0,
-      "_src": "service",
-      "_tgt": "orchestrator",
-      "source": "orchestrator",
-      "target": "service",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/orchestrator.test.ts",
-      "source_location": "L3",
-      "weight": 1.0,
-      "_src": "orchestrator_test",
-      "_tgt": "orchestrator",
-      "source": "orchestrator",
-      "target": "orchestrator_test",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/runtime.test.ts",
-      "source_location": "L4",
-      "weight": 1.0,
-      "_src": "runtime_test",
-      "_tgt": "orchestrator",
-      "source": "orchestrator",
-      "target": "runtime_test",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/orchestrator.ts",
-      "source_location": "L66",
-      "weight": 0.8,
-      "_src": "orchestrator_markissuerunning",
-      "_tgt": "orchestrator_normalizeretryattempt",
-      "source": "orchestrator_markissuerunning",
-      "target": "orchestrator_normalizeretryattempt",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/orchestrator.ts",
-      "source_location": "L95",
-      "weight": 0.8,
-      "_src": "orchestrator_selectdispatchcandidates",
-      "_tgt": "orchestrator_getavailableglobalslots",
-      "source": "orchestrator_getavailableglobalslots",
-      "target": "orchestrator_selectdispatchcandidates",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/orchestrator.ts",
-      "source_location": "L105",
-      "weight": 0.8,
-      "_src": "orchestrator_selectdispatchcandidates",
-      "_tgt": "orchestrator_getrunningcountbystate",
-      "source": "orchestrator_getrunningcountbystate",
-      "target": "orchestrator_selectdispatchcandidates",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/orchestrator.ts",
-      "source_location": "L188",
-      "weight": 0.8,
-      "_src": "orchestrator_onworkerexit",
-      "_tgt": "orchestrator_scheduleretry",
-      "source": "orchestrator_scheduleretry",
-      "target": "orchestrator_onworkerexit",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/retry.ts",
-      "source_location": "L1",
-      "weight": 1.0,
-      "_src": "retry",
-      "_tgt": "retry_calculatefailureretrydelay",
-      "source": "retry",
-      "target": "retry_calculatefailureretrydelay",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/retry.ts",
-      "source_location": "L7",
-      "weight": 1.0,
-      "_src": "retry",
-      "_tgt": "retry_calculatecontinuationdelay",
-      "source": "retry",
-      "target": "retry_calculatecontinuationdelay",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/retry.test.ts",
-      "source_location": "L2",
-      "weight": 1.0,
-      "_src": "retry_test",
-      "_tgt": "retry",
-      "source": "retry",
-      "target": "retry_test",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/runtime.ts",
-      "source_location": "L15",
-      "weight": 1.0,
-      "_src": "runtime",
-      "_tgt": "validate",
-      "source": "runtime",
-      "target": "validate",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/runtime.ts",
-      "source_location": "L58",
-      "weight": 1.0,
-      "_src": "runtime",
-      "_tgt": "runtime_runorchestratortick",
-      "source": "runtime",
-      "target": "runtime_runorchestratortick",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/runtime.ts",
-      "source_location": "L155",
-      "weight": 1.0,
-      "_src": "runtime",
-      "_tgt": "runtime_isguardrailblockederror",
-      "source": "runtime",
-      "target": "runtime_isguardrailblockederror",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/runtime.ts",
-      "source_location": "L163",
-      "weight": 1.0,
-      "_src": "runtime",
-      "_tgt": "runtime_reconcilerunningissues",
-      "source": "runtime",
-      "target": "runtime_reconcilerunningissues",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/runtime.ts",
-      "source_location": "L188",
-      "weight": 1.0,
-      "_src": "runtime",
-      "_tgt": "runtime_normalizedispatchattempt",
-      "source": "runtime",
-      "target": "runtime_normalizedispatchattempt",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/runtime.ts",
-      "source_location": "L196",
-      "weight": 1.0,
-      "_src": "runtime",
-      "_tgt": "runtime_nextretryattempt",
-      "source": "runtime",
-      "target": "runtime_nextretryattempt",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/runtime.ts",
-      "source_location": "L204",
-      "weight": 1.0,
-      "_src": "runtime",
-      "_tgt": "runtime_processdueretries",
-      "source": "runtime",
-      "target": "runtime_processdueretries",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/runtime.ts",
-      "source_location": "L304",
-      "weight": 1.0,
-      "_src": "runtime",
-      "_tgt": "runtime_candispatchretryissue",
-      "source": "runtime",
-      "target": "runtime_candispatchretryissue",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/runtime.ts",
-      "source_location": "L326",
-      "weight": 1.0,
-      "_src": "runtime",
-      "_tgt": "runtime_requeueretryentry",
-      "source": "runtime",
-      "target": "runtime_requeueretryentry",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L7",
-      "weight": 1.0,
-      "_src": "service",
-      "_tgt": "runtime",
-      "source": "runtime",
-      "target": "service",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/runtime.test.ts",
-      "source_location": "L5",
-      "weight": 1.0,
-      "_src": "runtime_test",
-      "_tgt": "runtime",
-      "source": "runtime",
-      "target": "runtime_test",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/runtime.ts",
-      "source_location": "L75",
-      "weight": 0.8,
-      "_src": "runtime_runorchestratortick",
-      "_tgt": "runtime_reconcilerunningissues",
-      "source": "runtime_runorchestratortick",
-      "target": "runtime_reconcilerunningissues",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/runtime.ts",
-      "source_location": "L112",
-      "weight": 0.8,
-      "_src": "runtime_runorchestratortick",
-      "_tgt": "runtime_normalizedispatchattempt",
-      "source": "runtime_runorchestratortick",
-      "target": "runtime_normalizedispatchattempt",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/runtime.ts",
-      "source_location": "L129",
-      "weight": 0.8,
-      "_src": "runtime_runorchestratortick",
-      "_tgt": "runtime_isguardrailblockederror",
-      "source": "runtime_runorchestratortick",
-      "target": "runtime_isguardrailblockederror",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/runtime.ts",
-      "source_location": "L136",
-      "weight": 0.8,
-      "_src": "runtime_runorchestratortick",
-      "_tgt": "runtime_nextretryattempt",
-      "source": "runtime_runorchestratortick",
-      "target": "runtime_nextretryattempt",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/runtime.ts",
-      "source_location": "L281",
-      "weight": 0.8,
-      "_src": "runtime_processdueretries",
-      "_tgt": "runtime_normalizedispatchattempt",
-      "source": "runtime_normalizedispatchattempt",
-      "target": "runtime_processdueretries",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/runtime.ts",
-      "source_location": "L234",
-      "weight": 0.8,
-      "_src": "runtime_processdueretries",
-      "_tgt": "runtime_requeueretryentry",
-      "source": "runtime_processdueretries",
-      "target": "runtime_requeueretryentry",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/runtime.ts",
-      "source_location": "L268",
-      "weight": 0.8,
-      "_src": "runtime_processdueretries",
-      "_tgt": "runtime_candispatchretryissue",
-      "source": "runtime_processdueretries",
-      "target": "runtime_candispatchretryissue",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/scheduler.ts",
-      "source_location": "L3",
-      "weight": 1.0,
-      "_src": "scheduler",
-      "_tgt": "scheduler_sortissuesfordispatch",
-      "source": "scheduler",
-      "target": "scheduler_sortissuesfordispatch",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/scheduler.ts",
-      "source_location": "L22",
-      "weight": 1.0,
-      "_src": "scheduler",
-      "_tgt": "scheduler_isissuedispatcheligible",
-      "source": "scheduler",
-      "target": "scheduler_isissuedispatcheligible",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/scheduler.ts",
-      "source_location": "L57",
-      "weight": 1.0,
-      "_src": "scheduler",
-      "_tgt": "scheduler_normalizepriority",
-      "source": "scheduler",
-      "target": "scheduler_normalizepriority",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/scheduler.test.ts",
-      "source_location": "L2",
-      "weight": 1.0,
-      "_src": "scheduler_test",
-      "_tgt": "scheduler",
-      "source": "scheduler",
-      "target": "scheduler_test",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L8",
-      "weight": 1.0,
-      "_src": "service",
-      "_tgt": "startup",
-      "source": "service",
-      "target": "startup",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L9",
-      "weight": 1.0,
-      "_src": "service",
-      "_tgt": "linear",
-      "source": "service",
-      "target": "linear",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L11",
-      "weight": 1.0,
-      "_src": "service",
-      "_tgt": "validate",
-      "source": "service",
-      "target": "validate",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L12",
-      "weight": 1.0,
-      "_src": "service",
-      "_tgt": "workspace",
-      "source": "service",
-      "target": "workspace",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L13",
-      "weight": 1.0,
-      "_src": "service",
-      "_tgt": "workflow",
-      "source": "service",
-      "target": "workflow",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L14",
-      "weight": 1.0,
-      "_src": "service",
-      "_tgt": "worker",
-      "source": "service",
-      "target": "worker",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L191",
-      "weight": 1.0,
-      "_src": "service",
-      "_tgt": "service_formatservicelogline",
-      "source": "service",
-      "target": "service_formatservicelogline",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L206",
-      "weight": 1.0,
-      "_src": "service",
-      "_tgt": "service_createsymphonyservice",
-      "source": "service",
-      "target": "service_createsymphonyservice",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L1412",
-      "weight": 1.0,
-      "_src": "service",
-      "_tgt": "service_resolvedependencies",
-      "source": "service",
-      "target": "service_resolvedependencies",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L1464",
-      "weight": 1.0,
-      "_src": "service",
-      "_tgt": "service_hasrecognizedpackagelabel",
-      "source": "service",
-      "target": "service_hasrecognizedpackagelabel",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L1483",
-      "weight": 1.0,
-      "_src": "service",
-      "_tgt": "service_isdonesignalstate",
-      "source": "service",
-      "target": "service_isdonesignalstate",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L1496",
-      "weight": 1.0,
-      "_src": "service",
-      "_tgt": "service_buildruncommentbody",
-      "source": "service",
-      "target": "service_buildruncommentbody",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L1524",
-      "weight": 1.0,
-      "_src": "service",
-      "_tgt": "service_normalizecodexeventkind",
-      "source": "service",
-      "target": "service_normalizecodexeventkind",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L1528",
-      "weight": 1.0,
-      "_src": "service",
-      "_tgt": "service_formatcodexeventmessage",
-      "source": "service",
-      "target": "service_formatcodexeventmessage",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L1541",
-      "weight": 1.0,
-      "_src": "service",
-      "_tgt": "service_extractcodexmethod",
-      "source": "service",
-      "target": "service_extractcodexmethod",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L1550",
-      "weight": 1.0,
-      "_src": "service",
-      "_tgt": "service_normalizeusage",
-      "source": "service",
-      "target": "service_normalizeusage",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L1570",
-      "weight": 1.0,
-      "_src": "service",
-      "_tgt": "service_normalizeratelimits",
-      "source": "service",
-      "target": "service_normalizeratelimits",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L1578",
-      "weight": 1.0,
-      "_src": "service",
-      "_tgt": "service_formatlogvalue",
-      "source": "service",
-      "target": "service_formatlogvalue",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L1594",
-      "weight": 1.0,
-      "_src": "service",
-      "_tgt": "service_asstring",
-      "source": "service",
-      "target": "service_asstring",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L1598",
-      "weight": 1.0,
-      "_src": "service",
-      "_tgt": "service_asnumber",
-      "source": "service",
-      "target": "service_asnumber",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/cli.test.ts",
-      "source_location": "L2",
-      "weight": 1.0,
-      "_src": "cli_test",
-      "_tgt": "service",
-      "source": "service",
-      "target": "cli_test",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/httpServer.test.ts",
-      "source_location": "L2",
-      "weight": 1.0,
-      "_src": "httpserver_test",
-      "_tgt": "service",
-      "source": "service",
-      "target": "httpserver_test",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/service.test.ts",
-      "source_location": "L5",
-      "weight": 1.0,
-      "_src": "service_test",
-      "_tgt": "service",
-      "source": "service",
-      "target": "service_test",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L199",
-      "weight": 0.8,
-      "_src": "service_formatservicelogline",
-      "_tgt": "service_formatlogvalue",
-      "source": "service_formatservicelogline",
-      "target": "service_formatlogvalue",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L207",
-      "weight": 0.8,
-      "_src": "service_createsymphonyservice",
-      "_tgt": "service_resolvedependencies",
-      "source": "service_createsymphonyservice",
-      "target": "service_resolvedependencies",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L1529",
-      "weight": 0.8,
-      "_src": "service_formatcodexeventmessage",
-      "_tgt": "service_extractcodexmethod",
-      "source": "service_formatcodexeventmessage",
-      "target": "service_extractcodexmethod",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/service.ts",
-      "source_location": "L1555",
-      "weight": 0.8,
-      "_src": "service_normalizeusage",
-      "_tgt": "service_asnumber",
-      "source": "service_normalizeusage",
-      "target": "service_asnumber",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/startup.ts",
-      "source_location": "L3",
-      "weight": 1.0,
-      "_src": "startup",
-      "_tgt": "workspace",
-      "source": "startup",
-      "target": "workspace",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/startup.ts",
-      "source_location": "L24",
-      "weight": 1.0,
-      "_src": "startup",
-      "_tgt": "startup_cleanupterminalissueworkspaces",
-      "source": "startup",
-      "target": "startup_cleanupterminalissueworkspaces",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/startup.test.ts",
-      "source_location": "L6",
-      "weight": 1.0,
-      "_src": "startup_test",
-      "_tgt": "startup",
-      "source": "startup",
-      "target": "startup_test",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/template.ts",
-      "source_location": "L10",
-      "weight": 1.0,
-      "_src": "template",
-      "_tgt": "template_renderprompttemplate",
-      "source": "template",
-      "target": "template_renderprompttemplate",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/template.ts",
-      "source_location": "L25",
-      "weight": 1.0,
-      "_src": "template",
-      "_tgt": "template_buildissueprompt",
-      "source": "template",
-      "target": "template_buildissueprompt",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/worker.ts",
-      "source_location": "L6",
-      "weight": 1.0,
-      "_src": "worker",
-      "_tgt": "template",
-      "source": "template",
-      "target": "worker",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/template.test.ts",
-      "source_location": "L3",
-      "weight": 1.0,
-      "_src": "template_test",
-      "_tgt": "template",
-      "source": "template",
-      "target": "template_test",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/template.ts",
-      "source_location": "L30",
-      "weight": 0.8,
-      "_src": "template_buildissueprompt",
-      "_tgt": "template_renderprompttemplate",
-      "source": "template_renderprompttemplate",
-      "target": "template_buildissueprompt",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L159",
-      "weight": 1.0,
-      "_src": "linear",
-      "_tgt": "linear_lineartrackerclient",
-      "source": "linear",
-      "target": "linear_lineartrackerclient",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L360",
-      "weight": 1.0,
-      "_src": "linear",
-      "_tgt": "linear_normalizeissue",
-      "source": "linear",
-      "target": "linear_normalizeissue",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L392",
-      "weight": 1.0,
-      "_src": "linear",
-      "_tgt": "linear_asstring",
-      "source": "linear",
-      "target": "linear_asstring",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L396",
-      "weight": 1.0,
-      "_src": "linear",
-      "_tgt": "linear_normalizepriority",
-      "source": "linear",
-      "target": "linear_normalizepriority",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L404",
-      "weight": 1.0,
-      "_src": "linear",
-      "_tgt": "linear_normalizeiso",
-      "source": "linear",
-      "target": "linear_normalizeiso",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L417",
-      "weight": 1.0,
-      "_src": "linear",
-      "_tgt": "linear_normalizelabels",
-      "source": "linear",
-      "target": "linear_normalizelabels",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L428",
-      "weight": 1.0,
-      "_src": "linear",
-      "_tgt": "linear_normalizeblockedby",
-      "source": "linear",
-      "target": "linear_normalizeblockedby",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/linearTracker.test.ts",
-      "source_location": "L3",
-      "weight": 1.0,
-      "_src": "lineartracker_test",
-      "_tgt": "linear",
-      "source": "linear",
-      "target": "lineartracker_test",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L169",
-      "weight": 1.0,
-      "_src": "linear_lineartrackerclient",
-      "_tgt": "linear_lineartrackerclient_constructor",
-      "source": "linear_lineartrackerclient",
-      "target": "linear_lineartrackerclient_constructor",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L179",
-      "weight": 1.0,
-      "_src": "linear_lineartrackerclient",
-      "_tgt": "linear_lineartrackerclient_fetchcandidateissues",
-      "source": "linear_lineartrackerclient",
-      "target": "linear_lineartrackerclient_fetchcandidateissues",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L186",
-      "weight": 1.0,
-      "_src": "linear_lineartrackerclient",
-      "_tgt": "linear_lineartrackerclient_fetchissuesbystates",
-      "source": "linear_lineartrackerclient",
-      "target": "linear_lineartrackerclient_fetchissuesbystates",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L197",
-      "weight": 1.0,
-      "_src": "linear_lineartrackerclient",
-      "_tgt": "linear_lineartrackerclient_fetchissuestatesbyids",
-      "source": "linear_lineartrackerclient",
-      "target": "linear_lineartrackerclient_fetchissuestatesbyids",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L214",
-      "weight": 1.0,
-      "_src": "linear_lineartrackerclient",
-      "_tgt": "linear_lineartrackerclient_createissuecomment",
-      "source": "linear_lineartrackerclient",
-      "target": "linear_lineartrackerclient_createissuecomment",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L225",
-      "weight": 1.0,
-      "_src": "linear_lineartrackerclient",
-      "_tgt": "linear_lineartrackerclient_updateissuestatebyname",
-      "source": "linear_lineartrackerclient",
-      "target": "linear_lineartrackerclient_updateissuestatebyname",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L248",
-      "weight": 1.0,
-      "_src": "linear_lineartrackerclient",
-      "_tgt": "linear_lineartrackerclient_fetchpaginatedissues",
-      "source": "linear_lineartrackerclient",
-      "target": "linear_lineartrackerclient_fetchpaginatedissues",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L288",
-      "weight": 1.0,
-      "_src": "linear_lineartrackerclient",
-      "_tgt": "linear_lineartrackerclient_resolveworkflowstateidbyname",
-      "source": "linear_lineartrackerclient",
-      "target": "linear_lineartrackerclient_resolveworkflowstateidbyname",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L314",
-      "weight": 1.0,
-      "_src": "linear_lineartrackerclient",
-      "_tgt": "linear_lineartrackerclient_graphqlrequest",
-      "source": "linear_lineartrackerclient",
-      "target": "linear_lineartrackerclient_graphqlrequest",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L180",
-      "weight": 0.8,
-      "_src": "linear_lineartrackerclient_fetchcandidateissues",
-      "_tgt": "linear_lineartrackerclient_fetchpaginatedissues",
-      "source": "linear_lineartrackerclient_fetchcandidateissues",
-      "target": "linear_lineartrackerclient_fetchpaginatedissues",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L191",
-      "weight": 0.8,
-      "_src": "linear_lineartrackerclient_fetchissuesbystates",
-      "_tgt": "linear_lineartrackerclient_fetchpaginatedissues",
-      "source": "linear_lineartrackerclient_fetchissuesbystates",
-      "target": "linear_lineartrackerclient_fetchpaginatedissues",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L235",
-      "weight": 0.8,
-      "_src": "linear_lineartrackerclient_updateissuestatebyname",
-      "_tgt": "linear_lineartrackerclient_resolveworkflowstateidbyname",
-      "source": "linear_lineartrackerclient_updateissuestatebyname",
-      "target": "linear_lineartrackerclient_resolveworkflowstateidbyname",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L305",
-      "weight": 0.8,
-      "_src": "linear_lineartrackerclient_resolveworkflowstateidbyname",
-      "_tgt": "linear_asstring",
-      "source": "linear_lineartrackerclient_resolveworkflowstateidbyname",
-      "target": "linear_asstring",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L366",
-      "weight": 0.8,
-      "_src": "linear_normalizeissue",
-      "_tgt": "linear_asstring",
-      "source": "linear_normalizeissue",
-      "target": "linear_asstring",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L384",
-      "weight": 0.8,
-      "_src": "linear_normalizeissue",
-      "_tgt": "linear_normalizepriority",
-      "source": "linear_normalizeissue",
-      "target": "linear_normalizepriority",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L385",
-      "weight": 0.8,
-      "_src": "linear_normalizeissue",
-      "_tgt": "linear_normalizeiso",
-      "source": "linear_normalizeissue",
-      "target": "linear_normalizeiso",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L387",
-      "weight": 0.8,
-      "_src": "linear_normalizeissue",
-      "_tgt": "linear_normalizelabels",
-      "source": "linear_normalizeissue",
-      "target": "linear_normalizelabels",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L388",
-      "weight": 0.8,
-      "_src": "linear_normalizeissue",
-      "_tgt": "linear_normalizeblockedby",
-      "source": "linear_normalizeissue",
-      "target": "linear_normalizeblockedby",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/tracker/linear.ts",
-      "source_location": "L450",
-      "weight": 0.8,
-      "_src": "linear_normalizeblockedby",
-      "_tgt": "linear_asstring",
-      "source": "linear_asstring",
-      "target": "linear_normalizeblockedby",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/validate.ts",
-      "source_location": "L4",
-      "weight": 1.0,
-      "_src": "validate",
-      "_tgt": "validate_validatedispatchpreflight",
-      "source": "validate",
-      "target": "validate_validatedispatchpreflight",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/worker.ts",
-      "source_location": "L8",
-      "weight": 1.0,
-      "_src": "worker",
-      "_tgt": "workspace",
-      "source": "worker",
-      "target": "workspace",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/worker.ts",
-      "source_location": "L42",
-      "weight": 1.0,
-      "_src": "worker",
-      "_tgt": "worker_runissueattempt",
-      "source": "worker",
-      "target": "worker_runissueattempt",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/worker.ts",
-      "source_location": "L254",
-      "weight": 1.0,
-      "_src": "worker",
-      "_tgt": "worker_shouldcontinueturns",
-      "source": "worker",
-      "target": "worker_shouldcontinueturns",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/worker.ts",
-      "source_location": "L262",
-      "weight": 1.0,
-      "_src": "worker",
-      "_tgt": "worker_getworkspacefingerprint",
-      "source": "worker",
-      "target": "worker_getworkspacefingerprint",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/worker.ts",
-      "source_location": "L274",
-      "weight": 1.0,
-      "_src": "worker",
-      "_tgt": "worker_toworkspaceconfig",
-      "source": "worker",
-      "target": "worker_toworkspaceconfig",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/worker.ts",
-      "source_location": "L287",
-      "weight": 1.0,
-      "_src": "worker",
-      "_tgt": "worker_totemplateissue",
-      "source": "worker",
-      "target": "worker_totemplateissue",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/worker.ts",
-      "source_location": "L301",
-      "weight": 1.0,
-      "_src": "worker",
-      "_tgt": "worker_asnumber",
-      "source": "worker",
-      "target": "worker_asnumber",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/worker.test.ts",
-      "source_location": "L8",
-      "weight": 1.0,
-      "_src": "worker_test",
-      "_tgt": "worker",
-      "source": "worker",
-      "target": "worker_test",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/worker.ts",
-      "source_location": "L43",
-      "weight": 0.8,
-      "_src": "worker_runissueattempt",
-      "_tgt": "worker_toworkspaceconfig",
-      "source": "worker_runissueattempt",
-      "target": "worker_toworkspaceconfig",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/worker.ts",
-      "source_location": "L61",
-      "weight": 0.8,
-      "_src": "worker_runissueattempt",
-      "_tgt": "worker_shouldcontinueturns",
-      "source": "worker_runissueattempt",
-      "target": "worker_shouldcontinueturns",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/worker.ts",
-      "source_location": "L63",
-      "weight": 0.8,
-      "_src": "worker_runissueattempt",
-      "_tgt": "worker_totemplateissue",
-      "source": "worker_runissueattempt",
-      "target": "worker_totemplateissue",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/worker.ts",
-      "source_location": "L119",
-      "weight": 0.8,
-      "_src": "worker_runissueattempt",
-      "_tgt": "worker_asnumber",
-      "source": "worker_runissueattempt",
-      "target": "worker_asnumber",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/worker.ts",
-      "source_location": "L162",
-      "weight": 0.8,
-      "_src": "worker_runissueattempt",
-      "_tgt": "worker_getworkspacefingerprint",
-      "source": "worker_runissueattempt",
-      "target": "worker_getworkspacefingerprint",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/workflow.ts",
-      "source_location": "L10",
-      "weight": 1.0,
-      "_src": "workflow",
-      "_tgt": "workflow_loadworkflowfile",
-      "source": "workflow",
-      "target": "workflow_loadworkflowfile",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/workflow.ts",
-      "source_location": "L32",
-      "weight": 1.0,
-      "_src": "workflow",
-      "_tgt": "workflow_parseworkflowcontent",
-      "source": "workflow",
-      "target": "workflow_parseworkflowcontent",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/workflow.ts",
-      "source_location": "L71",
-      "weight": 1.0,
-      "_src": "workflow",
-      "_tgt": "workflow_parsefrontmatter",
-      "source": "workflow",
-      "target": "workflow_parsefrontmatter",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/workflow.ts",
-      "source_location": "L97",
-      "weight": 1.0,
-      "_src": "workflow",
-      "_tgt": "workflow_watchworkflowfile",
-      "source": "workflow",
-      "target": "workflow_watchworkflowfile",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/workflow.test.ts",
-      "source_location": "L6",
-      "weight": 1.0,
-      "_src": "workflow_test",
-      "_tgt": "workflow",
-      "source": "workflow",
-      "target": "workflow_test",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/workflow.ts",
-      "source_location": "L23",
-      "weight": 0.8,
-      "_src": "workflow_loadworkflowfile",
-      "_tgt": "workflow_parseworkflowcontent",
-      "source": "workflow_loadworkflowfile",
-      "target": "workflow_parseworkflowcontent",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/workflow.ts",
-      "source_location": "L63",
-      "weight": 0.8,
-      "_src": "workflow_parseworkflowcontent",
-      "_tgt": "workflow_parsefrontmatter",
-      "source": "workflow_parseworkflowcontent",
-      "target": "workflow_parsefrontmatter",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/workspace.ts",
-      "source_location": "L25",
-      "weight": 1.0,
-      "_src": "workspace",
-      "_tgt": "workspace_ensureworkspaceforissue",
-      "source": "workspace",
-      "target": "workspace_ensureworkspaceforissue",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/workspace.ts",
-      "source_location": "L47",
-      "weight": 1.0,
-      "_src": "workspace",
-      "_tgt": "workspace_runbeforerunhook",
-      "source": "workspace",
-      "target": "workspace_runbeforerunhook",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/workspace.ts",
-      "source_location": "L55",
-      "weight": 1.0,
-      "_src": "workspace",
-      "_tgt": "workspace_runafterrunhook",
-      "source": "workspace",
-      "target": "workspace_runafterrunhook",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/workspace.ts",
-      "source_location": "L63",
-      "weight": 1.0,
-      "_src": "workspace",
-      "_tgt": "workspace_removeworkspace",
-      "source": "workspace",
-      "target": "workspace_removeworkspace",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/workspace.ts",
-      "source_location": "L73",
-      "weight": 1.0,
-      "_src": "workspace",
-      "_tgt": "workspace_resolveworkspacelocation",
-      "source": "workspace",
-      "target": "workspace_resolveworkspacelocation",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/workspace.ts",
-      "source_location": "L87",
-      "weight": 1.0,
-      "_src": "workspace",
-      "_tgt": "workspace_sanitizeworkspacekey",
-      "source": "workspace",
-      "target": "workspace_sanitizeworkspacekey",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/workspace.ts",
-      "source_location": "L98",
-      "weight": 1.0,
-      "_src": "workspace",
-      "_tgt": "workspace_assertworkspacepathsafety",
-      "source": "workspace",
-      "target": "workspace_assertworkspacepathsafety",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/workspace.ts",
-      "source_location": "L117",
-      "weight": 1.0,
-      "_src": "workspace",
-      "_tgt": "workspace_runrequiredhook",
-      "source": "workspace",
-      "target": "workspace_runrequiredhook",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/workspace.ts",
-      "source_location": "L127",
-      "weight": 1.0,
-      "_src": "workspace",
-      "_tgt": "workspace_runbestefforthook",
-      "source": "workspace",
-      "target": "workspace_runbestefforthook",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/workspace.ts",
-      "source_location": "L142",
-      "weight": 1.0,
-      "_src": "workspace",
-      "_tgt": "workspace_runhookscript",
-      "source": "workspace",
-      "target": "workspace_runhookscript",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/workspace.ts",
-      "source_location": "L219",
-      "weight": 1.0,
-      "_src": "workspace",
-      "_tgt": "workspace_pathexists",
-      "source": "workspace",
-      "target": "workspace_pathexists",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/src/workspace.ts",
-      "source_location": "L232",
-      "weight": 1.0,
-      "_src": "workspace",
-      "_tgt": "workspace_ismissingpatherror",
-      "source": "workspace",
-      "target": "workspace_ismissingpatherror",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/startup.test.ts",
-      "source_location": "L7",
-      "weight": 1.0,
-      "_src": "startup_test",
-      "_tgt": "workspace",
-      "source": "workspace",
-      "target": "startup_test",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "imports_from",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/workspace.test.ts",
-      "source_location": "L6",
-      "weight": 1.0,
-      "_src": "workspace_test",
-      "_tgt": "workspace",
-      "source": "workspace",
-      "target": "workspace_test",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/workspace.ts",
-      "source_location": "L29",
-      "weight": 0.8,
-      "_src": "workspace_ensureworkspaceforissue",
-      "_tgt": "workspace_resolveworkspacelocation",
-      "source": "workspace_ensureworkspaceforissue",
-      "target": "workspace_resolveworkspacelocation",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/workspace.ts",
-      "source_location": "L32",
-      "weight": 0.8,
-      "_src": "workspace_ensureworkspaceforissue",
-      "_tgt": "workspace_pathexists",
-      "source": "workspace_ensureworkspaceforissue",
-      "target": "workspace_pathexists",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/workspace.ts",
-      "source_location": "L38",
-      "weight": 0.8,
-      "_src": "workspace_ensureworkspaceforissue",
-      "_tgt": "workspace_runrequiredhook",
-      "source": "workspace_ensureworkspaceforissue",
-      "target": "workspace_runrequiredhook",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/workspace.ts",
-      "source_location": "L52",
-      "weight": 0.8,
-      "_src": "workspace_runbeforerunhook",
-      "_tgt": "workspace_runrequiredhook",
-      "source": "workspace_runbeforerunhook",
-      "target": "workspace_runrequiredhook",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/workspace.ts",
-      "source_location": "L60",
-      "weight": 0.8,
-      "_src": "workspace_runafterrunhook",
-      "_tgt": "workspace_runbestefforthook",
-      "source": "workspace_runafterrunhook",
-      "target": "workspace_runbestefforthook",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/workspace.ts",
-      "source_location": "L64",
-      "weight": 0.8,
-      "_src": "workspace_removeworkspace",
-      "_tgt": "workspace_assertworkspacepathsafety",
-      "source": "workspace_removeworkspace",
-      "target": "workspace_assertworkspacepathsafety",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/workspace.ts",
-      "source_location": "L67",
-      "weight": 0.8,
-      "_src": "workspace_removeworkspace",
-      "_tgt": "workspace_runbestefforthook",
-      "source": "workspace_removeworkspace",
-      "target": "workspace_runbestefforthook",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/workspace.ts",
-      "source_location": "L75",
-      "weight": 0.8,
-      "_src": "workspace_resolveworkspacelocation",
-      "_tgt": "workspace_sanitizeworkspacekey",
-      "source": "workspace_resolveworkspacelocation",
-      "target": "workspace_sanitizeworkspacekey",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/workspace.ts",
-      "source_location": "L78",
-      "weight": 0.8,
-      "_src": "workspace_resolveworkspacelocation",
-      "_tgt": "workspace_assertworkspacepathsafety",
-      "source": "workspace_resolveworkspacelocation",
-      "target": "workspace_assertworkspacepathsafety",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/workspace.ts",
-      "source_location": "L123",
-      "weight": 0.8,
-      "_src": "workspace_runrequiredhook",
-      "_tgt": "workspace_assertworkspacepathsafety",
-      "source": "workspace_assertworkspacepathsafety",
-      "target": "workspace_runrequiredhook",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/workspace.ts",
-      "source_location": "L133",
-      "weight": 0.8,
-      "_src": "workspace_runbestefforthook",
-      "_tgt": "workspace_assertworkspacepathsafety",
-      "source": "workspace_assertworkspacepathsafety",
-      "target": "workspace_runbestefforthook",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/workspace.ts",
-      "source_location": "L124",
-      "weight": 0.8,
-      "_src": "workspace_runrequiredhook",
-      "_tgt": "workspace_runhookscript",
-      "source": "workspace_runrequiredhook",
-      "target": "workspace_runhookscript",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/workspace.ts",
-      "source_location": "L136",
-      "weight": 0.8,
-      "_src": "workspace_runbestefforthook",
-      "_tgt": "workspace_runhookscript",
-      "source": "workspace_runbestefforthook",
-      "target": "workspace_runhookscript",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "packages/symphony-service/src/workspace.ts",
-      "source_location": "L224",
-      "weight": 0.8,
-      "_src": "workspace_pathexists",
-      "_tgt": "workspace_ismissingpatherror",
-      "source": "workspace_pathexists",
-      "target": "workspace_ismissingpatherror",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/cli.test.ts",
-      "source_location": "L5",
-      "weight": 1.0,
-      "_src": "cli_test",
-      "_tgt": "cli_test_makeservice",
-      "source": "cli_test",
-      "target": "cli_test_makeservice",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/codexClient.test.ts",
-      "source_location": "L350",
-      "weight": 1.0,
-      "_src": "codexclient_test",
-      "_tgt": "codexclient_test_writemockserver",
-      "source": "codexclient_test",
-      "target": "codexclient_test_writemockserver",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/httpServer.test.ts",
-      "source_location": "L5",
-      "weight": 1.0,
-      "_src": "httpserver_test",
-      "_tgt": "httpserver_test_makeservice",
-      "source": "httpserver_test",
-      "target": "httpserver_test_makeservice",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/linearTracker.test.ts",
-      "source_location": "L5",
-      "weight": 1.0,
-      "_src": "lineartracker_test",
-      "_tgt": "lineartracker_test_makefetch",
-      "source": "lineartracker_test",
-      "target": "lineartracker_test_makefetch",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/linearTracker.test.ts",
-      "source_location": "L28",
-      "weight": 1.0,
-      "_src": "lineartracker_test",
-      "_tgt": "lineartracker_test_clientwith",
-      "source": "lineartracker_test",
-      "target": "lineartracker_test_clientwith",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/orchestrator.test.ts",
-      "source_location": "L14",
-      "weight": 1.0,
-      "_src": "orchestrator_test",
-      "_tgt": "orchestrator_test_issue",
-      "source": "orchestrator_test",
-      "target": "orchestrator_test_issue",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/runtime.test.ts",
-      "source_location": "L7",
-      "weight": 1.0,
-      "_src": "runtime_test",
-      "_tgt": "runtime_test_issue",
-      "source": "runtime_test",
-      "target": "runtime_test_issue",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/runtime.test.ts",
-      "source_location": "L21",
-      "weight": 1.0,
-      "_src": "runtime_test",
-      "_tgt": "runtime_test_faketracker",
-      "source": "runtime_test",
-      "target": "runtime_test_faketracker",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/runtime.test.ts",
-      "source_location": "L40",
-      "weight": 1.0,
-      "_src": "runtime_test",
-      "_tgt": "runtime_test_config",
-      "source": "runtime_test",
-      "target": "runtime_test_config",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/runtime.test.ts",
-      "source_location": "L22",
-      "weight": 1.0,
-      "_src": "runtime_test_faketracker",
-      "_tgt": "runtime_test_faketracker_constructor",
-      "source": "runtime_test_faketracker",
-      "target": "runtime_test_faketracker_constructor",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/runtime.test.ts",
-      "source_location": "L27",
-      "weight": 1.0,
-      "_src": "runtime_test_faketracker",
-      "_tgt": "runtime_test_faketracker_fetchcandidateissues",
-      "source": "runtime_test_faketracker",
-      "target": "runtime_test_faketracker_fetchcandidateissues",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/runtime.test.ts",
-      "source_location": "L31",
-      "weight": 1.0,
-      "_src": "runtime_test_faketracker",
-      "_tgt": "runtime_test_faketracker_fetchissuesbystates",
-      "source": "runtime_test_faketracker",
-      "target": "runtime_test_faketracker_fetchissuesbystates",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/runtime.test.ts",
-      "source_location": "L35",
-      "weight": 1.0,
-      "_src": "runtime_test_faketracker",
-      "_tgt": "runtime_test_faketracker_fetchissuestatesbyids",
-      "source": "runtime_test_faketracker",
-      "target": "runtime_test_faketracker_fetchissuestatesbyids",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/scheduler.test.ts",
-      "source_location": "L5",
-      "weight": 1.0,
-      "_src": "scheduler_test",
-      "_tgt": "scheduler_test_makeissue",
-      "source": "scheduler_test",
-      "target": "scheduler_test_makeissue",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/service.test.ts",
-      "source_location": "L7",
-      "weight": 1.0,
-      "_src": "service_test",
-      "_tgt": "service_test_faketracker",
-      "source": "service_test",
-      "target": "service_test_faketracker",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/service.test.ts",
-      "source_location": "L21",
-      "weight": 1.0,
-      "_src": "service_test",
-      "_tgt": "service_test_issue",
-      "source": "service_test",
-      "target": "service_test_issue",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/service.test.ts",
-      "source_location": "L38",
-      "weight": 1.0,
-      "_src": "service_test",
-      "_tgt": "service_test_workflow",
-      "source": "service_test",
-      "target": "service_test_workflow",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/service.test.ts",
-      "source_location": "L8",
-      "weight": 1.0,
-      "_src": "service_test_faketracker",
-      "_tgt": "service_test_faketracker_fetchcandidateissues",
-      "source": "service_test_faketracker",
-      "target": "service_test_faketracker_fetchcandidateissues",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/service.test.ts",
-      "source_location": "L12",
-      "weight": 1.0,
-      "_src": "service_test_faketracker",
-      "_tgt": "service_test_faketracker_fetchissuesbystates",
-      "source": "service_test_faketracker",
-      "target": "service_test_faketracker_fetchissuesbystates",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/service.test.ts",
-      "source_location": "L16",
-      "weight": 1.0,
-      "_src": "service_test_faketracker",
-      "_tgt": "service_test_faketracker_fetchissuestatesbyids",
-      "source": "service_test_faketracker",
-      "target": "service_test_faketracker_fetchissuestatesbyids",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/startup.test.ts",
-      "source_location": "L9",
-      "weight": 1.0,
-      "_src": "startup_test",
-      "_tgt": "startup_test_issue",
-      "source": "startup_test",
-      "target": "startup_test_issue",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/startup.test.ts",
-      "source_location": "L23",
-      "weight": 1.0,
-      "_src": "startup_test",
-      "_tgt": "startup_test_faketracker",
-      "source": "startup_test",
-      "target": "startup_test_faketracker",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/startup.test.ts",
-      "source_location": "L24",
-      "weight": 1.0,
-      "_src": "startup_test_faketracker",
-      "_tgt": "startup_test_faketracker_constructor",
-      "source": "startup_test_faketracker",
-      "target": "startup_test_faketracker_constructor",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/startup.test.ts",
-      "source_location": "L29",
-      "weight": 1.0,
-      "_src": "startup_test_faketracker",
-      "_tgt": "startup_test_faketracker_fetchcandidateissues",
-      "source": "startup_test_faketracker",
-      "target": "startup_test_faketracker_fetchcandidateissues",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/startup.test.ts",
-      "source_location": "L33",
-      "weight": 1.0,
-      "_src": "startup_test_faketracker",
-      "_tgt": "startup_test_faketracker_fetchissuesbystates",
-      "source": "startup_test_faketracker",
-      "target": "startup_test_faketracker_fetchissuesbystates",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/startup.test.ts",
-      "source_location": "L41",
-      "weight": 1.0,
-      "_src": "startup_test_faketracker",
-      "_tgt": "startup_test_faketracker_fetchissuestatesbyids",
-      "source": "startup_test_faketracker",
-      "target": "startup_test_faketracker_fetchissuestatesbyids",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/worker.test.ts",
-      "source_location": "L10",
-      "weight": 1.0,
-      "_src": "worker_test",
-      "_tgt": "worker_test_issue",
-      "source": "worker_test",
-      "target": "worker_test_issue",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/worker.test.ts",
-      "source_location": "L24",
-      "weight": 1.0,
-      "_src": "worker_test",
-      "_tgt": "worker_test_faketracker",
-      "source": "worker_test",
-      "target": "worker_test_faketracker",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/worker.test.ts",
-      "source_location": "L42",
-      "weight": 1.0,
-      "_src": "worker_test",
-      "_tgt": "worker_test_fakecodex",
-      "source": "worker_test",
-      "target": "worker_test_fakecodex",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/worker.test.ts",
-      "source_location": "L91",
-      "weight": 1.0,
-      "_src": "worker_test",
-      "_tgt": "worker_test_config",
-      "source": "worker_test",
-      "target": "worker_test_config",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/worker.test.ts",
-      "source_location": "L25",
-      "weight": 1.0,
-      "_src": "worker_test_faketracker",
-      "_tgt": "worker_test_faketracker_constructor",
-      "source": "worker_test_faketracker",
-      "target": "worker_test_faketracker_constructor",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/worker.test.ts",
-      "source_location": "L29",
-      "weight": 1.0,
-      "_src": "worker_test_faketracker",
-      "_tgt": "worker_test_faketracker_fetchcandidateissues",
-      "source": "worker_test_faketracker",
-      "target": "worker_test_faketracker_fetchcandidateissues",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/worker.test.ts",
-      "source_location": "L33",
-      "weight": 1.0,
-      "_src": "worker_test_faketracker",
-      "_tgt": "worker_test_faketracker_fetchissuesbystates",
-      "source": "worker_test_faketracker",
-      "target": "worker_test_faketracker_fetchissuesbystates",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/worker.test.ts",
-      "source_location": "L37",
-      "weight": 1.0,
-      "_src": "worker_test_faketracker",
-      "_tgt": "worker_test_faketracker_fetchissuestatesbyids",
-      "source": "worker_test_faketracker",
-      "target": "worker_test_faketracker_fetchissuestatesbyids",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/worker.test.ts",
-      "source_location": "L48",
-      "weight": 1.0,
-      "_src": "worker_test_fakecodex",
-      "_tgt": "worker_test_fakecodex_constructor",
-      "source": "worker_test_fakecodex",
-      "target": "worker_test_fakecodex_constructor",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/worker.test.ts",
-      "source_location": "L53",
-      "weight": 1.0,
-      "_src": "worker_test_fakecodex",
-      "_tgt": "worker_test_fakecodex_startsession",
-      "source": "worker_test_fakecodex",
-      "target": "worker_test_fakecodex_startsession",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/worker.test.ts",
-      "source_location": "L58",
-      "weight": 1.0,
-      "_src": "worker_test_fakecodex",
-      "_tgt": "worker_test_fakecodex_runturn",
-      "source": "worker_test_fakecodex",
-      "target": "worker_test_fakecodex_runturn",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "method",
-      "confidence": "EXTRACTED",
-      "source_file": "packages/symphony-service/tests/worker.test.ts",
-      "source_location": "L86",
-      "weight": 1.0,
-      "_src": "worker_test_fakecodex",
-      "_tgt": "worker_test_fakecodex_stop",
-      "source": "worker_test_fakecodex",
-      "target": "worker_test_fakecodex_stop",
-      "confidence_score": 1.0
-    },
-    {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/valkey-proxy-server/test-connection.js",
@@ -78636,6 +72264,474 @@
     {
       "relation": "imports_from",
       "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-rebuild.test.ts",
+      "source_location": "L6",
+      "weight": 1.0,
+      "_src": "graphify_rebuild_test",
+      "_tgt": "graphify_rebuild",
+      "source": "graphify_rebuild_test",
+      "target": "graphify_rebuild",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-rebuild.test.ts",
+      "source_location": "L10",
+      "weight": 1.0,
+      "_src": "graphify_rebuild_test",
+      "_tgt": "graphify_rebuild_test_write",
+      "source": "graphify_rebuild_test",
+      "target": "graphify_rebuild_test_write",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-rebuild.test.ts",
+      "source_location": "L16",
+      "weight": 1.0,
+      "_src": "graphify_rebuild_test",
+      "_tgt": "graphify_rebuild_test_createfixtureroot",
+      "source": "graphify_rebuild_test",
+      "target": "graphify_rebuild_test_createfixtureroot",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-rebuild.test.ts",
+      "source_location": "L75",
+      "weight": 1.0,
+      "_src": "graphify_rebuild_test",
+      "_tgt": "graphify_rebuild_test_spawn",
+      "source": "graphify_rebuild_test",
+      "target": "graphify_rebuild_test_spawn",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L67",
+      "weight": 1.0,
+      "_src": "graphify_rebuild",
+      "_tgt": "graphify_rebuild_fileexists",
+      "source": "graphify_rebuild",
+      "target": "graphify_rebuild_fileexists",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L76",
+      "weight": 1.0,
+      "_src": "graphify_rebuild",
+      "_tgt": "graphify_rebuild_resolvegraphifypython",
+      "source": "graphify_rebuild",
+      "target": "graphify_rebuild_resolvegraphifypython",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L86",
+      "weight": 1.0,
+      "_src": "graphify_rebuild",
+      "_tgt": "graphify_rebuild_rungraphifyrebuild",
+      "source": "graphify_rebuild",
+      "target": "graphify_rebuild_rungraphifyrebuild",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L78",
+      "weight": 0.8,
+      "_src": "graphify_rebuild_resolvegraphifypython",
+      "_tgt": "graphify_rebuild_fileexists",
+      "source": "graphify_rebuild_fileexists",
+      "target": "graphify_rebuild_resolvegraphifypython",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L90",
+      "weight": 0.8,
+      "_src": "graphify_rebuild_rungraphifyrebuild",
+      "_tgt": "graphify_rebuild_resolvegraphifypython",
+      "source": "graphify_rebuild_resolvegraphifypython",
+      "target": "graphify_rebuild_rungraphifyrebuild",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-audit.test.ts",
+      "source_location": "L6",
+      "weight": 1.0,
+      "_src": "harness_audit_test",
+      "_tgt": "harness_audit",
+      "source": "harness_audit_test",
+      "target": "harness_audit",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-audit.test.ts",
+      "source_location": "L7",
+      "weight": 1.0,
+      "_src": "harness_audit_test",
+      "_tgt": "harness_generate",
+      "source": "harness_audit_test",
+      "target": "harness_generate",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-audit.test.ts",
+      "source_location": "L11",
+      "weight": 1.0,
+      "_src": "harness_audit_test",
+      "_tgt": "harness_audit_test_write",
+      "source": "harness_audit_test",
+      "target": "harness_audit_test_write",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-audit.test.ts",
+      "source_location": "L17",
+      "weight": 1.0,
+      "_src": "harness_audit_test",
+      "_tgt": "harness_audit_test_createfixturerepo",
+      "source": "harness_audit_test",
+      "target": "harness_audit_test_createfixturerepo",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-audit.test.ts",
+      "source_location": "L21",
+      "weight": 0.8,
+      "_src": "harness_audit_test_createfixturerepo",
+      "_tgt": "harness_audit_test_write",
+      "source": "harness_audit_test_write",
+      "target": "harness_audit_test_createfixturerepo",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L4",
+      "weight": 1.0,
+      "_src": "harness_audit",
+      "_tgt": "harness_check",
+      "source": "harness_audit",
+      "target": "harness_check",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L48",
+      "weight": 1.0,
+      "_src": "harness_audit",
+      "_tgt": "harness_audit_normalizerepopath",
+      "source": "harness_audit",
+      "target": "harness_audit_normalizerepopath",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L52",
+      "weight": 1.0,
+      "_src": "harness_audit",
+      "_tgt": "harness_audit_matchespathprefix",
+      "source": "harness_audit",
+      "target": "harness_audit_matchespathprefix",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L66",
+      "weight": 1.0,
+      "_src": "harness_audit",
+      "_tgt": "harness_audit_fileexists",
+      "source": "harness_audit",
+      "target": "harness_audit_fileexists",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L75",
+      "weight": 1.0,
+      "_src": "harness_audit",
+      "_tgt": "harness_audit_readjsonfile",
+      "source": "harness_audit",
+      "target": "harness_audit_readjsonfile",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L79",
+      "weight": 1.0,
+      "_src": "harness_audit",
+      "_tgt": "harness_audit_tovalidationsurfaces",
+      "source": "harness_audit",
+      "target": "harness_audit_tovalidationsurfaces",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L91",
+      "weight": 1.0,
+      "_src": "harness_audit",
+      "_tgt": "harness_audit_addgroupederror",
+      "source": "harness_audit",
+      "target": "harness_audit_addgroupederror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L105",
+      "weight": 1.0,
+      "_src": "harness_audit",
+      "_tgt": "harness_audit_infergroupfromerror",
+      "source": "harness_audit",
+      "target": "harness_audit_infergroupfromerror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L110",
+      "weight": 1.0,
+      "_src": "harness_audit",
+      "_tgt": "harness_audit_shouldskipsurfaceentry",
+      "source": "harness_audit",
+      "target": "harness_audit_shouldskipsurfaceentry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L121",
+      "weight": 1.0,
+      "_src": "harness_audit",
+      "_tgt": "harness_audit_collectlivesurfaceentries",
+      "source": "harness_audit",
+      "target": "harness_audit_collectlivesurfaceentries",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L150",
+      "weight": 1.0,
+      "_src": "harness_audit",
+      "_tgt": "harness_audit_loadaudittarget",
+      "source": "harness_audit",
+      "target": "harness_audit_loadaudittarget",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L278",
+      "weight": 1.0,
+      "_src": "harness_audit",
+      "_tgt": "harness_audit_formatgroupederrors",
+      "source": "harness_audit",
+      "target": "harness_audit_formatgroupederrors",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L293",
+      "weight": 1.0,
+      "_src": "harness_audit",
+      "_tgt": "harness_audit_runharnessaudit",
+      "source": "harness_audit",
+      "target": "harness_audit_runharnessaudit",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L53",
+      "weight": 0.8,
+      "_src": "harness_audit_matchespathprefix",
+      "_tgt": "harness_audit_normalizerepopath",
+      "source": "harness_audit_normalizerepopath",
+      "target": "harness_audit_matchespathprefix",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L140",
+      "weight": 0.8,
+      "_src": "harness_audit_collectlivesurfaceentries",
+      "_tgt": "harness_audit_normalizerepopath",
+      "source": "harness_audit_normalizerepopath",
+      "target": "harness_audit_collectlivesurfaceentries",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L130",
+      "weight": 0.8,
+      "_src": "harness_audit_collectlivesurfaceentries",
+      "_tgt": "harness_audit_fileexists",
+      "source": "harness_audit_fileexists",
+      "target": "harness_audit_collectlivesurfaceentries",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L158",
+      "weight": 0.8,
+      "_src": "harness_audit_loadaudittarget",
+      "_tgt": "harness_audit_fileexists",
+      "source": "harness_audit_fileexists",
+      "target": "harness_audit_loadaudittarget",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L226",
+      "weight": 0.8,
+      "_src": "harness_audit_loadaudittarget",
+      "_tgt": "harness_audit_tovalidationsurfaces",
+      "source": "harness_audit_tovalidationsurfaces",
+      "target": "harness_audit_loadaudittarget",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L159",
+      "weight": 0.8,
+      "_src": "harness_audit_loadaudittarget",
+      "_tgt": "harness_audit_addgroupederror",
+      "source": "harness_audit_addgroupederror",
+      "target": "harness_audit_loadaudittarget",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L297",
+      "weight": 0.8,
+      "_src": "harness_audit_runharnessaudit",
+      "_tgt": "harness_audit_addgroupederror",
+      "source": "harness_audit_addgroupederror",
+      "target": "harness_audit_runharnessaudit",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L297",
+      "weight": 0.8,
+      "_src": "harness_audit_runharnessaudit",
+      "_tgt": "harness_audit_infergroupfromerror",
+      "source": "harness_audit_infergroupfromerror",
+      "target": "harness_audit_runharnessaudit",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L136",
+      "weight": 0.8,
+      "_src": "harness_audit_collectlivesurfaceentries",
+      "_tgt": "harness_audit_shouldskipsurfaceentry",
+      "source": "harness_audit_shouldskipsurfaceentry",
+      "target": "harness_audit_collectlivesurfaceentries",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L319",
+      "weight": 0.8,
+      "_src": "harness_audit_runharnessaudit",
+      "_tgt": "harness_audit_collectlivesurfaceentries",
+      "source": "harness_audit_collectlivesurfaceentries",
+      "target": "harness_audit_runharnessaudit",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L302",
+      "weight": 0.8,
+      "_src": "harness_audit_runharnessaudit",
+      "_tgt": "harness_audit_loadaudittarget",
+      "source": "harness_audit_loadaudittarget",
+      "target": "harness_audit_runharnessaudit",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L346",
+      "weight": 0.8,
+      "_src": "harness_audit_runharnessaudit",
+      "_tgt": "harness_audit_formatgroupederrors",
+      "source": "harness_audit_formatgroupederrors",
+      "target": "harness_audit_runharnessaudit",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.test.ts",
       "source_location": "L6",
       "weight": 1.0,
@@ -78646,10 +72742,22 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-check.test.ts",
+      "source_location": "L7",
+      "weight": 1.0,
+      "_src": "harness_check_test",
+      "_tgt": "harness_generate",
+      "source": "harness_check_test",
+      "target": "harness_generate",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.test.ts",
-      "source_location": "L16",
+      "source_location": "L29",
       "weight": 1.0,
       "_src": "harness_check_test",
       "_tgt": "harness_check_test_write",
@@ -78661,7 +72769,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.test.ts",
-      "source_location": "L22",
+      "source_location": "L35",
       "weight": 1.0,
       "_src": "harness_check_test",
       "_tgt": "harness_check_test_createfixturerepo",
@@ -78673,7 +72781,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-check.test.ts",
-      "source_location": "L26",
+      "source_location": "L39",
       "weight": 0.8,
       "_src": "harness_check_test_createfixturerepo",
       "_tgt": "harness_check_test_write",
@@ -78682,10 +72790,22 @@
       "confidence_score": 0.5
     },
     {
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L4",
+      "weight": 1.0,
+      "_src": "harness_check",
+      "_tgt": "harness_generate",
+      "source": "harness_check",
+      "target": "harness_generate",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L29",
+      "source_location": "L44",
       "weight": 1.0,
       "_src": "harness_check",
       "_tgt": "harness_check_striplinkdecorations",
@@ -78697,7 +72817,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L33",
+      "source_location": "L48",
       "weight": 1.0,
       "_src": "harness_check",
       "_tgt": "harness_check_isrelativelink",
@@ -78709,7 +72829,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L41",
+      "source_location": "L56",
       "weight": 1.0,
       "_src": "harness_check",
       "_tgt": "harness_check_fileexists",
@@ -78721,7 +72841,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L50",
+      "source_location": "L65",
       "weight": 1.0,
       "_src": "harness_check",
       "_tgt": "harness_check_collectmarkdownlinkerrors",
@@ -78733,7 +72853,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L79",
+      "source_location": "L94",
       "weight": 1.0,
       "_src": "harness_check",
       "_tgt": "harness_check_extractinlinecode",
@@ -78745,7 +72865,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L85",
+      "source_location": "L100",
       "weight": 1.0,
       "_src": "harness_check",
       "_tgt": "harness_check_normalizepathreference",
@@ -78757,7 +72877,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L98",
+      "source_location": "L113",
       "weight": 1.0,
       "_src": "harness_check",
       "_tgt": "harness_check_islikelypathreference",
@@ -78769,7 +72889,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L123",
+      "source_location": "L138",
       "weight": 1.0,
       "_src": "harness_check",
       "_tgt": "harness_check_resolvepathreference",
@@ -78781,7 +72901,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L149",
+      "source_location": "L164",
       "weight": 1.0,
       "_src": "harness_check",
       "_tgt": "harness_check_collectreferencedpatherrors",
@@ -78793,7 +72913,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L184",
+      "source_location": "L199",
       "weight": 1.0,
       "_src": "harness_check",
       "_tgt": "harness_check_readpackageconfig",
@@ -78805,7 +72925,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L209",
+      "source_location": "L224",
       "weight": 1.0,
       "_src": "harness_check",
       "_tgt": "harness_check_extracttestscriptfromcommand",
@@ -78817,7 +72937,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L241",
+      "source_location": "L256",
       "weight": 1.0,
       "_src": "harness_check",
       "_tgt": "harness_check_walkfiles",
@@ -78829,7 +72949,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L261",
+      "source_location": "L276",
       "weight": 1.0,
       "_src": "harness_check",
       "_tgt": "harness_check_collecttestsurfaceroots",
@@ -78841,7 +72961,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L303",
+      "source_location": "L318",
       "weight": 1.0,
       "_src": "harness_check",
       "_tgt": "harness_check_collecttestingdocerrors",
@@ -78853,7 +72973,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L348",
+      "source_location": "L363",
       "weight": 1.0,
       "_src": "harness_check",
       "_tgt": "harness_check_validateharnessdocs",
@@ -78865,7 +72985,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L446",
+      "source_location": "L496",
       "weight": 1.0,
       "_src": "harness_check",
       "_tgt": "harness_check_runharnesscheck",
@@ -78889,7 +73009,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L56",
+      "source_location": "L71",
       "weight": 0.8,
       "_src": "harness_check_collectmarkdownlinkerrors",
       "_tgt": "harness_check_striplinkdecorations",
@@ -78901,7 +73021,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L86",
+      "source_location": "L101",
       "weight": 0.8,
       "_src": "harness_check_normalizepathreference",
       "_tgt": "harness_check_striplinkdecorations",
@@ -78913,7 +73033,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L58",
+      "source_location": "L73",
       "weight": 0.8,
       "_src": "harness_check_collectmarkdownlinkerrors",
       "_tgt": "harness_check_isrelativelink",
@@ -78925,7 +73045,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L68",
+      "source_location": "L83",
       "weight": 0.8,
       "_src": "harness_check_collectmarkdownlinkerrors",
       "_tgt": "harness_check_fileexists",
@@ -78937,7 +73057,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L176",
+      "source_location": "L191",
       "weight": 0.8,
       "_src": "harness_check_collectreferencedpatherrors",
       "_tgt": "harness_check_fileexists",
@@ -78949,7 +73069,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L188",
+      "source_location": "L203",
       "weight": 0.8,
       "_src": "harness_check_readpackageconfig",
       "_tgt": "harness_check_fileexists",
@@ -78961,7 +73081,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L242",
+      "source_location": "L257",
       "weight": 0.8,
       "_src": "harness_check_walkfiles",
       "_tgt": "harness_check_fileexists",
@@ -78973,7 +73093,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L290",
+      "source_location": "L305",
       "weight": 0.8,
       "_src": "harness_check_collecttestsurfaceroots",
       "_tgt": "harness_check_fileexists",
@@ -78985,7 +73105,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L356",
+      "source_location": "L372",
       "weight": 0.8,
       "_src": "harness_check_validateharnessdocs",
       "_tgt": "harness_check_fileexists",
@@ -78997,7 +73117,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L385",
+      "source_location": "L401",
       "weight": 0.8,
       "_src": "harness_check_validateharnessdocs",
       "_tgt": "harness_check_collectmarkdownlinkerrors",
@@ -79009,7 +73129,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L158",
+      "source_location": "L173",
       "weight": 0.8,
       "_src": "harness_check_collectreferencedpatherrors",
       "_tgt": "harness_check_extractinlinecode",
@@ -79021,7 +73141,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L312",
+      "source_location": "L327",
       "weight": 0.8,
       "_src": "harness_check_collecttestingdocerrors",
       "_tgt": "harness_check_extractinlinecode",
@@ -79033,7 +73153,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L103",
+      "source_location": "L118",
       "weight": 0.8,
       "_src": "harness_check_islikelypathreference",
       "_tgt": "harness_check_normalizepathreference",
@@ -79045,7 +73165,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L129",
+      "source_location": "L144",
       "weight": 0.8,
       "_src": "harness_check_resolvepathreference",
       "_tgt": "harness_check_normalizepathreference",
@@ -79057,7 +73177,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L163",
+      "source_location": "L178",
       "weight": 0.8,
       "_src": "harness_check_collectreferencedpatherrors",
       "_tgt": "harness_check_normalizepathreference",
@@ -79069,7 +73189,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L159",
+      "source_location": "L174",
       "weight": 0.8,
       "_src": "harness_check_collectreferencedpatherrors",
       "_tgt": "harness_check_islikelypathreference",
@@ -79081,7 +73201,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L169",
+      "source_location": "L184",
       "weight": 0.8,
       "_src": "harness_check_collectreferencedpatherrors",
       "_tgt": "harness_check_resolvepathreference",
@@ -79093,7 +73213,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L404",
+      "source_location": "L425",
       "weight": 0.8,
       "_src": "harness_check_validateharnessdocs",
       "_tgt": "harness_check_collectreferencedpatherrors",
@@ -79105,7 +73225,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L362",
+      "source_location": "L378",
       "weight": 0.8,
       "_src": "harness_check_validateharnessdocs",
       "_tgt": "harness_check_readpackageconfig",
@@ -79117,7 +73237,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L313",
+      "source_location": "L328",
       "weight": 0.8,
       "_src": "harness_check_collecttestingdocerrors",
       "_tgt": "harness_check_extracttestscriptfromcommand",
@@ -79129,7 +73249,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L266",
+      "source_location": "L281",
       "weight": 0.8,
       "_src": "harness_check_collecttestsurfaceroots",
       "_tgt": "harness_check_walkfiles",
@@ -79141,7 +73261,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L338",
+      "source_location": "L353",
       "weight": 0.8,
       "_src": "harness_check_collecttestingdocerrors",
       "_tgt": "harness_check_collecttestsurfaceroots",
@@ -79153,7 +73273,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L416",
+      "source_location": "L444",
       "weight": 0.8,
       "_src": "harness_check_validateharnessdocs",
       "_tgt": "harness_check_collecttestingdocerrors",
@@ -79165,12 +73285,696 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L447",
+      "source_location": "L497",
       "weight": 0.8,
       "_src": "harness_check_runharnesscheck",
       "_tgt": "harness_check_validateharnessdocs",
       "source": "harness_check_validateharnessdocs",
       "target": "harness_check_runharnesscheck",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-generate.test.ts",
+      "source_location": "L6",
+      "weight": 1.0,
+      "_src": "harness_generate_test",
+      "_tgt": "harness_generate",
+      "source": "harness_generate_test",
+      "target": "harness_generate",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-generate.test.ts",
+      "source_location": "L10",
+      "weight": 1.0,
+      "_src": "harness_generate_test",
+      "_tgt": "harness_generate_test_write",
+      "source": "harness_generate_test",
+      "target": "harness_generate_test_write",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-generate.test.ts",
+      "source_location": "L16",
+      "weight": 1.0,
+      "_src": "harness_generate_test",
+      "_tgt": "harness_generate_test_createfixturerepo",
+      "source": "harness_generate_test",
+      "target": "harness_generate_test_createfixturerepo",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-generate.test.ts",
+      "source_location": "L20",
+      "weight": 0.8,
+      "_src": "harness_generate_test_createfixturerepo",
+      "_tgt": "harness_generate_test_write",
+      "source": "harness_generate_test_write",
+      "target": "harness_generate_test_createfixturerepo",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L250",
+      "weight": 1.0,
+      "_src": "harness_generate",
+      "_tgt": "harness_generate_normalizerepopath",
+      "source": "harness_generate",
+      "target": "harness_generate_normalizerepopath",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L254",
+      "weight": 1.0,
+      "_src": "harness_generate",
+      "_tgt": "harness_generate_shouldskipgeneratedentry",
+      "source": "harness_generate",
+      "target": "harness_generate_shouldskipgeneratedentry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L258",
+      "weight": 1.0,
+      "_src": "harness_generate",
+      "_tgt": "harness_generate_fileexists",
+      "source": "harness_generate",
+      "target": "harness_generate_fileexists",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L267",
+      "weight": 1.0,
+      "_src": "harness_generate",
+      "_tgt": "harness_generate_walkfiles",
+      "source": "harness_generate",
+      "target": "harness_generate_walkfiles",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L289",
+      "weight": 1.0,
+      "_src": "harness_generate",
+      "_tgt": "harness_generate_readpackageconfig",
+      "source": "harness_generate",
+      "target": "harness_generate_readpackageconfig",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L307",
+      "weight": 1.0,
+      "_src": "harness_generate",
+      "_tgt": "harness_generate_todocpath",
+      "source": "harness_generate",
+      "target": "harness_generate_todocpath",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L311",
+      "weight": 1.0,
+      "_src": "harness_generate",
+      "_tgt": "harness_generate_formatmarkdownlink",
+      "source": "harness_generate",
+      "target": "harness_generate_formatmarkdownlink",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L315",
+      "weight": 1.0,
+      "_src": "harness_generate",
+      "_tgt": "harness_generate_headingfromsegment",
+      "source": "harness_generate",
+      "target": "harness_generate_headingfromsegment",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L323",
+      "weight": 1.0,
+      "_src": "harness_generate",
+      "_tgt": "harness_generate_summarizechildren",
+      "source": "harness_generate",
+      "target": "harness_generate_summarizechildren",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L331",
+      "weight": 1.0,
+      "_src": "harness_generate",
+      "_tgt": "harness_generate_collectroutegroups",
+      "source": "harness_generate",
+      "target": "harness_generate_collectroutegroups",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L357",
+      "weight": 1.0,
+      "_src": "harness_generate",
+      "_tgt": "harness_generate_collecttestfiles",
+      "source": "harness_generate",
+      "target": "harness_generate_collecttestfiles",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L387",
+      "weight": 1.0,
+      "_src": "harness_generate",
+      "_tgt": "harness_generate_collecttestsurfaceroots",
+      "source": "harness_generate",
+      "target": "harness_generate_collecttestsurfaceroots",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L429",
+      "weight": 1.0,
+      "_src": "harness_generate",
+      "_tgt": "harness_generate_collectfolderfacts",
+      "source": "harness_generate",
+      "target": "harness_generate_collectfolderfacts",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L452",
+      "weight": 1.0,
+      "_src": "harness_generate",
+      "_tgt": "harness_generate_formatscriptcommand",
+      "source": "harness_generate",
+      "target": "harness_generate_formatscriptcommand",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L462",
+      "weight": 1.0,
+      "_src": "harness_generate",
+      "_tgt": "harness_generate_buildgenerateddoc",
+      "source": "harness_generate",
+      "target": "harness_generate_buildgenerateddoc",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L472",
+      "weight": 1.0,
+      "_src": "harness_generate",
+      "_tgt": "harness_generate_buildrouteindex",
+      "source": "harness_generate",
+      "target": "harness_generate_buildrouteindex",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L499",
+      "weight": 1.0,
+      "_src": "harness_generate",
+      "_tgt": "harness_generate_buildtestindex",
+      "source": "harness_generate",
+      "target": "harness_generate_buildtestindex",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L544",
+      "weight": 1.0,
+      "_src": "harness_generate",
+      "_tgt": "harness_generate_buildkeyfolderindex",
+      "source": "harness_generate",
+      "target": "harness_generate_buildkeyfolderindex",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L577",
+      "weight": 1.0,
+      "_src": "harness_generate",
+      "_tgt": "harness_generate_buildvalidationguide",
+      "source": "harness_generate",
+      "target": "harness_generate_buildvalidationguide",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L616",
+      "weight": 1.0,
+      "_src": "harness_generate",
+      "_tgt": "harness_generate_generateharnessdocs",
+      "source": "harness_generate",
+      "target": "harness_generate_generateharnessdocs",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L642",
+      "weight": 1.0,
+      "_src": "harness_generate",
+      "_tgt": "harness_generate_writegeneratedharnessdocs",
+      "source": "harness_generate",
+      "target": "harness_generate_writegeneratedharnessdocs",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L308",
+      "weight": 0.8,
+      "_src": "harness_generate_todocpath",
+      "_tgt": "harness_generate_normalizerepopath",
+      "source": "harness_generate_normalizerepopath",
+      "target": "harness_generate_todocpath",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L397",
+      "weight": 0.8,
+      "_src": "harness_generate_collecttestsurfaceroots",
+      "_tgt": "harness_generate_normalizerepopath",
+      "source": "harness_generate_normalizerepopath",
+      "target": "harness_generate_collecttestsurfaceroots",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L268",
+      "weight": 0.8,
+      "_src": "harness_generate_walkfiles",
+      "_tgt": "harness_generate_fileexists",
+      "source": "harness_generate_fileexists",
+      "target": "harness_generate_walkfiles",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L416",
+      "weight": 0.8,
+      "_src": "harness_generate_collecttestsurfaceroots",
+      "_tgt": "harness_generate_fileexists",
+      "source": "harness_generate_fileexists",
+      "target": "harness_generate_collecttestsurfaceroots",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L435",
+      "weight": 0.8,
+      "_src": "harness_generate_collectfolderfacts",
+      "_tgt": "harness_generate_fileexists",
+      "source": "harness_generate_fileexists",
+      "target": "harness_generate_collectfolderfacts",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L336",
+      "weight": 0.8,
+      "_src": "harness_generate_collectroutegroups",
+      "_tgt": "harness_generate_walkfiles",
+      "source": "harness_generate_walkfiles",
+      "target": "harness_generate_collectroutegroups",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L362",
+      "weight": 0.8,
+      "_src": "harness_generate_collecttestfiles",
+      "_tgt": "harness_generate_walkfiles",
+      "source": "harness_generate_walkfiles",
+      "target": "harness_generate_collecttestfiles",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L393",
+      "weight": 0.8,
+      "_src": "harness_generate_collecttestsurfaceroots",
+      "_tgt": "harness_generate_walkfiles",
+      "source": "harness_generate_walkfiles",
+      "target": "harness_generate_collecttestsurfaceroots",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L439",
+      "weight": 0.8,
+      "_src": "harness_generate_collectfolderfacts",
+      "_tgt": "harness_generate_walkfiles",
+      "source": "harness_generate_walkfiles",
+      "target": "harness_generate_collectfolderfacts",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L620",
+      "weight": 0.8,
+      "_src": "harness_generate_generateharnessdocs",
+      "_tgt": "harness_generate_readpackageconfig",
+      "source": "harness_generate_readpackageconfig",
+      "target": "harness_generate_generateharnessdocs",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L312",
+      "weight": 0.8,
+      "_src": "harness_generate_formatmarkdownlink",
+      "_tgt": "harness_generate_todocpath",
+      "source": "harness_generate_todocpath",
+      "target": "harness_generate_formatmarkdownlink",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L485",
+      "weight": 0.8,
+      "_src": "harness_generate_buildrouteindex",
+      "_tgt": "harness_generate_formatmarkdownlink",
+      "source": "harness_generate_formatmarkdownlink",
+      "target": "harness_generate_buildrouteindex",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L530",
+      "weight": 0.8,
+      "_src": "harness_generate_buildtestindex",
+      "_tgt": "harness_generate_formatmarkdownlink",
+      "source": "harness_generate_formatmarkdownlink",
+      "target": "harness_generate_buildtestindex",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L561",
+      "weight": 0.8,
+      "_src": "harness_generate_buildkeyfolderindex",
+      "_tgt": "harness_generate_formatmarkdownlink",
+      "source": "harness_generate_formatmarkdownlink",
+      "target": "harness_generate_buildkeyfolderindex",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L482",
+      "weight": 0.8,
+      "_src": "harness_generate_buildrouteindex",
+      "_tgt": "harness_generate_headingfromsegment",
+      "source": "harness_generate_headingfromsegment",
+      "target": "harness_generate_buildrouteindex",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L527",
+      "weight": 0.8,
+      "_src": "harness_generate_buildtestindex",
+      "_tgt": "harness_generate_headingfromsegment",
+      "source": "harness_generate_headingfromsegment",
+      "target": "harness_generate_buildtestindex",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L448",
+      "weight": 0.8,
+      "_src": "harness_generate_collectfolderfacts",
+      "_tgt": "harness_generate_summarizechildren",
+      "source": "harness_generate_summarizechildren",
+      "target": "harness_generate_collectfolderfacts",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L476",
+      "weight": 0.8,
+      "_src": "harness_generate_buildrouteindex",
+      "_tgt": "harness_generate_collectroutegroups",
+      "source": "harness_generate_collectroutegroups",
+      "target": "harness_generate_buildrouteindex",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L504",
+      "weight": 0.8,
+      "_src": "harness_generate_buildtestindex",
+      "_tgt": "harness_generate_collecttestfiles",
+      "source": "harness_generate_collecttestfiles",
+      "target": "harness_generate_buildtestindex",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L505",
+      "weight": 0.8,
+      "_src": "harness_generate_buildtestindex",
+      "_tgt": "harness_generate_collecttestsurfaceroots",
+      "source": "harness_generate_collecttestsurfaceroots",
+      "target": "harness_generate_buildtestindex",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L555",
+      "weight": 0.8,
+      "_src": "harness_generate_buildkeyfolderindex",
+      "_tgt": "harness_generate_collectfolderfacts",
+      "source": "harness_generate_collectfolderfacts",
+      "target": "harness_generate_buildkeyfolderindex",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L513",
+      "weight": 0.8,
+      "_src": "harness_generate_buildtestindex",
+      "_tgt": "harness_generate_formatscriptcommand",
+      "source": "harness_generate_formatscriptcommand",
+      "target": "harness_generate_buildtestindex",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L599",
+      "weight": 0.8,
+      "_src": "harness_generate_buildvalidationguide",
+      "_tgt": "harness_generate_formatscriptcommand",
+      "source": "harness_generate_formatscriptcommand",
+      "target": "harness_generate_buildvalidationguide",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L490",
+      "weight": 0.8,
+      "_src": "harness_generate_buildrouteindex",
+      "_tgt": "harness_generate_buildgenerateddoc",
+      "source": "harness_generate_buildgenerateddoc",
+      "target": "harness_generate_buildrouteindex",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L535",
+      "weight": 0.8,
+      "_src": "harness_generate_buildtestindex",
+      "_tgt": "harness_generate_buildgenerateddoc",
+      "source": "harness_generate_buildgenerateddoc",
+      "target": "harness_generate_buildtestindex",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L568",
+      "weight": 0.8,
+      "_src": "harness_generate_buildkeyfolderindex",
+      "_tgt": "harness_generate_buildgenerateddoc",
+      "source": "harness_generate_buildgenerateddoc",
+      "target": "harness_generate_buildkeyfolderindex",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L609",
+      "weight": 0.8,
+      "_src": "harness_generate_buildvalidationguide",
+      "_tgt": "harness_generate_buildgenerateddoc",
+      "source": "harness_generate_buildgenerateddoc",
+      "target": "harness_generate_buildvalidationguide",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L623",
+      "weight": 0.8,
+      "_src": "harness_generate_generateharnessdocs",
+      "_tgt": "harness_generate_buildrouteindex",
+      "source": "harness_generate_buildrouteindex",
+      "target": "harness_generate_generateharnessdocs",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L627",
+      "weight": 0.8,
+      "_src": "harness_generate_generateharnessdocs",
+      "_tgt": "harness_generate_buildtestindex",
+      "source": "harness_generate_buildtestindex",
+      "target": "harness_generate_generateharnessdocs",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L631",
+      "weight": 0.8,
+      "_src": "harness_generate_generateharnessdocs",
+      "_tgt": "harness_generate_buildkeyfolderindex",
+      "source": "harness_generate_buildkeyfolderindex",
+      "target": "harness_generate_generateharnessdocs",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L635",
+      "weight": 0.8,
+      "_src": "harness_generate_generateharnessdocs",
+      "_tgt": "harness_generate_buildvalidationguide",
+      "source": "harness_generate_buildvalidationguide",
+      "target": "harness_generate_generateharnessdocs",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L643",
+      "weight": 0.8,
+      "_src": "harness_generate_writegeneratedharnessdocs",
+      "_tgt": "harness_generate_generateharnessdocs",
+      "source": "harness_generate_generateharnessdocs",
+      "target": "harness_generate_writegeneratedharnessdocs",
       "confidence_score": 0.5
     },
     {
@@ -79249,7 +74053,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L44",
+      "source_location": "L51",
       "weight": 1.0,
       "_src": "harness_review",
       "_tgt": "harness_review_normalizerepopath",
@@ -79261,7 +74065,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L48",
+      "source_location": "L55",
       "weight": 1.0,
       "_src": "harness_review",
       "_tgt": "harness_review_matchespathprefix",
@@ -79273,7 +74077,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L62",
+      "source_location": "L69",
       "weight": 1.0,
       "_src": "harness_review",
       "_tgt": "harness_review_fileexists",
@@ -79285,7 +74089,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L71",
+      "source_location": "L78",
       "weight": 1.0,
       "_src": "harness_review",
       "_tgt": "harness_review_readjsonfile",
@@ -79297,7 +74101,19 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L75",
+      "source_location": "L82",
+      "weight": 1.0,
+      "_src": "harness_review",
+      "_tgt": "harness_review_tovalidationrules",
+      "source": "harness_review",
+      "target": "harness_review_tovalidationrules",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L95",
       "weight": 1.0,
       "_src": "harness_review",
       "_tgt": "harness_review_loadreviewtarget",
@@ -79309,7 +74125,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L145",
+      "source_location": "L167",
       "weight": 1.0,
       "_src": "harness_review",
       "_tgt": "harness_review_loadreviewtargets",
@@ -79321,7 +74137,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L161",
+      "source_location": "L183",
       "weight": 1.0,
       "_src": "harness_review",
       "_tgt": "harness_review_collectscriptsforchangedfiles",
@@ -79333,7 +74149,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L216",
+      "source_location": "L238",
       "weight": 1.0,
       "_src": "harness_review",
       "_tgt": "harness_review_getchangedfilesfromgit",
@@ -79345,7 +74161,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L254",
+      "source_location": "L276",
       "weight": 1.0,
       "_src": "harness_review",
       "_tgt": "harness_review_runpackagescript",
@@ -79357,7 +74173,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L268",
+      "source_location": "L290",
       "weight": 1.0,
       "_src": "harness_review",
       "_tgt": "harness_review_runharnessreview",
@@ -79366,10 +74182,22 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/pre-push-review.ts",
+      "source_location": "L1",
+      "weight": 1.0,
+      "_src": "pre_push_review",
+      "_tgt": "harness_review",
+      "source": "harness_review",
+      "target": "pre_push_review",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L49",
+      "source_location": "L56",
       "weight": 0.8,
       "_src": "harness_review_matchespathprefix",
       "_tgt": "harness_review_normalizerepopath",
@@ -79381,7 +74209,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L135",
+      "source_location": "L157",
       "weight": 0.8,
       "_src": "harness_review_loadreviewtarget",
       "_tgt": "harness_review_normalizerepopath",
@@ -79393,7 +74221,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L101",
+      "source_location": "L121",
       "weight": 0.8,
       "_src": "harness_review_loadreviewtarget",
       "_tgt": "harness_review_fileexists",
@@ -79405,7 +74233,19 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L150",
+      "source_location": "L138",
+      "weight": 0.8,
+      "_src": "harness_review_loadreviewtarget",
+      "_tgt": "harness_review_tovalidationrules",
+      "source": "harness_review_tovalidationrules",
+      "target": "harness_review_loadreviewtarget",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L172",
       "weight": 0.8,
       "_src": "harness_review_loadreviewtargets",
       "_tgt": "harness_review_loadreviewtarget",
@@ -79417,7 +74257,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L279",
+      "source_location": "L301",
       "weight": 0.8,
       "_src": "harness_review_runharnessreview",
       "_tgt": "harness_review_loadreviewtargets",
@@ -79429,12 +74269,60 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L281",
+      "source_location": "L303",
       "weight": 0.8,
       "_src": "harness_review_runharnessreview",
       "_tgt": "harness_review_collectscriptsforchangedfiles",
       "source": "harness_review_collectscriptsforchangedfiles",
       "target": "harness_review_runharnessreview",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/pre-push-review.ts",
+      "source_location": "L6",
+      "weight": 1.0,
+      "_src": "pre_push_review",
+      "_tgt": "pre_push_review_getchangedfilesvsoriginmain",
+      "source": "pre_push_review",
+      "target": "pre_push_review_getchangedfilesvsoriginmain",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/pre-push-review.ts",
+      "source_location": "L44",
+      "weight": 1.0,
+      "_src": "pre_push_review",
+      "_tgt": "pre_push_review_runarchitecturecheck",
+      "source": "pre_push_review",
+      "target": "pre_push_review_runarchitecturecheck",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/pre-push-review.ts",
+      "source_location": "L56",
+      "weight": 1.0,
+      "_src": "pre_push_review",
+      "_tgt": "pre_push_review_main",
+      "source": "pre_push_review",
+      "target": "pre_push_review_main",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/pre-push-review.ts",
+      "source_location": "L60",
+      "weight": 0.8,
+      "_src": "pre_push_review_main",
+      "_tgt": "pre_push_review_runarchitecturecheck",
+      "source": "pre_push_review_runarchitecturecheck",
+      "target": "pre_push_review_main",
       "confidence_score": 0.5
     }
   ],

--- a/package.json
+++ b/package.json
@@ -2,11 +2,14 @@
   "name": "athena",
   "private": true,
   "scripts": {
+    "prepare": "husky",
     "architecture:check": "bun scripts/architecture-boundary-check.ts",
+    "graphify:rebuild": "bun scripts/graphify-rebuild.ts",
     "harness:audit": "bun scripts/harness-audit.ts",
     "harness:check": "bun scripts/harness-check.ts",
     "harness:generate": "bun scripts/harness-generate.ts",
     "harness:review": "bun scripts/harness-review.ts",
+    "pre-push:review": "bun scripts/pre-push-review.ts",
     "pr:athena": "bun run --filter '@athena/webapp' audit:convex && bun run --filter '@athena/webapp' lint:convex:changed && bun run architecture:check && bun run --filter '@athena/webapp' test && bun run --filter '@athena/storefront-webapp' test && bun run harness:check",
     "test": "bun run --filter '@athena/webapp' test && bun run --filter '@athena/storefront-webapp' test",
     "test:coverage": "bun run --filter '@athena/webapp' test:coverage && bun run --filter '@athena/storefront-webapp' test:coverage && bun scripts/coverage-summary.mjs"
@@ -21,6 +24,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
+    "husky": "^9.1.7",
     "jsdom": "^26.1.0",
     "vitest": "^3.1.4"
   }

--- a/scripts/graphify-rebuild.test.ts
+++ b/scripts/graphify-rebuild.test.ts
@@ -1,0 +1,84 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { GRAPHIFY_REBUILD_SNIPPET, runGraphifyRebuild } from "./graphify-rebuild";
+
+const tempRoots: string[] = [];
+
+async function write(relativePath: string, contents: string, rootDir: string) {
+  const filePath = path.join(rootDir, relativePath);
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, contents);
+}
+
+async function createFixtureRoot() {
+  const rootDir = await mkdtemp(path.join(tmpdir(), "athena-graphify-rebuild-"));
+  tempRoots.push(rootDir);
+  return rootDir;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((rootDir) =>
+      rm(rootDir, { recursive: true, force: true })
+    )
+  );
+});
+
+describe("runGraphifyRebuild", () => {
+  it("uses the repo-pinned graphify python when available", async () => {
+    const rootDir = await createFixtureRoot();
+    await write(".graphify_python", "/tmp/graphify-python\n", rootDir);
+
+    const commands: string[][] = [];
+
+    await runGraphifyRebuild(rootDir, {
+      spawn(command) {
+        commands.push(command);
+        return {
+          exited: Promise.resolve(0),
+          stderr: new ReadableStream(),
+        };
+      },
+    });
+
+    expect(commands).toEqual([
+      ["/tmp/graphify-python", "-c", GRAPHIFY_REBUILD_SNIPPET],
+    ]);
+  });
+
+  it("falls back to python3 when no pinned graphify python is configured", async () => {
+    const rootDir = await createFixtureRoot();
+    const commands: string[][] = [];
+
+    await runGraphifyRebuild(rootDir, {
+      spawn(command) {
+        commands.push(command);
+        return {
+          exited: Promise.resolve(0),
+          stderr: new ReadableStream(),
+        };
+      },
+    });
+
+    expect(commands).toEqual([["python3", "-c", GRAPHIFY_REBUILD_SNIPPET]]);
+  });
+
+  it("surfaces stderr when the graphify rebuild command fails", async () => {
+    const rootDir = await createFixtureRoot();
+    await write(".graphify_python", "/tmp/graphify-python\n", rootDir);
+
+    await expect(
+      runGraphifyRebuild(rootDir, {
+        spawn() {
+          return {
+            exited: Promise.resolve(1),
+            stderr: new Response("graphify exploded\n").body!,
+          };
+        },
+      })
+    ).rejects.toThrow("graphify exploded");
+  });
+});

--- a/scripts/graphify-rebuild.ts
+++ b/scripts/graphify-rebuild.ts
@@ -1,0 +1,115 @@
+import { access, readFile } from "node:fs/promises";
+import path from "node:path";
+
+export const GRAPHIFY_REBUILD_SNIPPET =
+  [
+    "import os",
+    "from pathlib import Path",
+    "from graphify.extract import extract",
+    "from graphify.build import build_from_json",
+    "from graphify.cluster import cluster, score_all",
+    "from graphify.analyze import god_nodes, surprising_connections, suggest_questions",
+    "from graphify.report import generate",
+    "from graphify.export import to_json",
+    "ROOT = Path('.')",
+    "EXTENSIONS = {'.py', '.js', '.ts', '.tsx', '.go', '.rs', '.java', '.c', '.h', '.cpp', '.cc', '.cxx', '.hpp', '.rb', '.cs', '.kt', '.kts', '.scala', '.php', '.swift', '.lua', '.toc', '.zig', '.ps1', '.m', '.mm'}",
+    "SKIP_DIRS = {'node_modules', 'worktrees', 'graphify-out', '__pycache__', 'coverage', 'dist'}",
+    "def collect_repo_files(root: Path) -> list[Path]:",
+    "    results = []",
+    "    for dirpath, dirnames, filenames in os.walk(root):",
+    "        dp = Path(dirpath)",
+    "        if any(part.startswith('.') for part in dp.parts):",
+    "            dirnames[:] = []",
+    "            continue",
+    "        dirnames[:] = [d for d in dirnames if not d.startswith('.') and d not in SKIP_DIRS]",
+    "        for fname in filenames:",
+    "            if fname.startswith('.'):",
+    "                continue",
+    "            file_path = dp / fname",
+    "            if any(part in SKIP_DIRS for part in file_path.parts):",
+    "                continue",
+    "            if file_path.suffix in EXTENSIONS:",
+    "                results.append(file_path)",
+    "    return sorted(results)",
+    "code_files = collect_repo_files(ROOT)",
+    "if not code_files:",
+    "    raise SystemExit('[graphify rebuild] No code files found - nothing to rebuild.')",
+    "result = extract(code_files)",
+    "detection = {'files': {'code': [str(f) for f in code_files], 'document': [], 'paper': [], 'image': []}, 'total_files': len(code_files), 'total_words': 0}",
+    "graph = build_from_json(result)",
+    "communities = cluster(graph)",
+    "cohesion = score_all(graph, communities)",
+    "gods = god_nodes(graph)",
+    "surprises = surprising_connections(graph, communities)",
+    "labels = {cid: 'Community ' + str(cid) for cid in communities}",
+    "questions = suggest_questions(graph, communities, labels)",
+    "out = ROOT / 'graphify-out'",
+    "out.mkdir(exist_ok=True)",
+    "report = generate(graph, communities, cohesion, labels, gods, surprises, detection, {'input': 0, 'output': 0}, str(ROOT), suggested_questions=questions)",
+    "(out / 'GRAPH_REPORT.md').write_text(report)",
+    "to_json(graph, communities, str(out / 'graph.json'))",
+    "flag = out / 'needs_update'",
+    "if flag.exists():",
+    "    flag.unlink()",
+    "print(f'[graphify rebuild] Rebuilt: {graph.number_of_nodes()} nodes, {graph.number_of_edges()} edges, {len(communities)} communities')",
+    "print(f'[graphify rebuild] graph.json and GRAPH_REPORT.md updated in {out}')",
+  ].join("\n");
+
+type SpawnedProcess = {
+  exited: Promise<number>;
+  stderr?: ReadableStream | null;
+};
+
+type GraphifyRebuildOptions = {
+  spawn?: (command: string[], options: { cwd: string }) => SpawnedProcess;
+};
+
+async function fileExists(filePath: string) {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveGraphifyPython(rootDir: string) {
+  const configuredPythonPath = path.join(rootDir, ".graphify_python");
+  if (!(await fileExists(configuredPythonPath))) {
+    return "python3";
+  }
+
+  const configuredPython = (await readFile(configuredPythonPath, "utf8")).trim();
+  return configuredPython || "python3";
+}
+
+export async function runGraphifyRebuild(
+  rootDir: string,
+  options: GraphifyRebuildOptions = {}
+) {
+  const graphifyPython = await resolveGraphifyPython(rootDir);
+  const command = [graphifyPython, "-c", GRAPHIFY_REBUILD_SNIPPET];
+  const subprocess =
+    options.spawn?.(command, { cwd: rootDir }) ??
+    Bun.spawn(command, {
+      cwd: rootDir,
+      stdout: "inherit",
+      stderr: "pipe",
+    });
+  const exitCode = await subprocess.exited;
+
+  if (exitCode === 0) {
+    return;
+  }
+
+  const stderr = subprocess.stderr
+    ? (await new Response(subprocess.stderr).text()).trim()
+    : "";
+  throw new Error(
+    stderr || `Graphify rebuild failed (${exitCode}): ${command.join(" ")}`
+  );
+}
+
+if (import.meta.main) {
+  await runGraphifyRebuild(process.cwd());
+}

--- a/scripts/harness-audit.test.ts
+++ b/scripts/harness-audit.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { runHarnessAudit } from "./harness-audit";
+import { writeGeneratedHarnessDocs } from "./harness-generate";
 
 const tempRoots: string[] = [];
 
@@ -35,6 +36,8 @@ async function createFixtureRepo() {
         name: "@athena/webapp",
         scripts: {
           "audit:convex": "echo audit",
+          build: "echo build",
+          "lint:architecture": "echo architecture",
           "lint:convex:changed": "echo lint",
           test: "echo test",
         },
@@ -50,6 +53,8 @@ async function createFixtureRepo() {
       {
         name: "@athena/storefront-webapp",
         scripts: {
+          build: "echo build",
+          "lint:architecture": "echo architecture",
           test: "echo test",
           "test:e2e": "echo e2e",
         },
@@ -94,6 +99,10 @@ async function createFixtureRepo() {
         "- [Architecture](./architecture.md)",
         "- [Testing](./testing.md)",
         "- [Code map](./code-map.md)",
+        "- [Route index](./route-index.md)",
+        "- [Test index](./test-index.md)",
+        "- [Key folder index](./key-folder-index.md)",
+        "- [Validation guide](./validation-guide.md)",
       ].join("\n"),
       rootDir
     );
@@ -109,11 +118,17 @@ async function createFixtureRepo() {
         ? [
             "# Athena Webapp Code Map",
             "",
+            "- [Route index](./route-index.md)",
+            "- [Key folder index](./key-folder-index.md)",
+            "",
             "- [Routes](../../src/routes/index.tsx)",
             "- [Convex HTTP](../../convex/http.ts)",
           ].join("\n")
         : [
             "# Storefront Webapp Code Map",
+            "",
+            "- [Route index](./route-index.md)",
+            "- [Key folder index](./key-folder-index.md)",
             "",
             "- [Routes](../../src/routes/__root.tsx)",
             "- [API](../../src/api/storefront.ts)",
@@ -131,6 +146,8 @@ async function createFixtureRepo() {
       "Run `bun run harness:review` for touched-file validation coverage.",
       "Run `bun run harness:audit` for full-app stale-doc and validation-map coverage auditing.",
       "Machine-readable review coverage lives in [validation-map.json](./validation-map.json).",
+      "- [Test index](./test-index.md)",
+      "- [Validation guide](./validation-guide.md)",
       "Default regression: `bun run --filter '@athena/webapp' test`.",
       "Convex validation: `bun run --filter '@athena/webapp' audit:convex` and `bun run --filter '@athena/webapp' lint:convex:changed`.",
       "Covered test surfaces include `src/tests` and `convex`.",
@@ -146,6 +163,8 @@ async function createFixtureRepo() {
       "Run `bun run harness:review` for touched-file validation coverage.",
       "Run `bun run harness:audit` for full-app stale-doc and validation-map coverage auditing.",
       "Machine-readable review coverage lives in [validation-map.json](./validation-map.json).",
+      "- [Test index](./test-index.md)",
+      "- [Validation guide](./validation-guide.md)",
       "Default regression: `bun run --filter '@athena/storefront-webapp' test`.",
       "Browser journeys: `bun run --filter '@athena/storefront-webapp' test:e2e`.",
       "Covered test surfaces include `tests/e2e`.",
@@ -280,6 +299,8 @@ async function createFixtureRepo() {
   await write("packages/storefront-webapp/src/utils/price.ts", "export {};\n", rootDir);
   await write("packages/storefront-webapp/tests/e2e/checkout.spec.ts", "export {};\n", rootDir);
 
+  await writeGeneratedHarnessDocs(rootDir);
+
   return rootDir;
 }
 
@@ -294,6 +315,15 @@ afterEach(async () => {
 describe("runHarnessAudit", () => {
   it("passes when current app surfaces are fully mapped", async () => {
     const rootDir = await createFixtureRepo();
+
+    await expect(runHarnessAudit(rootDir)).resolves.toBeUndefined();
+  });
+
+  it("ignores local-only noise files when auditing live surfaces", async () => {
+    const rootDir = await createFixtureRepo();
+    await write("packages/athena-webapp/src/.DS_Store", "", rootDir);
+    await write("packages/athena-webapp/convex/.DS_Store", "", rootDir);
+    await write("packages/storefront-webapp/src/.env", "FOO=bar\n", rootDir);
 
     await expect(runHarnessAudit(rootDir)).resolves.toBeUndefined();
   });
@@ -381,6 +411,8 @@ describe("runHarnessAudit", () => {
         {
           name: "@athena/storefront-webapp",
           scripts: {
+            build: "echo build",
+            "lint:architecture": "echo architecture",
             test: "echo test",
           },
         },
@@ -391,7 +423,7 @@ describe("runHarnessAudit", () => {
     );
 
     await expect(runHarnessAudit(rootDir)).rejects.toThrow(
-      /storefront-webapp[\s\S]*Invalid documented test command in packages\/storefront-webapp\/docs\/agent\/testing\.md: bun run --filter '@athena\/storefront-webapp' test:e2e/
+      /Missing required script "@athena\/storefront-webapp:test:e2e" while generating harness docs\./
     );
   });
 });

--- a/scripts/harness-audit.ts
+++ b/scripts/harness-audit.ts
@@ -109,6 +109,7 @@ function inferGroupFromError(error: string) {
 
 function shouldSkipSurfaceEntry(entryName: string) {
   return (
+    entryName.startsWith(".") ||
     entryName === "_generated" ||
     entryName === "README.md" ||
     entryName === "coverage" ||

--- a/scripts/harness-generate.ts
+++ b/scripts/harness-generate.ts
@@ -251,6 +251,10 @@ function normalizeRepoPath(filePath: string) {
   return filePath.split(path.sep).join("/");
 }
 
+function shouldSkipGeneratedEntry(entryName: string) {
+  return entryName.startsWith(".");
+}
+
 async function fileExists(filePath: string) {
   try {
     await access(filePath);
@@ -267,14 +271,16 @@ async function walkFiles(dirPath: string): Promise<string[]> {
 
   const entries = await readdir(dirPath, { withFileTypes: true });
   const files = await Promise.all(
-    entries.map(async (entry) => {
+    entries
+      .filter((entry) => !shouldSkipGeneratedEntry(entry.name))
+      .map(async (entry) => {
       const entryPath = path.join(dirPath, entry.name);
       if (entry.isDirectory()) {
         return walkFiles(entryPath);
       }
 
       return [entryPath];
-    })
+      })
   );
 
   return files.flat();
@@ -432,7 +438,10 @@ async function collectFolderFacts(
 
   const allFiles = await walkFiles(absoluteFolderPath);
   const directChildren = await readdir(absoluteFolderPath, { withFileTypes: true });
-  const childNames = directChildren.map((entry) => entry.name).sort();
+  const childNames = directChildren
+    .filter((entry) => !shouldSkipGeneratedEntry(entry.name))
+    .map((entry) => entry.name)
+    .sort();
 
   return {
     fileCount: allFiles.length,


### PR DESCRIPTION
## Summary
- add a repo-owned `bun run graphify:rebuild` command that uses the pinned graphify interpreter and skips non-source directories such as `node_modules` and `worktrees`
- update the root AGENTS graphify instruction to use the new command and add focused tests for the rebuild wrapper
- keep the harness refresh work in place by filtering audit/generation noise, enforcing harness checks in CI, and refreshing the tracked graph outputs

## Why
The previous graphify maintenance command depended on the ambient `python3` environment, which failed with `ModuleNotFoundError` in this repo. After routing through the repo-pinned graphify interpreter, the rebuild still spent too long traversing non-source directories during a repo-root scan. This change fixes both root causes so the documented maintenance command is reliable again, and keeps the harness checks aligned with the active repo state.

## Validation
- `bun test /Users/kwamina/athena/scripts/graphify-rebuild.test.ts /Users/kwamina/athena/scripts/harness-audit.test.ts /Users/kwamina/athena/scripts/harness-check.test.ts /Users/kwamina/athena/scripts/harness-generate.test.ts /Users/kwamina/athena/scripts/harness-review.test.ts`
- `bun run graphify:rebuild && bun run harness:check && bun run harness:audit && bun run architecture:check`

https://linear.app/v26-labs/issue/V26-194/add-bun-run-harnessaudit-for-stale-doc-and-uncovered-validation
