### PR TITLE
[V26-194]: polish harness ergonomics and drift coverage

### DIFF
--- a/.github/workflows/athena-pr-tests.yml
+++ b/.github/workflows/athena-pr-tests.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+  schedule:
+    - cron: "0 14 * * 1"
   workflow_dispatch:
 
 permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -180,6 +180,7 @@ packages/.claude/worktrees/
 docs/superpowers/plans/
 docs/superpowers/specs/
 .dual-graph/
+graphify-out/cache/
 
 packages/athena-webapp/stats.html
 packages/storefront-webapp/stats.html

--- a/README.md
+++ b/README.md
@@ -1,5 +1,33 @@
 # athena
 
-let's go again
+## Harness
 
-ci-check-smoke: storefront workflow validation.
+This repo uses a docs-first agent harness for `packages/athena-webapp` and `packages/storefront-webapp`.
+
+Key repo-level commands:
+
+- `bun run harness:check`
+- `bun run harness:audit`
+- `bun run harness:review`
+- `bun run architecture:check`
+- `bun run pre-push:review`
+- `bun run pr:athena`
+
+## Graphify
+
+The repo keeps a graphify knowledge graph at `graphify-out/`.
+
+Use `bun run graphify:rebuild` after code changes. The command prefers the interpreter recorded in `.graphify_python` and falls back to `python3` only if that file is missing.
+
+If you need to repair the local graphify setup, make sure `.graphify_python` points at a Python environment that can import `graphify`. In this repo that is typically a pipx-managed interpreter.
+
+Tracked graphify artifacts:
+
+- `graphify-out/GRAPH_REPORT.md`
+- `graphify-out/graph.json`
+
+Local-only graphify artifacts:
+
+- `graphify-out/cache/`
+
+`graphify-out/cache/` is intentionally ignored because it is a large local acceleration cache, not a reviewable source artifact.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,12 +1,12 @@
 # Graph Report - .  (2026-04-11)
 
 ## Corpus Check
-- 1170 files · ~0 words
+- 1171 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 2102 nodes · 4792 edges · 72 communities detected
-- Extraction: 92% EXTRACTED · 8% INFERRED · 0% AMBIGUOUS · INFERRED: 401 edges (avg confidence: 0.5)
+- 2106 nodes · 4795 edges · 72 communities detected
+- Extraction: 92% EXTRACTED · 8% INFERRED · 0% AMBIGUOUS · INFERRED: 400 edges (avg confidence: 0.5)
 - Token cost: 0 input · 0 output
 
 ## God Nodes (most connected - your core abstractions)
@@ -37,83 +37,83 @@
 
 ### Community 0 - "Community 0"
 Cohesion: 0.01
-Nodes (2): handleFileSelect(), validateFile()
+Nodes (6): handleKeyDown(), handleRedeemPromoCode(), getPromoAlertCopy(), PromoAlert(), clearFilters(), onMobileFiltersCloseClick()
 
 ### Community 1 - "Community 1"
 Cohesion: 0.01
-Nodes (9): handleKeyDown(), handleRedeemPromoCode(), getPromoAlertCopy(), PromoAlert(), getBaseUrl(), getPromoCodes(), redeemPromoCode(), clearFilters() (+1 more)
+Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
 ### Community 2 - "Community 2"
 Cohesion: 0.02
-Nodes (44): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory(), getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore(), expectIndex() (+36 more)
+Nodes (19): AnalyticsCombinedUsers(), processAnalyticsToUsers(), AnalyticsTopUsers(), processAnalyticsToUsers(), handleSave(), hasReceivingAccountDetails(), normalizePrimaryAccounts(), toPatchReceivingAccounts() (+11 more)
 
 ### Community 3 - "Community 3"
 Cohesion: 0.02
-Nodes (19): AnalyticsCombinedUsers(), processAnalyticsToUsers(), AnalyticsTopUsers(), processAnalyticsToUsers(), handleSave(), hasReceivingAccountDetails(), normalizePrimaryAccounts(), toPatchReceivingAccounts() (+11 more)
+Nodes (49): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory(), getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore(), expectIndex() (+41 more)
 
 ### Community 4 - "Community 4"
 Cohesion: 0.02
-Nodes (17): handleNewSession(), resetAutoSessionInitialized(), Logger, handleNewSession(), resetAutoSessionInitialized(), usePOSActiveSession(), usePOSSessionComplete(), usePOSSessionCreate() (+9 more)
+Nodes (16): handleNewSession(), resetAutoSessionInitialized(), handleNewSession(), resetAutoSessionInitialized(), usePOSActiveSession(), usePOSSessionComplete(), usePOSSessionCreate(), usePOSSessionHold() (+8 more)
 
 ### Community 5 - "Community 5"
-Cohesion: 0.03
-Nodes (11): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold(), onSubmit(), saveStoreChanges(), getActiveUser() (+3 more)
+Cohesion: 0.02
+Nodes (15): buildUsername(), normalizeNameSegment(), getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold(), onSubmit() (+7 more)
 
 ### Community 6 - "Community 6"
 Cohesion: 0.03
-Nodes (14): isSkuReserved(), shouldDisable(), createReview(), deleteReview(), getBaseUrl(), getReviewByOrderItem(), getReviewsByProductId(), getReviewsByProductSkuId() (+6 more)
+Nodes (56): bootstrapCheckout(), createBootstrapToken(), createMarker(), createOffer(), getBaseUrl(), getUserRedeemedOffers(), isDuplicate(), submitOffer() (+48 more)
 
 ### Community 7 - "Community 7"
-Cohesion: 0.05
-Nodes (63): onSubmit(), reportAuthFailure(), resendVerificationCode(), addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), listBagItems() (+55 more)
+Cohesion: 0.03
+Nodes (9): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource(), modifyProduct(), onSubmit(), saveProduct(), onSubmit() (+1 more)
 
 ### Community 8 - "Community 8"
-Cohesion: 0.03
-Nodes (5): modifyProduct(), onSubmit(), saveProduct(), onSubmit(), saveStoreChanges()
+Cohesion: 0.04
+Nodes (37): checkIfItemsHaveChanged(), CheckoutSessionError, createCheckoutSession(), createOnlineOrder(), defaultCheckoutActionMessage(), findBestValuePromoCode(), getActiveCheckoutSession(), getBaseUrl() (+29 more)
 
 ### Community 9 - "Community 9"
-Cohesion: 0.05
-Nodes (39): buildUsername(), normalizeNameSegment(), buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins(), getDeliveryAddress() (+31 more)
+Cohesion: 0.03
+Nodes (2): isSkuReserved(), shouldDisable()
 
 ### Community 10 - "Community 10"
 Cohesion: 0.05
-Nodes (37): checkIfItemsHaveChanged(), CheckoutSessionError, createCheckoutSession(), createOnlineOrder(), defaultCheckoutActionMessage(), findBestValuePromoCode(), getActiveCheckoutSession(), getBaseUrl() (+29 more)
-
-### Community 11 - "Community 11"
-Cohesion: 0.03
-Nodes (4): cancelOrder(), getErrorMessage(), placeOrder(), ValkeyClient
-
-### Community 12 - "Community 12"
-Cohesion: 0.05
 Nodes (21): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventoryHold(), releaseInventoryHold(), validateInventoryAvailability(), collectAllPages(), createTransactionFromSessionHandler(), listCompletedTransactionsForDay() (+13 more)
 
-### Community 13 - "Community 13"
+### Community 11 - "Community 11"
 Cohesion: 0.07
 Nodes (53): addGroupedError(), collectLiveSurfaceEntries(), fileExists(), formatGroupedErrors(), inferGroupFromError(), loadAuditTarget(), matchesPathPrefix(), normalizeRepoPath() (+45 more)
+
+### Community 12 - "Community 12"
+Cohesion: 0.06
+Nodes (20): getAllColors(), getBaseUrl(), buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct() (+12 more)
+
+### Community 13 - "Community 13"
+Cohesion: 0.08
+Nodes (27): asArray(), asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), assignOrDelete(), asString() (+19 more)
 
 ### Community 14 - "Community 14"
 Cohesion: 0.05
 Nodes (7): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile(), MockImage
 
 ### Community 15 - "Community 15"
-Cohesion: 0.05
-Nodes (13): getAllColors(), getBaseUrl(), getNonEmptyString(), isFailureStatus(), normalizeEvent(), buildQueryString(), getAllProducts(), getBaseUrl() (+5 more)
+Cohesion: 0.08
+Nodes (27): onSubmit(), reportAuthFailure(), resendVerificationCode(), addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), listBagItems() (+19 more)
 
 ### Community 16 - "Community 16"
-Cohesion: 0.06
-Nodes (0): 
-
-### Community 17 - "Community 17"
-Cohesion: 0.12
+Cohesion: 0.1
 Nodes (26): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction(), asBoolean(), asMtnMomoSetupStatus() (+18 more)
 
+### Community 17 - "Community 17"
+Cohesion: 0.08
+Nodes (5): getNonEmptyString(), isFailureStatus(), normalizeEvent(), getNonEmptyString(), normalizeStorefrontObservabilityEvent()
+
 ### Community 18 - "Community 18"
-Cohesion: 0.14
-Nodes (12): collectScriptsForChangedFiles(), fileExists(), loadReviewTarget(), loadReviewTargets(), matchesPathPrefix(), normalizeRepoPath(), runHarnessReview(), createFixtureRepo() (+4 more)
+Cohesion: 0.11
+Nodes (10): collectScriptsForChangedFiles(), fileExists(), loadReviewTarget(), loadReviewTargets(), matchesPathPrefix(), normalizeRepoPath(), runHarnessReview(), createFixtureRepo() (+2 more)
 
 ### Community 19 - "Community 19"
-Cohesion: 0.22
-Nodes (9): awardPointsForGuestOrders(), awardPointsForPastOrder(), getBaseUrl(), getEligiblePastOrders(), getOrderRewardPoints(), getPointHistory(), getRewardTiers(), getUserPoints() (+1 more)
+Cohesion: 0.1
+Nodes (0): 
 
 ### Community 20 - "Community 20"
 Cohesion: 0.17
@@ -124,24 +124,24 @@ Cohesion: 0.18
 Nodes (0): 
 
 ### Community 22 - "Community 22"
-Cohesion: 0.24
-Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
-
-### Community 23 - "Community 23"
 Cohesion: 0.2
 Nodes (0): 
 
-### Community 24 - "Community 24"
+### Community 23 - "Community 23"
 Cohesion: 0.39
 Nodes (7): calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock(), validateRefund()
+
+### Community 24 - "Community 24"
+Cohesion: 0.54
+Nodes (1): Logger
 
 ### Community 25 - "Community 25"
 Cohesion: 0.32
 Nodes (3): fileExists(), resolveGraphifyPython(), runGraphifyRebuild()
 
 ### Community 26 - "Community 26"
-Cohesion: 0.7
-Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
+Cohesion: 0.4
+Nodes (1): ValkeyClient
 
 ### Community 27 - "Community 27"
 Cohesion: 0.7
@@ -414,6 +414,10 @@ Nodes (0):
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
+- **Why does `Logger` connect `Community 24` to `Community 4`?**
+  _High betweenness centrality (0.006) - this node is a cross-community bridge._
+- **Why does `ValkeyClient` connect `Community 26` to `Community 1`?**
+  _High betweenness centrality (0.003) - this node is a cross-community bridge._
 - **Are the 39 inferred relationships involving `createJourneyEvent()` (e.g. with `compactContext()` and `createLandingPageViewedEvent()`) actually correct?**
   _`createJourneyEvent()` has 39 INFERRED edges - model-reasoned connections that need verification._
 - **Are the 15 inferred relationships involving `getStoreConfigV2()` (e.g. with `getRawConfig()` and `asRecord()`) actually correct?**
@@ -424,7 +428,3 @@ _Questions this graph is uniquely positioned to answer:_
   _`getBaseUrl()` has 11 INFERRED edges - model-reasoned connections that need verification._
 - **Are the 8 inferred relationships involving `usePOSSessionManager()` (e.g. with `usePOSSessionCreate()` and `usePOSSessionUpdate()`) actually correct?**
   _`usePOSSessionManager()` has 8 INFERRED edges - model-reasoned connections that need verification._
-- **Should `Community 0` be split into smaller, more focused modules?**
-  _Cohesion score 0.01 - nodes in this community are weakly interconnected._
-- **Should `Community 1` be split into smaller, more focused modules?**
-  _Cohesion score 0.01 - nodes in this community are weakly interconnected._

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -9,7 +9,7 @@
       "source_file": "packages/athena-webapp/convex/_generated/api.d.ts",
       "source_location": "L1",
       "id": "api_d",
-      "community": 2
+      "community": 3
     },
     {
       "label": "api.js",
@@ -17,7 +17,7 @@
       "source_file": "packages/athena-webapp/convex/_generated/api.js",
       "source_location": "L1",
       "id": "api",
-      "community": 0
+      "community": 3
     },
     {
       "label": "dataModel.d.ts",
@@ -25,7 +25,7 @@
       "source_file": "packages/athena-webapp/convex/_generated/dataModel.d.ts",
       "source_location": "L1",
       "id": "datamodel_d",
-      "community": 2
+      "community": 3
     },
     {
       "label": "server.d.ts",
@@ -33,7 +33,7 @@
       "source_file": "packages/athena-webapp/convex/_generated/server.d.ts",
       "source_location": "L1",
       "id": "server_d",
-      "community": 2
+      "community": 3
     },
     {
       "label": "server.js",
@@ -41,7 +41,7 @@
       "source_file": "packages/athena-webapp/convex/_generated/server.js",
       "source_location": "L1",
       "id": "server",
-      "community": 2
+      "community": 3
     },
     {
       "label": "app.ts",
@@ -49,7 +49,7 @@
       "source_file": "packages/athena-webapp/convex/app.ts",
       "source_location": "L1",
       "id": "app",
-      "community": 2
+      "community": 3
     },
     {
       "label": "auth.config.js",
@@ -65,7 +65,7 @@
       "source_file": "packages/storefront-webapp/src/components/auth/Auth.tsx",
       "source_location": "L1",
       "id": "auth",
-      "community": 2
+      "community": 3
     },
     {
       "label": "index.js",
@@ -73,7 +73,7 @@
       "source_file": "packages/valkey-proxy-server/index.js",
       "source_location": "L1",
       "id": "index",
-      "community": 11
+      "community": 1
     },
     {
       "label": "ValkeyClient",
@@ -81,7 +81,7 @@
       "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L4",
       "id": "index_valkeyclient",
-      "community": 11
+      "community": 26
     },
     {
       "label": ".constructor()",
@@ -89,7 +89,7 @@
       "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L11",
       "id": "index_valkeyclient_constructor",
-      "community": 11
+      "community": 26
     },
     {
       "label": ".get()",
@@ -97,7 +97,7 @@
       "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L20",
       "id": "index_valkeyclient_get",
-      "community": 11
+      "community": 26
     },
     {
       "label": ".set()",
@@ -105,7 +105,7 @@
       "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L48",
       "id": "index_valkeyclient_set",
-      "community": 11
+      "community": 26
     },
     {
       "label": ".invalidate()",
@@ -113,7 +113,7 @@
       "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L75",
       "id": "index_valkeyclient_invalidate",
-      "community": 11
+      "community": 26
     },
     {
       "label": "r2.ts",
@@ -121,7 +121,7 @@
       "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
       "source_location": "L1",
       "id": "r2",
-      "community": 2
+      "community": 3
     },
     {
       "label": "uploadFileToR2()",
@@ -129,7 +129,7 @@
       "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
       "source_location": "L21",
       "id": "r2_uploadfiletor2",
-      "community": 2
+      "community": 3
     },
     {
       "label": "deleteFileInR2()",
@@ -137,7 +137,7 @@
       "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
       "source_location": "L40",
       "id": "r2_deletefileinr2",
-      "community": 2
+      "community": 3
     },
     {
       "label": "deleteDirectoryInR2()",
@@ -145,7 +145,7 @@
       "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
       "source_location": "L62",
       "id": "r2_deletedirectoryinr2",
-      "community": 2
+      "community": 3
     },
     {
       "label": "listItemsInR2Directory()",
@@ -153,7 +153,7 @@
       "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
       "source_location": "L106",
       "id": "r2_listitemsinr2directory",
-      "community": 2
+      "community": 3
     },
     {
       "label": "stream.ts",
@@ -161,7 +161,7 @@
       "source_file": "packages/athena-webapp/convex/cloudflare/stream.ts",
       "source_location": "L1",
       "id": "stream",
-      "community": 2
+      "community": 3
     },
     {
       "label": "getCloudflareConfig()",
@@ -169,7 +169,7 @@
       "source_file": "packages/athena-webapp/convex/cloudflare/stream.ts",
       "source_location": "L8",
       "id": "stream_getcloudflareconfig",
-      "community": 2
+      "community": 3
     },
     {
       "label": "countries.ts",
@@ -185,7 +185,7 @@
       "source_file": "packages/storefront-webapp/src/lib/validations/email.ts",
       "source_location": "L1",
       "id": "email",
-      "community": 1
+      "community": 6
     },
     {
       "label": "ghana.ts",
@@ -201,7 +201,7 @@
       "source_file": "packages/athena-webapp/convex/types/payment.ts",
       "source_location": "L1",
       "id": "payment",
-      "community": 2
+      "community": 3
     },
     {
       "label": "crons.ts",
@@ -209,7 +209,7 @@
       "source_file": "packages/athena-webapp/convex/crons.ts",
       "source_location": "L1",
       "id": "crons",
-      "community": 2
+      "community": 3
     },
     {
       "label": "DiscountCode.tsx",
@@ -217,7 +217,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
       "source_location": "L1",
       "id": "discountcode",
-      "community": 11
+      "community": 1
     },
     {
       "label": "ProductCard()",
@@ -225,7 +225,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
       "source_location": "L33",
       "id": "discountcode_productcard",
-      "community": 11
+      "community": 1
     },
     {
       "label": "chunkProducts()",
@@ -233,7 +233,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
       "source_location": "L98",
       "id": "discountcode_chunkproducts",
-      "community": 11
+      "community": 1
     },
     {
       "label": "DiscountReminder.tsx",
@@ -241,7 +241,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
       "source_location": "L1",
       "id": "discountreminder",
-      "community": 11
+      "community": 1
     },
     {
       "label": "ProductCard()",
@@ -249,7 +249,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
       "source_location": "L31",
       "id": "discountreminder_productcard",
-      "community": 11
+      "community": 1
     },
     {
       "label": "chunkProducts()",
@@ -257,7 +257,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
       "source_location": "L85",
       "id": "discountreminder_chunkproducts",
-      "community": 11
+      "community": 1
     },
     {
       "label": "FeedbackRequest.tsx",
@@ -265,7 +265,7 @@
       "source_file": "packages/athena-webapp/convex/emails/FeedbackRequest.tsx",
       "source_location": "L1",
       "id": "feedbackrequest",
-      "community": 11
+      "community": 1
     },
     {
       "label": "NewOrderAdmin.tsx",
@@ -273,7 +273,7 @@
       "source_file": "packages/athena-webapp/convex/emails/NewOrderAdmin.tsx",
       "source_location": "L1",
       "id": "neworderadmin",
-      "community": 11
+      "community": 1
     },
     {
       "label": "OrderEmail.tsx",
@@ -281,7 +281,7 @@
       "source_file": "packages/athena-webapp/convex/emails/OrderEmail.tsx",
       "source_location": "L1",
       "id": "orderemail",
-      "community": 11
+      "community": 1
     },
     {
       "label": "PosReceiptEmail.tsx",
@@ -297,7 +297,7 @@
       "source_file": "packages/athena-webapp/convex/emails/VerificationCode.tsx",
       "source_location": "L1",
       "id": "verificationcode",
-      "community": 11
+      "community": 1
     },
     {
       "label": "VerificationCode()",
@@ -305,7 +305,7 @@
       "source_file": "packages/athena-webapp/convex/emails/VerificationCode.tsx",
       "source_location": "L18",
       "id": "verificationcode_verificationcode",
-      "community": 11
+      "community": 1
     },
     {
       "label": "env.ts",
@@ -313,7 +313,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
       "source_location": "L1",
       "id": "env",
-      "community": 22
+      "community": 6
     },
     {
       "label": "analytics.ts",
@@ -321,7 +321,7 @@
       "source_file": "packages/storefront-webapp/src/lib/mutations.ts/analytics.ts",
       "source_location": "L1",
       "id": "analytics",
-      "community": 15
+      "community": 17
     },
     {
       "label": "bannerMessage.ts",
@@ -329,7 +329,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/bannerMessage.ts",
       "source_location": "L1",
       "id": "bannermessage",
-      "community": 2
+      "community": 3
     },
     {
       "label": "categories.ts",
@@ -337,7 +337,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/categories.ts",
       "source_location": "L1",
       "id": "categories",
-      "community": 2
+      "community": 3
     },
     {
       "label": "colors.ts",
@@ -345,7 +345,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/colors.ts",
       "source_location": "L1",
       "id": "colors",
-      "community": 2
+      "community": 3
     },
     {
       "label": "organizations.ts",
@@ -353,7 +353,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/organizations.ts",
       "source_location": "L1",
       "id": "organizations",
-      "community": 2
+      "community": 3
     },
     {
       "label": "Products.tsx",
@@ -361,7 +361,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/Products.tsx",
       "source_location": "L1",
       "id": "products",
-      "community": 0
+      "community": 2
     },
     {
       "label": "stores.ts",
@@ -369,7 +369,7 @@
       "source_file": "packages/storefront-webapp/src/api/stores.ts",
       "source_location": "L1",
       "id": "stores",
-      "community": 2
+      "community": 3
     },
     {
       "label": "subcategories.ts",
@@ -377,7 +377,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/subcategories.ts",
       "source_location": "L1",
       "id": "subcategories",
-      "community": 2
+      "community": 3
     },
     {
       "label": "mtnMomo.ts",
@@ -385,7 +385,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/mtnMomo.ts",
       "source_location": "L1",
       "id": "mtnmomo",
-      "community": 2
+      "community": 3
     },
     {
       "label": "handleCollectionNotification()",
@@ -393,7 +393,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/mtnMomo.ts",
       "source_location": "L10",
       "id": "mtnmomo_handlecollectionnotification",
-      "community": 2
+      "community": 3
     },
     {
       "label": "bag.ts",
@@ -401,7 +401,7 @@
       "source_file": "packages/storefront-webapp/src/lib/schemas/bag.ts",
       "source_location": "L1",
       "id": "bag",
-      "community": 7
+      "community": 15
     },
     {
       "label": "checkout.ts",
@@ -409,7 +409,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/checkout.ts",
       "source_location": "L1",
       "id": "checkout",
-      "community": 1
+      "community": 0
     },
     {
       "label": "hasValidCanonicalBagItem()",
@@ -417,7 +417,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/checkout.ts",
       "source_location": "L84",
       "id": "checkout_hasvalidcanonicalbagitem",
-      "community": 1
+      "community": 0
     },
     {
       "label": "hasValidSessionItems()",
@@ -425,7 +425,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/checkout.ts",
       "source_location": "L95",
       "id": "checkout_hasvalidsessionitems",
-      "community": 1
+      "community": 0
     },
     {
       "label": "hasAllVisibileSessionItems()",
@@ -433,7 +433,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/checkout.ts",
       "source_location": "L109",
       "id": "checkout_hasallvisibilesessionitems",
-      "community": 1
+      "community": 0
     },
     {
       "label": "guest.ts",
@@ -441,7 +441,7 @@
       "source_file": "packages/storefront-webapp/src/api/guest.ts",
       "source_location": "L1",
       "id": "guest",
-      "community": 2
+      "community": 3
     },
     {
       "label": "me.ts",
@@ -449,7 +449,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/me.ts",
       "source_location": "L1",
       "id": "me",
-      "community": 2
+      "community": 3
     },
     {
       "label": "offers.ts",
@@ -457,7 +457,7 @@
       "source_file": "packages/storefront-webapp/src/api/offers.ts",
       "source_location": "L1",
       "id": "offers",
-      "community": 2
+      "community": 6
     },
     {
       "label": "onlineOrder.ts",
@@ -465,7 +465,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/onlineOrder.ts",
       "source_location": "L1",
       "id": "onlineorder",
-      "community": 2
+      "community": 3
     },
     {
       "label": "paystack.ts",
@@ -473,7 +473,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/paystack.ts",
       "source_location": "L1",
       "id": "paystack",
-      "community": 2
+      "community": 3
     },
     {
       "label": "reviews.ts",
@@ -481,7 +481,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/reviews.ts",
       "source_location": "L1",
       "id": "reviews",
-      "community": 6
+      "community": 12
     },
     {
       "label": "rewards.ts",
@@ -489,7 +489,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/rewards.ts",
       "source_location": "L1",
       "id": "rewards",
-      "community": 19
+      "community": 15
     },
     {
       "label": "SavedBag.tsx",
@@ -497,7 +497,7 @@
       "source_file": "packages/storefront-webapp/src/components/saved-items/SavedBag.tsx",
       "source_location": "L1",
       "id": "savedbag",
-      "community": 7
+      "community": 15
     },
     {
       "label": "security.test.ts",
@@ -505,7 +505,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.test.ts",
       "source_location": "L1",
       "id": "security_test",
-      "community": 2
+      "community": 3
     },
     {
       "label": "security.ts",
@@ -513,7 +513,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
       "source_location": "L1",
       "id": "security",
-      "community": 2
+      "community": 3
     },
     {
       "label": "hasValidPositiveQuantity()",
@@ -521,7 +521,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
       "source_location": "L27",
       "id": "security_hasvalidpositivequantity",
-      "community": 2
+      "community": 3
     },
     {
       "label": "isAuthorizedResourceOwner()",
@@ -529,7 +529,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
       "source_location": "L31",
       "id": "security_isauthorizedresourceowner",
-      "community": 2
+      "community": 3
     },
     {
       "label": "buildCanonicalCheckoutProducts()",
@@ -537,7 +537,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
       "source_location": "L42",
       "id": "security_buildcanonicalcheckoutproducts",
-      "community": 2
+      "community": 3
     },
     {
       "label": "isAmountTampered()",
@@ -545,7 +545,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
       "source_location": "L65",
       "id": "security_isamounttampered",
-      "community": 2
+      "community": 3
     },
     {
       "label": "isDuplicateChargeSuccess()",
@@ -553,7 +553,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
       "source_location": "L76",
       "id": "security_isduplicatechargesuccess",
-      "community": 2
+      "community": 3
     },
     {
       "label": "storefront.ts",
@@ -561,7 +561,7 @@
       "source_file": "packages/storefront-webapp/src/api/storefront.ts",
       "source_location": "L1",
       "id": "storefront",
-      "community": 2
+      "community": 3
     },
     {
       "label": "upsells.ts",
@@ -569,7 +569,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/upsells.ts",
       "source_location": "L1",
       "id": "upsells",
-      "community": 2
+      "community": 3
     },
     {
       "label": "user.ts",
@@ -577,7 +577,7 @@
       "source_file": "packages/storefront-webapp/src/lib/schemas/user.ts",
       "source_location": "L1",
       "id": "user",
-      "community": 2
+      "community": 3
     },
     {
       "label": "userOffers.ts",
@@ -585,7 +585,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/userOffers.ts",
       "source_location": "L1",
       "id": "useroffers",
-      "community": 2
+      "community": 6
     },
     {
       "label": "routerComposition.test.ts",
@@ -609,7 +609,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L1",
       "id": "utils",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getStoreDataFromRequest()",
@@ -617,7 +617,7 @@
       "source_file": "packages/athena-webapp/convex/http/utils.ts",
       "source_location": "L5",
       "id": "utils_getstoredatafromrequest",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getStorefrontUserFromRequest()",
@@ -625,7 +625,7 @@
       "source_file": "packages/athena-webapp/convex/http/utils.ts",
       "source_location": "L12",
       "id": "utils_getstorefrontuserfromrequest",
-      "community": 3
+      "community": 2
     },
     {
       "label": "http.ts",
@@ -633,7 +633,7 @@
       "source_file": "packages/athena-webapp/convex/http.ts",
       "source_location": "L1",
       "id": "http",
-      "community": 2
+      "community": 3
     },
     {
       "label": "athenaUser.ts",
@@ -641,7 +641,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/athenaUser.ts",
       "source_location": "L1",
       "id": "athenauser",
-      "community": 2
+      "community": 3
     },
     {
       "label": "bestSeller.ts",
@@ -649,7 +649,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/bestSeller.ts",
       "source_location": "L1",
       "id": "bestseller",
-      "community": 2
+      "community": 3
     },
     {
       "label": "cashier.ts",
@@ -657,7 +657,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/cashier.ts",
       "source_location": "L1",
       "id": "cashier",
-      "community": 2
+      "community": 3
     },
     {
       "label": "authenticateHandler()",
@@ -665,7 +665,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/cashier.ts",
       "source_location": "L239",
       "id": "cashier_authenticatehandler",
-      "community": 2
+      "community": 3
     },
     {
       "label": "complimentaryProduct.ts",
@@ -673,7 +673,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/complimentaryProduct.ts",
       "source_location": "L1",
       "id": "complimentaryproduct",
-      "community": 2
+      "community": 3
     },
     {
       "label": "expenseSessionItems.ts",
@@ -681,7 +681,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessionItems.ts",
       "source_location": "L1",
       "id": "expensesessionitems",
-      "community": 12
+      "community": 10
     },
     {
       "label": "expenseSessions.ts",
@@ -689,7 +689,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
       "source_location": "L1",
       "id": "expensesessions",
-      "community": 12
+      "community": 10
     },
     {
       "label": "buildNextExpenseSessionNumber()",
@@ -697,7 +697,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
       "source_location": "L33",
       "id": "expensesessions_buildnextexpensesessionnumber",
-      "community": 12
+      "community": 10
     },
     {
       "label": "loadExpenseSessionItems()",
@@ -705,7 +705,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
       "source_location": "L41",
       "id": "expensesessions_loadexpensesessionitems",
-      "community": 12
+      "community": 10
     },
     {
       "label": "listExpenseSessionsByStatusBefore()",
@@ -713,7 +713,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
       "source_location": "L66",
       "id": "expensesessions_listexpensesessionsbystatusbefore",
-      "community": 12
+      "community": 10
     },
     {
       "label": "expenseTransactions.ts",
@@ -729,7 +729,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/featuredItem.ts",
       "source_location": "L1",
       "id": "featureditem",
-      "community": 2
+      "community": 3
     },
     {
       "label": "expenseSessionExpiration.ts",
@@ -737,7 +737,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionExpiration.ts",
       "source_location": "L1",
       "id": "expensesessionexpiration",
-      "community": 12
+      "community": 10
     },
     {
       "label": "calculateExpenseSessionExpiration()",
@@ -745,7 +745,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionExpiration.ts",
       "source_location": "L21",
       "id": "expensesessionexpiration_calculateexpensesessionexpiration",
-      "community": 12
+      "community": 10
     },
     {
       "label": "getExpenseSessionExpiryDuration()",
@@ -753,7 +753,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionExpiration.ts",
       "source_location": "L35",
       "id": "expensesessionexpiration_getexpensesessionexpiryduration",
-      "community": 12
+      "community": 10
     },
     {
       "label": "getExpenseSessionExpiryDurationMinutes()",
@@ -761,7 +761,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionExpiration.ts",
       "source_location": "L45",
       "id": "expensesessionexpiration_getexpensesessionexpirydurationminutes",
-      "community": 12
+      "community": 10
     },
     {
       "label": "expenseSessionValidation.ts",
@@ -769,7 +769,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
       "source_location": "L1",
       "id": "expensesessionvalidation",
-      "community": 12
+      "community": 10
     },
     {
       "label": "validateExpenseSessionExists()",
@@ -777,7 +777,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
       "source_location": "L19",
       "id": "expensesessionvalidation_validateexpensesessionexists",
-      "community": 12
+      "community": 10
     },
     {
       "label": "validateExpenseSessionActive()",
@@ -785,7 +785,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
       "source_location": "L39",
       "id": "expensesessionvalidation_validateexpensesessionactive",
-      "community": 12
+      "community": 10
     },
     {
       "label": "validateExpenseSessionModifiable()",
@@ -793,7 +793,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
       "source_location": "L92",
       "id": "expensesessionvalidation_validateexpensesessionmodifiable",
-      "community": 12
+      "community": 10
     },
     {
       "label": "validateExpenseItemBelongsToSession()",
@@ -801,7 +801,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
       "source_location": "L135",
       "id": "expensesessionvalidation_validateexpenseitembelongstosession",
-      "community": 12
+      "community": 10
     },
     {
       "label": "inventoryHolds.ts",
@@ -809,7 +809,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
       "source_location": "L1",
       "id": "inventoryholds",
-      "community": 12
+      "community": 10
     },
     {
       "label": "validateInventoryAvailability()",
@@ -817,7 +817,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
       "source_location": "L20",
       "id": "inventoryholds_validateinventoryavailability",
-      "community": 12
+      "community": 10
     },
     {
       "label": "acquireInventoryHold()",
@@ -825,7 +825,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
       "source_location": "L76",
       "id": "inventoryholds_acquireinventoryhold",
-      "community": 12
+      "community": 10
     },
     {
       "label": "releaseInventoryHold()",
@@ -833,7 +833,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
       "source_location": "L114",
       "id": "inventoryholds_releaseinventoryhold",
-      "community": 12
+      "community": 10
     },
     {
       "label": "adjustInventoryHold()",
@@ -841,7 +841,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
       "source_location": "L161",
       "id": "inventoryholds_adjustinventoryhold",
-      "community": 12
+      "community": 10
     },
     {
       "label": "acquireInventoryHoldsBatch()",
@@ -849,7 +849,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
       "source_location": "L190",
       "id": "inventoryholds_acquireinventoryholdsbatch",
-      "community": 12
+      "community": 10
     },
     {
       "label": "releaseInventoryHoldsBatch()",
@@ -857,7 +857,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
       "source_location": "L239",
       "id": "inventoryholds_releaseinventoryholdsbatch",
-      "community": 12
+      "community": 10
     },
     {
       "label": "resultTypes.ts",
@@ -865,7 +865,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L1",
       "id": "resulttypes",
-      "community": 12
+      "community": 10
     },
     {
       "label": "success()",
@@ -873,7 +873,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L21",
       "id": "resulttypes_success",
-      "community": 12
+      "community": 10
     },
     {
       "label": "error()",
@@ -881,7 +881,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L28",
       "id": "resulttypes_error",
-      "community": 12
+      "community": 10
     },
     {
       "label": "itemSuccess()",
@@ -889,7 +889,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L140",
       "id": "resulttypes_itemsuccess",
-      "community": 12
+      "community": 10
     },
     {
       "label": "operationSuccess()",
@@ -897,7 +897,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L150",
       "id": "resulttypes_operationsuccess",
-      "community": 12
+      "community": 10
     },
     {
       "label": "sessionSuccess()",
@@ -905,7 +905,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L157",
       "id": "resulttypes_sessionsuccess",
-      "community": 12
+      "community": 10
     },
     {
       "label": "isSuccess()",
@@ -913,7 +913,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L167",
       "id": "resulttypes_issuccess",
-      "community": 12
+      "community": 10
     },
     {
       "label": "isError()",
@@ -921,7 +921,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L176",
       "id": "resulttypes_iserror",
-      "community": 12
+      "community": 10
     },
     {
       "label": "expenseItemSuccess()",
@@ -929,7 +929,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L276",
       "id": "resulttypes_expenseitemsuccess",
-      "community": 12
+      "community": 10
     },
     {
       "label": "expenseSessionSuccess()",
@@ -937,7 +937,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L286",
       "id": "resulttypes_expensesessionsuccess",
-      "community": 12
+      "community": 10
     },
     {
       "label": "sessionExpiration.ts",
@@ -945,7 +945,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
       "source_location": "L1",
       "id": "sessionexpiration",
-      "community": 12
+      "community": 10
     },
     {
       "label": "calculateSessionExpiration()",
@@ -953,7 +953,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
       "source_location": "L21",
       "id": "sessionexpiration_calculatesessionexpiration",
-      "community": 12
+      "community": 10
     },
     {
       "label": "getSessionExpiryDuration()",
@@ -961,7 +961,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
       "source_location": "L35",
       "id": "sessionexpiration_getsessionexpiryduration",
-      "community": 12
+      "community": 10
     },
     {
       "label": "getSessionExpiryDurationMinutes()",
@@ -969,7 +969,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
       "source_location": "L45",
       "id": "sessionexpiration_getsessionexpirydurationminutes",
-      "community": 12
+      "community": 10
     },
     {
       "label": "sessionValidation.ts",
@@ -977,7 +977,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L1",
       "id": "sessionvalidation",
-      "community": 12
+      "community": 10
     },
     {
       "label": "validateSessionExists()",
@@ -985,7 +985,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L19",
       "id": "sessionvalidation_validatesessionexists",
-      "community": 12
+      "community": 10
     },
     {
       "label": "validateSessionActive()",
@@ -993,7 +993,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L39",
       "id": "sessionvalidation_validatesessionactive",
-      "community": 12
+      "community": 10
     },
     {
       "label": "validateSessionModifiable()",
@@ -1001,7 +1001,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L95",
       "id": "sessionvalidation_validatesessionmodifiable",
-      "community": 12
+      "community": 10
     },
     {
       "label": "validateSessionOwnership()",
@@ -1009,7 +1009,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L140",
       "id": "sessionvalidation_validatesessionownership",
-      "community": 12
+      "community": 10
     },
     {
       "label": "validateCartItems()",
@@ -1017,7 +1017,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L188",
       "id": "sessionvalidation_validatecartitems",
-      "community": 12
+      "community": 10
     },
     {
       "label": "validateItemBelongsToSession()",
@@ -1025,7 +1025,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L245",
       "id": "sessionvalidation_validateitembelongstosession",
-      "community": 12
+      "community": 10
     },
     {
       "label": "validateCustomerInfo()",
@@ -1033,7 +1033,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L272",
       "id": "sessionvalidation_validatecustomerinfo",
-      "community": 12
+      "community": 10
     },
     {
       "label": "isValidEmail()",
@@ -1041,7 +1041,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L300",
       "id": "sessionvalidation_isvalidemail",
-      "community": 12
+      "community": 10
     },
     {
       "label": "validatePaymentDetails()",
@@ -1049,7 +1049,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L308",
       "id": "sessionvalidation_validatepaymentdetails",
-      "community": 12
+      "community": 10
     },
     {
       "label": "inviteCode.ts",
@@ -1057,7 +1057,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/inviteCode.ts",
       "source_location": "L1",
       "id": "invitecode",
-      "community": 2
+      "community": 3
     },
     {
       "label": "organizationMembers.ts",
@@ -1065,7 +1065,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/organizationMembers.ts",
       "source_location": "L1",
       "id": "organizationmembers",
-      "community": 2
+      "community": 3
     },
     {
       "label": "pos.ts",
@@ -1073,7 +1073,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L1",
       "id": "pos",
-      "community": 12
+      "community": 10
     },
     {
       "label": "isConvexProductId()",
@@ -1081,7 +1081,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L15",
       "id": "pos_isconvexproductid",
-      "community": 12
+      "community": 10
     },
     {
       "label": "collectAllPages()",
@@ -1089,7 +1089,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L19",
       "id": "pos_collectallpages",
-      "community": 12
+      "community": 10
     },
     {
       "label": "listProductSkusByProductId()",
@@ -1097,7 +1097,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L41",
       "id": "pos_listproductskusbyproductid",
-      "community": 12
+      "community": 10
     },
     {
       "label": "listStoreProducts()",
@@ -1105,7 +1105,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L53",
       "id": "pos_liststoreproducts",
-      "community": 12
+      "community": 10
     },
     {
       "label": "listStoreSkus()",
@@ -1113,7 +1113,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L62",
       "id": "pos_liststoreskus",
-      "community": 12
+      "community": 10
     },
     {
       "label": "listTransactionItems()",
@@ -1121,7 +1121,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L71",
       "id": "pos_listtransactionitems",
-      "community": 12
+      "community": 10
     },
     {
       "label": "listSessionItems()",
@@ -1129,7 +1129,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L83",
       "id": "pos_listsessionitems",
-      "community": 12
+      "community": 10
     },
     {
       "label": "listCompletedTransactionsForDay()",
@@ -1137,7 +1137,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L92",
       "id": "pos_listcompletedtransactionsforday",
-      "community": 12
+      "community": 10
     },
     {
       "label": "createTransactionFromSessionHandler()",
@@ -1145,7 +1145,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L939",
       "id": "pos_createtransactionfromsessionhandler",
-      "community": 12
+      "community": 10
     },
     {
       "label": "posCustomers.ts",
@@ -1153,7 +1153,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posCustomers.ts",
       "source_location": "L1",
       "id": "poscustomers",
-      "community": 2
+      "community": 3
     },
     {
       "label": "posQueryCleanup.test.ts",
@@ -1177,7 +1177,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posSessionItems.ts",
       "source_location": "L1",
       "id": "possessionitems",
-      "community": 12
+      "community": 10
     },
     {
       "label": "posSessions.ts",
@@ -1185,7 +1185,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
       "source_location": "L1",
       "id": "possessions",
-      "community": 12
+      "community": 10
     },
     {
       "label": "buildNextSessionNumber()",
@@ -1193,7 +1193,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
       "source_location": "L34",
       "id": "possessions_buildnextsessionnumber",
-      "community": 12
+      "community": 10
     },
     {
       "label": "loadPosSessionItems()",
@@ -1201,7 +1201,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
       "source_location": "L45",
       "id": "possessions_loadpossessionitems",
-      "community": 12
+      "community": 10
     },
     {
       "label": "listPosSessionsByStatusBefore()",
@@ -1209,7 +1209,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
       "source_location": "L67",
       "id": "possessions_listpossessionsbystatusbefore",
-      "community": 12
+      "community": 10
     },
     {
       "label": "listPosSessionsForStoreStatus()",
@@ -1217,7 +1217,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
       "source_location": "L93",
       "id": "possessions_listpossessionsforstorestatus",
-      "community": 12
+      "community": 10
     },
     {
       "label": "posTerminal.ts",
@@ -1225,7 +1225,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/pos/posTerminal.ts",
       "source_location": "L1",
       "id": "posterminal",
-      "community": 2
+      "community": 3
     },
     {
       "label": "productSku.ts",
@@ -1233,7 +1233,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/productSku.ts",
       "source_location": "L1",
       "id": "productsku",
-      "community": 2
+      "community": 3
     },
     {
       "label": "productUtil.ts",
@@ -1241,7 +1241,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/productUtil.ts",
       "source_location": "L1",
       "id": "productutil",
-      "community": 2
+      "community": 3
     },
     {
       "label": "generateSKU()",
@@ -1249,7 +1249,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/products.ts",
       "source_location": "L18",
       "id": "products_generatesku",
-      "community": 0
+      "community": 2
     },
     {
       "label": "generateBarcode()",
@@ -1257,7 +1257,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/products.ts",
       "source_location": "L42",
       "id": "products_generatebarcode",
-      "community": 0
+      "community": 2
     },
     {
       "label": "calculateTotalInventoryCount()",
@@ -1265,7 +1265,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/products.ts",
       "source_location": "L65",
       "id": "products_calculatetotalinventorycount",
-      "community": 0
+      "community": 2
     },
     {
       "label": "calculateTotalAvailableCount()",
@@ -1273,7 +1273,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/products.ts",
       "source_location": "L70",
       "id": "products_calculatetotalavailablecount",
-      "community": 0
+      "community": 2
     },
     {
       "label": "promoCode.ts",
@@ -1281,7 +1281,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/promoCode.ts",
       "source_location": "L1",
       "id": "promocode",
-      "community": 1
+      "community": 3
     },
     {
       "label": "sessionQueryIndexes.test.ts",
@@ -1305,7 +1305,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/stockValidation.ts",
       "source_location": "L1",
       "id": "stockvalidation",
-      "community": 2
+      "community": 3
     },
     {
       "label": "storeConfigV2.test.ts",
@@ -1313,7 +1313,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.test.ts",
       "source_location": "L1",
       "id": "storeconfigv2_test",
-      "community": 9
+      "community": 13
     },
     {
       "label": "storeConfigV2.ts",
@@ -1321,7 +1321,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L1",
       "id": "storeconfigv2",
-      "community": 9
+      "community": 13
     },
     {
       "label": "isPlainObject()",
@@ -1329,7 +1329,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L53",
       "id": "storeconfigv2_isplainobject",
-      "community": 9
+      "community": 13
     },
     {
       "label": "asRecord()",
@@ -1337,7 +1337,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L57",
       "id": "storeconfigv2_asrecord",
-      "community": 9
+      "community": 13
     },
     {
       "label": "asNumber()",
@@ -1345,7 +1345,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L61",
       "id": "storeconfigv2_asnumber",
-      "community": 9
+      "community": 13
     },
     {
       "label": "asString()",
@@ -1353,7 +1353,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L65",
       "id": "storeconfigv2_asstring",
-      "community": 9
+      "community": 13
     },
     {
       "label": "asBoolean()",
@@ -1361,7 +1361,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L69",
       "id": "storeconfigv2_asboolean",
-      "community": 9
+      "community": 13
     },
     {
       "label": "asArray()",
@@ -1369,7 +1369,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L77",
       "id": "storeconfigv2_asarray",
-      "community": 9
+      "community": 13
     },
     {
       "label": "asOptionalArray()",
@@ -1377,7 +1377,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L90",
       "id": "storeconfigv2_asoptionalarray",
-      "community": 9
+      "community": 13
     },
     {
       "label": "firstDefined()",
@@ -1385,7 +1385,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L101",
       "id": "storeconfigv2_firstdefined",
-      "community": 9
+      "community": 13
     },
     {
       "label": "mapPromotion()",
@@ -1393,7 +1393,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L111",
       "id": "storeconfigv2_mappromotion",
-      "community": 9
+      "community": 13
     },
     {
       "label": "mapStreamReel()",
@@ -1401,7 +1401,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L115",
       "id": "storeconfigv2_mapstreamreel",
-      "community": 9
+      "community": 13
     },
     {
       "label": "normalizeWaiveDeliveryFees()",
@@ -1409,7 +1409,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L135",
       "id": "storeconfigv2_normalizewaivedeliveryfees",
-      "community": 9
+      "community": 13
     },
     {
       "label": "cleanUndefined()",
@@ -1417,7 +1417,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L153",
       "id": "storeconfigv2_cleanundefined",
-      "community": 9
+      "community": 13
     },
     {
       "label": "asMtnMomoSetupStatus()",
@@ -1425,7 +1425,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L165",
       "id": "storeconfigv2_asmtnmomosetupstatus",
-      "community": 9
+      "community": 13
     },
     {
       "label": "hasMtnMomoReceivingAccountDetails()",
@@ -1433,7 +1433,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L178",
       "id": "storeconfigv2_hasmtnmomoreceivingaccountdetails",
-      "community": 9
+      "community": 13
     },
     {
       "label": "mapMtnMomoReceivingAccount()",
@@ -1441,7 +1441,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L191",
       "id": "storeconfigv2_mapmtnmomoreceivingaccount",
-      "community": 9
+      "community": 13
     },
     {
       "label": "normalizeMtnMomoReceivingAccounts()",
@@ -1449,7 +1449,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L214",
       "id": "storeconfigv2_normalizemtnmomoreceivingaccounts",
-      "community": 9
+      "community": 13
     },
     {
       "label": "toV2Config()",
@@ -1457,7 +1457,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L231",
       "id": "storeconfigv2_tov2config",
-      "community": 9
+      "community": 13
     },
     {
       "label": "normalizeStoreConfig()",
@@ -1465,7 +1465,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L474",
       "id": "storeconfigv2_normalizestoreconfig",
-      "community": 9
+      "community": 13
     },
     {
       "label": "deepMerge()",
@@ -1473,7 +1473,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L478",
       "id": "storeconfigv2_deepmerge",
-      "community": 9
+      "community": 13
     },
     {
       "label": "patchV2Config()",
@@ -1481,7 +1481,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L498",
       "id": "storeconfigv2_patchv2config",
-      "community": 9
+      "community": 13
     },
     {
       "label": "assignOrDelete()",
@@ -1489,7 +1489,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L507",
       "id": "storeconfigv2_assignordelete",
-      "community": 9
+      "community": 13
     },
     {
       "label": "mirrorLegacyKeys()",
@@ -1497,7 +1497,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L520",
       "id": "storeconfigv2_mirrorlegacykeys",
-      "community": 9
+      "community": 13
     },
     {
       "label": "getUnknownStoreConfigRootKeys()",
@@ -1505,7 +1505,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L591",
       "id": "storeconfigv2_getunknownstoreconfigrootkeys",
-      "community": 9
+      "community": 13
     },
     {
       "label": "isStoreCheckoutDisabled()",
@@ -1513,7 +1513,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L597",
       "id": "storeconfigv2_isstorecheckoutdisabled",
-      "community": 9
+      "community": 13
     },
     {
       "label": "removeLegacyRootKeysFromConfig()",
@@ -1521,7 +1521,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L606",
       "id": "storeconfigv2_removelegacyrootkeysfromconfig",
-      "community": 9
+      "community": 13
     },
     {
       "label": "isLegacyRootKey()",
@@ -1529,7 +1529,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L623",
       "id": "storeconfigv2_islegacyrootkey",
-      "community": 9
+      "community": 13
     },
     {
       "label": "isV2RootKey()",
@@ -1537,7 +1537,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L627",
       "id": "storeconfigv2_isv2rootkey",
-      "community": 9
+      "community": 13
     },
     {
       "label": "toV2OnlyConfig()",
@@ -1545,7 +1545,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/stores.ts",
       "source_location": "L27",
       "id": "stores_tov2onlyconfig",
-      "community": 2
+      "community": 3
     },
     {
       "label": "getDiscountValue()",
@@ -1553,7 +1553,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L17",
       "id": "utils_getdiscountvalue",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getProductDiscountValue()",
@@ -1561,7 +1561,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
       "source_location": "L75",
       "id": "utils_getproductdiscountvalue",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getOrderAmount()",
@@ -1569,7 +1569,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L51",
       "id": "utils_getorderamount",
-      "community": 3
+      "community": 2
     },
     {
       "label": "formatDeliveryAddress()",
@@ -1577,7 +1577,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L74",
       "id": "utils_formatdeliveryaddress",
-      "community": 3
+      "community": 2
     },
     {
       "label": "currency.test.ts",
@@ -1585,7 +1585,7 @@
       "source_file": "packages/athena-webapp/convex/lib/currency.test.ts",
       "source_location": "L1",
       "id": "currency_test",
-      "community": 9
+      "community": 13
     },
     {
       "label": "currency.ts",
@@ -1593,7 +1593,7 @@
       "source_file": "packages/storefront-webapp/src/lib/currency.ts",
       "source_location": "L1",
       "id": "currency",
-      "community": 9
+      "community": 13
     },
     {
       "label": "toPesewas()",
@@ -1601,7 +1601,7 @@
       "source_file": "packages/storefront-webapp/src/lib/currency.ts",
       "source_location": "L1",
       "id": "currency_topesewas",
-      "community": 9
+      "community": 13
     },
     {
       "label": "toDisplayAmount()",
@@ -1609,7 +1609,7 @@
       "source_file": "packages/storefront-webapp/src/lib/currency.ts",
       "source_location": "L5",
       "id": "currency_todisplayamount",
-      "community": 9
+      "community": 13
     },
     {
       "label": "callLlmProvider.ts",
@@ -1617,7 +1617,7 @@
       "source_file": "packages/athena-webapp/convex/llm/callLlmProvider.ts",
       "source_location": "L1",
       "id": "callllmprovider",
-      "community": 2
+      "community": 3
     },
     {
       "label": "callLlmProvider()",
@@ -1625,7 +1625,7 @@
       "source_file": "packages/athena-webapp/convex/llm/callLlmProvider.ts",
       "source_location": "L4",
       "id": "callllmprovider_callllmprovider",
-      "community": 2
+      "community": 3
     },
     {
       "label": "anthropic.ts",
@@ -1633,7 +1633,7 @@
       "source_file": "packages/athena-webapp/convex/llm/providers/anthropic.ts",
       "source_location": "L1",
       "id": "anthropic",
-      "community": 2
+      "community": 3
     },
     {
       "label": "callAnthropic()",
@@ -1641,7 +1641,7 @@
       "source_file": "packages/athena-webapp/convex/llm/providers/anthropic.ts",
       "source_location": "L3",
       "id": "anthropic_callanthropic",
-      "community": 2
+      "community": 3
     },
     {
       "label": "openai.ts",
@@ -1649,7 +1649,7 @@
       "source_file": "packages/athena-webapp/convex/llm/providers/openai.ts",
       "source_location": "L1",
       "id": "openai",
-      "community": 2
+      "community": 3
     },
     {
       "label": "callOpenAi()",
@@ -1657,7 +1657,7 @@
       "source_file": "packages/athena-webapp/convex/llm/providers/openai.ts",
       "source_location": "L3",
       "id": "openai_callopenai",
-      "community": 2
+      "community": 3
     },
     {
       "label": "StoreInsights.tsx",
@@ -1665,7 +1665,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/StoreInsights.tsx",
       "source_location": "L1",
       "id": "storeinsights",
-      "community": 2
+      "community": 3
     },
     {
       "label": "userInsights.ts",
@@ -1673,7 +1673,7 @@
       "source_file": "packages/athena-webapp/convex/llm/userInsights.ts",
       "source_location": "L1",
       "id": "userinsights",
-      "community": 2
+      "community": 3
     },
     {
       "label": "analyticsUtils.ts",
@@ -1681,7 +1681,7 @@
       "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
       "source_location": "L1",
       "id": "analyticsutils",
-      "community": 2
+      "community": 3
     },
     {
       "label": "calculateDeviceDistribution()",
@@ -1689,7 +1689,7 @@
       "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
       "source_location": "L11",
       "id": "analyticsutils_calculatedevicedistribution",
-      "community": 2
+      "community": 3
     },
     {
       "label": "calculateActivityTrend()",
@@ -1697,7 +1697,7 @@
       "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
       "source_location": "L43",
       "id": "analyticsutils_calculateactivitytrend",
-      "community": 2
+      "community": 3
     },
     {
       "label": "sendVerificationCode()",
@@ -1705,7 +1705,7 @@
       "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L3",
       "id": "index_sendverificationcode",
-      "community": 11
+      "community": 1
     },
     {
       "label": "sendOrderEmail()",
@@ -1713,7 +1713,7 @@
       "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L43",
       "id": "index_sendorderemail",
-      "community": 11
+      "community": 1
     },
     {
       "label": "sendNewOrderEmail()",
@@ -1721,7 +1721,7 @@
       "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L117",
       "id": "index_sendneworderemail",
-      "community": 11
+      "community": 1
     },
     {
       "label": "sendFeedbackRequestEmail()",
@@ -1729,7 +1729,7 @@
       "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L167",
       "id": "index_sendfeedbackrequestemail",
-      "community": 11
+      "community": 1
     },
     {
       "label": "sendDiscountCodeEmail()",
@@ -1737,7 +1737,7 @@
       "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L255",
       "id": "index_senddiscountcodeemail",
-      "community": 11
+      "community": 1
     },
     {
       "label": "sendDiscountReminderEmail()",
@@ -1745,7 +1745,7 @@
       "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L334",
       "id": "index_senddiscountreminderemail",
-      "community": 11
+      "community": 1
     },
     {
       "label": "migrateAmountsToPesewas.ts",
@@ -1753,7 +1753,7 @@
       "source_file": "packages/athena-webapp/convex/migrations/migrateAmountsToPesewas.ts",
       "source_location": "L1",
       "id": "migrateamountstopesewas",
-      "community": 9
+      "community": 13
     },
     {
       "label": "client.test.ts",
@@ -1761,7 +1761,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.test.ts",
       "source_location": "L1",
       "id": "client_test",
-      "community": 10
+      "community": 8
     },
     {
       "label": "client.tsx",
@@ -1769,7 +1769,7 @@
       "source_file": "packages/storefront-webapp/src/client.tsx",
       "source_location": "L1",
       "id": "client",
-      "community": 10
+      "community": 8
     },
     {
       "label": "encodeBasicAuth()",
@@ -1777,7 +1777,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L9",
       "id": "client_encodebasicauth",
-      "community": 10
+      "community": 8
     },
     {
       "label": "toError()",
@@ -1785,7 +1785,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L13",
       "id": "client_toerror",
-      "community": 10
+      "community": 8
     },
     {
       "label": "buildHeaders()",
@@ -1793,7 +1793,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L20",
       "id": "client_buildheaders",
-      "community": 10
+      "community": 8
     },
     {
       "label": "createCollectionsAccessToken()",
@@ -1801,7 +1801,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L30",
       "id": "client_createcollectionsaccesstoken",
-      "community": 10
+      "community": 8
     },
     {
       "label": "requestToPay()",
@@ -1809,7 +1809,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L65",
       "id": "client_requesttopay",
-      "community": 10
+      "community": 8
     },
     {
       "label": "getRequestToPayStatus()",
@@ -1817,7 +1817,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L115",
       "id": "client_getrequesttopaystatus",
-      "community": 10
+      "community": 8
     },
     {
       "label": "collections.ts",
@@ -1825,7 +1825,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
       "source_location": "L1",
       "id": "collections",
-      "community": 2
+      "community": 3
     },
     {
       "label": "getCachedTokenRecord()",
@@ -1833,7 +1833,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
       "source_location": "L26",
       "id": "collections_getcachedtokenrecord",
-      "community": 2
+      "community": 3
     },
     {
       "label": "resolveConfigForStore()",
@@ -1841,7 +1841,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
       "source_location": "L33",
       "id": "collections_resolveconfigforstore",
-      "community": 2
+      "community": 3
     },
     {
       "label": "resolveAccessTokenForStore()",
@@ -1849,7 +1849,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
       "source_location": "L79",
       "id": "collections_resolveaccesstokenforstore",
-      "community": 2
+      "community": 3
     },
     {
       "label": "config.test.ts",
@@ -1857,7 +1857,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.test.ts",
       "source_location": "L1",
       "id": "config_test",
-      "community": 2
+      "community": 3
     },
     {
       "label": "config.ts",
@@ -1865,7 +1865,7 @@
       "source_file": "packages/storefront-webapp/src/config.ts",
       "source_location": "L1",
       "id": "config",
-      "community": 2
+      "community": 3
     },
     {
       "label": "toEnvSegment()",
@@ -1873,7 +1873,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L29",
       "id": "config_toenvsegment",
-      "community": 2
+      "community": 3
     },
     {
       "label": "buildMtnCollectionsLookupPrefixes()",
@@ -1881,7 +1881,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L43",
       "id": "config_buildmtncollectionslookupprefixes",
-      "community": 2
+      "community": 3
     },
     {
       "label": "readScopedValue()",
@@ -1889,7 +1889,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L56",
       "id": "config_readscopedvalue",
-      "community": 2
+      "community": 3
     },
     {
       "label": "isTargetEnvironment()",
@@ -1897,7 +1897,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L67",
       "id": "config_istargetenvironment",
-      "community": 2
+      "community": 3
     },
     {
       "label": "resolveConfigForPrefix()",
@@ -1905,7 +1905,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L73",
       "id": "config_resolveconfigforprefix",
-      "community": 2
+      "community": 3
     },
     {
       "label": "resolveMtnCollectionsConfigFromEnv()",
@@ -1913,7 +1913,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L108",
       "id": "config_resolvemtncollectionsconfigfromenv",
-      "community": 2
+      "community": 3
     },
     {
       "label": "buildMtnCollectionsCallbackUrl()",
@@ -1921,7 +1921,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L135",
       "id": "config_buildmtncollectionscallbackurl",
-      "community": 2
+      "community": 3
     },
     {
       "label": "foundation.test.ts",
@@ -1945,7 +1945,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/normalize.test.ts",
       "source_location": "L1",
       "id": "normalize_test",
-      "community": 2
+      "community": 3
     },
     {
       "label": "normalize.ts",
@@ -1953,7 +1953,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
       "source_location": "L1",
       "id": "normalize",
-      "community": 2
+      "community": 3
     },
     {
       "label": "maskMtnPartyId()",
@@ -1961,7 +1961,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
       "source_location": "L10",
       "id": "normalize_maskmtnpartyid",
-      "community": 2
+      "community": 3
     },
     {
       "label": "normalizeCollectionsTransaction()",
@@ -1969,7 +1969,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
       "source_location": "L18",
       "id": "normalize_normalizecollectionstransaction",
-      "community": 2
+      "community": 3
     },
     {
       "label": "parseCollectionsNotificationRequest()",
@@ -1977,7 +1977,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
       "source_location": "L52",
       "id": "normalize_parsecollectionsnotificationrequest",
-      "community": 2
+      "community": 3
     },
     {
       "label": "types.ts",
@@ -1985,7 +1985,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/types.ts",
       "source_location": "L1",
       "id": "types",
-      "community": 1
+      "community": 4
     },
     {
       "label": "ResendOTP.ts",
@@ -1993,7 +1993,7 @@
       "source_file": "packages/athena-webapp/convex/otp/ResendOTP.ts",
       "source_location": "L1",
       "id": "resendotp",
-      "community": 22
+      "community": 6
     },
     {
       "label": "VerificationCodeEmail.tsx",
@@ -2001,7 +2001,7 @@
       "source_file": "packages/athena-webapp/convex/otp/VerificationCodeEmail.tsx",
       "source_location": "L1",
       "id": "verificationcodeemail",
-      "community": 22
+      "community": 6
     },
     {
       "label": "VerificationCodeEmail()",
@@ -2009,7 +2009,7 @@
       "source_file": "packages/athena-webapp/convex/otp/VerificationCodeEmail.tsx",
       "source_location": "L11",
       "id": "verificationcodeemail_verificationcodeemail",
-      "community": 22
+      "community": 6
     },
     {
       "label": "listTransactions()",
@@ -2017,7 +2017,7 @@
       "source_file": "packages/athena-webapp/convex/paystack/index.ts",
       "source_location": "L7",
       "id": "index_listtransactions",
-      "community": 11
+      "community": 1
     },
     {
       "label": "verifyTransaction()",
@@ -2025,7 +2025,7 @@
       "source_file": "packages/athena-webapp/convex/paystack/index.ts",
       "source_location": "L109",
       "id": "index_verifytransaction",
-      "community": 11
+      "community": 1
     },
     {
       "label": "schema.ts",
@@ -2033,7 +2033,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/schema.ts",
       "source_location": "L1",
       "id": "schema",
-      "community": 2
+      "community": 3
     },
     {
       "label": "appVerificationCode.ts",
@@ -2049,7 +2049,7 @@
       "source_file": "packages/storefront-webapp/src/lib/schemas/category.ts",
       "source_location": "L1",
       "id": "category",
-      "community": 2
+      "community": 3
     },
     {
       "label": "color.ts",
@@ -2057,7 +2057,7 @@
       "source_file": "packages/storefront-webapp/src/api/color.ts",
       "source_location": "L1",
       "id": "color",
-      "community": 15
+      "community": 12
     },
     {
       "label": "organization.ts",
@@ -2065,7 +2065,7 @@
       "source_file": "packages/storefront-webapp/src/lib/schemas/organization.ts",
       "source_location": "L1",
       "id": "organization",
-      "community": 2
+      "community": 3
     },
     {
       "label": "organizationMember.ts",
@@ -2081,7 +2081,7 @@
       "source_file": "packages/storefront-webapp/src/lib/schemas/product.ts",
       "source_location": "L1",
       "id": "product",
-      "community": 15
+      "community": 12
     },
     {
       "label": "redeemedPromoCode.ts",
@@ -2097,7 +2097,7 @@
       "source_file": "packages/storefront-webapp/src/lib/schemas/store.ts",
       "source_location": "L1",
       "id": "store",
-      "community": 2
+      "community": 3
     },
     {
       "label": "subcategory.ts",
@@ -2105,7 +2105,7 @@
       "source_file": "packages/storefront-webapp/src/lib/schemas/subcategory.ts",
       "source_location": "L1",
       "id": "subcategory",
-      "community": 2
+      "community": 3
     },
     {
       "label": "mtnCollections.ts",
@@ -2113,7 +2113,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/payments/mtnCollections.ts",
       "source_location": "L1",
       "id": "mtncollections",
-      "community": 2
+      "community": 3
     },
     {
       "label": "customer.ts",
@@ -2161,7 +2161,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/pos/posSession.ts",
       "source_location": "L1",
       "id": "possession",
-      "community": 2
+      "community": 3
     },
     {
       "label": "posSessionItem.ts",
@@ -2193,7 +2193,7 @@
       "source_file": "packages/storefront-webapp/src/lib/schemas/bagItem.ts",
       "source_location": "L1",
       "id": "bagitem",
-      "community": 7
+      "community": 15
     },
     {
       "label": "checkoutSession.ts",
@@ -2201,7 +2201,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L1",
       "id": "checkoutsession",
-      "community": 10
+      "community": 8
     },
     {
       "label": "checkoutSessionItem.ts",
@@ -2225,7 +2225,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderItem.ts",
       "source_location": "L1",
       "id": "onlineorderitem",
-      "community": 2
+      "community": 3
     },
     {
       "label": "review.tsx",
@@ -2233,7 +2233,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
       "source_location": "L1",
       "id": "review",
-      "community": 1
+      "community": 0
     },
     {
       "label": "savedBagItem.ts",
@@ -2241,7 +2241,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/savedBagItem.ts",
       "source_location": "L1",
       "id": "savedbagitem",
-      "community": 2
+      "community": 3
     },
     {
       "label": "storeFrontSession.ts",
@@ -2273,7 +2273,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/supportTicket.ts",
       "source_location": "L1",
       "id": "supportticket",
-      "community": 2
+      "community": 3
     },
     {
       "label": "orderEmailService.ts",
@@ -2281,7 +2281,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L1",
       "id": "orderemailservice",
-      "community": 9
+      "community": 3
     },
     {
       "label": "shouldSendToAdmins()",
@@ -2289,7 +2289,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L42",
       "id": "orderemailservice_shouldsendtoadmins",
-      "community": 9
+      "community": 3
     },
     {
       "label": "buildOrderStatusMessage()",
@@ -2297,7 +2297,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L49",
       "id": "orderemailservice_buildorderstatusmessage",
-      "community": 9
+      "community": 3
     },
     {
       "label": "buildPickupDetails()",
@@ -2305,7 +2305,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L77",
       "id": "orderemailservice_buildpickupdetails",
-      "community": 9
+      "community": 3
     },
     {
       "label": "sendPODOrderEmails()",
@@ -2313,7 +2313,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L96",
       "id": "orderemailservice_sendpodorderemails",
-      "community": 9
+      "community": 3
     },
     {
       "label": "sendPaymentVerificationEmails()",
@@ -2321,7 +2321,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L217",
       "id": "orderemailservice_sendpaymentverificationemails",
-      "community": 9
+      "community": 3
     },
     {
       "label": "paystackService.ts",
@@ -2329,7 +2329,7 @@
       "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
       "source_location": "L1",
       "id": "paystackservice",
-      "community": 2
+      "community": 3
     },
     {
       "label": "getPaystackHeaders()",
@@ -2337,7 +2337,7 @@
       "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
       "source_location": "L11",
       "id": "paystackservice_getpaystackheaders",
-      "community": 2
+      "community": 3
     },
     {
       "label": "initializeTransaction()",
@@ -2345,7 +2345,7 @@
       "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
       "source_location": "L21",
       "id": "paystackservice_initializetransaction",
-      "community": 2
+      "community": 3
     },
     {
       "label": "verifyTransaction()",
@@ -2353,7 +2353,7 @@
       "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
       "source_location": "L65",
       "id": "paystackservice_verifytransaction",
-      "community": 2
+      "community": 3
     },
     {
       "label": "initiateRefund()",
@@ -2361,7 +2361,7 @@
       "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
       "source_location": "L87",
       "id": "paystackservice_initiaterefund",
-      "community": 2
+      "community": 3
     },
     {
       "label": "extractPromoCodeId()",
@@ -2369,7 +2369,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L18",
       "id": "analytics_extractpromocodeid",
-      "community": 15
+      "community": 17
     },
     {
       "label": "getAnalyticsByStoreQuery()",
@@ -2377,7 +2377,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L28",
       "id": "analytics_getanalyticsbystorequery",
-      "community": 15
+      "community": 17
     },
     {
       "label": "getCompletedOrdersQuery()",
@@ -2385,7 +2385,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L59",
       "id": "analytics_getcompletedordersquery",
-      "community": 15
+      "community": 17
     },
     {
       "label": "getAnalyticsByStoreAndActionQuery()",
@@ -2393,7 +2393,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L97",
       "id": "analytics_getanalyticsbystoreandactionquery",
-      "community": 15
+      "community": 17
     },
     {
       "label": "getSkuMapForProducts()",
@@ -2401,7 +2401,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L132",
       "id": "analytics_getskumapforproducts",
-      "community": 15
+      "community": 17
     },
     {
       "label": "getStoreFrontActorById()",
@@ -2409,7 +2409,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/auth.ts",
       "source_location": "L15",
       "id": "auth_getstorefrontactorbyid",
-      "community": 2
+      "community": 3
     },
     {
       "label": "listSessionItems()",
@@ -2417,7 +2417,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L40",
       "id": "checkoutsession_listsessionitems",
-      "community": 10
+      "community": 8
     },
     {
       "label": "checkIfItemsHaveChanged()",
@@ -2425,7 +2425,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L50",
       "id": "checkoutsession_checkifitemshavechanged",
-      "community": 10
+      "community": 8
     },
     {
       "label": "createPatchObject()",
@@ -2433,7 +2433,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L651",
       "id": "checkoutsession_createpatchobject",
-      "community": 10
+      "community": 8
     },
     {
       "label": "handlePlaceOrder()",
@@ -2441,7 +2441,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L698",
       "id": "checkoutsession_handleplaceorder",
-      "community": 10
+      "community": 8
     },
     {
       "label": "handleOrderCreation()",
@@ -2449,7 +2449,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L734",
       "id": "checkoutsession_handleordercreation",
-      "community": 10
+      "community": 8
     },
     {
       "label": "createOnlineOrder()",
@@ -2457,7 +2457,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L765",
       "id": "checkoutsession_createonlineorder",
-      "community": 10
+      "community": 8
     },
     {
       "label": "retrieveActiveCheckoutSession()",
@@ -2465,7 +2465,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L951",
       "id": "checkoutsession_retrieveactivecheckoutsession",
-      "community": 10
+      "community": 8
     },
     {
       "label": "fetchProductSkus()",
@@ -2473,7 +2473,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L979",
       "id": "checkoutsession_fetchproductskus",
-      "community": 10
+      "community": 8
     },
     {
       "label": "checkAdjustedAvailability()",
@@ -2481,7 +2481,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L990",
       "id": "checkoutsession_checkadjustedavailability",
-      "community": 10
+      "community": 8
     },
     {
       "label": "updateExistingSession()",
@@ -2489,7 +2489,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1020",
       "id": "checkoutsession_updateexistingsession",
-      "community": 10
+      "community": 8
     },
     {
       "label": "createSessionItems()",
@@ -2497,7 +2497,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1102",
       "id": "checkoutsession_createsessionitems",
-      "community": 10
+      "community": 8
     },
     {
       "label": "updateProductAvailability()",
@@ -2505,7 +2505,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1123",
       "id": "checkoutsession_updateproductavailability",
-      "community": 10
+      "community": 8
     },
     {
       "label": "updateAvailability()",
@@ -2513,7 +2513,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1140",
       "id": "checkoutsession_updateavailability",
-      "community": 10
+      "community": 8
     },
     {
       "label": "handleExistingSession()",
@@ -2521,7 +2521,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1161",
       "id": "checkoutsession_handleexistingsession",
-      "community": 10
+      "community": 8
     },
     {
       "label": "validateExistingDiscount()",
@@ -2529,7 +2529,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1321",
       "id": "checkoutsession_validateexistingdiscount",
-      "community": 10
+      "community": 8
     },
     {
       "label": "calculatePromoCodeValue()",
@@ -2537,7 +2537,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1447",
       "id": "checkoutsession_calculatepromocodevalue",
-      "community": 10
+      "community": 8
     },
     {
       "label": "findBestValuePromoCode()",
@@ -2545,7 +2545,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1495",
       "id": "checkoutsession_findbestvaluepromocode",
-      "community": 10
+      "community": 8
     },
     {
       "label": "commerceQueryIndexes.test.ts",
@@ -2553,7 +2553,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
       "source_location": "L1",
       "id": "commercequeryindexes_test",
-      "community": 2
+      "community": 3
     },
     {
       "label": "getTableIndexes()",
@@ -2561,7 +2561,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
       "source_location": "L12",
       "id": "commercequeryindexes_test_gettableindexes",
-      "community": 2
+      "community": 3
     },
     {
       "label": "expectIndex()",
@@ -2569,7 +2569,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
       "source_location": "L19",
       "id": "commercequeryindexes_test_expectindex",
-      "community": 2
+      "community": 3
     },
     {
       "label": "getSource()",
@@ -2577,7 +2577,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
       "source_location": "L26",
       "id": "commercequeryindexes_test_getsource",
-      "community": 2
+      "community": 3
     },
     {
       "label": "CustomerBehaviorTimeline.tsx",
@@ -2585,7 +2585,7 @@
       "source_file": "packages/athena-webapp/src/components/users/CustomerBehaviorTimeline.tsx",
       "source_location": "L1",
       "id": "customerbehaviortimeline",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getTimeFilterForRange()",
@@ -2593,7 +2593,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
       "source_location": "L11",
       "id": "customerbehaviortimeline_gettimefilterforrange",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getCustomerAnalyticsQuery()",
@@ -2601,7 +2601,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
       "source_location": "L26",
       "id": "customerbehaviortimeline_getcustomeranalyticsquery",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getTimelineUserData()",
@@ -2609,7 +2609,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
       "source_location": "L42",
       "id": "customerbehaviortimeline_gettimelineuserdata",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getProductInfoMaps()",
@@ -2617,7 +2617,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
       "source_location": "L66",
       "id": "customerbehaviortimeline_getproductinfomaps",
-      "community": 3
+      "community": 2
     },
     {
       "label": "customerObservabilityTimeline.test.ts",
@@ -2625,7 +2625,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimeline.test.ts",
       "source_location": "L1",
       "id": "customerobservabilitytimeline_test",
-      "community": 15
+      "community": 17
     },
     {
       "label": "createAnalyticsEvent()",
@@ -2633,7 +2633,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimeline.test.ts",
       "source_location": "L17",
       "id": "customerobservabilitytimeline_test_createanalyticsevent",
-      "community": 15
+      "community": 17
     },
     {
       "label": "customerObservabilityTimelineData.ts",
@@ -2641,7 +2641,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L1",
       "id": "customerobservabilitytimelinedata",
-      "community": 15
+      "community": 17
     },
     {
       "label": "getNonEmptyString()",
@@ -2649,7 +2649,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L64",
       "id": "customerobservabilitytimelinedata_getnonemptystring",
-      "community": 15
+      "community": 17
     },
     {
       "label": "isFailureStatus()",
@@ -2657,7 +2657,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L68",
       "id": "customerobservabilitytimelinedata_isfailurestatus",
-      "community": 15
+      "community": 17
     },
     {
       "label": "normalizeEvent()",
@@ -2665,7 +2665,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L72",
       "id": "customerobservabilitytimelinedata_normalizeevent",
-      "community": 15
+      "community": 17
     },
     {
       "label": "buildCustomerObservabilityTimeline()",
@@ -2673,7 +2673,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L118",
       "id": "customerobservabilitytimelinedata_buildcustomerobservabilitytimeline",
-      "community": 15
+      "community": 17
     },
     {
       "label": "helperOrchestration.test.ts",
@@ -2697,7 +2697,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/bag.ts",
       "source_location": "L7",
       "id": "bag_listbagitems",
-      "community": 7
+      "community": 15
     },
     {
       "label": "loadBagWithItems()",
@@ -2705,7 +2705,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/bag.ts",
       "source_location": "L14",
       "id": "bag_loadbagwithitems",
-      "community": 7
+      "community": 15
     },
     {
       "label": "generateOrderNumber()",
@@ -2713,7 +2713,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
       "source_location": "L8",
       "id": "onlineorder_generateordernumber",
-      "community": 2
+      "community": 3
     },
     {
       "label": "findOrderByExternalReference()",
@@ -2721,7 +2721,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
       "source_location": "L15",
       "id": "onlineorder_findorderbyexternalreference",
-      "community": 2
+      "community": 3
     },
     {
       "label": "clearBagItems()",
@@ -2729,7 +2729,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
       "source_location": "L27",
       "id": "onlineorder_clearbagitems",
-      "community": 2
+      "community": 3
     },
     {
       "label": "returnOrderItemsToStock()",
@@ -2737,7 +2737,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
       "source_location": "L39",
       "id": "onlineorder_returnorderitemstostock",
-      "community": 2
+      "community": 3
     },
     {
       "label": "createOrderFromCheckoutSession()",
@@ -2745,7 +2745,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
       "source_location": "L75",
       "id": "onlineorder_createorderfromcheckoutsession",
-      "community": 2
+      "community": 3
     },
     {
       "label": "orderUpdateEmails.ts",
@@ -2753,7 +2753,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L1",
       "id": "orderupdateemails",
-      "community": 9
+      "community": 3
     },
     {
       "label": "getPickupLocation()",
@@ -2761,7 +2761,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L52",
       "id": "orderupdateemails_getpickuplocation",
-      "community": 9
+      "community": 3
     },
     {
       "label": "getDeliveryAddress()",
@@ -2769,7 +2769,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L55",
       "id": "orderupdateemails_getdeliveryaddress",
-      "community": 9
+      "community": 3
     },
     {
       "label": "getLocationDetails()",
@@ -2777,7 +2777,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L58",
       "id": "orderupdateemails_getlocationdetails",
-      "community": 9
+      "community": 3
     },
     {
       "label": "formatOrderItems()",
@@ -2785,7 +2785,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L64",
       "id": "orderupdateemails_formatorderitems",
-      "community": 9
+      "community": 3
     },
     {
       "label": "handleOrderStatusUpdate()",
@@ -2793,7 +2793,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L118",
       "id": "orderupdateemails_handleorderstatusupdate",
-      "community": 9
+      "community": 3
     },
     {
       "label": "processOrderUpdateEmail()",
@@ -2801,7 +2801,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L293",
       "id": "orderupdateemails_processorderupdateemail",
-      "community": 9
+      "community": 3
     },
     {
       "label": "paymentHelpers.ts",
@@ -2809,7 +2809,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
       "source_location": "L1",
       "id": "paymenthelpers",
-      "community": 2
+      "community": 3
     },
     {
       "label": "generatePODReference()",
@@ -2817,7 +2817,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
       "source_location": "L9",
       "id": "paymenthelpers_generatepodreference",
-      "community": 2
+      "community": 3
     },
     {
       "label": "extractOrderItems()",
@@ -2825,7 +2825,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
       "source_location": "L18",
       "id": "paymenthelpers_extractorderitems",
-      "community": 2
+      "community": 3
     },
     {
       "label": "calculateOrderAmount()",
@@ -2833,7 +2833,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
       "source_location": "L35",
       "id": "paymenthelpers_calculateorderamount",
-      "community": 2
+      "community": 3
     },
     {
       "label": "calculateRewardPoints()",
@@ -2841,7 +2841,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
       "source_location": "L53",
       "id": "paymenthelpers_calculaterewardpoints",
-      "community": 2
+      "community": 3
     },
     {
       "label": "validatePaymentAmount()",
@@ -2849,7 +2849,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
       "source_location": "L61",
       "id": "paymenthelpers_validatepaymentamount",
-      "community": 2
+      "community": 3
     },
     {
       "label": "getOrderDiscountValue()",
@@ -2857,7 +2857,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
       "source_location": "L75",
       "id": "paymenthelpers_getorderdiscountvalue",
-      "community": 2
+      "community": 3
     },
     {
       "label": "isDuplicate()",
@@ -2865,7 +2865,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
       "source_location": "L36",
       "id": "offers_isduplicate",
-      "community": 2
+      "community": 6
     },
     {
       "label": "updateStoreFrontActorEmail()",
@@ -2873,7 +2873,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
       "source_location": "L59",
       "id": "offers_updatestorefrontactoremail",
-      "community": 2
+      "community": 6
     },
     {
       "label": "createOffer()",
@@ -2881,7 +2881,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
       "source_location": "L88",
       "id": "offers_createoffer",
-      "community": 2
+      "community": 6
     },
     {
       "label": "getUpsellProducts()",
@@ -2889,7 +2889,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
       "source_location": "L685",
       "id": "offers_getupsellproducts",
-      "community": 2
+      "community": 6
     },
     {
       "label": "listOrderItems()",
@@ -2897,7 +2897,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
       "source_location": "L27",
       "id": "onlineorder_listorderitems",
-      "community": 2
+      "community": 3
     },
     {
       "label": "updateOnlineOrderItem()",
@@ -2905,7 +2905,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderItem.ts",
       "source_location": "L21",
       "id": "onlineorderitem_updateonlineorderitem",
-      "community": 2
+      "community": 3
     },
     {
       "label": "onlineOrderUtilFns.ts",
@@ -2913,7 +2913,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderUtilFns.ts",
       "source_location": "L1",
       "id": "onlineorderutilfns",
-      "community": 9
+      "community": 3
     },
     {
       "label": "paystackActions.ts",
@@ -2921,7 +2921,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/paystackActions.ts",
       "source_location": "L1",
       "id": "paystackactions",
-      "community": 2
+      "community": 3
     },
     {
       "label": "getStoreFrontActorById()",
@@ -2929,7 +2929,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/reviews.ts",
       "source_location": "L17",
       "id": "reviews_getstorefrontactorbyid",
-      "community": 6
+      "community": 12
     },
     {
       "label": "listSavedBagItems()",
@@ -2937,7 +2937,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/savedBag.ts",
       "source_location": "L14",
       "id": "savedbag_listsavedbagitems",
-      "community": 7
+      "community": 15
     },
     {
       "label": "storefrontObservabilityReport.test.ts",
@@ -2945,7 +2945,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.test.ts",
       "source_location": "L1",
       "id": "storefrontobservabilityreport_test",
-      "community": 15
+      "community": 17
     },
     {
       "label": "createAnalyticsEvent()",
@@ -2953,7 +2953,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.test.ts",
       "source_location": "L7",
       "id": "storefrontobservabilityreport_test_createanalyticsevent",
-      "community": 15
+      "community": 17
     },
     {
       "label": "storefrontObservabilityReport.ts",
@@ -2961,7 +2961,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
       "source_location": "L1",
       "id": "storefrontobservabilityreport",
-      "community": 15
+      "community": 17
     },
     {
       "label": "getNonEmptyString()",
@@ -2969,7 +2969,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
       "source_location": "L59",
       "id": "storefrontobservabilityreport_getnonemptystring",
-      "community": 15
+      "community": 17
     },
     {
       "label": "normalizeStorefrontObservabilityEvent()",
@@ -2977,7 +2977,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
       "source_location": "L63",
       "id": "storefrontobservabilityreport_normalizestorefrontobservabilityevent",
-      "community": 15
+      "community": 17
     },
     {
       "label": "buildStorefrontObservabilityReport()",
@@ -2985,7 +2985,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
       "source_location": "L95",
       "id": "storefrontobservabilityreport_buildstorefrontobservabilityreport",
-      "community": 15
+      "community": 17
     },
     {
       "label": "timeQueryRefactors.test.ts",
@@ -3009,7 +3009,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/user.ts",
       "source_location": "L15",
       "id": "user_getstorefrontactorbyid",
-      "community": 2
+      "community": 3
     },
     {
       "label": "determineOfferEligibility()",
@@ -3017,7 +3017,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/userOffers.ts",
       "source_location": "L30",
       "id": "useroffers_determineoffereligibility",
-      "community": 2
+      "community": 6
     },
     {
       "label": "users.ts",
@@ -3025,7 +3025,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/users.ts",
       "source_location": "L1",
       "id": "users",
-      "community": 2
+      "community": 3
     },
     {
       "label": "toSlug()",
@@ -3033,7 +3033,7 @@
       "source_file": "packages/athena-webapp/src/lib/utils.ts",
       "source_location": "L37",
       "id": "utils_toslug",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getAddressString()",
@@ -3041,7 +3041,7 @@
       "source_file": "packages/athena-webapp/convex/utils.ts",
       "source_location": "L14",
       "id": "utils_getaddressstring",
-      "community": 3
+      "community": 2
     },
     {
       "label": "capitalizeWords()",
@@ -3049,7 +3049,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L23",
       "id": "utils_capitalizewords",
-      "community": 3
+      "community": 2
     },
     {
       "label": "currencyFormatter()",
@@ -3057,7 +3057,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L35",
       "id": "utils_currencyformatter",
-      "community": 3
+      "community": 2
     },
     {
       "label": "formatDate()",
@@ -3065,7 +3065,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L44",
       "id": "utils_formatdate",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getProductName()",
@@ -3073,7 +3073,7 @@
       "source_file": "packages/athena-webapp/convex/utils.ts",
       "source_location": "L64",
       "id": "utils_getproductname",
-      "community": 3
+      "community": 2
     },
     {
       "label": "generateTransactionNumber()",
@@ -3081,7 +3081,7 @@
       "source_file": "packages/athena-webapp/convex/utils.ts",
       "source_location": "L77",
       "id": "utils_generatetransactionnumber",
-      "community": 3
+      "community": 2
     },
     {
       "label": "eslint.config.js",
@@ -3113,7 +3113,7 @@
       "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
       "source_location": "L1",
       "id": "navbar",
-      "community": 0
+      "community": 1
     },
     {
       "label": "SettingsHeader()",
@@ -3121,7 +3121,7 @@
       "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
       "source_location": "L20",
       "id": "navbar_settingsheader",
-      "community": 0
+      "community": 1
     },
     {
       "label": "AppHeader()",
@@ -3129,7 +3129,7 @@
       "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
       "source_location": "L61",
       "id": "navbar_appheader",
-      "community": 0
+      "community": 1
     },
     {
       "label": "Header()",
@@ -3137,7 +3137,7 @@
       "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
       "source_location": "L75",
       "id": "navbar_header",
-      "community": 0
+      "community": 1
     },
     {
       "label": "Navbar()",
@@ -3145,7 +3145,7 @@
       "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
       "source_location": "L116",
       "id": "navbar_navbar",
-      "community": 0
+      "community": 1
     },
     {
       "label": "OrganizationView.tsx",
@@ -3153,7 +3153,7 @@
       "source_file": "packages/athena-webapp/src/components/OrganizationView.tsx",
       "source_location": "L1",
       "id": "organizationview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "Navigation()",
@@ -3161,7 +3161,7 @@
       "source_file": "packages/athena-webapp/src/components/OrganizationView.tsx",
       "source_location": "L7",
       "id": "organizationview_navigation",
-      "community": 0
+      "community": 1
     },
     {
       "label": "OrganizationsView.tsx",
@@ -3169,7 +3169,7 @@
       "source_file": "packages/athena-webapp/src/components/OrganizationsView.tsx",
       "source_location": "L1",
       "id": "organizationsview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "Navigation()",
@@ -3177,7 +3177,7 @@
       "source_file": "packages/athena-webapp/src/components/OrganizationsView.tsx",
       "source_location": "L12",
       "id": "organizationsview_navigation",
-      "community": 0
+      "community": 1
     },
     {
       "label": "PermissionGate.tsx",
@@ -3185,7 +3185,7 @@
       "source_file": "packages/athena-webapp/src/components/PermissionGate.tsx",
       "source_location": "L1",
       "id": "permissiongate",
-      "community": 0
+      "community": 1
     },
     {
       "label": "PermissionGate()",
@@ -3193,7 +3193,7 @@
       "source_file": "packages/athena-webapp/src/components/PermissionGate.tsx",
       "source_location": "L11",
       "id": "permissiongate_permissiongate",
-      "community": 0
+      "community": 1
     },
     {
       "label": "ProtectedRoute.tsx",
@@ -3201,7 +3201,7 @@
       "source_file": "packages/athena-webapp/src/components/ProtectedRoute.tsx",
       "source_location": "L1",
       "id": "protectedroute",
-      "community": 8
+      "community": 7
     },
     {
       "label": "ProtectedRoute()",
@@ -3209,7 +3209,7 @@
       "source_file": "packages/athena-webapp/src/components/ProtectedRoute.tsx",
       "source_location": "L11",
       "id": "protectedroute_protectedroute",
-      "community": 8
+      "community": 7
     },
     {
       "label": "SettingsView.tsx",
@@ -3217,7 +3217,7 @@
       "source_file": "packages/athena-webapp/src/components/SettingsView.tsx",
       "source_location": "L1",
       "id": "settingsview",
-      "community": 11
+      "community": 1
     },
     {
       "label": "SettingsView()",
@@ -3225,7 +3225,7 @@
       "source_file": "packages/athena-webapp/src/components/SettingsView.tsx",
       "source_location": "L3",
       "id": "settingsview_settingsview",
-      "community": 11
+      "community": 1
     },
     {
       "label": "StoreAccordion.tsx",
@@ -3273,7 +3273,7 @@
       "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
       "source_location": "L1",
       "id": "storeview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "Navigation()",
@@ -3281,7 +3281,7 @@
       "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
       "source_location": "L13",
       "id": "storeview_navigation",
-      "community": 0
+      "community": 1
     },
     {
       "label": "StoresAccordion.tsx",
@@ -3321,7 +3321,7 @@
       "source_file": "packages/storefront-webapp/src/components/View.tsx",
       "source_location": "L1",
       "id": "view",
-      "community": 0
+      "community": 1
     },
     {
       "label": "View()",
@@ -3329,7 +3329,7 @@
       "source_file": "packages/storefront-webapp/src/components/View.tsx",
       "source_location": "L4",
       "id": "view_view",
-      "community": 0
+      "community": 1
     },
     {
       "label": "AttributesManager.tsx",
@@ -3337,7 +3337,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
       "source_location": "L1",
       "id": "attributesmanager",
-      "community": 0
+      "community": 5
     },
     {
       "label": "Sidebar()",
@@ -3345,7 +3345,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
       "source_location": "L26",
       "id": "attributesmanager_sidebar",
-      "community": 0
+      "community": 5
     },
     {
       "label": "ColorManager()",
@@ -3353,7 +3353,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
       "source_location": "L45",
       "id": "attributesmanager_colormanager",
-      "community": 0
+      "community": 5
     },
     {
       "label": "AttributesManager()",
@@ -3361,7 +3361,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
       "source_location": "L228",
       "id": "attributesmanager_attributesmanager",
-      "community": 0
+      "community": 5
     },
     {
       "label": "AttributesTable.tsx",
@@ -3369,7 +3369,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
       "source_location": "L1",
       "id": "attributestable",
-      "community": 9
+      "community": 1
     },
     {
       "label": "handleChange()",
@@ -3377,7 +3377,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
       "source_location": "L32",
       "id": "attributestable_handlechange",
-      "community": 9
+      "community": 1
     },
     {
       "label": "getProductAttribute()",
@@ -3385,7 +3385,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
       "source_location": "L55",
       "id": "attributestable_getproductattribute",
-      "community": 9
+      "community": 1
     },
     {
       "label": "onSubmit()",
@@ -3393,7 +3393,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
       "source_location": "L210",
       "id": "attributestable_onsubmit",
-      "community": 9
+      "community": 1
     },
     {
       "label": "BarcodeQRViewer.tsx",
@@ -3401,7 +3401,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/BarcodeQRViewer.tsx",
       "source_location": "L1",
       "id": "barcodeqrviewer",
-      "community": 6
+      "community": 9
     },
     {
       "label": "handlePrint()",
@@ -3409,7 +3409,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/BarcodeQRViewer.tsx",
       "source_location": "L31",
       "id": "barcodeqrviewer_handleprint",
-      "community": 6
+      "community": 9
     },
     {
       "label": "CategorySubcategoryManager.tsx",
@@ -3417,7 +3417,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
       "source_location": "L1",
       "id": "categorysubcategorymanager",
-      "community": 0
+      "community": 5
     },
     {
       "label": "Sidebar()",
@@ -3425,7 +3425,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
       "source_location": "L26",
       "id": "categorysubcategorymanager_sidebar",
-      "community": 0
+      "community": 5
     },
     {
       "label": "CategoryManager()",
@@ -3433,7 +3433,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
       "source_location": "L51",
       "id": "categorysubcategorymanager_categorymanager",
-      "community": 0
+      "community": 5
     },
     {
       "label": "SubcategoryManager()",
@@ -3441,7 +3441,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
       "source_location": "L290",
       "id": "categorysubcategorymanager_subcategorymanager",
-      "community": 0
+      "community": 5
     },
     {
       "label": "DefaultAttributesToggleGroup.tsx",
@@ -3449,7 +3449,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/DefaultAttributesToggleGroup.tsx",
       "source_location": "L1",
       "id": "defaultattributestogglegroup",
-      "community": 16
+      "community": 1
     },
     {
       "label": "ProcessingFees.tsx",
@@ -3457,7 +3457,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProcessingFees.tsx",
       "source_location": "L1",
       "id": "processingfees",
-      "community": 0
+      "community": 1
     },
     {
       "label": "ProcessingFeesView()",
@@ -3465,7 +3465,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProcessingFees.tsx",
       "source_location": "L10",
       "id": "processingfees_processingfeesview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "ProductAttributes.tsx",
@@ -3473,7 +3473,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttributes.tsx",
       "source_location": "L1",
       "id": "productattributes",
-      "community": 0
+      "community": 1
     },
     {
       "label": "isAllowedAttribute()",
@@ -3481,7 +3481,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAttributes.tsx",
       "source_location": "L14",
       "id": "productattributes_isallowedattribute",
-      "community": 0
+      "community": 1
     },
     {
       "label": "ProductAttributesView.tsx",
@@ -3489,7 +3489,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAttributesView.tsx",
       "source_location": "L1",
       "id": "productattributesview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "ProductAvailability.tsx",
@@ -3497,7 +3497,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
       "source_location": "L1",
       "id": "productavailability",
-      "community": 16
+      "community": 1
     },
     {
       "label": "ProductAvailabilityView()",
@@ -3505,7 +3505,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
       "source_location": "L5",
       "id": "productavailability_productavailabilityview",
-      "community": 16
+      "community": 1
     },
     {
       "label": "ProductAvailability()",
@@ -3513,7 +3513,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
       "source_location": "L18",
       "id": "productavailability_productavailability",
-      "community": 16
+      "community": 1
     },
     {
       "label": "ProductAvailabilityToggleGroup.tsx",
@@ -3521,7 +3521,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailabilityToggleGroup.tsx",
       "source_location": "L1",
       "id": "productavailabilitytogglegroup",
-      "community": 16
+      "community": 1
     },
     {
       "label": "ProductAvailabilityToggleGroup()",
@@ -3529,7 +3529,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailabilityToggleGroup.tsx",
       "source_location": "L5",
       "id": "productavailabilitytogglegroup_productavailabilitytogglegroup",
-      "community": 16
+      "community": 1
     },
     {
       "label": "ProductCategorization.tsx",
@@ -3537,7 +3537,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
       "source_location": "L1",
       "id": "productcategorization",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleClose()",
@@ -3545,7 +3545,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
       "source_location": "L203",
       "id": "productcategorization_handleclose",
-      "community": 0
+      "community": 1
     },
     {
       "label": "setInitialSelectedOption()",
@@ -3553,7 +3553,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
       "source_location": "L230",
       "id": "productcategorization_setinitialselectedoption",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleProductVisibility()",
@@ -3561,7 +3561,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
       "source_location": "L243",
       "id": "productcategorization_handleproductvisibility",
-      "community": 0
+      "community": 1
     },
     {
       "label": "getProductName()",
@@ -3569,7 +3569,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
       "source_location": "L286",
       "id": "productcategorization_getproductname",
-      "community": 0
+      "community": 1
     },
     {
       "label": "ProductDetails.tsx",
@@ -3577,7 +3577,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
       "source_location": "L1",
       "id": "productdetails",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleNameChange()",
@@ -3585,7 +3585,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductDetails.tsx",
       "source_location": "L10",
       "id": "productdetails_handlenamechange",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ProductImages.tsx",
@@ -3593,7 +3593,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductImages.tsx",
       "source_location": "L1",
       "id": "productimages",
-      "community": 0
+      "community": 1
     },
     {
       "label": "Header()",
@@ -3601,7 +3601,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductImages.tsx",
       "source_location": "L15",
       "id": "productimages_header",
-      "community": 0
+      "community": 1
     },
     {
       "label": "ProductPage.tsx",
@@ -3609,7 +3609,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductPage.tsx",
       "source_location": "L1",
       "id": "productpage",
-      "community": 6
+      "community": 9
     },
     {
       "label": "ProductPage()",
@@ -3617,7 +3617,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductPage.tsx",
       "source_location": "L13",
       "id": "productpage_productpage",
-      "community": 6
+      "community": 9
     },
     {
       "label": "ProductStock.tsx",
@@ -3625,7 +3625,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
       "source_location": "L1",
       "id": "productstock",
-      "community": 6
+      "community": 9
     },
     {
       "label": "restock()",
@@ -3633,7 +3633,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L107",
       "id": "productstock_restock",
-      "community": 6
+      "community": 9
     },
     {
       "label": "isSkuReserved()",
@@ -3641,7 +3641,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L174",
       "id": "productstock_isskureserved",
-      "community": 6
+      "community": 9
     },
     {
       "label": "getReservationType()",
@@ -3649,7 +3649,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L178",
       "id": "productstock_getreservationtype",
-      "community": 6
+      "community": 9
     },
     {
       "label": "handleGenerateBarcode()",
@@ -3657,7 +3657,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L239",
       "id": "productstock_handlegeneratebarcode",
-      "community": 6
+      "community": 9
     },
     {
       "label": "handleSaveBarcode()",
@@ -3665,7 +3665,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L285",
       "id": "productstock_handlesavebarcode",
-      "community": 6
+      "community": 9
     },
     {
       "label": "handleViewBarcode()",
@@ -3673,7 +3673,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L300",
       "id": "productstock_handleviewbarcode",
-      "community": 6
+      "community": 9
     },
     {
       "label": "handleClearBarcodeClick()",
@@ -3681,7 +3681,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L308",
       "id": "productstock_handleclearbarcodeclick",
-      "community": 6
+      "community": 9
     },
     {
       "label": "handleClearBarcodeConfirm()",
@@ -3689,7 +3689,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L313",
       "id": "productstock_handleclearbarcodeconfirm",
-      "community": 6
+      "community": 9
     },
     {
       "label": "handleClearBarcodeCancel()",
@@ -3697,7 +3697,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L379",
       "id": "productstock_handleclearbarcodecancel",
-      "community": 6
+      "community": 9
     },
     {
       "label": "handleChange()",
@@ -3705,7 +3705,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L384",
       "id": "productstock_handlechange",
-      "community": 6
+      "community": 9
     },
     {
       "label": "addRow()",
@@ -3713,7 +3713,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L430",
       "id": "productstock_addrow",
-      "community": 6
+      "community": 9
     },
     {
       "label": "handleDeleteAction()",
@@ -3721,7 +3721,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L445",
       "id": "productstock_handledeleteaction",
-      "community": 6
+      "community": 9
     },
     {
       "label": "setOutOfStock()",
@@ -3729,7 +3729,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L462",
       "id": "productstock_setoutofstock",
-      "community": 6
+      "community": 9
     },
     {
       "label": "setVisibility()",
@@ -3737,7 +3737,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L472",
       "id": "productstock_setvisibility",
-      "community": 6
+      "community": 9
     },
     {
       "label": "isLastActiveVariant()",
@@ -3745,7 +3745,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L486",
       "id": "productstock_islastactivevariant",
-      "community": 6
+      "community": 9
     },
     {
       "label": "isLastVisibleVariant()",
@@ -3753,7 +3753,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L492",
       "id": "productstock_islastvisiblevariant",
-      "community": 6
+      "community": 9
     },
     {
       "label": "shouldDisable()",
@@ -3761,7 +3761,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L498",
       "id": "productstock_shoulddisable",
-      "community": 6
+      "community": 9
     },
     {
       "label": "hasQuantityError()",
@@ -3769,7 +3769,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L506",
       "id": "productstock_hasquantityerror",
-      "community": 6
+      "community": 9
     },
     {
       "label": "hasPriceError()",
@@ -3777,7 +3777,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L514",
       "id": "productstock_haspriceerror",
-      "community": 6
+      "community": 9
     },
     {
       "label": "ProductView.tsx",
@@ -3785,7 +3785,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L1",
       "id": "productview",
-      "community": 8
+      "community": 7
     },
     {
       "label": "deleteActiveProduct()",
@@ -3793,7 +3793,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L82",
       "id": "productview_deleteactiveproduct",
-      "community": 8
+      "community": 7
     },
     {
       "label": "saveProduct()",
@@ -3801,7 +3801,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L115",
       "id": "productview_saveproduct",
-      "community": 8
+      "community": 7
     },
     {
       "label": "modifyProduct()",
@@ -3809,7 +3809,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L170",
       "id": "productview_modifyproduct",
-      "community": 8
+      "community": 7
     },
     {
       "label": "createVariantSku()",
@@ -3817,7 +3817,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L245",
       "id": "productview_createvariantsku",
-      "community": 8
+      "community": 7
     },
     {
       "label": "updateVariantSku()",
@@ -3825,7 +3825,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L300",
       "id": "productview_updatevariantsku",
-      "community": 8
+      "community": 7
     },
     {
       "label": "onSubmit()",
@@ -3833,7 +3833,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L369",
       "id": "productview_onsubmit",
-      "community": 8
+      "community": 7
     },
     {
       "label": "handleKeyDown()",
@@ -3841,7 +3841,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L380",
       "id": "productview_handlekeydown",
-      "community": 8
+      "community": 7
     },
     {
       "label": "updateProductVisibility()",
@@ -3849,7 +3849,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L431",
       "id": "productview_updateproductvisibility",
-      "community": 8
+      "community": 7
     },
     {
       "label": "SheetProvider.tsx",
@@ -3857,7 +3857,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
       "source_location": "L1",
       "id": "sheetprovider",
-      "community": 6
+      "community": 9
     },
     {
       "label": "useSheet()",
@@ -3865,7 +3865,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
       "source_location": "L11",
       "id": "sheetprovider_usesheet",
-      "community": 6
+      "community": 9
     },
     {
       "label": "SheetProvider()",
@@ -3873,7 +3873,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
       "source_location": "L19",
       "id": "sheetprovider_sheetprovider",
-      "community": 6
+      "community": 9
     },
     {
       "label": "WigType.tsx",
@@ -3881,7 +3881,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
       "source_location": "L1",
       "id": "wigtype",
-      "community": 0
+      "community": 1
     },
     {
       "label": "WigTypeView()",
@@ -3889,7 +3889,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
       "source_location": "L8",
       "id": "wigtype_wigtypeview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "WigType()",
@@ -3897,7 +3897,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
       "source_location": "L21",
       "id": "wigtype_wigtype",
-      "community": 0
+      "community": 1
     },
     {
       "label": "CopyImagesProvider.tsx",
@@ -3905,7 +3905,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
       "source_location": "L1",
       "id": "copyimagesprovider",
-      "community": 6
+      "community": 9
     },
     {
       "label": "useCopyImages()",
@@ -3913,7 +3913,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
       "source_location": "L13",
       "id": "copyimagesprovider_usecopyimages",
-      "community": 6
+      "community": 9
     },
     {
       "label": "CopyImagesProvider()",
@@ -3921,7 +3921,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
       "source_location": "L21",
       "id": "copyimagesprovider_copyimagesprovider",
-      "community": 6
+      "community": 9
     },
     {
       "label": "CopyImagesView.tsx",
@@ -3929,7 +3929,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesView.tsx",
       "source_location": "L1",
       "id": "copyimagesview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "setIsUpdatingSku()",
@@ -3937,7 +3937,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesView.tsx",
       "source_location": "L116",
       "id": "copyimagesview_setisupdatingsku",
-      "community": 0
+      "community": 1
     },
     {
       "label": "constants.ts",
@@ -3945,7 +3945,7 @@
       "source_file": "packages/storefront-webapp/src/lib/constants.ts",
       "source_location": "L1",
       "id": "constants",
-      "community": 1
+      "community": 0
     },
     {
       "label": "data-table-column-header.tsx",
@@ -3953,7 +3953,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "data_table_column_header",
-      "community": 3
+      "community": 2
     },
     {
       "label": "DataTableColumnHeader()",
@@ -3961,7 +3961,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-column-header.tsx",
       "source_location": "L20",
       "id": "data_table_column_header_datatablecolumnheader",
-      "community": 3
+      "community": 2
     },
     {
       "label": "data-table-faceted-filter.tsx",
@@ -3977,7 +3977,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "data_table_pagination",
-      "community": 3
+      "community": 2
     },
     {
       "label": "data-table-toolbar-provider.tsx",
@@ -4041,7 +4041,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table.tsx",
       "source_location": "L1",
       "id": "data_table",
-      "community": 0
+      "community": 2
     },
     {
       "label": "product-variant-columns.tsx",
@@ -4049,7 +4049,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
       "source_location": "L1",
       "id": "product_variant_columns",
-      "community": 6
+      "community": 9
     },
     {
       "label": "setSourceVariant()",
@@ -4057,7 +4057,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
       "source_location": "L47",
       "id": "product_variant_columns_setsourcevariant",
-      "community": 6
+      "community": 9
     },
     {
       "label": "ActivityTimeline.tsx",
@@ -4065,7 +4065,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/ActivityTimeline.tsx",
       "source_location": "L1",
       "id": "activitytimeline",
-      "community": 3
+      "community": 2
     },
     {
       "label": "capitalizeFirstLetter()",
@@ -4073,7 +4073,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/ActivityTimeline.tsx",
       "source_location": "L151",
       "id": "activitytimeline_capitalizefirstletter",
-      "community": 3
+      "community": 2
     },
     {
       "label": "AnalyticsCombinedUsers.tsx",
@@ -4081,7 +4081,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
       "source_location": "L1",
       "id": "analyticscombinedusers",
-      "community": 3
+      "community": 2
     },
     {
       "label": "processAnalyticsToUsers()",
@@ -4089,7 +4089,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
       "source_location": "L10",
       "id": "analyticscombinedusers_processanalyticstousers",
-      "community": 3
+      "community": 2
     },
     {
       "label": "AnalyticsCombinedUsers()",
@@ -4097,7 +4097,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
       "source_location": "L100",
       "id": "analyticscombinedusers_analyticscombinedusers",
-      "community": 3
+      "community": 2
     },
     {
       "label": "AnalyticsItems.tsx",
@@ -4105,7 +4105,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsItems.tsx",
       "source_location": "L1",
       "id": "analyticsitems",
-      "community": 0
+      "community": 2
     },
     {
       "label": "AnalyticsItems()",
@@ -4113,7 +4113,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsItems.tsx",
       "source_location": "L6",
       "id": "analyticsitems_analyticsitems",
-      "community": 0
+      "community": 2
     },
     {
       "label": "AnalyticsProducts.tsx",
@@ -4121,7 +4121,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsProducts.tsx",
       "source_location": "L1",
       "id": "analyticsproducts",
-      "community": 0
+      "community": 2
     },
     {
       "label": "AnalyticsProducts()",
@@ -4129,7 +4129,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsProducts.tsx",
       "source_location": "L19",
       "id": "analyticsproducts_analyticsproducts",
-      "community": 0
+      "community": 2
     },
     {
       "label": "AnalyticsTopUsers.tsx",
@@ -4137,7 +4137,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsTopUsers.tsx",
       "source_location": "L1",
       "id": "analyticstopusers",
-      "community": 3
+      "community": 2
     },
     {
       "label": "processAnalyticsToUsers()",
@@ -4145,7 +4145,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsTopUsers.tsx",
       "source_location": "L10",
       "id": "analyticstopusers_processanalyticstousers",
-      "community": 3
+      "community": 2
     },
     {
       "label": "AnalyticsTopUsers()",
@@ -4153,7 +4153,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsTopUsers.tsx",
       "source_location": "L100",
       "id": "analyticstopusers_analyticstopusers",
-      "community": 3
+      "community": 2
     },
     {
       "label": "AnalyticsUsers.tsx",
@@ -4161,7 +4161,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsUsers.tsx",
       "source_location": "L1",
       "id": "analyticsusers",
-      "community": 0
+      "community": 2
     },
     {
       "label": "AnalyticsUsers()",
@@ -4169,7 +4169,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsUsers.tsx",
       "source_location": "L7",
       "id": "analyticsusers_analyticsusers",
-      "community": 0
+      "community": 2
     },
     {
       "label": "AnalyticsView.tsx",
@@ -4177,7 +4177,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
       "source_location": "L1",
       "id": "analyticsview",
-      "community": 0
+      "community": 2
     },
     {
       "label": "StoreVisitors()",
@@ -4185,7 +4185,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
       "source_location": "L14",
       "id": "analyticsview_storevisitors",
-      "community": 0
+      "community": 2
     },
     {
       "label": "ActiveCheckoutSessions()",
@@ -4193,7 +4193,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
       "source_location": "L44",
       "id": "analyticsview_activecheckoutsessions",
-      "community": 0
+      "community": 2
     },
     {
       "label": "AnalyticsView()",
@@ -4201,7 +4201,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
       "source_location": "L84",
       "id": "analyticsview_analyticsview",
-      "community": 0
+      "community": 2
     },
     {
       "label": "ConversionFunnelChart.tsx",
@@ -4209,7 +4209,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/ConversionFunnelChart.tsx",
       "source_location": "L1",
       "id": "conversionfunnelchart",
-      "community": 3
+      "community": 2
     },
     {
       "label": "EnhancedAnalyticsView.tsx",
@@ -4217,7 +4217,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/EnhancedAnalyticsView.tsx",
       "source_location": "L1",
       "id": "enhancedanalyticsview",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getDateRangeMilliseconds()",
@@ -4225,7 +4225,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/EnhancedAnalyticsView.tsx",
       "source_location": "L42",
       "id": "enhancedanalyticsview_getdaterangemilliseconds",
-      "community": 3
+      "community": 2
     },
     {
       "label": "RevenueChart.tsx",
@@ -4233,7 +4233,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/RevenueChart.tsx",
       "source_location": "L1",
       "id": "revenuechart",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getTrendIcon()",
@@ -4241,7 +4241,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/StoreInsights.tsx",
       "source_location": "L66",
       "id": "storeinsights_gettrendicon",
-      "community": 2
+      "community": 3
     },
     {
       "label": "StorefrontObservabilityPanel.tsx",
@@ -4249,7 +4249,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
       "source_location": "L1",
       "id": "storefrontobservabilitypanel",
-      "community": 3
+      "community": 2
     },
     {
       "label": "formatLabel()",
@@ -4257,7 +4257,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
       "source_location": "L15",
       "id": "storefrontobservabilitypanel_formatlabel",
-      "community": 3
+      "community": 2
     },
     {
       "label": "SummaryCard()",
@@ -4265,7 +4265,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
       "source_location": "L19",
       "id": "storefrontobservabilitypanel_summarycard",
-      "community": 3
+      "community": 2
     },
     {
       "label": "VisitorChart.tsx",
@@ -4273,7 +4273,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/VisitorChart.tsx",
       "source_location": "L1",
       "id": "visitorchart",
-      "community": 3
+      "community": 2
     },
     {
       "label": "formatHour()",
@@ -4281,7 +4281,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/VisitorChart.tsx",
       "source_location": "L18",
       "id": "visitorchart_formathour",
-      "community": 3
+      "community": 2
     },
     {
       "label": "analytics-columns.tsx",
@@ -4289,7 +4289,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/analytics-columns.tsx",
       "source_location": "L1",
       "id": "analytics_columns",
-      "community": 0
+      "community": 2
     },
     {
       "label": "data-table-row-actions.tsx",
@@ -4313,7 +4313,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
       "source_location": "L1",
       "id": "selectable_data_provider",
-      "community": 8
+      "community": 7
     },
     {
       "label": "SelectedProductsProvider()",
@@ -4321,7 +4321,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
       "source_location": "L16",
       "id": "selectable_data_provider_selectedproductsprovider",
-      "community": 8
+      "community": 7
     },
     {
       "label": "useSelectedProducts()",
@@ -4329,7 +4329,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
       "source_location": "L37",
       "id": "selectable_data_provider_useselectedproducts",
-      "community": 8
+      "community": 7
     },
     {
       "label": "columns.tsx",
@@ -4337,7 +4337,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/columns.tsx",
       "source_location": "L1",
       "id": "columns",
-      "community": 3
+      "community": 2
     },
     {
       "label": "chart.tsx",
@@ -4345,7 +4345,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/chart.tsx",
       "source_location": "L1",
       "id": "chart",
-      "community": 3
+      "community": 2
     },
     {
       "label": "data.ts",
@@ -4361,7 +4361,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
       "source_location": "L3",
       "id": "utils_groupanalytics",
-      "community": 3
+      "community": 2
     },
     {
       "label": "countGroupedAnalytics()",
@@ -4369,7 +4369,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
       "source_location": "L52",
       "id": "utils_countgroupedanalytics",
-      "community": 3
+      "community": 2
     },
     {
       "label": "groupProductViewsByDay()",
@@ -4377,7 +4377,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
       "source_location": "L90",
       "id": "utils_groupproductviewsbyday",
-      "community": 3
+      "community": 2
     },
     {
       "label": "LogItems.tsx",
@@ -4385,7 +4385,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/LogItems.tsx",
       "source_location": "L1",
       "id": "logitems",
-      "community": 3
+      "community": 2
     },
     {
       "label": "LogItems()",
@@ -4393,7 +4393,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/LogItems.tsx",
       "source_location": "L6",
       "id": "logitems_logitems",
-      "community": 3
+      "community": 2
     },
     {
       "label": "LogView.tsx",
@@ -4401,7 +4401,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/LogView.tsx",
       "source_location": "L1",
       "id": "logview",
-      "community": 0
+      "community": 7
     },
     {
       "label": "Header()",
@@ -4409,7 +4409,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/LogView.tsx",
       "source_location": "L10",
       "id": "logview_header",
-      "community": 0
+      "community": 7
     },
     {
       "label": "LogsView.tsx",
@@ -4417,7 +4417,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
       "source_location": "L1",
       "id": "logsview",
-      "community": 3
+      "community": 9
     },
     {
       "label": "Navigation()",
@@ -4425,7 +4425,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
       "source_location": "L27",
       "id": "logsview_navigation",
-      "community": 3
+      "community": 9
     },
     {
       "label": "log-items-provider.tsx",
@@ -4433,7 +4433,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
       "source_location": "L1",
       "id": "log_items_provider",
-      "community": 3
+      "community": 2
     },
     {
       "label": "LogItemsProvider()",
@@ -4441,7 +4441,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
       "source_location": "L15",
       "id": "log_items_provider_logitemsprovider",
-      "community": 3
+      "community": 2
     },
     {
       "label": "useLogItems()",
@@ -4449,7 +4449,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
       "source_location": "L39",
       "id": "log_items_provider_uselogitems",
-      "community": 3
+      "community": 2
     },
     {
       "label": "useLoadLogItems.ts",
@@ -4457,7 +4457,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/hooks/useLoadLogItems.ts",
       "source_location": "L1",
       "id": "useloadlogitems",
-      "community": 0
+      "community": 3
     },
     {
       "label": "useLoadLogItems()",
@@ -4465,7 +4465,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/hooks/useLoadLogItems.ts",
       "source_location": "L12",
       "id": "useloadlogitems_useloadlogitems",
-      "community": 0
+      "community": 3
     },
     {
       "label": "app-sidebar.tsx",
@@ -4473,7 +4473,7 @@
       "source_file": "packages/athena-webapp/src/components/app-sidebar.tsx",
       "source_location": "L1",
       "id": "app_sidebar",
-      "community": 0
+      "community": 1
     },
     {
       "label": "assetsColumns.tsx",
@@ -4481,7 +4481,7 @@
       "source_file": "packages/athena-webapp/src/components/assets/assets-table/assetsColumns.tsx",
       "source_location": "L1",
       "id": "assetscolumns",
-      "community": 0
+      "community": 2
     },
     {
       "label": "Header()",
@@ -4489,7 +4489,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
       "source_location": "L42",
       "id": "index_header",
-      "community": 11
+      "community": 1
     },
     {
       "label": "FeesView()",
@@ -4497,7 +4497,7 @@
       "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
       "source_location": "L29",
       "id": "index_feesview",
-      "community": 11
+      "community": 1
     },
     {
       "label": "Auth()",
@@ -4505,7 +4505,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Auth.tsx",
       "source_location": "L3",
       "id": "auth_auth",
-      "community": 2
+      "community": 3
     },
     {
       "label": "DefaultCatchBoundary.tsx",
@@ -4513,7 +4513,7 @@
       "source_file": "packages/storefront-webapp/src/components/DefaultCatchBoundary.tsx",
       "source_location": "L1",
       "id": "defaultcatchboundary",
-      "community": 10
+      "community": 8
     },
     {
       "label": "InputOTP.tsx",
@@ -4521,7 +4521,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
       "source_location": "L1",
       "id": "inputotp",
-      "community": 11
+      "community": 5
     },
     {
       "label": "handlePinChange()",
@@ -4529,7 +4529,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
       "source_location": "L48",
       "id": "inputotp_handlepinchange",
-      "community": 11
+      "community": 5
     },
     {
       "label": "onSubmit()",
@@ -4537,7 +4537,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
       "source_location": "L56",
       "id": "inputotp_onsubmit",
-      "community": 11
+      "community": 5
     },
     {
       "label": "LoginForm.tsx",
@@ -4545,7 +4545,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Login/LoginForm.tsx",
       "source_location": "L1",
       "id": "loginform",
-      "community": 0
+      "community": 5
     },
     {
       "label": "Login()",
@@ -4553,7 +4553,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Login/index.tsx",
       "source_location": "L5",
       "id": "index_login",
-      "community": 11
+      "community": 1
     },
     {
       "label": "BulkOperationsFilters.tsx",
@@ -4561,7 +4561,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsFilters.tsx",
       "source_location": "L1",
       "id": "bulkoperationsfilters",
-      "community": 5
+      "community": 1
     },
     {
       "label": "handleLoadProducts()",
@@ -4569,7 +4569,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsFilters.tsx",
       "source_location": "L49",
       "id": "bulkoperationsfilters_handleloadproducts",
-      "community": 5
+      "community": 1
     },
     {
       "label": "BulkOperationsPage.tsx",
@@ -4577,7 +4577,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPage.tsx",
       "source_location": "L1",
       "id": "bulkoperationspage",
-      "community": 0
+      "community": 1
     },
     {
       "label": "BulkOperationsPreview.test.tsx",
@@ -4585,7 +4585,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.test.tsx",
       "source_location": "L1",
       "id": "bulkoperationspreview_test",
-      "community": 9
+      "community": 13
     },
     {
       "label": "makeRow()",
@@ -4593,7 +4593,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.test.tsx",
       "source_location": "L23",
       "id": "bulkoperationspreview_test_makerow",
-      "community": 9
+      "community": 13
     },
     {
       "label": "BulkOperationsPreview.tsx",
@@ -4601,7 +4601,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.tsx",
       "source_location": "L1",
       "id": "bulkoperationspreview",
-      "community": 9
+      "community": 13
     },
     {
       "label": "formatPrice()",
@@ -4609,7 +4609,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.tsx",
       "source_location": "L50",
       "id": "bulkoperationspreview_formatprice",
-      "community": 9
+      "community": 13
     },
     {
       "label": "CashierManagement.tsx",
@@ -4617,7 +4617,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L1",
       "id": "cashiermanagement",
-      "community": 9
+      "community": 5
     },
     {
       "label": "normalizeNameSegment()",
@@ -4625,7 +4625,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L42",
       "id": "cashiermanagement_normalizenamesegment",
-      "community": 9
+      "community": 5
     },
     {
       "label": "buildUsername()",
@@ -4633,7 +4633,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L50",
       "id": "cashiermanagement_buildusername",
-      "community": 9
+      "community": 5
     },
     {
       "label": "handleSubmit()",
@@ -4641,7 +4641,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L109",
       "id": "cashiermanagement_handlesubmit",
-      "community": 9
+      "community": 5
     },
     {
       "label": "handlePinKeyDown()",
@@ -4649,7 +4649,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L169",
       "id": "cashiermanagement_handlepinkeydown",
-      "community": 9
+      "community": 5
     },
     {
       "label": "handleDelete()",
@@ -4657,7 +4657,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L320",
       "id": "cashiermanagement_handledelete",
-      "community": 9
+      "community": 5
     },
     {
       "label": "CheckoutSessionsTable.tsx",
@@ -4665,7 +4665,7 @@
       "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSessionsTable.tsx",
       "source_location": "L1",
       "id": "checkoutsessionstable",
-      "community": 0
+      "community": 1
     },
     {
       "label": "CheckoutSessionsTable()",
@@ -4673,7 +4673,7 @@
       "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSessionsTable.tsx",
       "source_location": "L13",
       "id": "checkoutsessionstable_checkoutsessionstable",
-      "community": 0
+      "community": 1
     },
     {
       "label": "CheckoutSesssionsView.tsx",
@@ -4681,7 +4681,7 @@
       "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSesssionsView.tsx",
       "source_location": "L1",
       "id": "checkoutsesssionsview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "Navigation()",
@@ -4689,7 +4689,7 @@
       "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSesssionsView.tsx",
       "source_location": "L11",
       "id": "checkoutsesssionsview_navigation",
-      "community": 0
+      "community": 1
     },
     {
       "label": "FadeIn.tsx",
@@ -4697,7 +4697,7 @@
       "source_file": "packages/storefront-webapp/src/components/common/FadeIn.tsx",
       "source_location": "L1",
       "id": "fadein",
-      "community": 0
+      "community": 1
     },
     {
       "label": "FadeIn()",
@@ -4705,7 +4705,7 @@
       "source_file": "packages/storefront-webapp/src/components/common/FadeIn.tsx",
       "source_location": "L3",
       "id": "fadein_fadein",
-      "community": 0
+      "community": 1
     },
     {
       "label": "PageHeader.tsx",
@@ -4713,7 +4713,7 @@
       "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
       "source_location": "L1",
       "id": "pageheader",
-      "community": 0
+      "community": 1
     },
     {
       "label": "PageHeader()",
@@ -4721,7 +4721,7 @@
       "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
       "source_location": "L7",
       "id": "pageheader_pageheader",
-      "community": 0
+      "community": 1
     },
     {
       "label": "Dashboard.tsx",
@@ -4729,7 +4729,7 @@
       "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
       "source_location": "L1",
       "id": "dashboard",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getPeriodRange()",
@@ -4737,7 +4737,7 @@
       "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
       "source_location": "L20",
       "id": "dashboard_getperiodrange",
-      "community": 3
+      "community": 2
     },
     {
       "label": "LoadingSection()",
@@ -4745,7 +4745,7 @@
       "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
       "source_location": "L50",
       "id": "dashboard_loadingsection",
-      "community": 3
+      "community": 2
     },
     {
       "label": "renderSalesSection()",
@@ -4753,7 +4753,7 @@
       "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
       "source_location": "L322",
       "id": "dashboard_rendersalessection",
-      "community": 3
+      "community": 2
     },
     {
       "label": "renderProductsSection()",
@@ -4761,7 +4761,7 @@
       "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
       "source_location": "L342",
       "id": "dashboard_renderproductssection",
-      "community": 3
+      "community": 2
     },
     {
       "label": "MetricCard.tsx",
@@ -4769,7 +4769,7 @@
       "source_file": "packages/athena-webapp/src/components/dashboard/MetricCard.tsx",
       "source_location": "L1",
       "id": "metriccard",
-      "community": 3
+      "community": 2
     },
     {
       "label": "ExpenseCompletion.tsx",
@@ -4857,7 +4857,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L1",
       "id": "bannermessageeditor",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleSave()",
@@ -4865,7 +4865,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L46",
       "id": "bannermessageeditor_handlesave",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleClear()",
@@ -4873,7 +4873,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L66",
       "id": "bannermessageeditor_handleclear",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleActiveToggle()",
@@ -4881,7 +4881,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L91",
       "id": "bannermessageeditor_handleactivetoggle",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleCountdownChange()",
@@ -4889,7 +4889,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L113",
       "id": "bannermessageeditor_handlecountdownchange",
-      "community": 0
+      "community": 1
     },
     {
       "label": "getCountdownStatus()",
@@ -4897,7 +4897,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L123",
       "id": "bannermessageeditor_getcountdownstatus",
-      "community": 0
+      "community": 1
     },
     {
       "label": "BestSellers.tsx",
@@ -4905,7 +4905,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
       "source_location": "L1",
       "id": "bestsellers",
-      "community": 0
+      "community": 4
     },
     {
       "label": "handleRemoveBestSeller()",
@@ -4913,7 +4913,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
       "source_location": "L53",
       "id": "bestsellers_handleremovebestseller",
-      "community": 0
+      "community": 4
     },
     {
       "label": "onDragEnd()",
@@ -4921,7 +4921,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
       "source_location": "L65",
       "id": "bestsellers_ondragend",
-      "community": 0
+      "community": 4
     },
     {
       "label": "BestSellersDialog.tsx",
@@ -4929,7 +4929,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BestSellersDialog.tsx",
       "source_location": "L1",
       "id": "bestsellersdialog",
-      "community": 0
+      "community": 4
     },
     {
       "label": "handleAddBestSeller()",
@@ -4937,7 +4937,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BestSellersDialog.tsx",
       "source_location": "L29",
       "id": "bestsellersdialog_handleaddbestseller",
-      "community": 0
+      "community": 4
     },
     {
       "label": "FeaturedSection.tsx",
@@ -4945,7 +4945,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
       "source_location": "L1",
       "id": "featuredsection",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleHighlightedItem()",
@@ -4953,7 +4953,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
       "source_location": "L47",
       "id": "featuredsection_handlehighlighteditem",
-      "community": 0
+      "community": 1
     },
     {
       "label": "onDragEnd()",
@@ -4961,7 +4961,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
       "source_location": "L53",
       "id": "featuredsection_ondragend",
-      "community": 0
+      "community": 1
     },
     {
       "label": "FeaturedSectionDialog.tsx",
@@ -4969,7 +4969,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSectionDialog.tsx",
       "source_location": "L1",
       "id": "featuredsectiondialog",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleAddFeaturedItem()",
@@ -4977,7 +4977,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSectionDialog.tsx",
       "source_location": "L37",
       "id": "featuredsectiondialog_handleaddfeatureditem",
-      "community": 0
+      "community": 1
     },
     {
       "label": "HeroHeaderImageUploader.tsx",
@@ -5065,7 +5065,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
       "source_location": "L1",
       "id": "herosectiontabs",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleImageUpdate()",
@@ -5073,7 +5073,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
       "source_location": "L57",
       "id": "herosectiontabs_handleimageupdate",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleDisplayTypeChange()",
@@ -5081,7 +5081,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
       "source_location": "L61",
       "id": "herosectiontabs_handledisplaytypechange",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleOverlayToggle()",
@@ -5089,7 +5089,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
       "source_location": "L98",
       "id": "herosectiontabs_handleoverlaytoggle",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleTextToggle()",
@@ -5097,7 +5097,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
       "source_location": "L134",
       "id": "herosectiontabs_handletexttoggle",
-      "community": 0
+      "community": 1
     },
     {
       "label": "home.tsx",
@@ -5105,7 +5105,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/home.tsx",
       "source_location": "L1",
       "id": "home",
-      "community": 0
+      "community": 1
     },
     {
       "label": "Navigation()",
@@ -5113,7 +5113,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/Home.tsx",
       "source_location": "L25",
       "id": "home_navigation",
-      "community": 0
+      "community": 1
     },
     {
       "label": "LandingPageReelVersion.tsx",
@@ -5121,7 +5121,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/LandingPageReelVersion.tsx",
       "source_location": "L1",
       "id": "landingpagereelversion",
-      "community": 0
+      "community": 16
     },
     {
       "label": "handleUpdateConfig()",
@@ -5129,7 +5129,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/LandingPageReelVersion.tsx",
       "source_location": "L83",
       "id": "landingpagereelversion_handleupdateconfig",
-      "community": 0
+      "community": 16
     },
     {
       "label": "MaintenanceMessageEditor.tsx",
@@ -5137,7 +5137,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
       "source_location": "L1",
       "id": "maintenancemessageeditor",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleSave()",
@@ -5145,7 +5145,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
       "source_location": "L52",
       "id": "maintenancemessageeditor_handlesave",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleCountdownChange()",
@@ -5153,7 +5153,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
       "source_location": "L76",
       "id": "maintenancemessageeditor_handlecountdownchange",
-      "community": 0
+      "community": 1
     },
     {
       "label": "getCountdownStatus()",
@@ -5161,7 +5161,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
       "source_location": "L86",
       "id": "maintenancemessageeditor_getcountdownstatus",
-      "community": 0
+      "community": 1
     },
     {
       "label": "ReelUploader.tsx",
@@ -5169,7 +5169,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
       "source_location": "L1",
       "id": "reeluploader",
-      "community": 0
+      "community": 5
     },
     {
       "label": "formatFileSize()",
@@ -5177,7 +5177,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
       "source_location": "L38",
       "id": "reeluploader_formatfilesize",
-      "community": 0
+      "community": 5
     },
     {
       "label": "validateFile()",
@@ -5185,7 +5185,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
       "source_location": "L43",
       "id": "reeluploader_validatefile",
-      "community": 0
+      "community": 5
     },
     {
       "label": "handleFileSelect()",
@@ -5193,7 +5193,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
       "source_location": "L64",
       "id": "reeluploader_handlefileselect",
-      "community": 0
+      "community": 5
     },
     {
       "label": "handleUpload()",
@@ -5201,7 +5201,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
       "source_location": "L135",
       "id": "reeluploader_handleupload",
-      "community": 0
+      "community": 5
     },
     {
       "label": "ShopLook.tsx",
@@ -5209,7 +5209,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
       "source_location": "L1",
       "id": "shoplook",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleHighlightedItem()",
@@ -5217,7 +5217,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
       "source_location": "L67",
       "id": "shoplook_handlehighlighteditem",
-      "community": 0
+      "community": 1
     },
     {
       "label": "onDragEnd()",
@@ -5225,7 +5225,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
       "source_location": "L73",
       "id": "shoplook_ondragend",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleImageUpdate()",
@@ -5233,7 +5233,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
       "source_location": "L90",
       "id": "shoplook_handleimageupdate",
-      "community": 0
+      "community": 1
     },
     {
       "label": "ShopLookDialog.tsx",
@@ -5241,7 +5241,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ShopLookDialog.tsx",
       "source_location": "L1",
       "id": "shoplookdialog",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleAddFeaturedItem()",
@@ -5249,7 +5249,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ShopLookDialog.tsx",
       "source_location": "L35",
       "id": "shoplookdialog_handleaddfeatureditem",
-      "community": 0
+      "community": 1
     },
     {
       "label": "ShopLookImageUploader.tsx",
@@ -5257,7 +5257,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
       "source_location": "L1",
       "id": "shoplookimageuploader",
-      "community": 0
+      "community": 14
     },
     {
       "label": "ShopLookImageUploader()",
@@ -5265,7 +5265,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
       "source_location": "L28",
       "id": "shoplookimageuploader_shoplookimageuploader",
-      "community": 0
+      "community": 14
     },
     {
       "label": "VideoPlayer.tsx",
@@ -5273,7 +5273,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
       "source_location": "L1",
       "id": "videoplayer",
-      "community": 1
+      "community": 16
     },
     {
       "label": "VideoPlayer()",
@@ -5281,7 +5281,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
       "source_location": "L9",
       "id": "videoplayer_videoplayer",
-      "community": 1
+      "community": 16
     },
     {
       "label": "JoinTeam()",
@@ -5289,7 +5289,7 @@
       "source_file": "packages/athena-webapp/src/components/join-team/index.tsx",
       "source_location": "L11",
       "id": "index_jointeam",
-      "community": 11
+      "community": 1
     },
     {
       "label": "ActivityView.tsx",
@@ -5297,7 +5297,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
       "source_location": "L1",
       "id": "activityview",
-      "community": 0
+      "community": 19
     },
     {
       "label": "isRefundAction()",
@@ -5305,7 +5305,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
       "source_location": "L50",
       "id": "activityview_isrefundaction",
-      "community": 0
+      "community": 19
     },
     {
       "label": "isTransitionAction()",
@@ -5313,7 +5313,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
       "source_location": "L53",
       "id": "activityview_istransitionaction",
-      "community": 0
+      "community": 19
     },
     {
       "label": "isCreatedAction()",
@@ -5321,7 +5321,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
       "source_location": "L58",
       "id": "activityview_iscreatedaction",
-      "community": 0
+      "community": 19
     },
     {
       "label": "isFeedbackRequestAction()",
@@ -5329,7 +5329,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
       "source_location": "L63",
       "id": "activityview_isfeedbackrequestaction",
-      "community": 0
+      "community": 19
     },
     {
       "label": "CustomerDetailsView.tsx",
@@ -5337,7 +5337,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/CustomerDetailsView.tsx",
       "source_location": "L1",
       "id": "customerdetailsview",
-      "community": 0
+      "community": 2
     },
     {
       "label": "CustomerDetailsView()",
@@ -5345,7 +5345,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/CustomerDetailsView.tsx",
       "source_location": "L13",
       "id": "customerdetailsview_customerdetailsview",
-      "community": 0
+      "community": 2
     },
     {
       "label": "EmailStatusView.tsx",
@@ -5353,7 +5353,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/EmailStatusView.tsx",
       "source_location": "L1",
       "id": "emailstatusview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleSendOrderEmail()",
@@ -5361,7 +5361,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/EmailStatusView.tsx",
       "source_location": "L41",
       "id": "emailstatusview_handlesendorderemail",
-      "community": 0
+      "community": 1
     },
     {
       "label": "OrderDetailsView.tsx",
@@ -5369,7 +5369,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
       "source_location": "L1",
       "id": "orderdetailsview",
-      "community": 0
+      "community": 19
     },
     {
       "label": "VerifiedBadge()",
@@ -5377,7 +5377,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
       "source_location": "L41",
       "id": "orderdetailsview_verifiedbadge",
-      "community": 0
+      "community": 19
     },
     {
       "label": "fetchTransactions()",
@@ -5385,7 +5385,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
       "source_location": "L136",
       "id": "orderdetailsview_fetchtransactions",
-      "community": 0
+      "community": 19
     },
     {
       "label": "handleMarkAsVerified()",
@@ -5393,7 +5393,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
       "source_location": "L173",
       "id": "orderdetailsview_handlemarkasverified",
-      "community": 0
+      "community": 19
     },
     {
       "label": "handleMarkPaymentCollected()",
@@ -5401,7 +5401,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
       "source_location": "L187",
       "id": "orderdetailsview_handlemarkpaymentcollected",
-      "community": 0
+      "community": 19
     },
     {
       "label": "OrderItemsView.tsx",
@@ -5409,7 +5409,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
       "source_location": "L1",
       "id": "orderitemsview",
-      "community": 0
+      "community": 19
     },
     {
       "label": "handleUpdateOrderItem()",
@@ -5417,7 +5417,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
       "source_location": "L47",
       "id": "orderitemsview_handleupdateorderitem",
-      "community": 0
+      "community": 19
     },
     {
       "label": "handleReturnItemToStock()",
@@ -5425,7 +5425,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
       "source_location": "L61",
       "id": "orderitemsview_handlereturnitemtostock",
-      "community": 0
+      "community": 19
     },
     {
       "label": "handleRequestFeedback()",
@@ -5433,7 +5433,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
       "source_location": "L77",
       "id": "orderitemsview_handlerequestfeedback",
-      "community": 0
+      "community": 19
     },
     {
       "label": "handleRestockAll()",
@@ -5441,7 +5441,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
       "source_location": "L295",
       "id": "orderitemsview_handlerestockall",
-      "community": 0
+      "community": 19
     },
     {
       "label": "OrderMetricsPanel.tsx",
@@ -5449,7 +5449,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
       "source_location": "L1",
       "id": "ordermetricspanel",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleTimeRangeChange()",
@@ -5457,7 +5457,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
       "source_location": "L33",
       "id": "ordermetricspanel_handletimerangechange",
-      "community": 0
+      "community": 1
     },
     {
       "label": "OrderStatus.tsx",
@@ -5465,7 +5465,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderStatus.tsx",
       "source_location": "L1",
       "id": "orderstatus",
-      "community": 3
+      "community": 2
     },
     {
       "label": "OrderSummary.tsx",
@@ -5505,7 +5505,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/Orders.tsx",
       "source_location": "L1",
       "id": "orders",
-      "community": 3
+      "community": 2
     },
     {
       "label": "OrdersView.tsx",
@@ -5513,7 +5513,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
       "source_location": "L1",
       "id": "ordersview",
-      "community": 8
+      "community": 7
     },
     {
       "label": "getTimeFilter()",
@@ -5521,7 +5521,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
       "source_location": "L35",
       "id": "ordersview_gettimefilter",
-      "community": 8
+      "community": 7
     },
     {
       "label": "PickupDetailsView.tsx",
@@ -5529,7 +5529,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/PickupDetailsView.tsx",
       "source_location": "L1",
       "id": "pickupdetailsview",
-      "community": 0
+      "community": 5
     },
     {
       "label": "PickupDetailsView()",
@@ -5537,7 +5537,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/PickupDetailsView.tsx",
       "source_location": "L9",
       "id": "pickupdetailsview_pickupdetailsview",
-      "community": 0
+      "community": 5
     },
     {
       "label": "DeliveryDetails()",
@@ -5545,7 +5545,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/PickupDetailsView.tsx",
       "source_location": "L67",
       "id": "pickupdetailsview_deliverydetails",
-      "community": 0
+      "community": 5
     },
     {
       "label": "RefundsView.tsx",
@@ -5569,7 +5569,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/hooks/useGetActiveOnlineOrder.ts",
       "source_location": "L1",
       "id": "usegetactiveonlineorder",
-      "community": 0
+      "community": 19
     },
     {
       "label": "useGetActiveOnlineOrder()",
@@ -5577,7 +5577,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/hooks/useGetActiveOnlineOrder.ts",
       "source_location": "L6",
       "id": "usegetactiveonlineorder_usegetactiveonlineorder",
-      "community": 0
+      "community": 19
     },
     {
       "label": "handleClearFilters()",
@@ -5593,7 +5593,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/orderColumns.tsx",
       "source_location": "L1",
       "id": "ordercolumns",
-      "community": 3
+      "community": 2
     },
     {
       "label": "if()",
@@ -5601,7 +5601,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/orderColumns.tsx",
       "source_location": "L89",
       "id": "ordercolumns_if",
-      "community": 3
+      "community": 2
     },
     {
       "label": "refundUtils.ts",
@@ -5609,7 +5609,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L1",
       "id": "refundutils",
-      "community": 24
+      "community": 23
     },
     {
       "label": "refundReducer()",
@@ -5617,7 +5617,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L31",
       "id": "refundutils_refundreducer",
-      "community": 24
+      "community": 23
     },
     {
       "label": "getAmountRefunded()",
@@ -5625,7 +5625,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L98",
       "id": "refundutils_getamountrefunded",
-      "community": 24
+      "community": 23
     },
     {
       "label": "getNetAmount()",
@@ -5633,7 +5633,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L106",
       "id": "refundutils_getnetamount",
-      "community": 24
+      "community": 23
     },
     {
       "label": "getAvailableItems()",
@@ -5641,7 +5641,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L115",
       "id": "refundutils_getavailableitems",
-      "community": 24
+      "community": 23
     },
     {
       "label": "calculateRefundAmount()",
@@ -5649,7 +5649,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L124",
       "id": "refundutils_calculaterefundamount",
-      "community": 24
+      "community": 23
     },
     {
       "label": "getItemsToRefund()",
@@ -5657,7 +5657,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L174",
       "id": "refundutils_getitemstorefund",
-      "community": 24
+      "community": 23
     },
     {
       "label": "validateRefund()",
@@ -5665,7 +5665,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L199",
       "id": "refundutils_validaterefund",
-      "community": 24
+      "community": 23
     },
     {
       "label": "shouldShowReturnToStock()",
@@ -5673,7 +5673,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L255",
       "id": "refundutils_shouldshowreturntostock",
-      "community": 24
+      "community": 23
     },
     {
       "label": "getOrderState()",
@@ -5681,7 +5681,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
       "source_location": "L1",
       "id": "utils_getorderstate",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getAmountPaidForOrder()",
@@ -5689,7 +5689,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
       "source_location": "L108",
       "id": "utils_getamountpaidfororder",
-      "community": 3
+      "community": 2
     },
     {
       "label": "onSubmit()",
@@ -5697,7 +5697,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
       "source_location": "L105",
       "id": "index_onsubmit",
-      "community": 11
+      "community": 1
     },
     {
       "label": "inviteColumns.tsx",
@@ -5705,7 +5705,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/inviteColumns.tsx",
       "source_location": "L1",
       "id": "invitecolumns",
-      "community": 3
+      "community": 2
     },
     {
       "label": "membersColumns.tsx",
@@ -5713,7 +5713,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/membersColumns.tsx",
       "source_location": "L1",
       "id": "memberscolumns",
-      "community": 3
+      "community": 2
     },
     {
       "label": "organization-switcher.tsx",
@@ -5721,7 +5721,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-switcher.tsx",
       "source_location": "L1",
       "id": "organization_switcher",
-      "community": 16
+      "community": 0
     },
     {
       "label": "onOrganizationSelect()",
@@ -5729,7 +5729,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-switcher.tsx",
       "source_location": "L94",
       "id": "organization_switcher_onorganizationselect",
-      "community": 16
+      "community": 0
     },
     {
       "label": "handleSignOut()",
@@ -5737,7 +5737,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-switcher.tsx",
       "source_location": "L99",
       "id": "organization_switcher_handlesignout",
-      "community": 16
+      "community": 0
     },
     {
       "label": "CartItems.tsx",
@@ -5745,7 +5745,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CartItems.tsx",
       "source_location": "L1",
       "id": "cartitems",
-      "community": 0
+      "community": 1
     },
     {
       "label": "CashierAuthDialog.tsx",
@@ -5753,7 +5753,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx",
       "source_location": "L1",
       "id": "cashierauthdialog",
-      "community": 0
+      "community": 5
     },
     {
       "label": "CashierView.tsx",
@@ -5833,7 +5833,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/DebugProducts.tsx",
       "source_location": "L1",
       "id": "debugproducts",
-      "community": 0
+      "community": 3
     },
     {
       "label": "DebugProducts()",
@@ -5841,7 +5841,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/DebugProducts.tsx",
       "source_location": "L5",
       "id": "debugproducts_debugproducts",
-      "community": 0
+      "community": 3
     },
     {
       "label": "NewTransactionView.tsx",
@@ -5849,7 +5849,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
       "source_location": "L1",
       "id": "newtransactionview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "Navigation()",
@@ -5857,7 +5857,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
       "source_location": "L22",
       "id": "newtransactionview_navigation",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleStartTransaction()",
@@ -5865,7 +5865,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
       "source_location": "L68",
       "id": "newtransactionview_handlestarttransaction",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleQuickStart()",
@@ -5873,7 +5873,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
       "source_location": "L91",
       "id": "newtransactionview_handlequickstart",
-      "community": 0
+      "community": 1
     },
     {
       "label": "NoResultsMessage.tsx",
@@ -6073,7 +6073,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
       "source_location": "L1",
       "id": "pininput",
-      "community": 3
+      "community": 5
     },
     {
       "label": "PinInput()",
@@ -6081,7 +6081,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
       "source_location": "L13",
       "id": "pininput_pininput",
-      "community": 3
+      "community": 5
     },
     {
       "label": "PointOfSaleView.tsx",
@@ -6089,7 +6089,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
       "source_location": "L1",
       "id": "pointofsaleview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "Navigation()",
@@ -6097,7 +6097,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
       "source_location": "L34",
       "id": "pointofsaleview_navigation",
-      "community": 0
+      "community": 1
     },
     {
       "label": "PrintInstructions.tsx",
@@ -6121,7 +6121,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductCard.tsx",
       "source_location": "L1",
       "id": "productcard",
-      "community": 1
+      "community": 4
     },
     {
       "label": "ProductCard()",
@@ -6129,7 +6129,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/ProductCard.tsx",
       "source_location": "L14",
       "id": "productcard_productcard",
-      "community": 1
+      "community": 4
     },
     {
       "label": "ProductEntry.tsx",
@@ -6137,7 +6137,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
       "source_location": "L1",
       "id": "productentry",
-      "community": 1
+      "community": 4
     },
     {
       "label": "handleClearSearch()",
@@ -6145,7 +6145,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
       "source_location": "L86",
       "id": "productentry_handleclearsearch",
-      "community": 1
+      "community": 4
     },
     {
       "label": "ProductLookup.tsx",
@@ -6185,7 +6185,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SearchResultsSection.tsx",
       "source_location": "L1",
       "id": "searchresultssection",
-      "community": 1
+      "community": 4
     },
     {
       "label": "SessionDemo.tsx",
@@ -6193,7 +6193,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionDemo.tsx",
       "source_location": "L1",
       "id": "sessiondemo",
-      "community": 3
+      "community": 2
     },
     {
       "label": "SessionDemo()",
@@ -6201,7 +6201,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionDemo.tsx",
       "source_location": "L15",
       "id": "sessiondemo_sessiondemo",
-      "community": 3
+      "community": 2
     },
     {
       "label": "SessionManager.tsx",
@@ -6265,7 +6265,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportView.tsx",
       "source_location": "L1",
       "id": "expensereportview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "ExpenseReportsView.tsx",
@@ -6273,7 +6273,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
       "source_location": "L1",
       "id": "expensereportsview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "isToday()",
@@ -6281,7 +6281,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
       "source_location": "L17",
       "id": "expensereportsview_istoday",
-      "community": 0
+      "community": 1
     },
     {
       "label": "expenseReportColumns.tsx",
@@ -6289,7 +6289,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/expense-reports/expenseReportColumns.tsx",
       "source_location": "L1",
       "id": "expensereportcolumns",
-      "community": 0
+      "community": 2
     },
     {
       "label": "hooks.ts",
@@ -6297,7 +6297,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
       "source_location": "L1",
       "id": "hooks",
-      "community": 1
+      "community": 0
     },
     {
       "label": "usePOSCashier()",
@@ -6305,7 +6305,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/hooks.ts",
       "source_location": "L5",
       "id": "hooks_useposcashier",
-      "community": 1
+      "community": 0
     },
     {
       "label": "HeldSessionsList.tsx",
@@ -6353,7 +6353,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/VoidSessionDialog.tsx",
       "source_location": "L1",
       "id": "voidsessiondialog",
-      "community": 3
+      "community": 5
     },
     {
       "label": "VoidSessionDialog()",
@@ -6361,7 +6361,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/VoidSessionDialog.tsx",
       "source_location": "L19",
       "id": "voidsessiondialog_voidsessiondialog",
-      "community": 3
+      "community": 5
     },
     {
       "label": "POSSettingsView.tsx",
@@ -6369,7 +6369,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
       "source_location": "L1",
       "id": "possettingsview",
-      "community": 0
+      "community": 7
     },
     {
       "label": "loadFingerprint()",
@@ -6377,7 +6377,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
       "source_location": "L166",
       "id": "possettingsview_loadfingerprint",
-      "community": 0
+      "community": 7
     },
     {
       "label": "handleRegisterTerminal()",
@@ -6385,7 +6385,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
       "source_location": "L247",
       "id": "possettingsview_handleregisterterminal",
-      "community": 0
+      "community": 7
     },
     {
       "label": "handleUpdateExistingTerminal()",
@@ -6393,7 +6393,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
       "source_location": "L284",
       "id": "possettingsview_handleupdateexistingterminal",
-      "community": 0
+      "community": 7
     },
     {
       "label": "TransactionView.tsx",
@@ -6401,7 +6401,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
       "source_location": "L1",
       "id": "transactionview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "TransactionsView.tsx",
@@ -6409,7 +6409,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
       "source_location": "L1",
       "id": "transactionsview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "formatPaymentMethod()",
@@ -6417,7 +6417,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
       "source_location": "L19",
       "id": "transactionsview_formatpaymentmethod",
-      "community": 0
+      "community": 1
     },
     {
       "label": "isToday()",
@@ -6425,7 +6425,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
       "source_location": "L25",
       "id": "transactionsview_istoday",
-      "community": 0
+      "community": 1
     },
     {
       "label": "transactionColumns.tsx",
@@ -6433,7 +6433,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
       "source_location": "L1",
       "id": "transactioncolumns",
-      "community": 0
+      "community": 2
     },
     {
       "label": "getPaymentMethodIcon()",
@@ -6441,7 +6441,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
       "source_location": "L22",
       "id": "transactioncolumns_getpaymentmethodicon",
-      "community": 0
+      "community": 2
     },
     {
       "label": "AnalyticsInsights.tsx",
@@ -6449,7 +6449,7 @@
       "source_file": "packages/athena-webapp/src/components/product/AnalyticsInsights.tsx",
       "source_location": "L1",
       "id": "analyticsinsights",
-      "community": 0
+      "community": 1
     },
     {
       "label": "AttributesView.tsx",
@@ -6457,7 +6457,7 @@
       "source_file": "packages/athena-webapp/src/components/product/AttributesView.tsx",
       "source_location": "L1",
       "id": "attributesview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "BarcodeView.tsx",
@@ -6465,7 +6465,7 @@
       "source_file": "packages/athena-webapp/src/components/product/BarcodeView.tsx",
       "source_location": "L1",
       "id": "barcodeview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "BarcodeView()",
@@ -6473,7 +6473,7 @@
       "source_file": "packages/athena-webapp/src/components/product/BarcodeView.tsx",
       "source_location": "L14",
       "id": "barcodeview_barcodeview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "CategorizationView.tsx",
@@ -6481,7 +6481,7 @@
       "source_file": "packages/athena-webapp/src/components/product/CategorizationView.tsx",
       "source_location": "L1",
       "id": "categorizationview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "CategorizationView()",
@@ -6489,7 +6489,7 @@
       "source_file": "packages/athena-webapp/src/components/product/CategorizationView.tsx",
       "source_location": "L6",
       "id": "categorizationview_categorizationview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "DetailsView.tsx",
@@ -6497,7 +6497,7 @@
       "source_file": "packages/athena-webapp/src/components/product/DetailsView.tsx",
       "source_location": "L1",
       "id": "detailsview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "ImagesView.tsx",
@@ -6505,7 +6505,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ImagesView.tsx",
       "source_location": "L1",
       "id": "imagesview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleKeyDown()",
@@ -6513,7 +6513,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ImagesView.tsx",
       "source_location": "L36",
       "id": "imagesview_handlekeydown",
-      "community": 0
+      "community": 1
     },
     {
       "label": "ProductDetailView.tsx",
@@ -6521,7 +6521,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ProductDetailView.tsx",
       "source_location": "L1",
       "id": "productdetailview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "ProductStatus.tsx",
@@ -6529,7 +6529,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ProductStatus.tsx",
       "source_location": "L1",
       "id": "productstatus",
-      "community": 3
+      "community": 2
     },
     {
       "label": "ProductStockStatus()",
@@ -6537,7 +6537,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
       "source_location": "L4",
       "id": "productstock_productstockstatus",
-      "community": 6
+      "community": 9
     },
     {
       "label": "OutOfStockStatus()",
@@ -6545,7 +6545,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
       "source_location": "L38",
       "id": "productstock_outofstockstatus",
-      "community": 6
+      "community": 9
     },
     {
       "label": "LowStockStatus()",
@@ -6553,7 +6553,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
       "source_location": "L47",
       "id": "productstock_lowstockstatus",
-      "community": 6
+      "community": 9
     },
     {
       "label": "SKUSelector.tsx",
@@ -6561,7 +6561,7 @@
       "source_file": "packages/athena-webapp/src/components/product/SKUSelector.tsx",
       "source_location": "L1",
       "id": "skuselector",
-      "community": 0
+      "community": 1
     },
     {
       "label": "SKUSelector()",
@@ -6569,7 +6569,7 @@
       "source_file": "packages/athena-webapp/src/components/product/SKUSelector.tsx",
       "source_location": "L10",
       "id": "skuselector_skuselector",
-      "community": 0
+      "community": 1
     },
     {
       "label": "product-actions.tsx",
@@ -6577,7 +6577,7 @@
       "source_file": "packages/athena-webapp/src/components/product-actions.tsx",
       "source_location": "L1",
       "id": "product_actions",
-      "community": 0
+      "community": 3
     },
     {
       "label": "useDeleteProduct()",
@@ -6585,7 +6585,7 @@
       "source_file": "packages/athena-webapp/src/components/product-actions.tsx",
       "source_location": "L6",
       "id": "product_actions_usedeleteproduct",
-      "community": 0
+      "community": 3
     },
     {
       "label": "CategoryListView.tsx",
@@ -6593,7 +6593,7 @@
       "source_file": "packages/athena-webapp/src/components/products/CategoryListView.tsx",
       "source_location": "L1",
       "id": "categorylistview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "ProductSubcategoryToggleGroup.tsx",
@@ -6601,7 +6601,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductSubcategoryToggleGroup.tsx",
       "source_location": "L1",
       "id": "productsubcategorytogglegroup",
-      "community": 0
+      "community": 1
     },
     {
       "label": "ProductsListView.tsx",
@@ -6609,7 +6609,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsListView.tsx",
       "source_location": "L1",
       "id": "productslistview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "ProductActionsToggleGroup()",
@@ -6617,7 +6617,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsListView.tsx",
       "source_location": "L20",
       "id": "productslistview_productactionstogglegroup",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleClearCache()",
@@ -6625,7 +6625,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsListView.tsx",
       "source_location": "L65",
       "id": "productslistview_handleclearcache",
-      "community": 0
+      "community": 1
     },
     {
       "label": "ProductsTableContext.tsx",
@@ -6633,7 +6633,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsTableContext.tsx",
       "source_location": "L1",
       "id": "productstablecontext",
-      "community": 0
+      "community": 1
     },
     {
       "label": "ProductsTableProvider()",
@@ -6641,7 +6641,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsTableContext.tsx",
       "source_location": "L16",
       "id": "productstablecontext_productstableprovider",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useProductsTableState()",
@@ -6649,7 +6649,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsTableContext.tsx",
       "source_location": "L60",
       "id": "productstablecontext_useproductstablestate",
-      "community": 0
+      "community": 1
     },
     {
       "label": "ProductsView.tsx",
@@ -6657,7 +6657,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsView.tsx",
       "source_location": "L1",
       "id": "productsview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "ProductsView()",
@@ -6665,7 +6665,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsView.tsx",
       "source_location": "L5",
       "id": "productsview_productsview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "StoreProducts.tsx",
@@ -6673,7 +6673,7 @@
       "source_file": "packages/athena-webapp/src/components/products/StoreProducts.tsx",
       "source_location": "L1",
       "id": "storeproducts",
-      "community": 0
+      "community": 1
     },
     {
       "label": "StoreProductsView.tsx",
@@ -6681,7 +6681,7 @@
       "source_file": "packages/athena-webapp/src/components/products/StoreProductsView.tsx",
       "source_location": "L1",
       "id": "storeproductsview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "ProductActionsToggleGroup()",
@@ -6689,7 +6689,7 @@
       "source_file": "packages/athena-webapp/src/components/products/StoreProductsView.tsx",
       "source_location": "L19",
       "id": "storeproductsview_productactionstogglegroup",
-      "community": 0
+      "community": 1
     },
     {
       "label": "Navigation()",
@@ -6697,7 +6697,7 @@
       "source_file": "packages/athena-webapp/src/components/products/StoreProductsView.tsx",
       "source_location": "L45",
       "id": "storeproductsview_navigation",
-      "community": 0
+      "community": 1
     },
     {
       "label": "UnresolvedProducts.tsx",
@@ -6705,7 +6705,7 @@
       "source_file": "packages/athena-webapp/src/components/products/UnresolvedProducts.tsx",
       "source_location": "L1",
       "id": "unresolvedproducts",
-      "community": 0
+      "community": 1
     },
     {
       "label": "AddComplimentaryProduct.tsx",
@@ -6713,7 +6713,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/AddComplimentaryProduct.tsx",
       "source_location": "L1",
       "id": "addcomplimentaryproduct",
-      "community": 0
+      "community": 7
     },
     {
       "label": "handleAddComplimentaryProducts()",
@@ -6721,7 +6721,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/AddComplimentaryProduct.tsx",
       "source_location": "L40",
       "id": "addcomplimentaryproduct_handleaddcomplimentaryproducts",
-      "community": 0
+      "community": 7
     },
     {
       "label": "AddComplimentaryProduct()",
@@ -6729,7 +6729,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/AddComplimentaryProduct.tsx",
       "source_location": "L128",
       "id": "addcomplimentaryproduct_addcomplimentaryproduct",
-      "community": 0
+      "community": 7
     },
     {
       "label": "ComplimentaryProducts.tsx",
@@ -6737,7 +6737,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProducts.tsx",
       "source_location": "L1",
       "id": "complimentaryproducts",
-      "community": 0
+      "community": 2
     },
     {
       "label": "ComplimentaryProductsView.tsx",
@@ -6745,7 +6745,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
       "source_location": "L1",
       "id": "complimentaryproductsview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "Navigation()",
@@ -6753,7 +6753,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
       "source_location": "L6",
       "id": "complimentaryproductsview_navigation",
-      "community": 0
+      "community": 1
     },
     {
       "label": "Body()",
@@ -6761,7 +6761,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
       "source_location": "L16",
       "id": "complimentaryproductsview_body",
-      "community": 0
+      "community": 1
     },
     {
       "label": "ComplimentaryProductsView()",
@@ -6769,7 +6769,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
       "source_location": "L35",
       "id": "complimentaryproductsview_complimentaryproductsview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "complimentaryProductsColumn.tsx",
@@ -6777,7 +6777,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/complimentaryProductsColumn.tsx",
       "source_location": "L1",
       "id": "complimentaryproductscolumn",
-      "community": 3
+      "community": 2
     },
     {
       "label": "add-product-command.tsx",
@@ -6785,7 +6785,7 @@
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/add-product-command.tsx",
       "source_location": "L1",
       "id": "add_product_command",
-      "community": 0
+      "community": 2
     },
     {
       "label": "AddProductCommand()",
@@ -6793,7 +6793,7 @@
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/add-product-command.tsx",
       "source_location": "L17",
       "id": "add_product_command_addproductcommand",
-      "community": 0
+      "community": 2
     },
     {
       "label": "productColumns.tsx",
@@ -6801,7 +6801,7 @@
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/productColumns.tsx",
       "source_location": "L1",
       "id": "productcolumns",
-      "community": 0
+      "community": 2
     },
     {
       "label": "Products()",
@@ -6809,7 +6809,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/Products.tsx",
       "source_location": "L4",
       "id": "products_products",
-      "community": 0
+      "community": 2
     },
     {
       "label": "PromoCodeForm.tsx",
@@ -6817,7 +6817,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeForm.tsx",
       "source_location": "L1",
       "id": "promocodeform",
-      "community": 16
+      "community": 0
     },
     {
       "label": "toggleDiscountType()",
@@ -6825,7 +6825,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeForm.tsx",
       "source_location": "L84",
       "id": "promocodeform_togglediscounttype",
-      "community": 16
+      "community": 0
     },
     {
       "label": "PromoCodeHeader.tsx",
@@ -6833,7 +6833,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
       "source_location": "L1",
       "id": "promocodeheader",
-      "community": 0
+      "community": 7
     },
     {
       "label": "handleDeletePromoCode()",
@@ -6841,7 +6841,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
       "source_location": "L22",
       "id": "promocodeheader_handledeletepromocode",
-      "community": 0
+      "community": 7
     },
     {
       "label": "PromoCodePreview.tsx",
@@ -6849,7 +6849,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodePreview.tsx",
       "source_location": "L1",
       "id": "promocodepreview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "PromoCodeView.tsx",
@@ -6857,7 +6857,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
       "source_location": "L1",
       "id": "promocodeview",
-      "community": 8
+      "community": 7
     },
     {
       "label": "handleAddPromoCode()",
@@ -6865,7 +6865,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
       "source_location": "L146",
       "id": "promocodeview_handleaddpromocode",
-      "community": 8
+      "community": 7
     },
     {
       "label": "handleUpdatePromoCode()",
@@ -6873,7 +6873,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
       "source_location": "L213",
       "id": "promocodeview_handleupdatepromocode",
-      "community": 8
+      "community": 7
     },
     {
       "label": "updateHomepageDiscountCode()",
@@ -6881,7 +6881,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
       "source_location": "L299",
       "id": "promocodeview_updatehomepagediscountcode",
-      "community": 8
+      "community": 7
     },
     {
       "label": "updateLeaveAReviewDiscountCode()",
@@ -6889,7 +6889,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
       "source_location": "L351",
       "id": "promocodeview_updateleaveareviewdiscountcode",
-      "community": 8
+      "community": 7
     },
     {
       "label": "promoCodes.ts",
@@ -6897,7 +6897,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L1",
       "id": "promocodes",
-      "community": 1
+      "community": 3
     },
     {
       "label": "PromoCodesView.tsx",
@@ -6905,7 +6905,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodesView.tsx",
       "source_location": "L1",
       "id": "promocodesview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "PromoCodesView()",
@@ -6913,7 +6913,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodesView.tsx",
       "source_location": "L9",
       "id": "promocodesview_promocodesview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "SelectableCategories.tsx",
@@ -6937,7 +6937,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/DiscountTypeToggleGroup.tsx",
       "source_location": "L1",
       "id": "discounttypetogglegroup",
-      "community": 16
+      "community": 4
     },
     {
       "label": "DiscountTypeToggleGroup()",
@@ -6945,7 +6945,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/DiscountTypeToggleGroup.tsx",
       "source_location": "L5",
       "id": "discounttypetogglegroup_discounttypetogglegroup",
-      "community": 16
+      "community": 4
     },
     {
       "label": "PromoCodeSpanToggleGroup.tsx",
@@ -6953,7 +6953,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/PromoCodeSpanToggleGroup.tsx",
       "source_location": "L1",
       "id": "promocodespantogglegroup",
-      "community": 16
+      "community": 4
     },
     {
       "label": "PromoCodeSpanToggleGroup()",
@@ -6961,7 +6961,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/PromoCodeSpanToggleGroup.tsx",
       "source_location": "L4",
       "id": "promocodespantogglegroup_promocodespantogglegroup",
-      "community": 16
+      "community": 4
     },
     {
       "label": "PromoCodeAnalytics.tsx",
@@ -6969,7 +6969,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/analytics/PromoCodeAnalytics.tsx",
       "source_location": "L1",
       "id": "promocodeanalytics",
-      "community": 0
+      "community": 2
     },
     {
       "label": "CapturedEmails.tsx",
@@ -6977,7 +6977,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/captured/CapturedEmails.tsx",
       "source_location": "L1",
       "id": "capturedemails",
-      "community": 0
+      "community": 2
     },
     {
       "label": "CapturedEmails()",
@@ -6985,7 +6985,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/captured/CapturedEmails.tsx",
       "source_location": "L13",
       "id": "capturedemails_capturedemails",
-      "community": 0
+      "community": 2
     },
     {
       "label": "captured-emails-columns.tsx",
@@ -6993,7 +6993,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/captured/captured-emails-columns.tsx",
       "source_location": "L1",
       "id": "captured_emails_columns",
-      "community": 3
+      "community": 2
     },
     {
       "label": "color-picker.tsx",
@@ -7001,7 +7001,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
       "source_location": "L1",
       "id": "color_picker",
-      "community": 16
+      "community": 5
     },
     {
       "label": "handleInputChange()",
@@ -7009,7 +7009,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
       "source_location": "L20",
       "id": "color_picker_handleinputchange",
-      "community": 16
+      "community": 5
     },
     {
       "label": "handleBlur()",
@@ -7017,7 +7017,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
       "source_location": "L24",
       "id": "color_picker_handleblur",
-      "community": 16
+      "community": 5
     },
     {
       "label": "promo-code-modal.tsx",
@@ -7041,7 +7041,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L1",
       "id": "welcome_offer_modal",
-      "community": 14
+      "community": 5
     },
     {
       "label": "handleChange()",
@@ -7049,7 +7049,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L76",
       "id": "welcome_offer_modal_handlechange",
-      "community": 14
+      "community": 5
     },
     {
       "label": "handleNumberChange()",
@@ -7057,7 +7057,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L83",
       "id": "welcome_offer_modal_handlenumberchange",
-      "community": 14
+      "community": 5
     },
     {
       "label": "handleSwitchChange()",
@@ -7065,7 +7065,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L88",
       "id": "welcome_offer_modal_handleswitchchange",
-      "community": 14
+      "community": 5
     },
     {
       "label": "handleColorChange()",
@@ -7073,7 +7073,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L92",
       "id": "welcome_offer_modal_handlecolorchange",
-      "community": 14
+      "community": 5
     },
     {
       "label": "handleSelectChange()",
@@ -7081,7 +7081,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L96",
       "id": "welcome_offer_modal_handleselectchange",
-      "community": 14
+      "community": 5
     },
     {
       "label": "updateImages()",
@@ -7089,7 +7089,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L100",
       "id": "welcome_offer_modal_updateimages",
-      "community": 14
+      "community": 5
     },
     {
       "label": "handleSubmit()",
@@ -7097,7 +7097,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L104",
       "id": "welcome_offer_modal_handlesubmit",
-      "community": 14
+      "community": 5
     },
     {
       "label": "welcome-offer-card.tsx",
@@ -7113,7 +7113,7 @@
       "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
       "source_location": "L1",
       "id": "currency_provider",
-      "community": 16
+      "community": 0
     },
     {
       "label": "useStoreCurrency()",
@@ -7121,7 +7121,7 @@
       "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
       "source_location": "L17",
       "id": "currency_provider_usestorecurrency",
-      "community": 16
+      "community": 0
     },
     {
       "label": "CurrencyProvider()",
@@ -7129,7 +7129,7 @@
       "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
       "source_location": "L25",
       "id": "currency_provider_currencyprovider",
-      "community": 16
+      "community": 0
     },
     {
       "label": "RatingStars.tsx",
@@ -7137,7 +7137,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/RatingStars.tsx",
       "source_location": "L1",
       "id": "ratingstars",
-      "community": 11
+      "community": 2
     },
     {
       "label": "ReviewActions.tsx",
@@ -7145,7 +7145,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewActions.tsx",
       "source_location": "L1",
       "id": "reviewactions",
-      "community": 11
+      "community": 4
     },
     {
       "label": "ReviewActions()",
@@ -7153,7 +7153,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewActions.tsx",
       "source_location": "L20",
       "id": "reviewactions_reviewactions",
-      "community": 11
+      "community": 4
     },
     {
       "label": "ReviewCard.tsx",
@@ -7161,7 +7161,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewCard.tsx",
       "source_location": "L1",
       "id": "reviewcard",
-      "community": 11
+      "community": 2
     },
     {
       "label": "ReviewMetadata.tsx",
@@ -7169,7 +7169,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewMetadata.tsx",
       "source_location": "L1",
       "id": "reviewmetadata",
-      "community": 11
+      "community": 2
     },
     {
       "label": "ReviewsView.tsx",
@@ -7177,7 +7177,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L1",
       "id": "reviewsview",
-      "community": 11
+      "community": 1
     },
     {
       "label": "Header()",
@@ -7185,7 +7185,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L13",
       "id": "reviewsview_header",
-      "community": 11
+      "community": 1
     },
     {
       "label": "handleApprove()",
@@ -7193,7 +7193,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L42",
       "id": "reviewsview_handleapprove",
-      "community": 11
+      "community": 1
     },
     {
       "label": "handleReject()",
@@ -7201,7 +7201,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L58",
       "id": "reviewsview_handlereject",
-      "community": 11
+      "community": 1
     },
     {
       "label": "handlePublish()",
@@ -7209,7 +7209,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L74",
       "id": "reviewsview_handlepublish",
-      "community": 11
+      "community": 1
     },
     {
       "label": "handleUnpublish()",
@@ -7217,7 +7217,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L90",
       "id": "reviewsview_handleunpublish",
-      "community": 11
+      "community": 1
     },
     {
       "label": "empty-state.tsx",
@@ -7225,7 +7225,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/empty/empty-state.tsx",
       "source_location": "L1",
       "id": "empty_state",
-      "community": 0
+      "community": 1
     },
     {
       "label": "onClick()",
@@ -7233,7 +7233,7 @@
       "source_file": "packages/athena-webapp/src/components/states/empty/empty-state.tsx",
       "source_location": "L29",
       "id": "empty_state_onclick",
-      "community": 0
+      "community": 1
     },
     {
       "label": "SingleLineError.tsx",
@@ -7257,7 +7257,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/error/index.tsx",
       "source_location": "L9",
       "id": "index_errorpage",
-      "community": 11
+      "community": 1
     },
     {
       "label": "app-skeleton.tsx",
@@ -7265,7 +7265,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/app-skeleton.tsx",
       "source_location": "L1",
       "id": "app_skeleton",
-      "community": 0
+      "community": 1
     },
     {
       "label": "AppSkeleton()",
@@ -7273,7 +7273,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/app-skeleton.tsx",
       "source_location": "L3",
       "id": "app_skeleton_appskeleton",
-      "community": 0
+      "community": 1
     },
     {
       "label": "dashboard-skeleton.tsx",
@@ -7281,7 +7281,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/dashboard-skeleton.tsx",
       "source_location": "L1",
       "id": "dashboard_skeleton",
-      "community": 0
+      "community": 1
     },
     {
       "label": "DashboardSkeleton()",
@@ -7289,7 +7289,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/dashboard-skeleton.tsx",
       "source_location": "L3",
       "id": "dashboard_skeleton_dashboardskeleton",
-      "community": 0
+      "community": 1
     },
     {
       "label": "table-skeleton.tsx",
@@ -7297,7 +7297,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/table-skeleton.tsx",
       "source_location": "L1",
       "id": "table_skeleton",
-      "community": 0
+      "community": 1
     },
     {
       "label": "TableSkeleton()",
@@ -7305,7 +7305,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/table-skeleton.tsx",
       "source_location": "L3",
       "id": "table_skeleton_tableskeleton",
-      "community": 0
+      "community": 1
     },
     {
       "label": "transactions-skeleton.tsx",
@@ -7313,7 +7313,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/transactions-skeleton.tsx",
       "source_location": "L1",
       "id": "transactions_skeleton",
-      "community": 0
+      "community": 1
     },
     {
       "label": "TransactionsSkeleton()",
@@ -7321,7 +7321,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/transactions-skeleton.tsx",
       "source_location": "L3",
       "id": "transactions_skeleton_transactionsskeleton",
-      "community": 0
+      "community": 1
     },
     {
       "label": "NoPermission.tsx",
@@ -7329,7 +7329,7 @@
       "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermission.tsx",
       "source_location": "L1",
       "id": "nopermission",
-      "community": 8
+      "community": 7
     },
     {
       "label": "NoPermission()",
@@ -7337,7 +7337,7 @@
       "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermission.tsx",
       "source_location": "L3",
       "id": "nopermission_nopermission",
-      "community": 8
+      "community": 7
     },
     {
       "label": "NoPermissionView.tsx",
@@ -7345,7 +7345,7 @@
       "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermissionView.tsx",
       "source_location": "L1",
       "id": "nopermissionview",
-      "community": 8
+      "community": 7
     },
     {
       "label": "NoPermissionView()",
@@ -7353,7 +7353,7 @@
       "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermissionView.tsx",
       "source_location": "L4",
       "id": "nopermissionview_nopermissionview",
-      "community": 8
+      "community": 7
     },
     {
       "label": "NotFound.tsx",
@@ -7361,7 +7361,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/not-found/NotFound.tsx",
       "source_location": "L1",
       "id": "notfound",
-      "community": 1
+      "community": 0
     },
     {
       "label": "NotFound()",
@@ -7369,7 +7369,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/not-found/NotFound.tsx",
       "source_location": "L4",
       "id": "notfound_notfound",
-      "community": 1
+      "community": 0
     },
     {
       "label": "NotFoundView.tsx",
@@ -7377,7 +7377,7 @@
       "source_file": "packages/athena-webapp/src/components/states/not-found/NotFoundView.tsx",
       "source_location": "L1",
       "id": "notfoundview",
-      "community": 8
+      "community": 7
     },
     {
       "label": "NotFoundView()",
@@ -7385,7 +7385,7 @@
       "source_file": "packages/athena-webapp/src/components/states/not-found/NotFoundView.tsx",
       "source_location": "L4",
       "id": "notfoundview_notfoundview",
-      "community": 8
+      "community": 7
     },
     {
       "label": "ContactView.tsx",
@@ -7393,7 +7393,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/ContactView.tsx",
       "source_location": "L1",
       "id": "contactview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "ContactView()",
@@ -7401,7 +7401,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/ContactView.tsx",
       "source_location": "L9",
       "id": "contactview_contactview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "FeesView.tsx",
@@ -7409,7 +7409,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FeesView.tsx",
       "source_location": "L1",
       "id": "feesview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleUpdateFees()",
@@ -7417,7 +7417,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FeesView.tsx",
       "source_location": "L36",
       "id": "feesview_handleupdatefees",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleToggleAllFees()",
@@ -7425,7 +7425,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FeesView.tsx",
       "source_location": "L104",
       "id": "feesview_handletoggleallfees",
-      "community": 0
+      "community": 1
     },
     {
       "label": "FulfillmentView.tsx",
@@ -7433,7 +7433,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L1",
       "id": "fulfillmentview",
-      "community": 17
+      "community": 16
     },
     {
       "label": "saveEnableStorePickupChanges()",
@@ -7441,7 +7441,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L43",
       "id": "fulfillmentview_saveenablestorepickupchanges",
-      "community": 17
+      "community": 16
     },
     {
       "label": "saveEnableDeliveryChanges()",
@@ -7449,7 +7449,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L75",
       "id": "fulfillmentview_saveenabledeliverychanges",
-      "community": 17
+      "community": 16
     },
     {
       "label": "savePickupRestriction()",
@@ -7457,7 +7457,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L107",
       "id": "fulfillmentview_savepickuprestriction",
-      "community": 17
+      "community": 16
     },
     {
       "label": "saveDeliveryRestriction()",
@@ -7465,7 +7465,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L132",
       "id": "fulfillmentview_savedeliveryrestriction",
-      "community": 17
+      "community": 16
     },
     {
       "label": "handlePickupRestrictionToggle()",
@@ -7473,7 +7473,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L157",
       "id": "fulfillmentview_handlepickuprestrictiontoggle",
-      "community": 17
+      "community": 16
     },
     {
       "label": "handleDeliveryRestrictionToggle()",
@@ -7481,7 +7481,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L196",
       "id": "fulfillmentview_handledeliveryrestrictiontoggle",
-      "community": 17
+      "community": 16
     },
     {
       "label": "handleSavePickupRestriction()",
@@ -7489,7 +7489,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L235",
       "id": "fulfillmentview_handlesavepickuprestriction",
-      "community": 17
+      "community": 16
     },
     {
       "label": "handleSaveDeliveryRestriction()",
@@ -7497,7 +7497,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L244",
       "id": "fulfillmentview_handlesavedeliveryrestriction",
-      "community": 17
+      "community": 16
     },
     {
       "label": "Header.tsx",
@@ -7505,7 +7505,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
       "source_location": "L1",
       "id": "header",
-      "community": 11
+      "community": 1
     },
     {
       "label": "Header()",
@@ -7513,7 +7513,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
       "source_location": "L1",
       "id": "header_header",
-      "community": 11
+      "community": 1
     },
     {
       "label": "MaintenanceView.tsx",
@@ -7521,7 +7521,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.tsx",
       "source_location": "L1",
       "id": "maintenanceview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "MaintenanceView()",
@@ -7529,7 +7529,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.tsx",
       "source_location": "L13",
       "id": "maintenanceview_maintenanceview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "MtnMomoView.test.tsx",
@@ -7537,7 +7537,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.test.tsx",
       "source_location": "L1",
       "id": "mtnmomoview_test",
-      "community": 3
+      "community": 2
     },
     {
       "label": "MtnMomoView.tsx",
@@ -7545,7 +7545,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L1",
       "id": "mtnmomoview",
-      "community": 3
+      "community": 2
     },
     {
       "label": "cloneReceivingAccount()",
@@ -7553,7 +7553,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L27",
       "id": "mtnmomoview_clonereceivingaccount",
-      "community": 3
+      "community": 2
     },
     {
       "label": "createEmptyReceivingAccount()",
@@ -7561,7 +7561,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L35",
       "id": "mtnmomoview_createemptyreceivingaccount",
-      "community": 3
+      "community": 2
     },
     {
       "label": "trimToUndefined()",
@@ -7569,7 +7569,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L47",
       "id": "mtnmomoview_trimtoundefined",
-      "community": 3
+      "community": 2
     },
     {
       "label": "cleanUndefinedFields()",
@@ -7577,7 +7577,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L52",
       "id": "mtnmomoview_cleanundefinedfields",
-      "community": 3
+      "community": 2
     },
     {
       "label": "hasReceivingAccountDetails()",
@@ -7585,7 +7585,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L64",
       "id": "mtnmomoview_hasreceivingaccountdetails",
-      "community": 3
+      "community": 2
     },
     {
       "label": "normalizePrimaryAccounts()",
@@ -7593,7 +7593,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L77",
       "id": "mtnmomoview_normalizeprimaryaccounts",
-      "community": 3
+      "community": 2
     },
     {
       "label": "toPatchReceivingAccounts()",
@@ -7601,7 +7601,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L93",
       "id": "mtnmomoview_topatchreceivingaccounts",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getStatusBadgeVariant()",
@@ -7609,7 +7609,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L114",
       "id": "mtnmomoview_getstatusbadgevariant",
-      "community": 3
+      "community": 2
     },
     {
       "label": "updateAccount()",
@@ -7617,7 +7617,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L141",
       "id": "mtnmomoview_updateaccount",
-      "community": 3
+      "community": 2
     },
     {
       "label": "handleAddAccount()",
@@ -7625,7 +7625,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L152",
       "id": "mtnmomoview_handleaddaccount",
-      "community": 3
+      "community": 2
     },
     {
       "label": "handleMakePrimary()",
@@ -7633,7 +7633,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L159",
       "id": "mtnmomoview_handlemakeprimary",
-      "community": 3
+      "community": 2
     },
     {
       "label": "handleRemoveAccount()",
@@ -7641,7 +7641,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L168",
       "id": "mtnmomoview_handleremoveaccount",
-      "community": 3
+      "community": 2
     },
     {
       "label": "handleSave()",
@@ -7649,7 +7649,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L188",
       "id": "mtnmomoview_handlesave",
-      "community": 3
+      "community": 2
     },
     {
       "label": "TaxView.tsx",
@@ -7657,7 +7657,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/TaxView.tsx",
       "source_location": "L1",
       "id": "taxview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleUpdateTaxSettings()",
@@ -7665,7 +7665,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/TaxView.tsx",
       "source_location": "L25",
       "id": "taxview_handleupdatetaxsettings",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useStoreConfigUpdate.ts",
@@ -7673,7 +7673,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/hooks/useStoreConfigUpdate.ts",
       "source_location": "L1",
       "id": "usestoreconfigupdate",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useStoreConfigUpdate()",
@@ -7681,7 +7681,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/hooks/useStoreConfigUpdate.ts",
       "source_location": "L19",
       "id": "usestoreconfigupdate_usestoreconfigupdate",
-      "community": 0
+      "community": 1
     },
     {
       "label": "store-switcher.tsx",
@@ -7689,7 +7689,7 @@
       "source_file": "packages/athena-webapp/src/components/store-switcher.tsx",
       "source_location": "L1",
       "id": "store_switcher",
-      "community": 16
+      "community": 0
     },
     {
       "label": "onStoreSelect()",
@@ -7697,7 +7697,7 @@
       "source_file": "packages/athena-webapp/src/components/store-switcher.tsx",
       "source_location": "L63",
       "id": "store_switcher_onstoreselect",
-      "community": 16
+      "community": 0
     },
     {
       "label": "accordion.tsx",
@@ -7729,7 +7729,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/badge.tsx",
       "source_location": "L1",
       "id": "badge",
-      "community": 3
+      "community": 2
     },
     {
       "label": "Badge()",
@@ -7737,7 +7737,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/badge.tsx",
       "source_location": "L30",
       "id": "badge_badge",
-      "community": 3
+      "community": 2
     },
     {
       "label": "button.test.tsx",
@@ -7761,7 +7761,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/calendar.test.tsx",
       "source_location": "L1",
       "id": "calendar_test",
-      "community": 16
+      "community": 0
     },
     {
       "label": "calendar.tsx",
@@ -7769,7 +7769,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/calendar.tsx",
       "source_location": "L1",
       "id": "calendar",
-      "community": 16
+      "community": 0
     },
     {
       "label": "card.tsx",
@@ -7777,7 +7777,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/card.tsx",
       "source_location": "L1",
       "id": "card",
-      "community": 3
+      "community": 2
     },
     {
       "label": "useChart()",
@@ -7785,7 +7785,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/chart.tsx",
       "source_location": "L25",
       "id": "chart_usechart",
-      "community": 3
+      "community": 2
     },
     {
       "label": "checkbox.tsx",
@@ -7825,7 +7825,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/copy-button.tsx",
       "source_location": "L1",
       "id": "copy_button",
-      "community": 0
+      "community": 2
     },
     {
       "label": "handleCopy()",
@@ -7833,7 +7833,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/copy-button.tsx",
       "source_location": "L15",
       "id": "copy_button_handlecopy",
-      "community": 0
+      "community": 2
     },
     {
       "label": "copy-wrapper.tsx",
@@ -7841,7 +7841,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/copy-wrapper.tsx",
       "source_location": "L1",
       "id": "copy_wrapper",
-      "community": 0
+      "community": 2
     },
     {
       "label": "handleCopy()",
@@ -7849,7 +7849,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/copy-wrapper.tsx",
       "source_location": "L21",
       "id": "copy_wrapper_handlecopy",
-      "community": 0
+      "community": 2
     },
     {
       "label": "date-time-picker.tsx",
@@ -7857,7 +7857,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/date-time-picker.tsx",
       "source_location": "L1",
       "id": "date_time_picker",
-      "community": 16
+      "community": 0
     },
     {
       "label": "DateTimePicker()",
@@ -7865,7 +7865,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/date-time-picker.tsx",
       "source_location": "L21",
       "id": "date_time_picker_datetimepicker",
-      "community": 16
+      "community": 0
     },
     {
       "label": "dialog.tsx",
@@ -7873,7 +7873,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/dialog.tsx",
       "source_location": "L1",
       "id": "dialog",
-      "community": 3
+      "community": 5
     },
     {
       "label": "dropdown-menu.tsx",
@@ -7897,7 +7897,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/icons.tsx",
       "source_location": "L1",
       "id": "icons",
-      "community": 1
+      "community": 0
     },
     {
       "label": "image-uploader.tsx",
@@ -7945,7 +7945,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/input-otp.tsx",
       "source_location": "L1",
       "id": "input_otp",
-      "community": 3
+      "community": 5
     },
     {
       "label": "input.tsx",
@@ -7961,7 +7961,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/label.tsx",
       "source_location": "L1",
       "id": "label",
-      "community": 0
+      "community": 1
     },
     {
       "label": "Label()",
@@ -7969,7 +7969,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/label.tsx",
       "source_location": "L6",
       "id": "label_label",
-      "community": 0
+      "community": 1
     },
     {
       "label": "loading-button.tsx",
@@ -7977,7 +7977,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/loading-button.tsx",
       "source_location": "L1",
       "id": "loading_button",
-      "community": 0
+      "community": 5
     },
     {
       "label": "LoadingButton()",
@@ -7985,7 +7985,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/loading-button.tsx",
       "source_location": "L9",
       "id": "loading_button_loadingbutton",
-      "community": 0
+      "community": 5
     },
     {
       "label": "modal.tsx",
@@ -8105,7 +8105,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/overlay-modal.tsx",
       "source_location": "L1",
       "id": "overlay_modal",
-      "community": 16
+      "community": 0
     },
     {
       "label": "OverlayModal()",
@@ -8113,7 +8113,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/overlay-modal.tsx",
       "source_location": "L12",
       "id": "overlay_modal_overlaymodal",
-      "community": 16
+      "community": 0
     },
     {
       "label": "store-modal.tsx",
@@ -8169,7 +8169,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/popover.tsx",
       "source_location": "L1",
       "id": "popover",
-      "community": 16
+      "community": 0
     },
     {
       "label": "radio-group.tsx",
@@ -8185,7 +8185,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/scroll-area.tsx",
       "source_location": "L1",
       "id": "scroll_area",
-      "community": 6
+      "community": 9
     },
     {
       "label": "select-native.tsx",
@@ -8193,7 +8193,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/select-native.tsx",
       "source_location": "L1",
       "id": "select_native",
-      "community": 3
+      "community": 16
     },
     {
       "label": "cn()",
@@ -8201,7 +8201,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/select-native.tsx",
       "source_location": "L15",
       "id": "select_native_cn",
-      "community": 3
+      "community": 16
     },
     {
       "label": "select.tsx",
@@ -8217,7 +8217,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/separator.tsx",
       "source_location": "L1",
       "id": "separator",
-      "community": 5
+      "community": 0
     },
     {
       "label": "sheet.tsx",
@@ -8225,7 +8225,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/sheet.tsx",
       "source_location": "L1",
       "id": "sheet",
-      "community": 6
+      "community": 9
     },
     {
       "label": "sidebar.tsx",
@@ -8233,7 +8233,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L1",
       "id": "sidebar",
-      "community": 5
+      "community": 9
     },
     {
       "label": "useSidebar()",
@@ -8241,7 +8241,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L45",
       "id": "sidebar_usesidebar",
-      "community": 5
+      "community": 9
     },
     {
       "label": "handleKeyDown()",
@@ -8249,7 +8249,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L105",
       "id": "sidebar_handlekeydown",
-      "community": 5
+      "community": 9
     },
     {
       "label": "cn()",
@@ -8257,7 +8257,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L147",
       "id": "sidebar_cn",
-      "community": 5
+      "community": 9
     },
     {
       "label": "handleOnHover()",
@@ -8265,7 +8265,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L224",
       "id": "sidebar_handleonhover",
-      "community": 5
+      "community": 9
     },
     {
       "label": "handleOnMouseLeave()",
@@ -8273,7 +8273,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L228",
       "id": "sidebar_handleonmouseleave",
-      "community": 5
+      "community": 9
     },
     {
       "label": "skeleton.tsx",
@@ -8281,7 +8281,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/skeleton.tsx",
       "source_location": "L1",
       "id": "skeleton",
-      "community": 0
+      "community": 1
     },
     {
       "label": "Skeleton()",
@@ -8289,7 +8289,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/skeleton.tsx",
       "source_location": "L3",
       "id": "skeleton_skeleton",
-      "community": 0
+      "community": 1
     },
     {
       "label": "sonner.tsx",
@@ -8297,7 +8297,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/sonner.tsx",
       "source_location": "L1",
       "id": "sonner",
-      "community": 0
+      "community": 4
     },
     {
       "label": "Toaster()",
@@ -8305,7 +8305,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/sonner.tsx",
       "source_location": "L6",
       "id": "sonner_toaster",
-      "community": 0
+      "community": 4
     },
     {
       "label": "spinner.tsx",
@@ -8313,7 +8313,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/spinner.tsx",
       "source_location": "L1",
       "id": "spinner",
-      "community": 1
+      "community": 0
     },
     {
       "label": "Spinner()",
@@ -8321,7 +8321,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/spinner.tsx",
       "source_location": "L3",
       "id": "spinner_spinner",
-      "community": 1
+      "community": 0
     },
     {
       "label": "switch.tsx",
@@ -8329,7 +8329,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/switch.tsx",
       "source_location": "L1",
       "id": "switch",
-      "community": 0
+      "community": 1
     },
     {
       "label": "table.tsx",
@@ -8337,7 +8337,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/table.tsx",
       "source_location": "L1",
       "id": "table",
-      "community": 9
+      "community": 13
     },
     {
       "label": "tabs.tsx",
@@ -8345,7 +8345,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/tabs.tsx",
       "source_location": "L1",
       "id": "tabs",
-      "community": 0
+      "community": 1
     },
     {
       "label": "textarea.tsx",
@@ -8353,7 +8353,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/textarea.tsx",
       "source_location": "L1",
       "id": "textarea",
-      "community": 3
+      "community": 5
     },
     {
       "label": "timeline-item.tsx",
@@ -8377,7 +8377,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/toggle-group.tsx",
       "source_location": "L1",
       "id": "toggle_group",
-      "community": 16
+      "community": 1
     },
     {
       "label": "toggle.tsx",
@@ -8385,7 +8385,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/toggle.tsx",
       "source_location": "L1",
       "id": "toggle",
-      "community": 16
+      "community": 1
     },
     {
       "label": "tooltip.tsx",
@@ -8393,7 +8393,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/tooltip.tsx",
       "source_location": "L1",
       "id": "tooltip",
-      "community": 0
+      "community": 2
     },
     {
       "label": "webp-image.tsx",
@@ -8417,7 +8417,7 @@
       "source_file": "packages/athena-webapp/src/components/upload-button.tsx",
       "source_location": "L1",
       "id": "upload_button",
-      "community": 11
+      "community": 0
     },
     {
       "label": "BagItems.tsx",
@@ -8425,7 +8425,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/BagItems.tsx",
       "source_location": "L1",
       "id": "bagitems",
-      "community": 0
+      "community": 2
     },
     {
       "label": "BagItems()",
@@ -8433,7 +8433,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/BagItems.tsx",
       "source_location": "L5",
       "id": "bagitems_bagitems",
-      "community": 0
+      "community": 2
     },
     {
       "label": "BagItemsView.tsx",
@@ -8441,7 +8441,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/BagItemsView.tsx",
       "source_location": "L1",
       "id": "bagitemsview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "BagItemsView()",
@@ -8449,7 +8449,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/BagItemsView.tsx",
       "source_location": "L11",
       "id": "bagitemsview_bagitemsview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "BagView.tsx",
@@ -8457,7 +8457,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/BagView.tsx",
       "source_location": "L1",
       "id": "bagview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "Bags.tsx",
@@ -8465,7 +8465,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
       "source_location": "L1",
       "id": "bags",
-      "community": 3
+      "community": 2
     },
     {
       "label": "Bags()",
@@ -8473,7 +8473,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
       "source_location": "L4",
       "id": "bags_bags",
-      "community": 3
+      "community": 2
     },
     {
       "label": "bag-columns.tsx",
@@ -8481,7 +8481,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bag-columns.tsx",
       "source_location": "L1",
       "id": "bag_columns",
-      "community": 3
+      "community": 2
     },
     {
       "label": "bags-table.tsx",
@@ -8489,7 +8489,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bags-table.tsx",
       "source_location": "L1",
       "id": "bags_table",
-      "community": 3
+      "community": 2
     },
     {
       "label": "ActivitySummaryCards.tsx",
@@ -8497,7 +8497,7 @@
       "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
       "source_location": "L1",
       "id": "activitysummarycards",
-      "community": 3
+      "community": 2
     },
     {
       "label": "SummaryCard()",
@@ -8505,7 +8505,7 @@
       "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
       "source_location": "L19",
       "id": "activitysummarycards_summarycard",
-      "community": 3
+      "community": 2
     },
     {
       "label": "ActivitySummaryCards()",
@@ -8513,7 +8513,7 @@
       "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
       "source_location": "L44",
       "id": "activitysummarycards_activitysummarycards",
-      "community": 3
+      "community": 2
     },
     {
       "label": "String()",
@@ -8521,7 +8521,7 @@
       "source_file": "packages/athena-webapp/src/components/users/CustomerBehaviorTimeline.tsx",
       "source_location": "L110",
       "id": "customerbehaviortimeline_string",
-      "community": 3
+      "community": 2
     },
     {
       "label": "LinkedAccounts.tsx",
@@ -8529,7 +8529,7 @@
       "source_file": "packages/athena-webapp/src/components/users/LinkedAccounts.tsx",
       "source_location": "L1",
       "id": "linkedaccounts",
-      "community": 0
+      "community": 2
     },
     {
       "label": "TimelineEventCard.test.tsx",
@@ -8537,7 +8537,7 @@
       "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.test.tsx",
       "source_location": "L1",
       "id": "timelineeventcard_test",
-      "community": 3
+      "community": 2
     },
     {
       "label": "TimelineEventCard.tsx",
@@ -8545,7 +8545,7 @@
       "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
       "source_location": "L1",
       "id": "timelineeventcard",
-      "community": 3
+      "community": 2
     },
     {
       "label": "formatObservabilityLabel()",
@@ -8553,7 +8553,7 @@
       "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
       "source_location": "L139",
       "id": "timelineeventcard_formatobservabilitylabel",
-      "community": 3
+      "community": 2
     },
     {
       "label": "loadMore()",
@@ -8561,7 +8561,7 @@
       "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
       "source_location": "L175",
       "id": "timelineeventcard_loadmore",
-      "community": 3
+      "community": 2
     },
     {
       "label": "UserActivity.tsx",
@@ -8569,7 +8569,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
       "source_location": "L1",
       "id": "useractivity",
-      "community": 0
+      "community": 2
     },
     {
       "label": "ActivityHeader()",
@@ -8577,7 +8577,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
       "source_location": "L22",
       "id": "useractivity_activityheader",
-      "community": 0
+      "community": 2
     },
     {
       "label": "UserActivity()",
@@ -8585,7 +8585,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
       "source_location": "L45",
       "id": "useractivity_useractivity",
-      "community": 0
+      "community": 2
     },
     {
       "label": "UserAnalyticsName.tsx",
@@ -8593,7 +8593,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserAnalyticsName.tsx",
       "source_location": "L1",
       "id": "useranalyticsname",
-      "community": 0
+      "community": 2
     },
     {
       "label": "UserAnalyticsName()",
@@ -8601,7 +8601,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserAnalyticsName.tsx",
       "source_location": "L13",
       "id": "useranalyticsname_useranalyticsname",
-      "community": 0
+      "community": 2
     },
     {
       "label": "UserBag.tsx",
@@ -8609,7 +8609,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserBag.tsx",
       "source_location": "L1",
       "id": "userbag",
-      "community": 0
+      "community": 3
     },
     {
       "label": "UserBag()",
@@ -8617,7 +8617,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserBag.tsx",
       "source_location": "L7",
       "id": "userbag_userbag",
-      "community": 0
+      "community": 3
     },
     {
       "label": "UserCheckoutSession.tsx",
@@ -8625,7 +8625,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserCheckoutSession.tsx",
       "source_location": "L1",
       "id": "usercheckoutsession",
-      "community": 0
+      "community": 1
     },
     {
       "label": "UserInsightsSection.tsx",
@@ -8633,7 +8633,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserInsightsSection.tsx",
       "source_location": "L1",
       "id": "userinsightssection",
-      "community": 0
+      "community": 2
     },
     {
       "label": "UserOnlineOrders.tsx",
@@ -8641,7 +8641,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserOnlineOrders.tsx",
       "source_location": "L1",
       "id": "useronlineorders",
-      "community": 0
+      "community": 2
     },
     {
       "label": "UserOnlineOrders()",
@@ -8649,7 +8649,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserOnlineOrders.tsx",
       "source_location": "L11",
       "id": "useronlineorders_useronlineorders",
-      "community": 0
+      "community": 2
     },
     {
       "label": "UserStatus.tsx",
@@ -8657,7 +8657,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserStatus.tsx",
       "source_location": "L1",
       "id": "userstatus",
-      "community": 3
+      "community": 2
     },
     {
       "label": "UserStatus()",
@@ -8665,7 +8665,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserStatus.tsx",
       "source_location": "L7",
       "id": "userstatus_userstatus",
-      "community": 3
+      "community": 2
     },
     {
       "label": "UserView.tsx",
@@ -8673,7 +8673,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserView.tsx",
       "source_location": "L1",
       "id": "userview",
-      "community": 0
+      "community": 2
     },
     {
       "label": "UserActions()",
@@ -8681,7 +8681,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserView.tsx",
       "source_location": "L45",
       "id": "userview_useractions",
-      "community": 0
+      "community": 2
     },
     {
       "label": "CustomerJourneyStage.tsx",
@@ -8689,7 +8689,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/CustomerJourneyStage.tsx",
       "source_location": "L1",
       "id": "customerjourneystage",
-      "community": 3
+      "community": 2
     },
     {
       "label": "CustomerJourneyStageCard()",
@@ -8697,7 +8697,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/CustomerJourneyStage.tsx",
       "source_location": "L13",
       "id": "customerjourneystage_customerjourneystagecard",
-      "community": 3
+      "community": 2
     },
     {
       "label": "EngagementMetrics.tsx",
@@ -8705,7 +8705,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
       "source_location": "L1",
       "id": "engagementmetrics",
-      "community": 3
+      "community": 2
     },
     {
       "label": "formatLastActivity()",
@@ -8713,7 +8713,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
       "source_location": "L75",
       "id": "engagementmetrics_formatlastactivity",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getDeviceIcon()",
@@ -8721,7 +8721,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
       "source_location": "L82",
       "id": "engagementmetrics_getdeviceicon",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getDeviceLabel()",
@@ -8729,7 +8729,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
       "source_location": "L93",
       "id": "engagementmetrics_getdevicelabel",
-      "community": 3
+      "community": 2
     },
     {
       "label": "RiskIndicators.tsx",
@@ -8737,7 +8737,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
       "source_location": "L1",
       "id": "riskindicators",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getRiskIcon()",
@@ -8745,7 +8745,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
       "source_location": "L15",
       "id": "riskindicators_getriskicon",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getRiskStyles()",
@@ -8753,7 +8753,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
       "source_location": "L28",
       "id": "riskindicators_getriskstyles",
-      "community": 3
+      "community": 2
     },
     {
       "label": "RiskIndicators()",
@@ -8761,7 +8761,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
       "source_location": "L54",
       "id": "riskindicators_riskindicators",
-      "community": 3
+      "community": 2
     },
     {
       "label": "UserBehaviorInsights.tsx",
@@ -8769,7 +8769,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/UserBehaviorInsights.tsx",
       "source_location": "L1",
       "id": "userbehaviorinsights",
-      "community": 3
+      "community": 2
     },
     {
       "label": "OnlineOrderContext.tsx",
@@ -8777,7 +8777,7 @@
       "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
       "source_location": "L1",
       "id": "onlineordercontext",
-      "community": 0
+      "community": 19
     },
     {
       "label": "OnlineOrderProvider()",
@@ -8785,7 +8785,7 @@
       "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
       "source_location": "L24",
       "id": "onlineordercontext_onlineorderprovider",
-      "community": 0
+      "community": 19
     },
     {
       "label": "useOnlineOrder()",
@@ -8793,7 +8793,7 @@
       "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
       "source_location": "L38",
       "id": "onlineordercontext_useonlineorder",
-      "community": 0
+      "community": 19
     },
     {
       "label": "PermissionsContext.tsx",
@@ -8825,7 +8825,7 @@
       "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
       "source_location": "L1",
       "id": "productcontext",
-      "community": 0
+      "community": 1
     },
     {
       "label": "ProductProvider()",
@@ -8833,7 +8833,7 @@
       "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
       "source_location": "L54",
       "id": "productcontext_productprovider",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useProduct()",
@@ -8841,7 +8841,7 @@
       "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
       "source_location": "L282",
       "id": "productcontext_useproduct",
-      "community": 0
+      "community": 1
     },
     {
       "label": "ThemeContext.tsx",
@@ -8857,7 +8857,7 @@
       "source_file": "packages/athena-webapp/src/contexts/UserContext.tsx",
       "source_location": "L1",
       "id": "usercontext",
-      "community": 16
+      "community": 0
     },
     {
       "label": "UserProvider()",
@@ -8865,7 +8865,7 @@
       "source_file": "packages/athena-webapp/src/contexts/UserContext.tsx",
       "source_location": "L12",
       "id": "usercontext_userprovider",
-      "community": 16
+      "community": 0
     },
     {
       "label": "useUserContext()",
@@ -8873,7 +8873,7 @@
       "source_file": "packages/athena-webapp/src/contexts/UserContext.tsx",
       "source_location": "L37",
       "id": "usercontext_useusercontext",
-      "community": 16
+      "community": 0
     },
     {
       "label": "use-image-upload.ts",
@@ -8881,7 +8881,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-image-upload.ts",
       "source_location": "L1",
       "id": "use_image_upload",
-      "community": 11
+      "community": 0
     },
     {
       "label": "useImageUpload()",
@@ -8889,7 +8889,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-image-upload.ts",
       "source_location": "L7",
       "id": "use_image_upload_useimageupload",
-      "community": 11
+      "community": 0
     },
     {
       "label": "use-mobile.tsx",
@@ -8897,7 +8897,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
       "source_location": "L1",
       "id": "use_mobile",
-      "community": 5
+      "community": 9
     },
     {
       "label": "useIsMobile()",
@@ -8905,7 +8905,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
       "source_location": "L5",
       "id": "use_mobile_useismobile",
-      "community": 5
+      "community": 9
     },
     {
       "label": "use-navigate-back.ts",
@@ -8913,7 +8913,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
       "source_location": "L1",
       "id": "use_navigate_back",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useNavigateBack()",
@@ -8921,7 +8921,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
       "source_location": "L5",
       "id": "use_navigate_back_usenavigateback",
-      "community": 0
+      "community": 1
     },
     {
       "label": "use-navigation-keyboard-shortcuts.ts",
@@ -8929,7 +8929,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-navigation-keyboard-shortcuts.ts",
       "source_location": "L1",
       "id": "use_navigation_keyboard_shortcuts",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useNavigationKeyboardShortcuts()",
@@ -8937,7 +8937,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-navigation-keyboard-shortcuts.ts",
       "source_location": "L7",
       "id": "use_navigation_keyboard_shortcuts_usenavigationkeyboardshortcuts",
-      "community": 1
+      "community": 0
     },
     {
       "label": "use-pagination-persistence.ts",
@@ -8945,7 +8945,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-pagination-persistence.ts",
       "source_location": "L1",
       "id": "use_pagination_persistence",
-      "community": 0
+      "community": 2
     },
     {
       "label": "usePaginationPersistence()",
@@ -8953,7 +8953,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-pagination-persistence.ts",
       "source_location": "L9",
       "id": "use_pagination_persistence_usepaginationpersistence",
-      "community": 0
+      "community": 2
     },
     {
       "label": "use-store-modal.tsx",
@@ -8969,7 +8969,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-table-keyboard-pagination.ts",
       "source_location": "L1",
       "id": "use_table_keyboard_pagination",
-      "community": 3
+      "community": 2
     },
     {
       "label": "useTableKeyboardPagination()",
@@ -8977,7 +8977,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-table-keyboard-pagination.ts",
       "source_location": "L6",
       "id": "use_table_keyboard_pagination_usetablekeyboardpagination",
-      "community": 3
+      "community": 2
     },
     {
       "label": "useAuth.ts",
@@ -8985,7 +8985,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useAuth.ts",
       "source_location": "L1",
       "id": "useauth",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useAuth()",
@@ -8993,7 +8993,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useAuth.ts",
       "source_location": "L4",
       "id": "useauth_useauth",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useBulkOperations.test.ts",
@@ -9001,7 +9001,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.test.ts",
       "source_location": "L1",
       "id": "usebulkoperations_test",
-      "community": 9
+      "community": 13
     },
     {
       "label": "makeSku()",
@@ -9009,7 +9009,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.test.ts",
       "source_location": "L168",
       "id": "usebulkoperations_test_makesku",
-      "community": 9
+      "community": 13
     },
     {
       "label": "useBulkOperations.ts",
@@ -9017,7 +9017,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L1",
       "id": "usebulkoperations",
-      "community": 9
+      "community": 13
     },
     {
       "label": "applyOperation()",
@@ -9025,7 +9025,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L56",
       "id": "usebulkoperations_applyoperation",
-      "community": 9
+      "community": 13
     },
     {
       "label": "calculatePriceWithFee()",
@@ -9033,7 +9033,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L87",
       "id": "usebulkoperations_calculatepricewithfee",
-      "community": 9
+      "community": 13
     },
     {
       "label": "computePreview()",
@@ -9041,7 +9041,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L101",
       "id": "usebulkoperations_computepreview",
-      "community": 9
+      "community": 13
     },
     {
       "label": "validateOperationValue()",
@@ -9049,7 +9049,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L139",
       "id": "usebulkoperations_validateoperationvalue",
-      "community": 9
+      "community": 13
     },
     {
       "label": "useBulkOperations()",
@@ -9057,7 +9057,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L158",
       "id": "usebulkoperations_usebulkoperations",
-      "community": 9
+      "community": 13
     },
     {
       "label": "useCartOperations.ts",
@@ -9081,7 +9081,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useCopyText.ts",
       "source_location": "L1",
       "id": "usecopytext",
-      "community": 0
+      "community": 2
     },
     {
       "label": "useCopyText()",
@@ -9089,7 +9089,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useCopyText.ts",
       "source_location": "L1",
       "id": "usecopytext_usecopytext",
-      "community": 0
+      "community": 2
     },
     {
       "label": "useCreateComplimentaryProduct.ts",
@@ -9097,7 +9097,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useCreateComplimentaryProduct.ts",
       "source_location": "L1",
       "id": "usecreatecomplimentaryproduct",
-      "community": 0
+      "community": 3
     },
     {
       "label": "useCreateComplimentaryProduct()",
@@ -9105,7 +9105,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useCreateComplimentaryProduct.ts",
       "source_location": "L6",
       "id": "usecreatecomplimentaryproduct_usecreatecomplimentaryproduct",
-      "community": 0
+      "community": 3
     },
     {
       "label": "useCustomerOperations.ts",
@@ -9209,7 +9209,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
       "source_location": "L1",
       "id": "usegetactiveproduct",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useGetActiveProduct()",
@@ -9217,7 +9217,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
       "source_location": "L6",
       "id": "usegetactiveproduct_usegetactiveproduct",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useGetActiveStore.ts",
@@ -9225,7 +9225,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetActiveStore.ts",
       "source_location": "L1",
       "id": "usegetactivestore",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useGetActiveStore()",
@@ -9233,7 +9233,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetActiveStore.ts",
       "source_location": "L9",
       "id": "usegetactivestore_usegetactivestore",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useGetStores()",
@@ -9241,7 +9241,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetActiveStore.ts",
       "source_location": "L50",
       "id": "usegetactivestore_usegetstores",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useGetAuthedUser.ts",
@@ -9249,7 +9249,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetAuthedUser.ts",
       "source_location": "L1",
       "id": "usegetautheduser",
-      "community": 0
+      "community": 3
     },
     {
       "label": "useGetAuthedUser()",
@@ -9257,7 +9257,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetAuthedUser.ts",
       "source_location": "L4",
       "id": "usegetautheduser_usegetautheduser",
-      "community": 0
+      "community": 3
     },
     {
       "label": "useGetCategories.ts",
@@ -9265,7 +9265,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetCategories.ts",
       "source_location": "L1",
       "id": "usegetcategories",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useGetCategories()",
@@ -9273,7 +9273,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetCategories.ts",
       "source_location": "L5",
       "id": "usegetcategories_usegetcategories",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useGetComplimentaryProducts.ts",
@@ -9281,7 +9281,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetComplimentaryProducts.ts",
       "source_location": "L1",
       "id": "usegetcomplimentaryproducts",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useGetComplimentaryProducts()",
@@ -9289,7 +9289,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetComplimentaryProducts.ts",
       "source_location": "L5",
       "id": "usegetcomplimentaryproducts_usegetcomplimentaryproducts",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useGetCurrencyFormatter.ts",
@@ -9297,7 +9297,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetCurrencyFormatter.ts",
       "source_location": "L1",
       "id": "usegetcurrencyformatter",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useGetCurrencyFormatter()",
@@ -9305,7 +9305,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetCurrencyFormatter.ts",
       "source_location": "L4",
       "id": "usegetcurrencyformatter_usegetcurrencyformatter",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useGetOrganizations.ts",
@@ -9313,7 +9313,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
       "source_location": "L1",
       "id": "usegetorganizations",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useGetActiveOrganization()",
@@ -9321,7 +9321,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
       "source_location": "L6",
       "id": "usegetorganizations_usegetactiveorganization",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useGetOrganizations()",
@@ -9329,7 +9329,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
       "source_location": "L31",
       "id": "usegetorganizations_usegetorganizations",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useGetProducts.ts",
@@ -9337,7 +9337,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
       "source_location": "L1",
       "id": "usegetproducts",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useGetProducts()",
@@ -9345,7 +9345,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
       "source_location": "L5",
       "id": "usegetproducts_usegetproducts",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useGetUnresolvedProducts()",
@@ -9353,7 +9353,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
       "source_location": "L31",
       "id": "usegetproducts_usegetunresolvedproducts",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useGetSubcategories.ts",
@@ -9361,7 +9361,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetSubcategories.ts",
       "source_location": "L1",
       "id": "usegetsubcategories",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useGetSubcategories()",
@@ -9369,7 +9369,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetSubcategories.ts",
       "source_location": "L5",
       "id": "usegetsubcategories_usegetsubcategories",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useGetTerminal.ts",
@@ -9377,7 +9377,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetTerminal.ts",
       "source_location": "L1",
       "id": "usegetterminal",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useGetTerminal()",
@@ -9385,7 +9385,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetTerminal.ts",
       "source_location": "L6",
       "id": "usegetterminal_usegetterminal",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useNewOrderNotification.ts",
@@ -9393,7 +9393,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useNewOrderNotification.ts",
       "source_location": "L1",
       "id": "usenewordernotification",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useNewOrderNotification()",
@@ -9401,7 +9401,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useNewOrderNotification.ts",
       "source_location": "L8",
       "id": "usenewordernotification_usenewordernotification",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useOrganizationModal.tsx",
@@ -9409,7 +9409,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useOrganizationModal.tsx",
       "source_location": "L1",
       "id": "useorganizationmodal",
-      "community": 16
+      "community": 5
     },
     {
       "label": "usePOSCustomers.ts",
@@ -9617,7 +9617,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePermissions.ts",
       "source_location": "L1",
       "id": "usepermissions",
-      "community": 0
+      "community": 1
     },
     {
       "label": "usePermissions()",
@@ -9625,7 +9625,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePermissions.ts",
       "source_location": "L12",
       "id": "usepermissions_usepermissions",
-      "community": 0
+      "community": 1
     },
     {
       "label": "usePrint.ts",
@@ -9649,7 +9649,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
       "source_location": "L1",
       "id": "useproductsearchresults",
-      "community": 1
+      "community": 4
     },
     {
       "label": "useProductSearchResults()",
@@ -9657,7 +9657,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
       "source_location": "L26",
       "id": "useproductsearchresults_useproductsearchresults",
-      "community": 1
+      "community": 4
     },
     {
       "label": "useProductWithNoImagesNotification.tsx",
@@ -9665,7 +9665,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useProductWithNoImagesNotification.tsx",
       "source_location": "L1",
       "id": "useproductwithnoimagesnotification",
-      "community": 0
+      "community": 4
     },
     {
       "label": "useProductWithNoImagesNotification()",
@@ -9673,7 +9673,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useProductWithNoImagesNotification.tsx",
       "source_location": "L7",
       "id": "useproductwithnoimagesnotification_useproductwithnoimagesnotification",
-      "community": 0
+      "community": 4
     },
     {
       "label": "useSessionManagement.ts",
@@ -9729,7 +9729,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSkusReservedInCheckout.ts",
       "source_location": "L1",
       "id": "useskusreservedincheckout",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useSkusReservedInCheckout()",
@@ -9737,7 +9737,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSkusReservedInCheckout.ts",
       "source_location": "L12",
       "id": "useskusreservedincheckout_useskusreservedincheckout",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useSkusReservedInPosSession.ts",
@@ -9745,7 +9745,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSkusReservedInPosSession.ts",
       "source_location": "L1",
       "id": "useskusreservedinpossession",
-      "community": 0
+      "community": 9
     },
     {
       "label": "useSkusReservedInPosSession()",
@@ -9753,7 +9753,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSkusReservedInPosSession.ts",
       "source_location": "L12",
       "id": "useskusreservedinpossession_useskusreservedinpossession",
-      "community": 0
+      "community": 9
     },
     {
       "label": "useToggleComplimentaryProductActive.ts",
@@ -9761,7 +9761,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useToggleComplimentaryProductActive.ts",
       "source_location": "L1",
       "id": "usetogglecomplimentaryproductactive",
-      "community": 0
+      "community": 2
     },
     {
       "label": "useToggleComplimentaryProductActive()",
@@ -9769,7 +9769,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useToggleComplimentaryProductActive.ts",
       "source_location": "L5",
       "id": "usetogglecomplimentaryproductactive_usetogglecomplimentaryproductactive",
-      "community": 0
+      "community": 2
     },
     {
       "label": "aws.ts",
@@ -9785,7 +9785,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L1",
       "id": "behaviorutils",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getCustomerJourneyStage()",
@@ -9793,7 +9793,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L36",
       "id": "behaviorutils_getcustomerjourneystage",
-      "community": 3
+      "community": 2
     },
     {
       "label": "calculateRiskIndicators()",
@@ -9801,7 +9801,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L71",
       "id": "behaviorutils_calculateriskindicators",
-      "community": 3
+      "community": 2
     },
     {
       "label": "calculateEngagementMetrics()",
@@ -9809,7 +9809,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L173",
       "id": "behaviorutils_calculateengagementmetrics",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getActivityPriority()",
@@ -9817,7 +9817,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L251",
       "id": "behaviorutils_getactivitypriority",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getJourneyStageInfo()",
@@ -9825,7 +9825,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L277",
       "id": "behaviorutils_getjourneystageinfo",
-      "community": 3
+      "community": 2
     },
     {
       "label": "browserFingerprint.ts",
@@ -9833,7 +9833,7 @@
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
       "source_location": "L1",
       "id": "browserfingerprint",
-      "community": 26
+      "community": 7
     },
     {
       "label": "bufferToHex()",
@@ -9841,7 +9841,7 @@
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
       "source_location": "L18",
       "id": "browserfingerprint_buffertohex",
-      "community": 26
+      "community": 7
     },
     {
       "label": "collectBrowserInfo()",
@@ -9849,7 +9849,7 @@
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
       "source_location": "L23",
       "id": "browserfingerprint_collectbrowserinfo",
-      "community": 26
+      "community": 7
     },
     {
       "label": "hashFingerprintSource()",
@@ -9857,7 +9857,7 @@
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
       "source_location": "L45",
       "id": "browserfingerprint_hashfingerprintsource",
-      "community": 26
+      "community": 7
     },
     {
       "label": "generateBrowserFingerprint()",
@@ -9865,7 +9865,7 @@
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
       "source_location": "L65",
       "id": "browserfingerprint_generatebrowserfingerprint",
-      "community": 26
+      "community": 7
     },
     {
       "label": "customerObservabilityTimeline.ts",
@@ -9873,7 +9873,7 @@
       "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
       "source_location": "L1",
       "id": "customerobservabilitytimeline",
-      "community": 3
+      "community": 2
     },
     {
       "label": "formatObservabilityLabel()",
@@ -9881,7 +9881,7 @@
       "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
       "source_location": "L59",
       "id": "customerobservabilitytimeline_formatobservabilitylabel",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getObservabilityStatusStyles()",
@@ -9889,7 +9889,7 @@
       "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
       "source_location": "L67",
       "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getDeviceIcon()",
@@ -9897,7 +9897,7 @@
       "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
       "source_location": "L114",
       "id": "customerobservabilitytimeline_getdeviceicon",
-      "community": 3
+      "community": 2
     },
     {
       "label": "ghanaRegions.ts",
@@ -10001,7 +10001,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L12",
       "id": "logger_logger",
-      "community": 4
+      "community": 24
     },
     {
       "label": ".constructor()",
@@ -10009,7 +10009,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L15",
       "id": "logger_logger_constructor",
-      "community": 4
+      "community": 24
     },
     {
       "label": ".shouldLog()",
@@ -10017,7 +10017,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L20",
       "id": "logger_logger_shouldlog",
-      "community": 4
+      "community": 24
     },
     {
       "label": ".formatMessage()",
@@ -10025,7 +10025,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L30",
       "id": "logger_logger_formatmessage",
-      "community": 4
+      "community": 24
     },
     {
       "label": ".debug()",
@@ -10033,7 +10033,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L45",
       "id": "logger_logger_debug",
-      "community": 4
+      "community": 24
     },
     {
       "label": ".info()",
@@ -10041,7 +10041,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L51",
       "id": "logger_logger_info",
-      "community": 4
+      "community": 24
     },
     {
       "label": ".warn()",
@@ -10049,7 +10049,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L57",
       "id": "logger_logger_warn",
-      "community": 4
+      "community": 24
     },
     {
       "label": ".error()",
@@ -10057,7 +10057,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L63",
       "id": "logger_logger_error",
-      "community": 4
+      "community": 24
     },
     {
       "label": "maintenanceUtils.ts",
@@ -10065,7 +10065,7 @@
       "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.ts",
       "source_location": "L1",
       "id": "maintenanceutils",
-      "community": 17
+      "community": 16
     },
     {
       "label": "isInMaintenanceMode()",
@@ -10073,7 +10073,7 @@
       "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.ts",
       "source_location": "L7",
       "id": "maintenanceutils_isinmaintenancemode",
-      "community": 17
+      "community": 16
     },
     {
       "label": "navigationUtils.ts",
@@ -10081,7 +10081,7 @@
       "source_file": "packages/athena-webapp/src/lib/navigationUtils.ts",
       "source_location": "L1",
       "id": "navigationutils",
-      "community": 0
+      "community": 2
     },
     {
       "label": "getOrigin()",
@@ -10089,7 +10089,7 @@
       "source_file": "packages/athena-webapp/src/lib/navigationUtils.ts",
       "source_location": "L1",
       "id": "navigationutils_getorigin",
-      "community": 0
+      "community": 2
     },
     {
       "label": "barcodeUtils.ts",
@@ -10129,7 +10129,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/calculations.ts",
       "source_location": "L1",
       "id": "calculations",
-      "community": 1
+      "community": 4
     },
     {
       "label": "calculateCartTotals()",
@@ -10137,7 +10137,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/calculations.ts",
       "source_location": "L10",
       "id": "calculations_calculatecarttotals",
-      "community": 1
+      "community": 4
     },
     {
       "label": "calculationService.ts",
@@ -10393,7 +10393,7 @@
       "source_file": "packages/athena-webapp/src/lib/productUtils.test.ts",
       "source_location": "L1",
       "id": "productutils_test",
-      "community": 1
+      "community": 0
     },
     {
       "label": "productUtils.ts",
@@ -10401,7 +10401,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L1",
       "id": "productutils",
-      "community": 1
+      "community": 0
     },
     {
       "label": "getProductName()",
@@ -10409,7 +10409,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L18",
       "id": "productutils_getproductname",
-      "community": 1
+      "community": 0
     },
     {
       "label": "sortProduct()",
@@ -10417,7 +10417,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L66",
       "id": "productutils_sortproduct",
-      "community": 1
+      "community": 0
     },
     {
       "label": "pinHash.ts",
@@ -10425,7 +10425,7 @@
       "source_file": "packages/athena-webapp/src/lib/security/pinHash.ts",
       "source_location": "L1",
       "id": "pinhash",
-      "community": 9
+      "community": 5
     },
     {
       "label": "hashPin()",
@@ -10433,7 +10433,7 @@
       "source_file": "packages/athena-webapp/src/lib/security/pinHash.ts",
       "source_location": "L12",
       "id": "pinhash_hashpin",
-      "community": 9
+      "community": 5
     },
     {
       "label": "storeConfig.test.ts",
@@ -10441,7 +10441,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.test.ts",
       "source_location": "L1",
       "id": "storeconfig_test",
-      "community": 17
+      "community": 16
     },
     {
       "label": "storeConfig.ts",
@@ -10449,7 +10449,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L1",
       "id": "storeconfig",
-      "community": 17
+      "community": 16
     },
     {
       "label": "asRecord()",
@@ -10457,7 +10457,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L103",
       "id": "storeconfig_asrecord",
-      "community": 17
+      "community": 16
     },
     {
       "label": "asString()",
@@ -10465,7 +10465,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L111",
       "id": "storeconfig_asstring",
-      "community": 17
+      "community": 16
     },
     {
       "label": "asNumber()",
@@ -10473,7 +10473,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L114",
       "id": "storeconfig_asnumber",
-      "community": 17
+      "community": 16
     },
     {
       "label": "asBoolean()",
@@ -10481,7 +10481,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L117",
       "id": "storeconfig_asboolean",
-      "community": 17
+      "community": 16
     },
     {
       "label": "asOptionalArray()",
@@ -10489,7 +10489,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L132",
       "id": "storeconfig_asoptionalarray",
-      "community": 17
+      "community": 16
     },
     {
       "label": "firstDefined()",
@@ -10497,7 +10497,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L120",
       "id": "storeconfig_firstdefined",
-      "community": 17
+      "community": 16
     },
     {
       "label": "cleanUndefined()",
@@ -10505,7 +10505,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L143",
       "id": "storeconfig_cleanundefined",
-      "community": 17
+      "community": 16
     },
     {
       "label": "asMtnMomoSetupStatus()",
@@ -10513,7 +10513,7 @@
       "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L80",
       "id": "storeconfig_asmtnmomosetupstatus",
-      "community": 17
+      "community": 16
     },
     {
       "label": "hasMtnMomoReceivingAccountDetails()",
@@ -10521,7 +10521,7 @@
       "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L93",
       "id": "storeconfig_hasmtnmomoreceivingaccountdetails",
-      "community": 17
+      "community": 16
     },
     {
       "label": "mapMtnMomoReceivingAccount()",
@@ -10529,7 +10529,7 @@
       "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L106",
       "id": "storeconfig_mapmtnmomoreceivingaccount",
-      "community": 17
+      "community": 16
     },
     {
       "label": "normalizeMtnMomoReceivingAccounts()",
@@ -10537,7 +10537,7 @@
       "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L126",
       "id": "storeconfig_normalizemtnmomoreceivingaccounts",
-      "community": 17
+      "community": 16
     },
     {
       "label": "getRawConfig()",
@@ -10545,7 +10545,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L196",
       "id": "storeconfig_getrawconfig",
-      "community": 17
+      "community": 16
     },
     {
       "label": "mapStreamReel()",
@@ -10553,7 +10553,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L155",
       "id": "storeconfig_mapstreamreel",
-      "community": 17
+      "community": 16
     },
     {
       "label": "mapPromotion()",
@@ -10561,7 +10561,7 @@
       "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L172",
       "id": "storeconfig_mappromotion",
-      "community": 17
+      "community": 16
     },
     {
       "label": "normalizeWaiveDeliveryFees()",
@@ -10569,7 +10569,7 @@
       "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L177",
       "id": "storeconfig_normalizewaivedeliveryfees",
-      "community": 17
+      "community": 16
     },
     {
       "label": "getStoreConfigV2()",
@@ -10577,7 +10577,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L208",
       "id": "storeconfig_getstoreconfigv2",
-      "community": 17
+      "community": 16
     },
     {
       "label": "timelineUtils.ts",
@@ -10585,7 +10585,7 @@
       "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
       "source_location": "L1",
       "id": "timelineutils",
-      "community": 3
+      "community": 2
     },
     {
       "label": "enrichTimelineEvent()",
@@ -10593,7 +10593,7 @@
       "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
       "source_location": "L184",
       "id": "timelineutils_enrichtimelineevent",
-      "community": 3
+      "community": 2
     },
     {
       "label": "enrichTimelineEvents()",
@@ -10601,7 +10601,7 @@
       "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
       "source_location": "L200",
       "id": "timelineutils_enrichtimelineevents",
-      "community": 3
+      "community": 2
     },
     {
       "label": "groupEventsByTimeframe()",
@@ -10609,7 +10609,7 @@
       "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
       "source_location": "L206",
       "id": "timelineutils_groupeventsbytimeframe",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getTimeRangeLabel()",
@@ -10617,7 +10617,7 @@
       "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
       "source_location": "L244",
       "id": "timelineutils_gettimerangelabel",
-      "community": 3
+      "community": 2
     },
     {
       "label": "utils.test.ts",
@@ -10625,7 +10625,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.test.ts",
       "source_location": "L1",
       "id": "utils_test",
-      "community": 3
+      "community": 4
     },
     {
       "label": "cn()",
@@ -10633,7 +10633,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L9",
       "id": "utils_cn",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getErrorForField()",
@@ -10641,7 +10641,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L14",
       "id": "utils_geterrorforfield",
-      "community": 3
+      "community": 2
     },
     {
       "label": "capitalizeFirstLetter()",
@@ -10649,7 +10649,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L18",
       "id": "utils_capitalizefirstletter",
-      "community": 3
+      "community": 2
     },
     {
       "label": "slugToWords()",
@@ -10657,7 +10657,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L31",
       "id": "utils_slugtowords",
-      "community": 3
+      "community": 2
     },
     {
       "label": "snakeCaseToWords()",
@@ -10665,7 +10665,7 @@
       "source_file": "packages/athena-webapp/src/lib/utils.ts",
       "source_location": "L50",
       "id": "utils_snakecasetowords",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getRelativeTime()",
@@ -10673,7 +10673,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L67",
       "id": "utils_getrelativetime",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getTimeRemaining()",
@@ -10681,7 +10681,7 @@
       "source_file": "packages/athena-webapp/src/lib/utils.ts",
       "source_location": "L71",
       "id": "utils_gettimeremaining",
-      "community": 3
+      "community": 2
     },
     {
       "label": "formatUserId()",
@@ -10689,7 +10689,7 @@
       "source_file": "packages/athena-webapp/src/lib/utils.ts",
       "source_location": "L91",
       "id": "utils_formatuserid",
-      "community": 3
+      "community": 2
     },
     {
       "label": "main.tsx",
@@ -10697,7 +10697,7 @@
       "source_file": "packages/storefront-webapp/src/main.tsx",
       "source_location": "L1",
       "id": "main",
-      "community": 10
+      "community": 8
     },
     {
       "label": "App()",
@@ -10705,7 +10705,7 @@
       "source_file": "packages/storefront-webapp/src/main.tsx",
       "source_location": "L38",
       "id": "main_app",
-      "community": 10
+      "community": 8
     },
     {
       "label": "routeTree.gen.ts",
@@ -10713,7 +10713,7 @@
       "source_file": "packages/storefront-webapp/src/routeTree.gen.ts",
       "source_location": "L1",
       "id": "routetree_gen",
-      "community": 8
+      "community": 7
     },
     {
       "label": "__root.tsx",
@@ -10721,7 +10721,7 @@
       "source_file": "packages/storefront-webapp/src/routes/__root.tsx",
       "source_location": "L1",
       "id": "root",
-      "community": 1
+      "community": 0
     },
     {
       "label": "$storeUrlSlug.tsx",
@@ -10729,7 +10729,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/stores/$storeUrlSlug.tsx",
       "source_location": "L1",
       "id": "storeurlslug",
-      "community": 8
+      "community": 7
     },
     {
       "label": "assets.index.tsx",
@@ -10737,7 +10737,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/assets.index.tsx",
       "source_location": "L1",
       "id": "assets_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "bags.$bagId.tsx",
@@ -10745,7 +10745,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.$bagId.tsx",
       "source_location": "L1",
       "id": "bags_bagid",
-      "community": 8
+      "community": 7
     },
     {
       "label": "bags.index.tsx",
@@ -10753,7 +10753,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.index.tsx",
       "source_location": "L1",
       "id": "bags_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "checkout-sessions.index.tsx",
@@ -10761,7 +10761,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/checkout-sessions.index.tsx",
       "source_location": "L1",
       "id": "checkout_sessions_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "configuration.index.tsx",
@@ -10769,7 +10769,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/configuration.index.tsx",
       "source_location": "L1",
       "id": "configuration_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "dashboard.index.tsx",
@@ -10777,7 +10777,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/dashboard.index.tsx",
       "source_location": "L1",
       "id": "dashboard_index",
-      "community": 3
+      "community": 2
     },
     {
       "label": "StoreRootRedirect()",
@@ -10785,7 +10785,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/index.tsx",
       "source_location": "L13",
       "id": "index_storerootredirect",
-      "community": 11
+      "community": 1
     },
     {
       "label": "logs.$logId.tsx",
@@ -10793,7 +10793,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.$logId.tsx",
       "source_location": "L1",
       "id": "logs_logid",
-      "community": 8
+      "community": 7
     },
     {
       "label": "logs.index.tsx",
@@ -10801,7 +10801,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.index.tsx",
       "source_location": "L1",
       "id": "logs_index",
-      "community": 3
+      "community": 9
     },
     {
       "label": "members.index.tsx",
@@ -10809,7 +10809,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/members.index.tsx",
       "source_location": "L1",
       "id": "members_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "all.index.tsx",
@@ -10817,7 +10817,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/all.index.tsx",
       "source_location": "L1",
       "id": "all_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "cancelled.index.tsx",
@@ -10825,7 +10825,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/cancelled.index.tsx",
       "source_location": "L1",
       "id": "cancelled_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "completed.index.tsx",
@@ -10833,7 +10833,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/completed.index.tsx",
       "source_location": "L1",
       "id": "completed_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "open.index.tsx",
@@ -10841,7 +10841,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/open.index.tsx",
       "source_location": "L1",
       "id": "open_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "out-for-delivery.index.tsx",
@@ -10849,7 +10849,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/out-for-delivery.index.tsx",
       "source_location": "L1",
       "id": "out_for_delivery_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "ready.index.tsx",
@@ -10857,7 +10857,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/ready.index.tsx",
       "source_location": "L1",
       "id": "ready_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "refunded.index.tsx",
@@ -10865,7 +10865,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/refunded.index.tsx",
       "source_location": "L1",
       "id": "refunded_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "$reportId.tsx",
@@ -10873,7 +10873,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports/$reportId.tsx",
       "source_location": "L1",
       "id": "reportid",
-      "community": 8
+      "community": 7
     },
     {
       "label": "expense-reports.index.tsx",
@@ -10881,7 +10881,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports.index.tsx",
       "source_location": "L1",
       "id": "expense_reports_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "expense.index.tsx",
@@ -10889,7 +10889,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense.index.tsx",
       "source_location": "L1",
       "id": "expense_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "register.index.tsx",
@@ -10897,7 +10897,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/register.index.tsx",
       "source_location": "L1",
       "id": "register_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "settings.index.tsx",
@@ -10905,7 +10905,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/settings.index.tsx",
       "source_location": "L1",
       "id": "settings_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "$transactionId.tsx",
@@ -10913,7 +10913,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId.tsx",
       "source_location": "L1",
       "id": "transactionid",
-      "community": 8
+      "community": 7
     },
     {
       "label": "transactions.index.tsx",
@@ -10921,7 +10921,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions.index.tsx",
       "source_location": "L1",
       "id": "transactions_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "edit.tsx",
@@ -10929,7 +10929,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/edit.tsx",
       "source_location": "L1",
       "id": "edit",
-      "community": 8
+      "community": 7
     },
     {
       "label": "new.tsx",
@@ -10937,7 +10937,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/new.tsx",
       "source_location": "L1",
       "id": "new",
-      "community": 8
+      "community": 7
     },
     {
       "label": "unresolved.tsx",
@@ -10945,7 +10945,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/unresolved.tsx",
       "source_location": "L1",
       "id": "unresolved",
-      "community": 8
+      "community": 7
     },
     {
       "label": "$promoCodeSlug.tsx",
@@ -10953,7 +10953,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/$promoCodeSlug.tsx",
       "source_location": "L1",
       "id": "promocodeslug",
-      "community": 8
+      "community": 7
     },
     {
       "label": "new.index.tsx",
@@ -10961,7 +10961,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/new.index.tsx",
       "source_location": "L1",
       "id": "new_index",
-      "community": 11
+      "community": 1
     },
     {
       "label": "published.index.tsx",
@@ -10969,7 +10969,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/published.index.tsx",
       "source_location": "L1",
       "id": "published_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "RouteComponent()",
@@ -10977,7 +10977,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/published.index.tsx",
       "source_location": "L9",
       "id": "published_index_routecomponent",
-      "community": 8
+      "community": 7
     },
     {
       "label": "users.$userId.tsx",
@@ -10985,7 +10985,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/users.$userId.tsx",
       "source_location": "L1",
       "id": "users_userid",
-      "community": 8
+      "community": 2
     },
     {
       "label": "_authed.tsx",
@@ -11017,7 +11017,7 @@
       "source_file": "packages/athena-webapp/src/routes/index.tsx",
       "source_location": "L13",
       "id": "index_index",
-      "community": 11
+      "community": 1
     },
     {
       "label": "join-team.index.tsx",
@@ -11025,7 +11025,7 @@
       "source_file": "packages/athena-webapp/src/routes/join-team.index.tsx",
       "source_location": "L1",
       "id": "join_team_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "_layout.index.tsx",
@@ -11041,7 +11041,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout.tsx",
       "source_location": "L1",
       "id": "layout",
-      "community": 1
+      "community": 0
     },
     {
       "label": "LoginLayout()",
@@ -11049,7 +11049,7 @@
       "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
       "source_location": "L36",
       "id": "layout_loginlayout",
-      "community": 1
+      "community": 0
     },
     {
       "label": "OrganizationSettingsView.tsx",
@@ -11121,7 +11121,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L1",
       "id": "storesettingsview",
-      "community": 8
+      "community": 7
     },
     {
       "label": "StoreSettings()",
@@ -11129,7 +11129,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L28",
       "id": "storesettingsview_storesettings",
-      "community": 8
+      "community": 7
     },
     {
       "label": "saveStoreChanges()",
@@ -11137,7 +11137,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L82",
       "id": "storesettingsview_savestorechanges",
-      "community": 8
+      "community": 7
     },
     {
       "label": "onSubmit()",
@@ -11145,7 +11145,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L116",
       "id": "storesettingsview_onsubmit",
-      "community": 8
+      "community": 7
     },
     {
       "label": "handleDeleteStore()",
@@ -11153,7 +11153,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L167",
       "id": "storesettingsview_handledeletestore",
-      "community": 8
+      "community": 7
     },
     {
       "label": "handleDeleteAllProductsInStore()",
@@ -11161,7 +11161,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L232",
       "id": "storesettingsview_handledeleteallproductsinstore",
-      "community": 8
+      "community": 7
     },
     {
       "label": "StoresSettingsAccordion.tsx",
@@ -11313,7 +11313,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L1",
       "id": "simple_test",
-      "community": 23
+      "community": 22
     },
     {
       "label": "generateTransactionNumber()",
@@ -11321,7 +11321,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L38",
       "id": "simple_test_generatetransactionnumber",
-      "community": 23
+      "community": 22
     },
     {
       "label": "validateInventory()",
@@ -11329,7 +11329,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L77",
       "id": "simple_test_validateinventory",
-      "community": 23
+      "community": 22
     },
     {
       "label": "validateInventoryWithAggregation()",
@@ -11337,7 +11337,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L130",
       "id": "simple_test_validateinventorywithaggregation",
-      "community": 23
+      "community": 22
     },
     {
       "label": "formatCurrency()",
@@ -11345,7 +11345,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L173",
       "id": "simple_test_formatcurrency",
-      "community": 23
+      "community": 22
     },
     {
       "label": "formatPaymentMethod()",
@@ -11353,7 +11353,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L201",
       "id": "simple_test_formatpaymentmethod",
-      "community": 23
+      "community": 22
     },
     {
       "label": "formatReceiptDate()",
@@ -11361,7 +11361,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L225",
       "id": "simple_test_formatreceiptdate",
-      "community": 23
+      "community": 22
     },
     {
       "label": "addToCart()",
@@ -11369,7 +11369,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L249",
       "id": "simple_test_addtocart",
-      "community": 23
+      "community": 22
     },
     {
       "label": "removeFromCart()",
@@ -11377,7 +11377,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L288",
       "id": "simple_test_removefromcart",
-      "community": 23
+      "community": 22
     },
     {
       "label": "updateQuantity()",
@@ -11385,7 +11385,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L311",
       "id": "simple_test_updatequantity",
-      "community": 23
+      "community": 22
     },
     {
       "label": "usePrint.test.ts",
@@ -11401,7 +11401,7 @@
       "source_file": "packages/athena-webapp/src/utils/formatNumber.ts",
       "source_location": "L1",
       "id": "formatnumber",
-      "community": 3
+      "community": 2
     },
     {
       "label": "formatNumber()",
@@ -11409,7 +11409,7 @@
       "source_file": "packages/athena-webapp/src/utils/formatNumber.ts",
       "source_location": "L1",
       "id": "formatnumber_formatnumber",
-      "community": 3
+      "community": 2
     },
     {
       "label": "hashPassword()",
@@ -11417,7 +11417,7 @@
       "source_file": "packages/storefront-webapp/src/utils/index.ts",
       "source_location": "L1",
       "id": "index_hashpassword",
-      "community": 11
+      "community": 1
     },
     {
       "label": "session.ts",
@@ -11425,7 +11425,7 @@
       "source_file": "packages/storefront-webapp/src/utils/session.ts",
       "source_location": "L1",
       "id": "session",
-      "community": 2
+      "community": 3
     },
     {
       "label": "useAppSession()",
@@ -11433,7 +11433,7 @@
       "source_file": "packages/storefront-webapp/src/utils/session.ts",
       "source_location": "L8",
       "id": "session_useappsession",
-      "community": 2
+      "community": 3
     },
     {
       "label": "versionChecker.ts",
@@ -11441,7 +11441,7 @@
       "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
       "source_location": "L1",
       "id": "versionchecker",
-      "community": 10
+      "community": 8
     },
     {
       "label": "createVersionChecker()",
@@ -11449,7 +11449,7 @@
       "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
       "source_location": "L16",
       "id": "versionchecker_createversionchecker",
-      "community": 10
+      "community": 8
     },
     {
       "label": "tailwind.config.js",
@@ -11465,7 +11465,7 @@
       "source_file": "packages/storefront-webapp/vite.config.ts",
       "source_location": "L1",
       "id": "vite_config",
-      "community": 2
+      "community": 3
     },
     {
       "label": "manualChunks()",
@@ -11473,7 +11473,7 @@
       "source_file": "packages/storefront-webapp/vite.config.ts",
       "source_location": "L19",
       "id": "vite_config_manualchunks",
-      "community": 2
+      "community": 3
     },
     {
       "label": "vitest.config.ts",
@@ -11481,7 +11481,7 @@
       "source_file": "packages/storefront-webapp/vitest.config.ts",
       "source_location": "L1",
       "id": "vitest_config",
-      "community": 2
+      "community": 3
     },
     {
       "label": "vitest.setup.ts",
@@ -11513,7 +11513,7 @@
       "source_file": "packages/storefront-webapp/src/api/analytics.ts",
       "source_location": "L3",
       "id": "analytics_postanalytics",
-      "community": 15
+      "community": 17
     },
     {
       "label": "updateAnalyticsOwner()",
@@ -11521,7 +11521,7 @@
       "source_file": "packages/storefront-webapp/src/api/analytics.ts",
       "source_location": "L32",
       "id": "analytics_updateanalyticsowner",
-      "community": 15
+      "community": 17
     },
     {
       "label": "logout()",
@@ -11529,7 +11529,7 @@
       "source_file": "packages/storefront-webapp/src/api/analytics.ts",
       "source_location": "L60",
       "id": "analytics_logout",
-      "community": 15
+      "community": 17
     },
     {
       "label": "getProductViewCount()",
@@ -11537,7 +11537,7 @@
       "source_file": "packages/storefront-webapp/src/api/analytics.ts",
       "source_location": "L78",
       "id": "analytics_getproductviewcount",
-      "community": 15
+      "community": 17
     },
     {
       "label": "verifyUserAccount()",
@@ -11545,7 +11545,7 @@
       "source_file": "packages/storefront-webapp/src/api/auth.ts",
       "source_location": "L3",
       "id": "auth_verifyuseraccount",
-      "community": 2
+      "community": 3
     },
     {
       "label": "logout()",
@@ -11553,7 +11553,7 @@
       "source_file": "packages/storefront-webapp/src/api/auth.ts",
       "source_location": "L32",
       "id": "auth_logout",
-      "community": 2
+      "community": 3
     },
     {
       "label": "getBaseUrl()",
@@ -11561,7 +11561,7 @@
       "source_file": "packages/storefront-webapp/src/api/bag.ts",
       "source_location": "L10",
       "id": "bag_getbaseurl",
-      "community": 7
+      "community": 15
     },
     {
       "label": "getActiveBag()",
@@ -11569,7 +11569,7 @@
       "source_file": "packages/storefront-webapp/src/api/bag.ts",
       "source_location": "L12",
       "id": "bag_getactivebag",
-      "community": 7
+      "community": 15
     },
     {
       "label": "addItemToBag()",
@@ -11577,7 +11577,7 @@
       "source_file": "packages/storefront-webapp/src/api/bag.ts",
       "source_location": "L27",
       "id": "bag_additemtobag",
-      "community": 7
+      "community": 15
     },
     {
       "label": "updateBagItem()",
@@ -11585,7 +11585,7 @@
       "source_file": "packages/storefront-webapp/src/api/bag.ts",
       "source_location": "L63",
       "id": "bag_updatebagitem",
-      "community": 7
+      "community": 15
     },
     {
       "label": "removeItemFromBag()",
@@ -11593,7 +11593,7 @@
       "source_file": "packages/storefront-webapp/src/api/bag.ts",
       "source_location": "L90",
       "id": "bag_removeitemfrombag",
-      "community": 7
+      "community": 15
     },
     {
       "label": "clearBag()",
@@ -11601,7 +11601,7 @@
       "source_file": "packages/storefront-webapp/src/api/bag.ts",
       "source_location": "L106",
       "id": "bag_clearbag",
-      "community": 7
+      "community": 15
     },
     {
       "label": "updateBagOwner()",
@@ -11609,7 +11609,7 @@
       "source_file": "packages/storefront-webapp/src/api/bag.ts",
       "source_location": "L118",
       "id": "bag_updatebagowner",
-      "community": 7
+      "community": 15
     },
     {
       "label": "getBannerMessage()",
@@ -11617,7 +11617,7 @@
       "source_file": "packages/storefront-webapp/src/api/bannerMessage.ts",
       "source_location": "L4",
       "id": "bannermessage_getbannermessage",
-      "community": 2
+      "community": 3
     },
     {
       "label": "getBaseUrl()",
@@ -11625,7 +11625,7 @@
       "source_file": "packages/storefront-webapp/src/api/category.ts",
       "source_location": "L9",
       "id": "category_getbaseurl",
-      "community": 2
+      "community": 3
     },
     {
       "label": "getAllCategories()",
@@ -11633,7 +11633,7 @@
       "source_file": "packages/storefront-webapp/src/api/category.ts",
       "source_location": "L11",
       "id": "category_getallcategories",
-      "community": 2
+      "community": 3
     },
     {
       "label": "getAllCategoriesWithSubcategories()",
@@ -11641,7 +11641,7 @@
       "source_file": "packages/storefront-webapp/src/api/category.ts",
       "source_location": "L25",
       "id": "category_getallcategorieswithsubcategories",
-      "community": 2
+      "community": 3
     },
     {
       "label": "getCategory()",
@@ -11649,7 +11649,7 @@
       "source_file": "packages/storefront-webapp/src/api/category.ts",
       "source_location": "L39",
       "id": "category_getcategory",
-      "community": 2
+      "community": 3
     },
     {
       "label": "checkoutSession.test.ts",
@@ -11657,7 +11657,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.test.ts",
       "source_location": "L1",
       "id": "checkoutsession_test",
-      "community": 10
+      "community": 8
     },
     {
       "label": "jsonResponse()",
@@ -11665,7 +11665,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.test.ts",
       "source_location": "L27",
       "id": "checkoutsession_test_jsonresponse",
-      "community": 10
+      "community": 8
     },
     {
       "label": "getBaseUrl()",
@@ -11673,7 +11673,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L5",
       "id": "checkoutsession_getbaseurl",
-      "community": 10
+      "community": 8
     },
     {
       "label": "CheckoutSessionError",
@@ -11681,7 +11681,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L64",
       "id": "checkoutsession_checkoutsessionerror",
-      "community": 10
+      "community": 8
     },
     {
       "label": ".constructor()",
@@ -11689,7 +11689,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L69",
       "id": "checkoutsession_checkoutsessionerror_constructor",
-      "community": 10
+      "community": 8
     },
     {
       "label": "isRecord()",
@@ -11697,7 +11697,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L78",
       "id": "checkoutsession_isrecord",
-      "community": 10
+      "community": 8
     },
     {
       "label": "parseJson()",
@@ -11705,7 +11705,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L81",
       "id": "checkoutsession_parsejson",
-      "community": 10
+      "community": 8
     },
     {
       "label": "getCheckoutErrorMessageFromPayload()",
@@ -11713,7 +11713,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L98",
       "id": "checkoutsession_getcheckouterrormessagefrompayload",
-      "community": 10
+      "community": 8
     },
     {
       "label": "parseCheckoutResponse()",
@@ -11721,7 +11721,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L115",
       "id": "checkoutsession_parsecheckoutresponse",
-      "community": 10
+      "community": 8
     },
     {
       "label": "defaultCheckoutActionMessage()",
@@ -11729,7 +11729,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L135",
       "id": "checkoutsession_defaultcheckoutactionmessage",
-      "community": 10
+      "community": 8
     },
     {
       "label": "getCheckoutActionErrorMessage()",
@@ -11737,7 +11737,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L147",
       "id": "checkoutsession_getcheckoutactionerrormessage",
-      "community": 10
+      "community": 8
     },
     {
       "label": "createCheckoutSession()",
@@ -11745,7 +11745,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L184",
       "id": "checkoutsession_createcheckoutsession",
-      "community": 10
+      "community": 8
     },
     {
       "label": "getActiveCheckoutSession()",
@@ -11753,7 +11753,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L204",
       "id": "checkoutsession_getactivecheckoutsession",
-      "community": 10
+      "community": 8
     },
     {
       "label": "getPendingCheckoutSessions()",
@@ -11761,7 +11761,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L215",
       "id": "checkoutsession_getpendingcheckoutsessions",
-      "community": 10
+      "community": 8
     },
     {
       "label": "getCheckoutSession()",
@@ -11769,7 +11769,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L226",
       "id": "checkoutsession_getcheckoutsession",
-      "community": 10
+      "community": 8
     },
     {
       "label": "updateCheckoutSession()",
@@ -11777,7 +11777,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L239",
       "id": "checkoutsession_updatecheckoutsession",
-      "community": 10
+      "community": 8
     },
     {
       "label": "verifyCheckoutSessionPayment()",
@@ -11785,7 +11785,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L274",
       "id": "checkoutsession_verifycheckoutsessionpayment",
-      "community": 10
+      "community": 8
     },
     {
       "label": "getBaseUrl()",
@@ -11793,7 +11793,7 @@
       "source_file": "packages/storefront-webapp/src/api/color.ts",
       "source_location": "L5",
       "id": "color_getbaseurl",
-      "community": 15
+      "community": 12
     },
     {
       "label": "getAllColors()",
@@ -11801,7 +11801,7 @@
       "source_file": "packages/storefront-webapp/src/api/color.ts",
       "source_location": "L7",
       "id": "color_getallcolors",
-      "community": 15
+      "community": 12
     },
     {
       "label": "updateGuest()",
@@ -11809,7 +11809,7 @@
       "source_file": "packages/storefront-webapp/src/api/guest.ts",
       "source_location": "L4",
       "id": "guest_updateguest",
-      "community": 2
+      "community": 3
     },
     {
       "label": "getBaseUrl()",
@@ -11817,7 +11817,7 @@
       "source_file": "packages/storefront-webapp/src/api/offers.ts",
       "source_location": "L13",
       "id": "offers_getbaseurl",
-      "community": 2
+      "community": 6
     },
     {
       "label": "submitOffer()",
@@ -11825,7 +11825,7 @@
       "source_file": "packages/storefront-webapp/src/api/offers.ts",
       "source_location": "L21",
       "id": "offers_submitoffer",
-      "community": 2
+      "community": 6
     },
     {
       "label": "getUserRedeemedOffers()",
@@ -11833,7 +11833,7 @@
       "source_file": "packages/storefront-webapp/src/api/offers.ts",
       "source_location": "L46",
       "id": "offers_getuserredeemedoffers",
-      "community": 2
+      "community": 6
     },
     {
       "label": "getBaseUrl()",
@@ -11841,7 +11841,7 @@
       "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
       "source_location": "L4",
       "id": "onlineorder_getbaseurl",
-      "community": 2
+      "community": 3
     },
     {
       "label": "getOrders()",
@@ -11849,7 +11849,7 @@
       "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
       "source_location": "L6",
       "id": "onlineorder_getorders",
-      "community": 2
+      "community": 3
     },
     {
       "label": "getOrder()",
@@ -11857,7 +11857,7 @@
       "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
       "source_location": "L24",
       "id": "onlineorder_getorder",
-      "community": 2
+      "community": 3
     },
     {
       "label": "updateOrdersOwner()",
@@ -11865,7 +11865,7 @@
       "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
       "source_location": "L42",
       "id": "onlineorder_updateordersowner",
-      "community": 2
+      "community": 3
     },
     {
       "label": "getAllOrganizations()",
@@ -11873,7 +11873,7 @@
       "source_file": "packages/storefront-webapp/src/api/organization.ts",
       "source_location": "L6",
       "id": "organization_getallorganizations",
-      "community": 2
+      "community": 3
     },
     {
       "label": "getOrganization()",
@@ -11881,7 +11881,7 @@
       "source_file": "packages/storefront-webapp/src/api/organization.ts",
       "source_location": "L18",
       "id": "organization_getorganization",
-      "community": 2
+      "community": 3
     },
     {
       "label": "buildQueryString()",
@@ -11889,7 +11889,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L5",
       "id": "product_buildquerystring",
-      "community": 15
+      "community": 12
     },
     {
       "label": "getBaseUrl()",
@@ -11897,7 +11897,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L18",
       "id": "product_getbaseurl",
-      "community": 15
+      "community": 12
     },
     {
       "label": "getAllProducts()",
@@ -11905,7 +11905,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L20",
       "id": "product_getallproducts",
-      "community": 15
+      "community": 12
     },
     {
       "label": "getProduct()",
@@ -11913,7 +11913,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L40",
       "id": "product_getproduct",
-      "community": 15
+      "community": 12
     },
     {
       "label": "getBestSellers()",
@@ -11921,7 +11921,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L59",
       "id": "product_getbestsellers",
-      "community": 15
+      "community": 12
     },
     {
       "label": "getFeatured()",
@@ -11929,7 +11929,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L73",
       "id": "product_getfeatured",
-      "community": 15
+      "community": 12
     },
     {
       "label": "getInventoryBySkuIds()",
@@ -11937,7 +11937,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L93",
       "id": "product_getinventorybyskuids",
-      "community": 15
+      "community": 12
     },
     {
       "label": "getBaseUrl()",
@@ -11945,7 +11945,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L4",
       "id": "promocodes_getbaseurl",
-      "community": 1
+      "community": 3
     },
     {
       "label": "redeemPromoCode()",
@@ -11953,7 +11953,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L6",
       "id": "promocodes_redeempromocode",
-      "community": 1
+      "community": 3
     },
     {
       "label": "getPromoCodes()",
@@ -11961,7 +11961,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L34",
       "id": "promocodes_getpromocodes",
-      "community": 1
+      "community": 3
     },
     {
       "label": "getPromoCodeItems()",
@@ -11969,7 +11969,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L49",
       "id": "promocodes_getpromocodeitems",
-      "community": 1
+      "community": 3
     },
     {
       "label": "getRedeemedPromoCodes()",
@@ -11977,7 +11977,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L74",
       "id": "promocodes_getredeemedpromocodes",
-      "community": 1
+      "community": 3
     },
     {
       "label": "getBaseUrl()",
@@ -11985,7 +11985,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L4",
       "id": "reviews_getbaseurl",
-      "community": 6
+      "community": 12
     },
     {
       "label": "createReview()",
@@ -11993,7 +11993,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L13",
       "id": "reviews_createreview",
-      "community": 6
+      "community": 12
     },
     {
       "label": "getReviewByOrderItem()",
@@ -12001,7 +12001,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L32",
       "id": "reviews_getreviewbyorderitem",
-      "community": 6
+      "community": 12
     },
     {
       "label": "updateReview()",
@@ -12009,7 +12009,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L48",
       "id": "reviews_updatereview",
-      "community": 6
+      "community": 12
     },
     {
       "label": "deleteReview()",
@@ -12017,7 +12017,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L69",
       "id": "reviews_deletereview",
-      "community": 6
+      "community": 12
     },
     {
       "label": "getReviewsByProductSkuId()",
@@ -12025,7 +12025,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L83",
       "id": "reviews_getreviewsbyproductskuid",
-      "community": 6
+      "community": 12
     },
     {
       "label": "getUserReviews()",
@@ -12033,7 +12033,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L99",
       "id": "reviews_getuserreviews",
-      "community": 6
+      "community": 12
     },
     {
       "label": "getUserReviewsForProduct()",
@@ -12041,7 +12041,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L113",
       "id": "reviews_getuserreviewsforproduct",
-      "community": 6
+      "community": 12
     },
     {
       "label": "getReviewsByProductId()",
@@ -12049,7 +12049,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L132",
       "id": "reviews_getreviewsbyproductid",
-      "community": 6
+      "community": 12
     },
     {
       "label": "markReviewHelpful()",
@@ -12057,7 +12057,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L148",
       "id": "reviews_markreviewhelpful",
-      "community": 6
+      "community": 12
     },
     {
       "label": "hasReviewForOrderItem()",
@@ -12065,7 +12065,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L164",
       "id": "reviews_hasreviewfororderitem",
-      "community": 6
+      "community": 12
     },
     {
       "label": "hasUserReviewForOrderItem()",
@@ -12073,7 +12073,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L183",
       "id": "reviews_hasuserreviewfororderitem",
-      "community": 6
+      "community": 12
     },
     {
       "label": "getBaseUrl()",
@@ -12081,7 +12081,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L3",
       "id": "rewards_getbaseurl",
-      "community": 19
+      "community": 15
     },
     {
       "label": "getUserPoints()",
@@ -12089,7 +12089,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L54",
       "id": "rewards_getuserpoints",
-      "community": 19
+      "community": 15
     },
     {
       "label": "getPointHistory()",
@@ -12097,7 +12097,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L71",
       "id": "rewards_getpointhistory",
-      "community": 19
+      "community": 15
     },
     {
       "label": "getRewardTiers()",
@@ -12105,7 +12105,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L90",
       "id": "rewards_getrewardtiers",
-      "community": 19
+      "community": 15
     },
     {
       "label": "redeemRewardPoints()",
@@ -12113,7 +12113,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L107",
       "id": "rewards_redeemrewardpoints",
-      "community": 19
+      "community": 15
     },
     {
       "label": "getEligiblePastOrders()",
@@ -12121,7 +12121,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L129",
       "id": "rewards_geteligiblepastorders",
-      "community": 19
+      "community": 15
     },
     {
       "label": "awardPointsForPastOrder()",
@@ -12129,7 +12129,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L151",
       "id": "rewards_awardpointsforpastorder",
-      "community": 19
+      "community": 15
     },
     {
       "label": "getOrderRewardPoints()",
@@ -12137,7 +12137,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L175",
       "id": "rewards_getorderrewardpoints",
-      "community": 19
+      "community": 15
     },
     {
       "label": "awardPointsForGuestOrders()",
@@ -12145,7 +12145,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L198",
       "id": "rewards_awardpointsforguestorders",
-      "community": 19
+      "community": 15
     },
     {
       "label": "getBaseUrl()",
@@ -12153,7 +12153,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L8",
       "id": "savedbag_getbaseurl",
-      "community": 7
+      "community": 15
     },
     {
       "label": "getActiveSavedBag()",
@@ -12161,7 +12161,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L10",
       "id": "savedbag_getactivesavedbag",
-      "community": 7
+      "community": 15
     },
     {
       "label": "addItemToSavedBag()",
@@ -12169,7 +12169,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L25",
       "id": "savedbag_additemtosavedbag",
-      "community": 7
+      "community": 15
     },
     {
       "label": "updateSavedBagItem()",
@@ -12177,7 +12177,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L61",
       "id": "savedbag_updatesavedbagitem",
-      "community": 7
+      "community": 15
     },
     {
       "label": "removeItemFromSavedBag()",
@@ -12185,7 +12185,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L91",
       "id": "savedbag_removeitemfromsavedbag",
-      "community": 7
+      "community": 15
     },
     {
       "label": "updateSavedBagOwner()",
@@ -12193,7 +12193,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L109",
       "id": "savedbag_updatesavedbagowner",
-      "community": 7
+      "community": 15
     },
     {
       "label": "getBaseUrl()",
@@ -12233,7 +12233,7 @@
       "source_file": "packages/storefront-webapp/src/api/storefront.ts",
       "source_location": "L5",
       "id": "storefront_getstore",
-      "community": 2
+      "community": 3
     },
     {
       "label": "getBaseUrl()",
@@ -12241,7 +12241,7 @@
       "source_file": "packages/storefront-webapp/src/api/stores.ts",
       "source_location": "L5",
       "id": "stores_getbaseurl",
-      "community": 2
+      "community": 3
     },
     {
       "label": "getAllStores()",
@@ -12249,7 +12249,7 @@
       "source_file": "packages/storefront-webapp/src/api/stores.ts",
       "source_location": "L8",
       "id": "stores_getallstores",
-      "community": 2
+      "community": 3
     },
     {
       "label": "getStore()",
@@ -12257,7 +12257,7 @@
       "source_file": "packages/storefront-webapp/src/api/stores.ts",
       "source_location": "L20",
       "id": "stores_getstore",
-      "community": 2
+      "community": 3
     },
     {
       "label": "getBaseUrl()",
@@ -12265,7 +12265,7 @@
       "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
       "source_location": "L9",
       "id": "subcategory_getbaseurl",
-      "community": 2
+      "community": 3
     },
     {
       "label": "getAllSubcategories()",
@@ -12273,7 +12273,7 @@
       "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
       "source_location": "L11",
       "id": "subcategory_getallsubcategories",
-      "community": 2
+      "community": 3
     },
     {
       "label": "getSubategory()",
@@ -12281,7 +12281,7 @@
       "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
       "source_location": "L25",
       "id": "subcategory_getsubategory",
-      "community": 2
+      "community": 3
     },
     {
       "label": "getBaseUrl()",
@@ -12289,7 +12289,7 @@
       "source_file": "packages/storefront-webapp/src/api/upsells.ts",
       "source_location": "L3",
       "id": "upsells_getbaseurl",
-      "community": 2
+      "community": 3
     },
     {
       "label": "getLastViewedProduct()",
@@ -12297,7 +12297,7 @@
       "source_file": "packages/storefront-webapp/src/api/upsells.ts",
       "source_location": "L5",
       "id": "upsells_getlastviewedproduct",
-      "community": 2
+      "community": 3
     },
     {
       "label": "getBaseUrl()",
@@ -12305,7 +12305,7 @@
       "source_file": "packages/storefront-webapp/src/api/userOffers.ts",
       "source_location": "L18",
       "id": "useroffers_getbaseurl",
-      "community": 2
+      "community": 6
     },
     {
       "label": "getUserOffersEligibility()",
@@ -12313,7 +12313,7 @@
       "source_file": "packages/storefront-webapp/src/api/userOffers.ts",
       "source_location": "L23",
       "id": "useroffers_getuserofferseligibility",
-      "community": 2
+      "community": 6
     },
     {
       "label": "HeartIconFilled.tsx",
@@ -12321,7 +12321,7 @@
       "source_file": "packages/storefront-webapp/src/assets/icons/HeartIconFilled.tsx",
       "source_location": "L1",
       "id": "hearticonfilled",
-      "community": 1
+      "community": 0
     },
     {
       "label": "EntityPage.tsx",
@@ -12329,7 +12329,7 @@
       "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
       "source_location": "L1",
       "id": "entitypage",
-      "community": 15
+      "community": 12
     },
     {
       "label": "EntityPage()",
@@ -12337,7 +12337,7 @@
       "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
       "source_location": "L10",
       "id": "entitypage_entitypage",
-      "community": 15
+      "community": 12
     },
     {
       "label": "HomePage.tsx",
@@ -12345,7 +12345,7 @@
       "source_file": "packages/storefront-webapp/src/components/HomePage.tsx",
       "source_location": "L1",
       "id": "homepage",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleScroll()",
@@ -12353,7 +12353,7 @@
       "source_file": "packages/storefront-webapp/src/components/HomePage.tsx",
       "source_location": "L106",
       "id": "homepage_handlescroll",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleClickOnDiscountCode()",
@@ -12361,7 +12361,7 @@
       "source_file": "packages/storefront-webapp/src/components/HomePage.tsx",
       "source_location": "L155",
       "id": "homepage_handleclickondiscountcode",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleClickOnLeaveReviewButton()",
@@ -12369,7 +12369,7 @@
       "source_file": "packages/storefront-webapp/src/components/HomePage.tsx",
       "source_location": "L167",
       "id": "homepage_handleclickonleavereviewbutton",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ProductActionBar.tsx",
@@ -12377,7 +12377,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
       "source_location": "L1",
       "id": "productactionbar",
-      "community": 1
+      "community": 0
     },
     {
       "label": "checkScroll()",
@@ -12385,7 +12385,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
       "source_location": "L50",
       "id": "productactionbar_checkscroll",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleDismiss()",
@@ -12393,7 +12393,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
       "source_location": "L74",
       "id": "productactionbar_handledismiss",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleAction()",
@@ -12401,7 +12401,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
       "source_location": "L92",
       "id": "productactionbar_handleaction",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ProductReminderBar.tsx",
@@ -12409,7 +12409,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
       "source_location": "L1",
       "id": "productreminderbar",
-      "community": 1
+      "community": 0
     },
     {
       "label": "checkScroll()",
@@ -12417,7 +12417,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
       "source_location": "L62",
       "id": "productreminderbar_checkscroll",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleAddToBag()",
@@ -12425,7 +12425,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
       "source_location": "L109",
       "id": "productreminderbar_handleaddtobag",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleDismiss()",
@@ -12433,7 +12433,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
       "source_location": "L177",
       "id": "productreminderbar_handledismiss",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ProductsPage.tsx",
@@ -12441,7 +12441,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductsPage.tsx",
       "source_location": "L1",
       "id": "productspage",
-      "community": 1
+      "community": 12
     },
     {
       "label": "ProductCardLoadingSkeleton()",
@@ -12449,7 +12449,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductsPage.tsx",
       "source_location": "L10",
       "id": "productspage_productcardloadingskeleton",
-      "community": 1
+      "community": 12
     },
     {
       "label": "Upsell.tsx",
@@ -12457,7 +12457,7 @@
       "source_file": "packages/storefront-webapp/src/components/Upsell.tsx",
       "source_location": "L1",
       "id": "upsell",
-      "community": 3
+      "community": 0
     },
     {
       "label": "AuthComponent()",
@@ -12465,7 +12465,7 @@
       "source_file": "packages/storefront-webapp/src/components/auth/Auth.tsx",
       "source_location": "L4",
       "id": "auth_authcomponent",
-      "community": 2
+      "community": 3
     },
     {
       "label": "BagSummary.tsx",
@@ -12473,7 +12473,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BagSummary.tsx",
       "source_location": "L1",
       "id": "bagsummary",
-      "community": 1
+      "community": 0
     },
     {
       "label": "toBagSummaryItems()",
@@ -12481,7 +12481,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BagSummary.tsx",
       "source_location": "L39",
       "id": "bagsummary_tobagsummaryitems",
-      "community": 1
+      "community": 0
     },
     {
       "label": "BillingDetails.tsx",
@@ -12585,7 +12585,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/CheckoutProvider.tsx",
       "source_location": "L1",
       "id": "checkoutprovider",
-      "community": 1
+      "community": 0
     },
     {
       "label": "CheckoutProvider()",
@@ -12593,7 +12593,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/CheckoutProvider.tsx",
       "source_location": "L71",
       "id": "checkoutprovider_checkoutprovider",
-      "community": 1
+      "community": 0
     },
     {
       "label": "CustomerDetails.tsx",
@@ -12721,7 +12721,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
       "source_location": "L1",
       "id": "mobilebagsummary",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleRedeemPromoCode()",
@@ -12729,7 +12729,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
       "source_location": "L89",
       "id": "mobilebagsummary_handleredeempromocode",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleKeyDown()",
@@ -12737,7 +12737,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
       "source_location": "L110",
       "id": "mobilebagsummary_handlekeydown",
-      "community": 1
+      "community": 0
     },
     {
       "label": "OrderSummary()",
@@ -12753,7 +12753,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/index.tsx",
       "source_location": "L10",
       "id": "index_pickupdetails",
-      "community": 11
+      "community": 1
     },
     {
       "label": "PaymentMethodSection.tsx",
@@ -12793,7 +12793,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.test.ts",
       "source_location": "L1",
       "id": "checkoutstorage_test",
-      "community": 1
+      "community": 0
     },
     {
       "label": "checkoutStorage.ts",
@@ -12801,7 +12801,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
       "source_location": "L1",
       "id": "checkoutstorage",
-      "community": 1
+      "community": 0
     },
     {
       "label": "loadCheckoutState()",
@@ -12809,7 +12809,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
       "source_location": "L4",
       "id": "checkoutstorage_loadcheckoutstate",
-      "community": 1
+      "community": 0
     },
     {
       "label": "saveCheckoutState()",
@@ -12817,7 +12817,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
       "source_location": "L24",
       "id": "checkoutstorage_savecheckoutstate",
-      "community": 1
+      "community": 0
     },
     {
       "label": "deliveryFees.test.ts",
@@ -12825,7 +12825,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.test.ts",
       "source_location": "L1",
       "id": "deliveryfees_test",
-      "community": 1
+      "community": 5
     },
     {
       "label": "deliveryFees.ts",
@@ -12833,7 +12833,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.ts",
       "source_location": "L1",
       "id": "deliveryfees",
-      "community": 1
+      "community": 5
     },
     {
       "label": "calculateDeliveryFee()",
@@ -12841,7 +12841,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.ts",
       "source_location": "L40",
       "id": "deliveryfees_calculatedeliveryfee",
-      "community": 1
+      "community": 5
     },
     {
       "label": "deriveCheckoutState.test.ts",
@@ -12849,7 +12849,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.test.ts",
       "source_location": "L1",
       "id": "derivecheckoutstate_test",
-      "community": 1
+      "community": 4
     },
     {
       "label": "deriveCheckoutState.ts",
@@ -12857,7 +12857,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
       "source_location": "L1",
       "id": "derivecheckoutstate",
-      "community": 1
+      "community": 4
     },
     {
       "label": "deriveCheckoutState()",
@@ -12865,7 +12865,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
       "source_location": "L3",
       "id": "derivecheckoutstate_derivecheckoutstate",
-      "community": 1
+      "community": 4
     },
     {
       "label": "billingDetailsSchema.ts",
@@ -12945,7 +12945,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L107",
       "id": "utils_getpotentialpoints",
-      "community": 3
+      "community": 2
     },
     {
       "label": "CustomerDetailsForm.tsx",
@@ -12985,7 +12985,7 @@
       "source_file": "packages/storefront-webapp/src/components/common/hooks.ts",
       "source_location": "L3",
       "id": "hooks_usecountdown",
-      "community": 1
+      "community": 0
     },
     {
       "label": "TrustSignals.tsx",
@@ -12993,7 +12993,7 @@
       "source_file": "packages/storefront-webapp/src/components/communication/TrustSignals.tsx",
       "source_location": "L1",
       "id": "trustsignals",
-      "community": 6
+      "community": 9
     },
     {
       "label": "TrustSignals()",
@@ -13001,7 +13001,7 @@
       "source_file": "packages/storefront-webapp/src/components/communication/TrustSignals.tsx",
       "source_location": "L4",
       "id": "trustsignals_trustsignals",
-      "community": 6
+      "community": 9
     },
     {
       "label": "ProductFilter.tsx",
@@ -13009,7 +13009,7 @@
       "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
       "source_location": "L1",
       "id": "productfilter",
-      "community": 5
+      "community": 0
     },
     {
       "label": "ProductFilter()",
@@ -13017,7 +13017,7 @@
       "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
       "source_location": "L14",
       "id": "productfilter_productfilter",
-      "community": 5
+      "community": 0
     },
     {
       "label": "ProductFilterBar.tsx",
@@ -13025,7 +13025,7 @@
       "source_file": "packages/storefront-webapp/src/components/filter/ProductFilterBar.tsx",
       "source_location": "L1",
       "id": "productfilterbar",
-      "community": 1
+      "community": 0
     },
     {
       "label": "Filter.tsx",
@@ -13049,7 +13049,7 @@
       "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
       "source_location": "L1",
       "id": "footer",
-      "community": 1
+      "community": 0
     },
     {
       "label": "LinkGroup()",
@@ -13057,7 +13057,7 @@
       "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
       "source_location": "L13",
       "id": "footer_linkgroup",
-      "community": 1
+      "community": 0
     },
     {
       "label": "BestSellersSection.tsx",
@@ -13065,7 +13065,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.tsx",
       "source_location": "L1",
       "id": "bestsellerssection",
-      "community": 1
+      "community": 0
     },
     {
       "label": "BestSellersSection()",
@@ -13073,7 +13073,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.tsx",
       "source_location": "L17",
       "id": "bestsellerssection_bestsellerssection",
-      "community": 1
+      "community": 0
     },
     {
       "label": "FeaturedProductsSection.tsx",
@@ -13081,7 +13081,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
       "source_location": "L1",
       "id": "featuredproductssection",
-      "community": 1
+      "community": 0
     },
     {
       "label": "FeaturedProductsSection()",
@@ -13089,7 +13089,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
       "source_location": "L20",
       "id": "featuredproductssection_featuredproductssection",
-      "community": 1
+      "community": 0
     },
     {
       "label": "FeaturedSection()",
@@ -13097,7 +13097,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
       "source_location": "L46",
       "id": "featuredproductssection_featuredsection",
-      "community": 1
+      "community": 0
     },
     {
       "label": "HomeHero.tsx",
@@ -13105,7 +13105,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/HomeHero.tsx",
       "source_location": "L1",
       "id": "homehero",
-      "community": 1
+      "community": 0
     },
     {
       "label": "HomeHeroSection.tsx",
@@ -13113,7 +13113,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/HomeHeroSection.tsx",
       "source_location": "L1",
       "id": "homeherosection",
-      "community": 1
+      "community": 0
     },
     {
       "label": "PromoAlert.tsx",
@@ -13121,7 +13121,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
       "source_location": "L1",
       "id": "promoalert",
-      "community": 1
+      "community": 0
     },
     {
       "label": "getPromoAlertCopy()",
@@ -13129,7 +13129,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
       "source_location": "L20",
       "id": "promoalert_getpromoalertcopy",
-      "community": 1
+      "community": 0
     },
     {
       "label": "PromoAlert()",
@@ -13137,7 +13137,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
       "source_location": "L59",
       "id": "promoalert_promoalert",
-      "community": 1
+      "community": 0
     },
     {
       "label": "RewardsAlert.tsx",
@@ -13145,7 +13145,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
       "source_location": "L1",
       "id": "rewardsalert",
-      "community": 1
+      "community": 0
     },
     {
       "label": "onRewardsAlertClose()",
@@ -13153,7 +13153,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
       "source_location": "L20",
       "id": "rewardsalert_onrewardsalertclose",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleShopNow()",
@@ -13161,7 +13161,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
       "source_location": "L25",
       "id": "rewardsalert_handleshopnow",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useGetStoreSubcategories()",
@@ -13169,7 +13169,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
       "source_location": "L10",
       "id": "hooks_usegetstoresubcategories",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useGetStoreCategories()",
@@ -13177,7 +13177,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
       "source_location": "L21",
       "id": "hooks_usegetstorecategories",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useGetShopSearchParams()",
@@ -13185,7 +13185,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
       "source_location": "L55",
       "id": "hooks_usegetshopsearchparams",
-      "community": 1
+      "community": 0
     },
     {
       "label": "BagMenu.tsx",
@@ -13193,7 +13193,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/BagMenu.tsx",
       "source_location": "L1",
       "id": "bagmenu",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleOnLinkClick()",
@@ -13201,7 +13201,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/BagMenu.tsx",
       "source_location": "L47",
       "id": "bagmenu_handleonlinkclick",
-      "community": 1
+      "community": 0
     },
     {
       "label": "MobileBagMenu.tsx",
@@ -13209,7 +13209,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileBagMenu.tsx",
       "source_location": "L1",
       "id": "mobilebagmenu",
-      "community": 1
+      "community": 0
     },
     {
       "label": "MobileBagMenu()",
@@ -13217,7 +13217,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileBagMenu.tsx",
       "source_location": "L7",
       "id": "mobilebagmenu_mobilebagmenu",
-      "community": 1
+      "community": 0
     },
     {
       "label": "MobileMenu.tsx",
@@ -13225,7 +13225,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileMenu.tsx",
       "source_location": "L1",
       "id": "mobilemenu",
-      "community": 1
+      "community": 0
     },
     {
       "label": "NavigationBar.tsx",
@@ -13233,7 +13233,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/NavigationBar.tsx",
       "source_location": "L1",
       "id": "navigationbar",
-      "community": 1
+      "community": 0
     },
     {
       "label": "StoreCategoriesSubmenu()",
@@ -13241,7 +13241,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/NavigationBar.tsx",
       "source_location": "L62",
       "id": "navigationbar_storecategoriessubmenu",
-      "community": 1
+      "community": 0
     },
     {
       "label": "SiteBanner.tsx",
@@ -13249,7 +13249,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/SiteBanner.tsx",
       "source_location": "L1",
       "id": "sitebanner",
-      "community": 1
+      "community": 3
     },
     {
       "label": "SiteBanner()",
@@ -13257,7 +13257,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/SiteBanner.tsx",
       "source_location": "L17",
       "id": "sitebanner_sitebanner",
-      "community": 1
+      "community": 3
     },
     {
       "label": "navBarConstants.ts",
@@ -13377,7 +13377,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/About.tsx",
       "source_location": "L1",
       "id": "about",
-      "community": 6
+      "community": 9
     },
     {
       "label": "AboutProduct.tsx",
@@ -13385,7 +13385,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/AboutProduct.tsx",
       "source_location": "L1",
       "id": "aboutproduct",
-      "community": 6
+      "community": 9
     },
     {
       "label": "DimensionBar.tsx",
@@ -13393,7 +13393,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
       "source_location": "L1",
       "id": "dimensionbar",
-      "community": 6
+      "community": 12
     },
     {
       "label": "mapValueToLabelIndex()",
@@ -13401,7 +13401,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
       "source_location": "L12",
       "id": "dimensionbar_mapvaluetolabelindex",
-      "community": 6
+      "community": 12
     },
     {
       "label": "DiscountBadge.tsx",
@@ -13409,7 +13409,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/DiscountBadge.tsx",
       "source_location": "L1",
       "id": "discountbadge",
-      "community": 1
+      "community": 0
     },
     {
       "label": "DiscountBadge()",
@@ -13417,7 +13417,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/DiscountBadge.tsx",
       "source_location": "L7",
       "id": "discountbadge_discountbadge",
-      "community": 1
+      "community": 0
     },
     {
       "label": "GalleryViewer.tsx",
@@ -13425,7 +13425,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/GalleryViewer.tsx",
       "source_location": "L1",
       "id": "galleryviewer",
-      "community": 6
+      "community": 9
     },
     {
       "label": "handleClickOnPreview()",
@@ -13433,7 +13433,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/GalleryViewer.tsx",
       "source_location": "L45",
       "id": "galleryviewer_handleclickonpreview",
-      "community": 6
+      "community": 9
     },
     {
       "label": "InventoryLevelBadge.tsx",
@@ -13441,7 +13441,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
       "source_location": "L1",
       "id": "inventorylevelbadge",
-      "community": 6
+      "community": 12
     },
     {
       "label": "SoldOutBadge()",
@@ -13449,7 +13449,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
       "source_location": "L3",
       "id": "inventorylevelbadge_soldoutbadge",
-      "community": 6
+      "community": 12
     },
     {
       "label": "LowStockBadge()",
@@ -13457,7 +13457,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
       "source_location": "L14",
       "id": "inventorylevelbadge_lowstockbadge",
-      "community": 6
+      "community": 12
     },
     {
       "label": "SellingFastBadge()",
@@ -13465,7 +13465,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
       "source_location": "L22",
       "id": "inventorylevelbadge_sellingfastbadge",
-      "community": 6
+      "community": 12
     },
     {
       "label": "SellingFastSignal()",
@@ -13473,7 +13473,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
       "source_location": "L30",
       "id": "inventorylevelbadge_sellingfastsignal",
-      "community": 6
+      "community": 12
     },
     {
       "label": "OnSaleProduct.tsx",
@@ -13481,7 +13481,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/OnSaleProduct.tsx",
       "source_location": "L1",
       "id": "onsaleproduct",
-      "community": 6
+      "community": 9
     },
     {
       "label": "OnsaleProduct()",
@@ -13489,7 +13489,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/OnSaleProduct.tsx",
       "source_location": "L5",
       "id": "onsaleproduct_onsaleproduct",
-      "community": 6
+      "community": 9
     },
     {
       "label": "ProductActions.tsx",
@@ -13497,7 +13497,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.tsx",
       "source_location": "L1",
       "id": "productactions",
-      "community": 6
+      "community": 9
     },
     {
       "label": "ProductActions()",
@@ -13505,7 +13505,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.tsx",
       "source_location": "L17",
       "id": "productactions_productactions",
-      "community": 6
+      "community": 9
     },
     {
       "label": "ProductAttribute.tsx",
@@ -13513,7 +13513,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
       "source_location": "L1",
       "id": "productattribute",
-      "community": 6
+      "community": 9
     },
     {
       "label": "findSize()",
@@ -13521,7 +13521,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
       "source_location": "L61",
       "id": "productattribute_findsize",
-      "community": 6
+      "community": 9
     },
     {
       "label": "handleClick()",
@@ -13529,7 +13529,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
       "source_location": "L65",
       "id": "productattribute_handleclick",
-      "community": 6
+      "community": 9
     },
     {
       "label": "ProductAttributes()",
@@ -13537,7 +13537,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttributes.tsx",
       "source_location": "L3",
       "id": "productattributes_productattributes",
-      "community": 0
+      "community": 1
     },
     {
       "label": "PickupDetails()",
@@ -13545,7 +13545,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
       "source_location": "L13",
       "id": "productdetails_pickupdetails",
-      "community": 1
+      "community": 0
     },
     {
       "label": "BagProduct()",
@@ -13553,7 +13553,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
       "source_location": "L43",
       "id": "productdetails_bagproduct",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ShippingPolicy()",
@@ -13561,7 +13561,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
       "source_location": "L88",
       "id": "productdetails_shippingpolicy",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ProductInfo.tsx",
@@ -13569,7 +13569,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductInfo.tsx",
       "source_location": "L1",
       "id": "productinfo",
-      "community": 6
+      "community": 12
     },
     {
       "label": "showShippingPolicy()",
@@ -13577,7 +13577,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductPage.tsx",
       "source_location": "L78",
       "id": "productpage_showshippingpolicy",
-      "community": 6
+      "community": 9
     },
     {
       "label": "ProductReview.tsx",
@@ -13585,7 +13585,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductReview.tsx",
       "source_location": "L1",
       "id": "productreview",
-      "community": 6
+      "community": 12
     },
     {
       "label": "handleHelpful()",
@@ -13593,7 +13593,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductReview.tsx",
       "source_location": "L87",
       "id": "productreview_handlehelpful",
-      "community": 6
+      "community": 12
     },
     {
       "label": "ProductReviews.tsx",
@@ -13601,7 +13601,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductReviews.tsx",
       "source_location": "L1",
       "id": "productreviews",
-      "community": 6
+      "community": 12
     },
     {
       "label": "ProductsNavigationBar.tsx",
@@ -13609,7 +13609,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductsNavigationBar.tsx",
       "source_location": "L1",
       "id": "productsnavigationbar",
-      "community": 3
+      "community": 2
     },
     {
       "label": "ReviewSummary.tsx",
@@ -13617,7 +13617,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
       "source_location": "L1",
       "id": "reviewsummary",
-      "community": 6
+      "community": 12
     },
     {
       "label": "ReviewSummary()",
@@ -13625,7 +13625,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
       "source_location": "L8",
       "id": "reviewsummary_reviewsummary",
-      "community": 6
+      "community": 12
     },
     {
       "label": "ErrorMessage.tsx",
@@ -13633,7 +13633,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ErrorMessage.tsx",
       "source_location": "L1",
       "id": "errormessage",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ExistingReviewMessage.tsx",
@@ -13641,7 +13641,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ExistingReviewMessage.tsx",
       "source_location": "L1",
       "id": "existingreviewmessage",
-      "community": 1
+      "community": 0
     },
     {
       "label": "OrderItem.tsx",
@@ -13649,7 +13649,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
       "source_location": "L1",
       "id": "orderitem",
-      "community": 1
+      "community": 0
     },
     {
       "label": "OrderItem()",
@@ -13657,7 +13657,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
       "source_location": "L12",
       "id": "orderitem_orderitem",
-      "community": 1
+      "community": 0
     },
     {
       "label": "RatingSelector.tsx",
@@ -13665,7 +13665,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/RatingSelector.tsx",
       "source_location": "L1",
       "id": "ratingselector",
-      "community": 1
+      "community": 2
     },
     {
       "label": "RatingSelector()",
@@ -13673,7 +13673,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/RatingSelector.tsx",
       "source_location": "L18",
       "id": "ratingselector_ratingselector",
-      "community": 1
+      "community": 2
     },
     {
       "label": "ReviewEditor.tsx",
@@ -13681,7 +13681,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
       "source_location": "L1",
       "id": "revieweditor",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleFormDataChange()",
@@ -13689,7 +13689,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
       "source_location": "L150",
       "id": "revieweditor_handleformdatachange",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleSubmit()",
@@ -13697,7 +13697,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
       "source_location": "L157",
       "id": "revieweditor_handlesubmit",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ReviewForm.tsx",
@@ -13705,7 +13705,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewForm.tsx",
       "source_location": "L1",
       "id": "reviewform",
-      "community": 1
+      "community": 5
     },
     {
       "label": "SuccessMessage.tsx",
@@ -13713,7 +13713,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/SuccessMessage.tsx",
       "source_location": "L1",
       "id": "successmessage",
-      "community": 1
+      "community": 0
     },
     {
       "label": "GuestRewardsPrompt.tsx",
@@ -13721,7 +13721,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/GuestRewardsPrompt.tsx",
       "source_location": "L1",
       "id": "guestrewardsprompt",
-      "community": 1
+      "community": 0
     },
     {
       "label": "GuestRewardsPrompt()",
@@ -13729,7 +13729,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/GuestRewardsPrompt.tsx",
       "source_location": "L10",
       "id": "guestrewardsprompt_guestrewardsprompt",
-      "community": 1
+      "community": 0
     },
     {
       "label": "OrderPointsDisplay.tsx",
@@ -13737,7 +13737,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
       "source_location": "L1",
       "id": "orderpointsdisplay",
-      "community": 19
+      "community": 15
     },
     {
       "label": "OrderPointsDisplay()",
@@ -13745,7 +13745,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
       "source_location": "L11",
       "id": "orderpointsdisplay_orderpointsdisplay",
-      "community": 19
+      "community": 15
     },
     {
       "label": "PastOrdersRewards.tsx",
@@ -13753,7 +13753,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/PastOrdersRewards.tsx",
       "source_location": "L1",
       "id": "pastordersrewards",
-      "community": 19
+      "community": 0
     },
     {
       "label": "handleClaimPoints()",
@@ -13761,7 +13761,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/PastOrdersRewards.tsx",
       "source_location": "L59",
       "id": "pastordersrewards_handleclaimpoints",
-      "community": 19
+      "community": 0
     },
     {
       "label": "RewardsPanel.tsx",
@@ -13785,7 +13785,7 @@
       "source_file": "packages/storefront-webapp/src/components/saved-items/SavedIcon.tsx",
       "source_location": "L1",
       "id": "savedicon",
-      "community": 1
+      "community": 0
     },
     {
       "label": "BagItem()",
@@ -13793,7 +13793,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/BagItem.tsx",
       "source_location": "L19",
       "id": "bagitem_bagitem",
-      "community": 7
+      "community": 15
     },
     {
       "label": "CartIcon.tsx",
@@ -13801,7 +13801,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/CartIcon.tsx",
       "source_location": "L1",
       "id": "carticon",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ShoppingBag.tsx",
@@ -13809,7 +13809,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L1",
       "id": "shoppingbag",
-      "community": 1
+      "community": 0
     },
     {
       "label": "PendingItem()",
@@ -13817,7 +13817,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L62",
       "id": "shoppingbag_pendingitem",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleOnCheckoutClick()",
@@ -13825,7 +13825,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L476",
       "id": "shoppingbag_handleoncheckoutclick",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleClickOnDiscountCode()",
@@ -13833,7 +13833,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L525",
       "id": "shoppingbag_handleclickondiscountcode",
-      "community": 1
+      "community": 0
     },
     {
       "label": "isSkuUnavailable()",
@@ -13841,7 +13841,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L537",
       "id": "shoppingbag_isskuunavailable",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleMoveToSaved()",
@@ -13849,7 +13849,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L552",
       "id": "shoppingbag_handlemovetosaved",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleDeleteItem()",
@@ -13857,7 +13857,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L566",
       "id": "shoppingbag_handledeleteitem",
-      "community": 1
+      "community": 0
     },
     {
       "label": "CheckoutUnavailable.tsx",
@@ -13865,7 +13865,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout unavailable/CheckoutUnavailable.tsx",
       "source_location": "L1",
       "id": "checkoutunavailable",
-      "community": 1
+      "community": 0
     },
     {
       "label": "CheckoutUnavailable()",
@@ -13873,7 +13873,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout unavailable/CheckoutUnavailable.tsx",
       "source_location": "L4",
       "id": "checkoutunavailable_checkoutunavailable",
-      "community": 1
+      "community": 0
     },
     {
       "label": "CheckoutExpired.tsx",
@@ -13881,7 +13881,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L1",
       "id": "checkoutexpired",
-      "community": 1
+      "community": 0
     },
     {
       "label": "CheckoutExpired()",
@@ -13889,7 +13889,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L9",
       "id": "checkoutexpired_checkoutexpired",
-      "community": 1
+      "community": 0
     },
     {
       "label": "NoCheckoutSession()",
@@ -13897,7 +13897,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L33",
       "id": "checkoutexpired_nocheckoutsession",
-      "community": 1
+      "community": 0
     },
     {
       "label": "CheckoutSessionNotFound()",
@@ -13905,7 +13905,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L54",
       "id": "checkoutexpired_checkoutsessionnotfound",
-      "community": 1
+      "community": 0
     },
     {
       "label": "CheckoutSessionGeneric()",
@@ -13913,7 +13913,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L73",
       "id": "checkoutexpired_checkoutsessiongeneric",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleSendEmail()",
@@ -13921,7 +13921,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L98",
       "id": "checkoutexpired_handlesendemail",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ErrorBoundary.tsx",
@@ -13929,7 +13929,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/error/ErrorBoundary.tsx",
       "source_location": "L1",
       "id": "errorboundary",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ErrorBoundary()",
@@ -13937,7 +13937,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/error/ErrorBoundary.tsx",
       "source_location": "L22",
       "id": "errorboundary_errorboundary",
-      "community": 1
+      "community": 0
     },
     {
       "label": "Maintenance.tsx",
@@ -13945,7 +13945,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/maintenance/Maintenance.tsx",
       "source_location": "L1",
       "id": "maintenance",
-      "community": 1
+      "community": 0
     },
     {
       "label": "AnimatedCard.tsx",
@@ -13953,7 +13953,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/AnimatedCard.tsx",
       "source_location": "L1",
       "id": "animatedcard",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ScrollDownButton.tsx",
@@ -13961,7 +13961,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/ScrollDownButton.tsx",
       "source_location": "L1",
       "id": "scrolldownbutton",
-      "community": 15
+      "community": 17
     },
     {
       "label": "ScrollDownButton()",
@@ -13969,7 +13969,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/ScrollDownButton.tsx",
       "source_location": "L11",
       "id": "scrolldownbutton_scrolldownbutton",
-      "community": 15
+      "community": 17
     },
     {
       "label": "alert.tsx",
@@ -13977,7 +13977,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/alert.tsx",
       "source_location": "L1",
       "id": "alert",
-      "community": 3
+      "community": 2
     },
     {
       "label": "breadcrumb.tsx",
@@ -13985,7 +13985,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/breadcrumb.tsx",
       "source_location": "L1",
       "id": "breadcrumb",
-      "community": 3
+      "community": 2
     },
     {
       "label": "country-select.tsx",
@@ -14041,7 +14041,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/image-with-fallback.tsx",
       "source_location": "L1",
       "id": "image_with_fallback",
-      "community": 1
+      "community": 0
     },
     {
       "label": "input-with-end-button.tsx",
@@ -14049,7 +14049,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/input-with-end-button.tsx",
       "source_location": "L1",
       "id": "input_with_end_button",
-      "community": 1
+      "community": 0
     },
     {
       "label": "LeaveAReviewModal.tsx",
@@ -14057,7 +14057,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
       "source_location": "L1",
       "id": "leaveareviewmodal",
-      "community": 1
+      "community": 6
     },
     {
       "label": "handleClose()",
@@ -14065,7 +14065,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
       "source_location": "L66",
       "id": "leaveareviewmodal_handleclose",
-      "community": 1
+      "community": 6
     },
     {
       "label": "LeaveAReviewModalForm.tsx",
@@ -14073,7 +14073,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModalForm.tsx",
       "source_location": "L1",
       "id": "leaveareviewmodalform",
-      "community": 1
+      "community": 6
     },
     {
       "label": "UpsellModal.tsx",
@@ -14081,7 +14081,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
       "source_location": "L1",
       "id": "upsellmodal",
-      "community": 1
+      "community": 6
     },
     {
       "label": "handleScroll()",
@@ -14089,7 +14089,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
       "source_location": "L66",
       "id": "upsellmodal_handlescroll",
-      "community": 1
+      "community": 6
     },
     {
       "label": "handleClose()",
@@ -14097,7 +14097,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
       "source_location": "L111",
       "id": "upsellmodal_handleclose",
-      "community": 1
+      "community": 6
     },
     {
       "label": "handleSuccess()",
@@ -14105,7 +14105,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
       "source_location": "L127",
       "id": "upsellmodal_handlesuccess",
-      "community": 1
+      "community": 6
     },
     {
       "label": "UpsellModalForm.tsx",
@@ -14113,7 +14113,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
       "source_location": "L1",
       "id": "upsellmodalform",
-      "community": 1
+      "community": 6
     },
     {
       "label": "handleSubmit()",
@@ -14121,7 +14121,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
       "source_location": "L48",
       "id": "upsellmodalform_handlesubmit",
-      "community": 1
+      "community": 6
     },
     {
       "label": "handleInputChange()",
@@ -14129,7 +14129,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
       "source_location": "L63",
       "id": "upsellmodalform_handleinputchange",
-      "community": 1
+      "community": 6
     },
     {
       "label": "UpsellModalSuccess.tsx",
@@ -14137,7 +14137,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalSuccess.tsx",
       "source_location": "L1",
       "id": "upsellmodalsuccess",
-      "community": 1
+      "community": 0
     },
     {
       "label": "UpsellModalSuccess()",
@@ -14145,7 +14145,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalSuccess.tsx",
       "source_location": "L19",
       "id": "upsellmodalsuccess_upsellmodalsuccess",
-      "community": 1
+      "community": 0
     },
     {
       "label": "WelcomeBackModal.tsx",
@@ -14153,7 +14153,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
       "source_location": "L1",
       "id": "welcomebackmodal",
-      "community": 1
+      "community": 6
     },
     {
       "label": "handleClose()",
@@ -14161,7 +14161,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
       "source_location": "L63",
       "id": "welcomebackmodal_handleclose",
-      "community": 1
+      "community": 6
     },
     {
       "label": "handleSuccess()",
@@ -14169,7 +14169,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
       "source_location": "L76",
       "id": "welcomebackmodal_handlesuccess",
-      "community": 1
+      "community": 6
     },
     {
       "label": "WelcomeBackModalForm.tsx",
@@ -14177,7 +14177,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
       "source_location": "L1",
       "id": "welcomebackmodalform",
-      "community": 1
+      "community": 6
     },
     {
       "label": "handleSubmit()",
@@ -14185,7 +14185,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
       "source_location": "L36",
       "id": "welcomebackmodalform_handlesubmit",
-      "community": 1
+      "community": 6
     },
     {
       "label": "handleInputChange()",
@@ -14193,7 +14193,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
       "source_location": "L51",
       "id": "welcomebackmodalform_handleinputchange",
-      "community": 1
+      "community": 6
     },
     {
       "label": "WelcomeBackModalSuccess.tsx",
@@ -14201,7 +14201,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalSuccess.tsx",
       "source_location": "L1",
       "id": "welcomebackmodalsuccess",
-      "community": 1
+      "community": 6
     },
     {
       "label": "WelcomeBackModalSuccess()",
@@ -14209,7 +14209,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalSuccess.tsx",
       "source_location": "L13",
       "id": "welcomebackmodalsuccess_welcomebackmodalsuccess",
-      "community": 1
+      "community": 6
     },
     {
       "label": "welcomeBackModalAnimations.ts",
@@ -14217,7 +14217,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/animations/welcomeBackModalAnimations.ts",
       "source_location": "L1",
       "id": "welcomebackmodalanimations",
-      "community": 1
+      "community": 6
     },
     {
       "label": "leaveReviewModalConfig.tsx",
@@ -14225,7 +14225,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/config/leaveReviewModalConfig.tsx",
       "source_location": "L1",
       "id": "leavereviewmodalconfig",
-      "community": 1
+      "community": 6
     },
     {
       "label": "getModalConfig()",
@@ -14233,7 +14233,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/config/leaveReviewModalConfig.tsx",
       "source_location": "L46",
       "id": "leavereviewmodalconfig_getmodalconfig",
-      "community": 1
+      "community": 6
     },
     {
       "label": "welcomeBackModalConfig.tsx",
@@ -14241,7 +14241,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/config/welcomeBackModalConfig.tsx",
       "source_location": "L1",
       "id": "welcomebackmodalconfig",
-      "community": 1
+      "community": 6
     },
     {
       "label": "getModalConfig()",
@@ -14249,7 +14249,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/config/welcomeBackModalConfig.tsx",
       "source_location": "L46",
       "id": "welcomebackmodalconfig_getmodalconfig",
-      "community": 1
+      "community": 6
     },
     {
       "label": "navigation-menu.tsx",
@@ -14257,7 +14257,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/navigation-menu.tsx",
       "source_location": "L1",
       "id": "navigation_menu",
-      "community": 3
+      "community": 2
     },
     {
       "label": "webp-jpg.tsx",
@@ -14297,7 +14297,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
       "source_location": "L1",
       "id": "navigationbarprovider",
-      "community": 1
+      "community": 0
     },
     {
       "label": "NavigationBarProvider()",
@@ -14305,7 +14305,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
       "source_location": "L16",
       "id": "navigationbarprovider_navigationbarprovider",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useNavigationBarContext()",
@@ -14313,7 +14313,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
       "source_location": "L39",
       "id": "navigationbarprovider_usenavigationbarcontext",
-      "community": 1
+      "community": 0
     },
     {
       "label": "StoreContext.tsx",
@@ -14321,7 +14321,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
       "source_location": "L1",
       "id": "storecontext",
-      "community": 1
+      "community": 0
     },
     {
       "label": "StoreProvider()",
@@ -14329,7 +14329,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
       "source_location": "L25",
       "id": "storecontext_storeprovider",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useStoreContext()",
@@ -14337,7 +14337,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
       "source_location": "L82",
       "id": "storecontext_usestorecontext",
-      "community": 1
+      "community": 0
     },
     {
       "label": "StorefrontObservabilityProvider.tsx",
@@ -14345,7 +14345,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
       "source_location": "L1",
       "id": "storefrontobservabilityprovider",
-      "community": 1
+      "community": 8
     },
     {
       "label": "StorefrontObservabilityProvider()",
@@ -14353,7 +14353,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
       "source_location": "L20",
       "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
-      "community": 1
+      "community": 8
     },
     {
       "label": "useStorefrontObservability()",
@@ -14361,7 +14361,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
       "source_location": "L55",
       "id": "storefrontobservabilityprovider_usestorefrontobservability",
-      "community": 1
+      "community": 8
     },
     {
       "label": "useCheckout.ts",
@@ -14385,7 +14385,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useDiscountCodeAlert.tsx",
       "source_location": "L1",
       "id": "usediscountcodealert",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useDiscountCodeAlert()",
@@ -14393,7 +14393,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useDiscountCodeAlert.tsx",
       "source_location": "L14",
       "id": "usediscountcodealert_usediscountcodealert",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useEnhancedTracking.ts",
@@ -14401,7 +14401,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useEnhancedTracking.ts",
       "source_location": "L1",
       "id": "useenhancedtracking",
-      "community": 15
+      "community": 17
     },
     {
       "label": "useEnhancedTracking()",
@@ -14409,7 +14409,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useEnhancedTracking.ts",
       "source_location": "L29",
       "id": "useenhancedtracking_useenhancedtracking",
-      "community": 15
+      "community": 17
     },
     {
       "label": "useGetActiveCheckoutSession.tsx",
@@ -14417,7 +14417,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetActiveCheckoutSession.tsx",
       "source_location": "L1",
       "id": "usegetactivecheckoutsession",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useGetActiveCheckoutSession()",
@@ -14425,7 +14425,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetActiveCheckoutSession.tsx",
       "source_location": "L5",
       "id": "usegetactivecheckoutsession_usegetactivecheckoutsession",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useGetProduct.tsx",
@@ -14433,7 +14433,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetProduct.tsx",
       "source_location": "L1",
       "id": "usegetproduct",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useGetProductQuery()",
@@ -14441,7 +14441,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetProduct.tsx",
       "source_location": "L5",
       "id": "usegetproduct_usegetproductquery",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useGetProductFilters.ts",
@@ -14449,7 +14449,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetProductFilters.ts",
       "source_location": "L1",
       "id": "usegetproductfilters",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useGetProductFilters()",
@@ -14457,7 +14457,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetProductFilters.ts",
       "source_location": "L3",
       "id": "usegetproductfilters_usegetproductfilters",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useGetProductReviews.ts",
@@ -14465,7 +14465,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetProductReviews.ts",
       "source_location": "L1",
       "id": "usegetproductreviews",
-      "community": 6
+      "community": 12
     },
     {
       "label": "useGetProductReviewsQuery()",
@@ -14473,7 +14473,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetProductReviews.ts",
       "source_location": "L4",
       "id": "usegetproductreviews_usegetproductreviewsquery",
-      "community": 6
+      "community": 12
     },
     {
       "label": "useGetStore.ts",
@@ -14481,7 +14481,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetStore.ts",
       "source_location": "L1",
       "id": "usegetstore",
-      "community": 2
+      "community": 3
     },
     {
       "label": "useGetStore()",
@@ -14489,7 +14489,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetStore.ts",
       "source_location": "L4",
       "id": "usegetstore_usegetstore",
-      "community": 2
+      "community": 3
     },
     {
       "label": "useInventoryStatus.ts",
@@ -14497,7 +14497,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useInventoryStatus.ts",
       "source_location": "L1",
       "id": "useinventorystatus",
-      "community": 15
+      "community": 12
     },
     {
       "label": "useInventoryStatus()",
@@ -14505,7 +14505,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useInventoryStatus.ts",
       "source_location": "L9",
       "id": "useinventorystatus_useinventorystatus",
-      "community": 15
+      "community": 12
     },
     {
       "label": "useLeaveAReviewModal.tsx",
@@ -14513,7 +14513,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useLeaveAReviewModal.tsx",
       "source_location": "L1",
       "id": "useleaveareviewmodal",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useLeaveAReviewModal()",
@@ -14521,7 +14521,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useLeaveAReviewModal.tsx",
       "source_location": "L17",
       "id": "useleaveareviewmodal_useleaveareviewmodal",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useLogout.ts",
@@ -14529,7 +14529,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useLogout.ts",
       "source_location": "L1",
       "id": "uselogout",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useLogout()",
@@ -14537,7 +14537,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useLogout.ts",
       "source_location": "L5",
       "id": "uselogout_uselogout",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useModalState.tsx",
@@ -14545,7 +14545,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useModalState.tsx",
       "source_location": "L1",
       "id": "usemodalstate",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useModalState()",
@@ -14553,7 +14553,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useModalState.tsx",
       "source_location": "L15",
       "id": "usemodalstate_usemodalstate",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useProductDiscount.ts",
@@ -14561,7 +14561,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
       "source_location": "L1",
       "id": "useproductdiscount",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useProductDiscounts()",
@@ -14569,7 +14569,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
       "source_location": "L25",
       "id": "useproductdiscount_useproductdiscounts",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useProductDiscount()",
@@ -14577,7 +14577,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
       "source_location": "L107",
       "id": "useproductdiscount_useproductdiscount",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useProductPageLogic.ts",
@@ -14585,7 +14585,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useProductPageLogic.ts",
       "source_location": "L1",
       "id": "useproductpagelogic",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useProductPageLogic()",
@@ -14593,7 +14593,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useProductPageLogic.ts",
       "source_location": "L18",
       "id": "useproductpagelogic_useproductpagelogic",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useProductReminder.tsx",
@@ -14601,7 +14601,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useProductReminder.tsx",
       "source_location": "L1",
       "id": "useproductreminder",
-      "community": 2
+      "community": 3
     },
     {
       "label": "useProductReminder()",
@@ -14609,7 +14609,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useProductReminder.tsx",
       "source_location": "L9",
       "id": "useproductreminder_useproductreminder",
-      "community": 2
+      "community": 3
     },
     {
       "label": "usePromoAlert.tsx",
@@ -14617,7 +14617,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/usePromoAlert.tsx",
       "source_location": "L1",
       "id": "usepromoalert",
-      "community": 1
+      "community": 0
     },
     {
       "label": "usePromoAlert()",
@@ -14625,7 +14625,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/usePromoAlert.tsx",
       "source_location": "L16",
       "id": "usepromoalert_usepromoalert",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useQueryEnabled.ts",
@@ -14633,7 +14633,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useQueryEnabled.ts",
       "source_location": "L1",
       "id": "usequeryenabled",
-      "community": 2
+      "community": 3
     },
     {
       "label": "useQueryEnabled()",
@@ -14641,7 +14641,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useQueryEnabled.ts",
       "source_location": "L4",
       "id": "usequeryenabled_usequeryenabled",
-      "community": 2
+      "community": 3
     },
     {
       "label": "useRewardsAlert.tsx",
@@ -14649,7 +14649,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useRewardsAlert.tsx",
       "source_location": "L1",
       "id": "userewardsalert",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useRewardsAlert()",
@@ -14657,7 +14657,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useRewardsAlert.tsx",
       "source_location": "L11",
       "id": "userewardsalert_userewardsalert",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useScrollToTop.ts",
@@ -14665,7 +14665,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useScrollToTop.ts",
       "source_location": "L1",
       "id": "usescrolltotop",
-      "community": 8
+      "community": 7
     },
     {
       "label": "useScrollToTop()",
@@ -14673,7 +14673,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useScrollToTop.ts",
       "source_location": "L3",
       "id": "usescrolltotop_usescrolltotop",
-      "community": 8
+      "community": 7
     },
     {
       "label": "useShoppingBag.ts",
@@ -14681,7 +14681,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
       "source_location": "L1",
       "id": "useshoppingbag",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useShoppingBag()",
@@ -14689,7 +14689,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
       "source_location": "L52",
       "id": "useshoppingbag_useshoppingbag",
-      "community": 1
+      "community": 0
     },
     {
       "label": "isUnavailableProductList()",
@@ -14697,7 +14697,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
       "source_location": "L540",
       "id": "useshoppingbag_isunavailableproductlist",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useStorefrontObservability.ts",
@@ -14705,7 +14705,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useStorefrontObservability.ts",
       "source_location": "L1",
       "id": "usestorefrontobservability",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useTrackAction.ts",
@@ -14713,7 +14713,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useTrackAction.ts",
       "source_location": "L1",
       "id": "usetrackaction",
-      "community": 15
+      "community": 17
     },
     {
       "label": "useTrackAction()",
@@ -14721,7 +14721,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useTrackAction.ts",
       "source_location": "L5",
       "id": "usetrackaction_usetrackaction",
-      "community": 15
+      "community": 17
     },
     {
       "label": "useTrackEvent.ts",
@@ -14729,7 +14729,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useTrackEvent.ts",
       "source_location": "L1",
       "id": "usetrackevent",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useTrackEvent()",
@@ -14737,7 +14737,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useTrackEvent.ts",
       "source_location": "L5",
       "id": "usetrackevent_usetrackevent",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useUpsellModal.tsx",
@@ -14745,7 +14745,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useUpsellModal.tsx",
       "source_location": "L1",
       "id": "useupsellmodal",
-      "community": 1
+      "community": 6
     },
     {
       "label": "useUpsellModal()",
@@ -14753,7 +14753,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useUpsellModal.tsx",
       "source_location": "L14",
       "id": "useupsellmodal_useupsellmodal",
-      "community": 1
+      "community": 6
     },
     {
       "label": "feeUtils.test.ts",
@@ -14817,7 +14817,7 @@
       "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.test.ts",
       "source_location": "L1",
       "id": "maintenanceutils_test",
-      "community": 17
+      "community": 16
     },
     {
       "label": "usePostAnalytics()",
@@ -14825,7 +14825,7 @@
       "source_file": "packages/storefront-webapp/src/lib/mutations.ts/analytics.ts",
       "source_location": "L4",
       "id": "analytics_usepostanalytics",
-      "community": 15
+      "community": 17
     },
     {
       "label": "isSoldOut()",
@@ -14833,7 +14833,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L45",
       "id": "productutils_issoldout",
-      "community": 1
+      "community": 0
     },
     {
       "label": "hasLowStock()",
@@ -14841,7 +14841,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L52",
       "id": "productutils_haslowstock",
-      "community": 1
+      "community": 0
     },
     {
       "label": "sortSkusByLength()",
@@ -14849,7 +14849,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L62",
       "id": "productutils_sortskusbylength",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useBagQueries()",
@@ -14857,7 +14857,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/bag.ts",
       "source_location": "L7",
       "id": "bag_usebagqueries",
-      "community": 7
+      "community": 15
     },
     {
       "label": "useBannerMessageQueries()",
@@ -14865,7 +14865,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/bannerMessage.ts",
       "source_location": "L6",
       "id": "bannermessage_usebannermessagequeries",
-      "community": 2
+      "community": 3
     },
     {
       "label": "useCheckoutSessionQueries()",
@@ -14873,7 +14873,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/checkout.ts",
       "source_location": "L10",
       "id": "checkout_usecheckoutsessionqueries",
-      "community": 1
+      "community": 0
     },
     {
       "label": "inventory.ts",
@@ -14881,7 +14881,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/inventory.ts",
       "source_location": "L1",
       "id": "inventory",
-      "community": 2
+      "community": 3
     },
     {
       "label": "useInventoryQueries()",
@@ -14889,7 +14889,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/inventory.ts",
       "source_location": "L6",
       "id": "inventory_useinventoryqueries",
-      "community": 2
+      "community": 3
     },
     {
       "label": "useOnlineOrderQueries()",
@@ -14897,7 +14897,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/onlineOrder.ts",
       "source_location": "L5",
       "id": "onlineorder_useonlineorderqueries",
-      "community": 2
+      "community": 3
     },
     {
       "label": "useProductQueries()",
@@ -14905,7 +14905,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/product.ts",
       "source_location": "L14",
       "id": "product_useproductqueries",
-      "community": 15
+      "community": 12
     },
     {
       "label": "usePromoCodesQueries()",
@@ -14913,7 +14913,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/promoCode.ts",
       "source_location": "L9",
       "id": "promocode_usepromocodesqueries",
-      "community": 1
+      "community": 3
     },
     {
       "label": "useReviewQueries()",
@@ -14921,7 +14921,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/reviews.ts",
       "source_location": "L10",
       "id": "reviews_usereviewqueries",
-      "community": 6
+      "community": 12
     },
     {
       "label": "useRewardsQueries()",
@@ -14929,7 +14929,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/rewards.ts",
       "source_location": "L11",
       "id": "rewards_userewardsqueries",
-      "community": 19
+      "community": 15
     },
     {
       "label": "useUpsellsQueries()",
@@ -14937,7 +14937,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/upsells.ts",
       "source_location": "L6",
       "id": "upsells_useupsellsqueries",
-      "community": 2
+      "community": 3
     },
     {
       "label": "useUserQueries()",
@@ -14945,7 +14945,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/user.ts",
       "source_location": "L5",
       "id": "user_useuserqueries",
-      "community": 2
+      "community": 3
     },
     {
       "label": "useUserOffersQueries()",
@@ -14953,7 +14953,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/userOffers.ts",
       "source_location": "L6",
       "id": "useroffers_useuseroffersqueries",
-      "community": 2
+      "community": 6
     },
     {
       "label": "states.ts",
@@ -14969,7 +14969,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.test.ts",
       "source_location": "L10",
       "id": "storeconfig_test_buildv2config",
-      "community": 17
+      "community": 16
     },
     {
       "label": "mapPromo()",
@@ -14977,7 +14977,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L172",
       "id": "storeconfig_mappromo",
-      "community": 17
+      "community": 16
     },
     {
       "label": "isStoreReadOnlyMode()",
@@ -14985,7 +14985,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L461",
       "id": "storeconfig_isstorereadonlymode",
-      "community": 17
+      "community": 16
     },
     {
       "label": "isStoreMaintenanceMode()",
@@ -14993,7 +14993,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L465",
       "id": "storeconfig_isstoremaintenancemode",
-      "community": 17
+      "community": 16
     },
     {
       "label": "getStoreFallbackImageUrl()",
@@ -15001,7 +15001,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L479",
       "id": "storeconfig_getstorefallbackimageurl",
-      "community": 17
+      "community": 16
     },
     {
       "label": "storefrontFailureObservability.test.ts",
@@ -15009,7 +15009,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.test.ts",
       "source_location": "L1",
       "id": "storefrontfailureobservability_test",
-      "community": 10
+      "community": 8
     },
     {
       "label": "storefrontFailureObservability.ts",
@@ -15017,7 +15017,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
       "source_location": "L1",
       "id": "storefrontfailureobservability",
-      "community": 10
+      "community": 8
     },
     {
       "label": "inferStorefrontJourneyFromRoute()",
@@ -15025,7 +15025,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
       "source_location": "L25",
       "id": "storefrontfailureobservability_inferstorefrontjourneyfromroute",
-      "community": 10
+      "community": 8
     },
     {
       "label": "normalizeStorefrontError()",
@@ -15033,7 +15033,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
       "source_location": "L47",
       "id": "storefrontfailureobservability_normalizestorefronterror",
-      "community": 10
+      "community": 8
     },
     {
       "label": "createStorefrontFailureEvent()",
@@ -15041,7 +15041,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
       "source_location": "L136",
       "id": "storefrontfailureobservability_createstorefrontfailureevent",
-      "community": 10
+      "community": 8
     },
     {
       "label": "emitStorefrontFailure()",
@@ -15049,7 +15049,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
       "source_location": "L154",
       "id": "storefrontfailureobservability_emitstorefrontfailure",
-      "community": 10
+      "community": 8
     },
     {
       "label": "storefrontJourneyEvents.test.ts",
@@ -15057,7 +15057,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.test.ts",
       "source_location": "L1",
       "id": "storefrontjourneyevents_test",
-      "community": 7
+      "community": 6
     },
     {
       "label": "storefrontJourneyEvents.ts",
@@ -15065,7 +15065,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L1",
       "id": "storefrontjourneyevents",
-      "community": 7
+      "community": 6
     },
     {
       "label": "compactContext()",
@@ -15073,7 +15073,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L7",
       "id": "storefrontjourneyevents_compactcontext",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createJourneyEvent()",
@@ -15081,7 +15081,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L19",
       "id": "storefrontjourneyevents_createjourneyevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createLandingPageViewedEvent()",
@@ -15089,7 +15089,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L33",
       "id": "storefrontjourneyevents_createlandingpageviewedevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createCategoryBrowseViewedEvent()",
@@ -15097,7 +15097,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L41",
       "id": "storefrontjourneyevents_createcategorybrowseviewedevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createProductDetailViewedEvent()",
@@ -15105,7 +15105,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L59",
       "id": "storefrontjourneyevents_createproductdetailviewedevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createBagViewedEvent()",
@@ -15113,7 +15113,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L83",
       "id": "storefrontjourneyevents_createbagviewedevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createBagAddSucceededEvent()",
@@ -15121,7 +15121,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L101",
       "id": "storefrontjourneyevents_createbagaddsucceededevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createBagRemoveSucceededEvent()",
@@ -15129,7 +15129,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L122",
       "id": "storefrontjourneyevents_createbagremovesucceededevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createCheckoutStartEvent()",
@@ -15137,7 +15137,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L143",
       "id": "storefrontjourneyevents_createcheckoutstartevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createCheckoutDetailsViewedEvent()",
@@ -15145,7 +15145,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L164",
       "id": "storefrontjourneyevents_createcheckoutdetailsviewedevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createOrderReviewViewedEvent()",
@@ -15153,7 +15153,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L179",
       "id": "storefrontjourneyevents_createorderreviewviewedevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createPaymentSubmissionStartedEvent()",
@@ -15161,7 +15161,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L194",
       "id": "storefrontjourneyevents_createpaymentsubmissionstartedevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createPaymentVerificationStartedEvent()",
@@ -15169,7 +15169,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L215",
       "id": "storefrontjourneyevents_createpaymentverificationstartedevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createCheckoutCompletionEvent()",
@@ -15177,7 +15177,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L233",
       "id": "storefrontjourneyevents_createcheckoutcompletionevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createCheckoutCompletionSucceededEvent()",
@@ -15185,7 +15185,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L256",
       "id": "storefrontjourneyevents_createcheckoutcompletionsucceededevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createCheckoutCompletionBlockedEvent()",
@@ -15193,7 +15193,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L273",
       "id": "storefrontjourneyevents_createcheckoutcompletionblockedevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createCheckoutCompletionCanceledEvent()",
@@ -15201,7 +15201,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L290",
       "id": "storefrontjourneyevents_createcheckoutcompletioncanceledevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "getAuthEntryStep()",
@@ -15209,7 +15209,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L307",
       "id": "storefrontjourneyevents_getauthentrystep",
-      "community": 7
+      "community": 6
     },
     {
       "label": "getAuthRequestStep()",
@@ -15217,7 +15217,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L311",
       "id": "storefrontjourneyevents_getauthrequeststep",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createAuthEntryViewedEvent()",
@@ -15225,7 +15225,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L315",
       "id": "storefrontjourneyevents_createauthentryviewedevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createAuthRequestStartedEvent()",
@@ -15233,7 +15233,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L335",
       "id": "storefrontjourneyevents_createauthrequeststartedevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createAuthVerificationViewedEvent()",
@@ -15241,7 +15241,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L355",
       "id": "storefrontjourneyevents_createauthverificationviewedevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createAuthVerificationSucceededEvent()",
@@ -15249,7 +15249,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L370",
       "id": "storefrontjourneyevents_createauthverificationsucceededevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createRewardsAlertViewedEvent()",
@@ -15257,7 +15257,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L387",
       "id": "storefrontjourneyevents_createrewardsalertviewedevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createRewardsAlertDismissedEvent()",
@@ -15265,7 +15265,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L395",
       "id": "storefrontjourneyevents_createrewardsalertdismissedevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createRewardsAlertShopNowEvent()",
@@ -15273,7 +15273,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L403",
       "id": "storefrontjourneyevents_createrewardsalertshopnowevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createPromoAlertViewedEvent()",
@@ -15281,7 +15281,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L411",
       "id": "storefrontjourneyevents_createpromoalertviewedevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createPromoAlertDismissedEvent()",
@@ -15289,7 +15289,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L435",
       "id": "storefrontjourneyevents_createpromoalertdismissedevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createPromoAlertShopNowEvent()",
@@ -15297,7 +15297,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L459",
       "id": "storefrontjourneyevents_createpromoalertshopnowevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createWelcomeBackModalViewedEvent()",
@@ -15305,7 +15305,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L483",
       "id": "storefrontjourneyevents_createwelcomebackmodalviewedevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createWelcomeBackModalDismissedEvent()",
@@ -15313,7 +15313,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L501",
       "id": "storefrontjourneyevents_createwelcomebackmodaldismissedevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createWelcomeBackModalSubmittedEvent()",
@@ -15321,7 +15321,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L519",
       "id": "storefrontjourneyevents_createwelcomebackmodalsubmittedevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createLeaveReviewModalViewedEvent()",
@@ -15329,7 +15329,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L537",
       "id": "storefrontjourneyevents_createleavereviewmodalviewedevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createLeaveReviewModalDismissedEvent()",
@@ -15337,7 +15337,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L555",
       "id": "storefrontjourneyevents_createleavereviewmodaldismissedevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createUpsellModalViewedEvent()",
@@ -15345,7 +15345,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L573",
       "id": "storefrontjourneyevents_createupsellmodalviewedevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createUpsellModalDismissedEvent()",
@@ -15353,7 +15353,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L600",
       "id": "storefrontjourneyevents_createupsellmodaldismissedevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createUpsellModalSubmittedEvent()",
@@ -15361,7 +15361,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L627",
       "id": "storefrontjourneyevents_createupsellmodalsubmittedevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createUpsellModalAddToBagEvent()",
@@ -15369,7 +15369,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L654",
       "id": "storefrontjourneyevents_createupsellmodaladdtobagevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createSavedBagViewedEvent()",
@@ -15377,7 +15377,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L676",
       "id": "storefrontjourneyevents_createsavedbagviewedevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createSavedBagMoveToBagEvent()",
@@ -15385,7 +15385,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L684",
       "id": "storefrontjourneyevents_createsavedbagmovetobagevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createSavedBagRemoveEvent()",
@@ -15393,7 +15393,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L705",
       "id": "storefrontjourneyevents_createsavedbagremoveevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createBagMoveToSavedEvent()",
@@ -15401,7 +15401,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L726",
       "id": "storefrontjourneyevents_createbagmovetosavedevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createDiscountCodeTriggerEvent()",
@@ -15409,7 +15409,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L747",
       "id": "storefrontjourneyevents_creatediscountcodetriggerevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createReviewEditorViewedEvent()",
@@ -15417,7 +15417,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L762",
       "id": "storefrontjourneyevents_createrevieweditorviewedevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "createReviewSubmittedEvent()",
@@ -15425,7 +15425,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L786",
       "id": "storefrontjourneyevents_createreviewsubmittedevent",
-      "community": 7
+      "community": 6
     },
     {
       "label": "storefrontObservability.test.ts",
@@ -15433,7 +15433,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.test.ts",
       "source_location": "L1",
       "id": "storefrontobservability_test",
-      "community": 10
+      "community": 8
     },
     {
       "label": "createMemoryStorage()",
@@ -15441,7 +15441,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.test.ts",
       "source_location": "L12",
       "id": "storefrontobservability_test_creatememorystorage",
-      "community": 10
+      "community": 8
     },
     {
       "label": "storefrontObservability.ts",
@@ -15449,7 +15449,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L1",
       "id": "storefrontobservability",
-      "community": 10
+      "community": 8
     },
     {
       "label": "getOrCreateStorefrontObservabilitySessionId()",
@@ -15457,7 +15457,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L109",
       "id": "storefrontobservability_getorcreatestorefrontobservabilitysessionid",
-      "community": 10
+      "community": 8
     },
     {
       "label": "createStorefrontObservabilityContext()",
@@ -15465,7 +15465,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L134",
       "id": "storefrontobservability_createstorefrontobservabilitycontext",
-      "community": 10
+      "community": 8
     },
     {
       "label": "createStorefrontObservabilityPayload()",
@@ -15473,7 +15473,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L157",
       "id": "storefrontobservability_createstorefrontobservabilitypayload",
-      "community": 10
+      "community": 8
     },
     {
       "label": "trackStorefrontEvent()",
@@ -15481,7 +15481,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L193",
       "id": "storefrontobservability_trackstorefrontevent",
-      "community": 10
+      "community": 8
     },
     {
       "label": "getStoreDetails()",
@@ -15489,7 +15489,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L53",
       "id": "utils_getstoredetails",
-      "community": 3
+      "community": 2
     },
     {
       "label": "enableQuery()",
@@ -15497,7 +15497,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L60",
       "id": "utils_enablequery",
-      "community": 3
+      "community": 2
     },
     {
       "label": "validateEmail()",
@@ -15505,7 +15505,7 @@
       "source_file": "packages/storefront-webapp/src/lib/validations/email.ts",
       "source_location": "L14",
       "id": "email_validateemail",
-      "community": 1
+      "community": 6
     },
     {
       "label": "router.tsx",
@@ -15513,7 +15513,7 @@
       "source_file": "packages/storefront-webapp/src/router.tsx",
       "source_location": "L1",
       "id": "router",
-      "community": 10
+      "community": 8
     },
     {
       "label": "createRouter()",
@@ -15521,7 +15521,7 @@
       "source_file": "packages/storefront-webapp/src/router.tsx",
       "source_location": "L5",
       "id": "router_createrouter",
-      "community": 10
+      "community": 8
     },
     {
       "label": "$orderItemId.review.tsx",
@@ -15529,7 +15529,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/$orderItemId.review.tsx",
       "source_location": "L1",
       "id": "orderitemid_review",
-      "community": 1
+      "community": 0
     },
     {
       "label": "getPaymentText()",
@@ -15537,7 +15537,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
       "source_location": "L102",
       "id": "index_getpaymenttext",
-      "community": 11
+      "community": 1
     },
     {
       "label": "getOrderMessage()",
@@ -15545,7 +15545,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
       "source_location": "L429",
       "id": "index_getordermessage",
-      "community": 11
+      "community": 1
     },
     {
       "label": "OrderNavigation()",
@@ -15553,7 +15553,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
       "source_location": "L46",
       "id": "review_ordernavigation",
-      "community": 1
+      "community": 0
     },
     {
       "label": "getOrderMessage()",
@@ -15561,7 +15561,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
       "source_location": "L250",
       "id": "review_getordermessage",
-      "community": 1
+      "community": 0
     },
     {
       "label": "_ordersLayout.tsx",
@@ -15569,7 +15569,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout.tsx",
       "source_location": "L1",
       "id": "orderslayout",
-      "community": 8
+      "community": 7
     },
     {
       "label": "LayoutComponent()",
@@ -15577,7 +15577,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout.tsx",
       "source_location": "L8",
       "id": "orderslayout_layoutcomponent",
-      "community": 8
+      "community": 7
     },
     {
       "label": "$subcategorySlug.tsx",
@@ -15585,7 +15585,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout/shop/$categorySlug/$subcategorySlug.tsx",
       "source_location": "L1",
       "id": "subcategoryslug",
-      "community": 15
+      "community": 12
     },
     {
       "label": "_shopLayout.tsx",
@@ -15593,7 +15593,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
       "source_location": "L1",
       "id": "shoplayout",
-      "community": 1
+      "community": 0
     },
     {
       "label": "onClickOnMobileFilters()",
@@ -15601,7 +15601,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
       "source_location": "L105",
       "id": "shoplayout_onclickonmobilefilters",
-      "community": 1
+      "community": 0
     },
     {
       "label": "onMobileFiltersCloseClick()",
@@ -15609,7 +15609,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
       "source_location": "L110",
       "id": "shoplayout_onmobilefilterscloseclick",
-      "community": 1
+      "community": 0
     },
     {
       "label": "clearFilters()",
@@ -15617,7 +15617,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
       "source_location": "L115",
       "id": "shoplayout_clearfilters",
-      "community": 1
+      "community": 0
     },
     {
       "label": "account.tsx",
@@ -15649,7 +15649,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/contact-us.tsx",
       "source_location": "L1",
       "id": "contact_us",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ContactUs()",
@@ -15657,7 +15657,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/contact-us.tsx",
       "source_location": "L14",
       "id": "contact_us_contactus",
-      "community": 1
+      "community": 0
     },
     {
       "label": "delivery-returns-exchanges.index.tsx",
@@ -15665,7 +15665,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/delivery-returns-exchanges.index.tsx",
       "source_location": "L1",
       "id": "delivery_returns_exchanges_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "OnlineOrderPolicy()",
@@ -15673,7 +15673,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/delivery-returns-exchanges.index.tsx",
       "source_location": "L13",
       "id": "delivery_returns_exchanges_index_onlineorderpolicy",
-      "community": 8
+      "community": 7
     },
     {
       "label": "privacy.index.tsx",
@@ -15681,7 +15681,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/privacy.index.tsx",
       "source_location": "L1",
       "id": "privacy_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "PrivacyPolicy()",
@@ -15689,7 +15689,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/privacy.index.tsx",
       "source_location": "L9",
       "id": "privacy_index_privacypolicy",
-      "community": 8
+      "community": 7
     },
     {
       "label": "tos.index.tsx",
@@ -15697,7 +15697,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
       "source_location": "L1",
       "id": "tos_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "TosSection()",
@@ -15705,7 +15705,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
       "source_location": "L15",
       "id": "tos_index_tossection",
-      "community": 8
+      "community": 7
     },
     {
       "label": "rewards.index.tsx",
@@ -15721,7 +15721,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/shop.product.$productSlug.tsx",
       "source_location": "L1",
       "id": "shop_product_productslug",
-      "community": 6
+      "community": 9
     },
     {
       "label": "Component()",
@@ -15729,7 +15729,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/shop.product.$productSlug.tsx",
       "source_location": "L16",
       "id": "shop_product_productslug_component",
-      "community": 6
+      "community": 9
     },
     {
       "label": "shop.saved.index.tsx",
@@ -15737,7 +15737,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/shop.saved.index.tsx",
       "source_location": "L1",
       "id": "shop_saved_index",
-      "community": 7
+      "community": 15
     },
     {
       "label": "LayoutComponent()",
@@ -15745,7 +15745,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout.tsx",
       "source_location": "L6",
       "id": "layout_layoutcomponent",
-      "community": 1
+      "community": 0
     },
     {
       "label": "auth.verify.tsx",
@@ -15753,7 +15753,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L1",
       "id": "auth_verify",
-      "community": 7
+      "community": 15
     },
     {
       "label": "reportAuthFailure()",
@@ -15761,7 +15761,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L93",
       "id": "auth_verify_reportauthfailure",
-      "community": 7
+      "community": 15
     },
     {
       "label": "formatTime()",
@@ -15769,7 +15769,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L149",
       "id": "auth_verify_formattime",
-      "community": 7
+      "community": 15
     },
     {
       "label": "handleCodeChange()",
@@ -15777,7 +15777,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L156",
       "id": "auth_verify_handlecodechange",
-      "community": 7
+      "community": 15
     },
     {
       "label": "onSubmit()",
@@ -15785,7 +15785,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L201",
       "id": "auth_verify_onsubmit",
-      "community": 7
+      "community": 15
     },
     {
       "label": "resendVerificationCode()",
@@ -15793,7 +15793,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L282",
       "id": "auth_verify_resendverificationcode",
-      "community": 7
+      "community": 15
     },
     {
       "label": "login.tsx",
@@ -15825,7 +15825,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/bag.index.tsx",
       "source_location": "L1",
       "id": "bag_index",
-      "community": 8
+      "community": 0
     },
     {
       "label": "canceled.tsx",
@@ -15833,7 +15833,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/canceled.tsx",
       "source_location": "L1",
       "id": "canceled",
-      "community": 1
+      "community": 0
     },
     {
       "label": "CheckoutCanceledView()",
@@ -15841,7 +15841,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/canceled.tsx",
       "source_location": "L21",
       "id": "canceled_checkoutcanceledview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "complete.tsx",
@@ -15849,7 +15849,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/complete.tsx",
       "source_location": "L1",
       "id": "complete",
-      "community": 1
+      "community": 0
     },
     {
       "label": "incomplete.tsx",
@@ -15857,7 +15857,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/incomplete.tsx",
       "source_location": "L1",
       "id": "incomplete",
-      "community": 1
+      "community": 0
     },
     {
       "label": "getErrorMessage()",
@@ -15865,7 +15865,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
       "source_location": "L26",
       "id": "index_geterrormessage",
-      "community": 11
+      "community": 1
     },
     {
       "label": "placeOrder()",
@@ -15873,7 +15873,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
       "source_location": "L71",
       "id": "index_placeorder",
-      "community": 11
+      "community": 1
     },
     {
       "label": "cancelOrder()",
@@ -15881,7 +15881,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
       "source_location": "L121",
       "id": "index_cancelorder",
-      "community": 11
+      "community": 1
     },
     {
       "label": "complete.index.tsx",
@@ -15889,7 +15889,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/complete.index.tsx",
       "source_location": "L1",
       "id": "complete_index",
-      "community": 1
+      "community": 0
     },
     {
       "label": "CheckoutComplete()",
@@ -15897,7 +15897,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/complete.index.tsx",
       "source_location": "L33",
       "id": "complete_index_checkoutcomplete",
-      "community": 1
+      "community": 0
     },
     {
       "label": "pending.tsx",
@@ -15905,7 +15905,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/pending.tsx",
       "source_location": "L1",
       "id": "pending",
-      "community": 1
+      "community": 0
     },
     {
       "label": "pod-confirmation.tsx",
@@ -15913,7 +15913,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/pod-confirmation.tsx",
       "source_location": "L1",
       "id": "pod_confirmation",
-      "community": 1
+      "community": 0
     },
     {
       "label": "completePODCheckoutSession()",
@@ -15921,7 +15921,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/pod-confirmation.tsx",
       "source_location": "L193",
       "id": "pod_confirmation_completepodcheckoutsession",
-      "community": 1
+      "community": 0
     },
     {
       "label": "verify.index.tsx",
@@ -15929,7 +15929,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
       "source_location": "L1",
       "id": "verify_index",
-      "community": 1
+      "community": 0
     },
     {
       "label": "Verify()",
@@ -15937,7 +15937,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
       "source_location": "L21",
       "id": "verify_index_verify",
-      "community": 1
+      "community": 0
     },
     {
       "label": "VerifyCheckoutSessionPayment()",
@@ -15945,7 +15945,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
       "source_location": "L107",
       "id": "verify_index_verifycheckoutsessionpayment",
-      "community": 1
+      "community": 0
     },
     {
       "label": "signup.tsx",
@@ -15977,7 +15977,7 @@
       "source_file": "packages/storefront-webapp/src/ssr.tsx",
       "source_location": "L1",
       "id": "ssr",
-      "community": 10
+      "community": 8
     },
     {
       "label": "bootstrap.ts",
@@ -15985,7 +15985,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
       "source_location": "L1",
       "id": "bootstrap",
-      "community": 22
+      "community": 6
     },
     {
       "label": "createMarker()",
@@ -15993,7 +15993,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
       "source_location": "L20",
       "id": "bootstrap_createmarker",
-      "community": 22
+      "community": 6
     },
     {
       "label": "createBootstrapToken()",
@@ -16001,7 +16001,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
       "source_location": "L24",
       "id": "bootstrap_createbootstraptoken",
-      "community": 22
+      "community": 6
     },
     {
       "label": "bootstrapCheckout()",
@@ -16009,7 +16009,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
       "source_location": "L46",
       "id": "bootstrap_bootstrapcheckout",
-      "community": 22
+      "community": 6
     },
     {
       "label": "requireEnv()",
@@ -16017,7 +16017,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
       "source_location": "L1",
       "id": "env_requireenv",
-      "community": 22
+      "community": 6
     },
     {
       "label": "optionalNumberEnv()",
@@ -16025,7 +16025,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
       "source_location": "L11",
       "id": "env_optionalnumberenv",
-      "community": 22
+      "community": 6
     },
     {
       "label": "test-connection.js",
@@ -16169,7 +16169,7 @@
       "source_file": "scripts/harness-audit.test.ts",
       "source_location": "L1",
       "id": "harness_audit_test",
-      "community": 13
+      "community": 11
     },
     {
       "label": "write()",
@@ -16177,7 +16177,7 @@
       "source_file": "scripts/harness-audit.test.ts",
       "source_location": "L11",
       "id": "harness_audit_test_write",
-      "community": 13
+      "community": 11
     },
     {
       "label": "createFixtureRepo()",
@@ -16185,7 +16185,7 @@
       "source_file": "scripts/harness-audit.test.ts",
       "source_location": "L17",
       "id": "harness_audit_test_createfixturerepo",
-      "community": 13
+      "community": 11
     },
     {
       "label": "harness-audit.ts",
@@ -16193,7 +16193,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L1",
       "id": "harness_audit",
-      "community": 13
+      "community": 11
     },
     {
       "label": "normalizeRepoPath()",
@@ -16201,7 +16201,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L48",
       "id": "harness_audit_normalizerepopath",
-      "community": 13
+      "community": 11
     },
     {
       "label": "matchesPathPrefix()",
@@ -16209,7 +16209,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L52",
       "id": "harness_audit_matchespathprefix",
-      "community": 13
+      "community": 11
     },
     {
       "label": "fileExists()",
@@ -16217,7 +16217,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L66",
       "id": "harness_audit_fileexists",
-      "community": 13
+      "community": 11
     },
     {
       "label": "readJsonFile()",
@@ -16225,7 +16225,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L75",
       "id": "harness_audit_readjsonfile",
-      "community": 13
+      "community": 11
     },
     {
       "label": "toValidationSurfaces()",
@@ -16233,7 +16233,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L79",
       "id": "harness_audit_tovalidationsurfaces",
-      "community": 13
+      "community": 11
     },
     {
       "label": "addGroupedError()",
@@ -16241,7 +16241,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L91",
       "id": "harness_audit_addgroupederror",
-      "community": 13
+      "community": 11
     },
     {
       "label": "inferGroupFromError()",
@@ -16249,7 +16249,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L105",
       "id": "harness_audit_infergroupfromerror",
-      "community": 13
+      "community": 11
     },
     {
       "label": "shouldSkipSurfaceEntry()",
@@ -16257,7 +16257,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L110",
       "id": "harness_audit_shouldskipsurfaceentry",
-      "community": 13
+      "community": 11
     },
     {
       "label": "collectLiveSurfaceEntries()",
@@ -16265,7 +16265,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L121",
       "id": "harness_audit_collectlivesurfaceentries",
-      "community": 13
+      "community": 11
     },
     {
       "label": "loadAuditTarget()",
@@ -16273,7 +16273,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L150",
       "id": "harness_audit_loadaudittarget",
-      "community": 13
+      "community": 11
     },
     {
       "label": "formatGroupedErrors()",
@@ -16281,7 +16281,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L278",
       "id": "harness_audit_formatgroupederrors",
-      "community": 13
+      "community": 11
     },
     {
       "label": "runHarnessAudit()",
@@ -16289,7 +16289,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L293",
       "id": "harness_audit_runharnessaudit",
-      "community": 13
+      "community": 11
     },
     {
       "label": "harness-check.test.ts",
@@ -16297,7 +16297,7 @@
       "source_file": "scripts/harness-check.test.ts",
       "source_location": "L1",
       "id": "harness_check_test",
-      "community": 13
+      "community": 11
     },
     {
       "label": "write()",
@@ -16305,7 +16305,7 @@
       "source_file": "scripts/harness-check.test.ts",
       "source_location": "L29",
       "id": "harness_check_test_write",
-      "community": 13
+      "community": 11
     },
     {
       "label": "createFixtureRepo()",
@@ -16313,7 +16313,7 @@
       "source_file": "scripts/harness-check.test.ts",
       "source_location": "L35",
       "id": "harness_check_test_createfixturerepo",
-      "community": 13
+      "community": 11
     },
     {
       "label": "harness-check.ts",
@@ -16321,7 +16321,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L1",
       "id": "harness_check",
-      "community": 13
+      "community": 11
     },
     {
       "label": "stripLinkDecorations()",
@@ -16329,7 +16329,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L44",
       "id": "harness_check_striplinkdecorations",
-      "community": 13
+      "community": 11
     },
     {
       "label": "isRelativeLink()",
@@ -16337,7 +16337,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L48",
       "id": "harness_check_isrelativelink",
-      "community": 13
+      "community": 11
     },
     {
       "label": "fileExists()",
@@ -16345,7 +16345,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L56",
       "id": "harness_check_fileexists",
-      "community": 13
+      "community": 11
     },
     {
       "label": "collectMarkdownLinkErrors()",
@@ -16353,7 +16353,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L65",
       "id": "harness_check_collectmarkdownlinkerrors",
-      "community": 13
+      "community": 11
     },
     {
       "label": "extractInlineCode()",
@@ -16361,7 +16361,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L94",
       "id": "harness_check_extractinlinecode",
-      "community": 13
+      "community": 11
     },
     {
       "label": "normalizePathReference()",
@@ -16369,7 +16369,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L100",
       "id": "harness_check_normalizepathreference",
-      "community": 13
+      "community": 11
     },
     {
       "label": "isLikelyPathReference()",
@@ -16377,7 +16377,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L113",
       "id": "harness_check_islikelypathreference",
-      "community": 13
+      "community": 11
     },
     {
       "label": "resolvePathReference()",
@@ -16385,7 +16385,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L138",
       "id": "harness_check_resolvepathreference",
-      "community": 13
+      "community": 11
     },
     {
       "label": "collectReferencedPathErrors()",
@@ -16393,7 +16393,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L164",
       "id": "harness_check_collectreferencedpatherrors",
-      "community": 13
+      "community": 11
     },
     {
       "label": "readPackageConfig()",
@@ -16401,7 +16401,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L199",
       "id": "harness_check_readpackageconfig",
-      "community": 13
+      "community": 11
     },
     {
       "label": "extractTestScriptFromCommand()",
@@ -16409,7 +16409,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L224",
       "id": "harness_check_extracttestscriptfromcommand",
-      "community": 13
+      "community": 11
     },
     {
       "label": "walkFiles()",
@@ -16417,7 +16417,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L256",
       "id": "harness_check_walkfiles",
-      "community": 13
+      "community": 11
     },
     {
       "label": "collectTestSurfaceRoots()",
@@ -16425,7 +16425,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L276",
       "id": "harness_check_collecttestsurfaceroots",
-      "community": 13
+      "community": 11
     },
     {
       "label": "collectTestingDocErrors()",
@@ -16433,7 +16433,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L318",
       "id": "harness_check_collecttestingdocerrors",
-      "community": 13
+      "community": 11
     },
     {
       "label": "validateHarnessDocs()",
@@ -16441,7 +16441,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L363",
       "id": "harness_check_validateharnessdocs",
-      "community": 13
+      "community": 11
     },
     {
       "label": "runHarnessCheck()",
@@ -16449,7 +16449,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L496",
       "id": "harness_check_runharnesscheck",
-      "community": 13
+      "community": 11
     },
     {
       "label": "harness-generate.test.ts",
@@ -16457,7 +16457,7 @@
       "source_file": "scripts/harness-generate.test.ts",
       "source_location": "L1",
       "id": "harness_generate_test",
-      "community": 13
+      "community": 11
     },
     {
       "label": "write()",
@@ -16465,7 +16465,7 @@
       "source_file": "scripts/harness-generate.test.ts",
       "source_location": "L10",
       "id": "harness_generate_test_write",
-      "community": 13
+      "community": 11
     },
     {
       "label": "createFixtureRepo()",
@@ -16473,7 +16473,7 @@
       "source_file": "scripts/harness-generate.test.ts",
       "source_location": "L16",
       "id": "harness_generate_test_createfixturerepo",
-      "community": 13
+      "community": 11
     },
     {
       "label": "harness-generate.ts",
@@ -16481,7 +16481,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L1",
       "id": "harness_generate",
-      "community": 13
+      "community": 11
     },
     {
       "label": "normalizeRepoPath()",
@@ -16489,7 +16489,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L250",
       "id": "harness_generate_normalizerepopath",
-      "community": 13
+      "community": 11
     },
     {
       "label": "shouldSkipGeneratedEntry()",
@@ -16497,7 +16497,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L254",
       "id": "harness_generate_shouldskipgeneratedentry",
-      "community": 13
+      "community": 11
     },
     {
       "label": "fileExists()",
@@ -16505,7 +16505,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L258",
       "id": "harness_generate_fileexists",
-      "community": 13
+      "community": 11
     },
     {
       "label": "walkFiles()",
@@ -16513,7 +16513,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L267",
       "id": "harness_generate_walkfiles",
-      "community": 13
+      "community": 11
     },
     {
       "label": "readPackageConfig()",
@@ -16521,7 +16521,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L289",
       "id": "harness_generate_readpackageconfig",
-      "community": 13
+      "community": 11
     },
     {
       "label": "toDocPath()",
@@ -16529,7 +16529,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L307",
       "id": "harness_generate_todocpath",
-      "community": 13
+      "community": 11
     },
     {
       "label": "formatMarkdownLink()",
@@ -16537,7 +16537,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L311",
       "id": "harness_generate_formatmarkdownlink",
-      "community": 13
+      "community": 11
     },
     {
       "label": "headingFromSegment()",
@@ -16545,7 +16545,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L315",
       "id": "harness_generate_headingfromsegment",
-      "community": 13
+      "community": 11
     },
     {
       "label": "summarizeChildren()",
@@ -16553,7 +16553,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L323",
       "id": "harness_generate_summarizechildren",
-      "community": 13
+      "community": 11
     },
     {
       "label": "collectRouteGroups()",
@@ -16561,7 +16561,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L331",
       "id": "harness_generate_collectroutegroups",
-      "community": 13
+      "community": 11
     },
     {
       "label": "collectTestFiles()",
@@ -16569,7 +16569,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L357",
       "id": "harness_generate_collecttestfiles",
-      "community": 13
+      "community": 11
     },
     {
       "label": "collectTestSurfaceRoots()",
@@ -16577,7 +16577,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L387",
       "id": "harness_generate_collecttestsurfaceroots",
-      "community": 13
+      "community": 11
     },
     {
       "label": "collectFolderFacts()",
@@ -16585,7 +16585,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L429",
       "id": "harness_generate_collectfolderfacts",
-      "community": 13
+      "community": 11
     },
     {
       "label": "formatScriptCommand()",
@@ -16593,7 +16593,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L452",
       "id": "harness_generate_formatscriptcommand",
-      "community": 13
+      "community": 11
     },
     {
       "label": "buildGeneratedDoc()",
@@ -16601,7 +16601,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L462",
       "id": "harness_generate_buildgenerateddoc",
-      "community": 13
+      "community": 11
     },
     {
       "label": "buildRouteIndex()",
@@ -16609,7 +16609,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L472",
       "id": "harness_generate_buildrouteindex",
-      "community": 13
+      "community": 11
     },
     {
       "label": "buildTestIndex()",
@@ -16617,7 +16617,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L499",
       "id": "harness_generate_buildtestindex",
-      "community": 13
+      "community": 11
     },
     {
       "label": "buildKeyFolderIndex()",
@@ -16625,7 +16625,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L544",
       "id": "harness_generate_buildkeyfolderindex",
-      "community": 13
+      "community": 11
     },
     {
       "label": "buildValidationGuide()",
@@ -16633,7 +16633,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L577",
       "id": "harness_generate_buildvalidationguide",
-      "community": 13
+      "community": 11
     },
     {
       "label": "generateHarnessDocs()",
@@ -16641,7 +16641,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L616",
       "id": "harness_generate_generateharnessdocs",
-      "community": 13
+      "community": 11
     },
     {
       "label": "writeGeneratedHarnessDocs()",
@@ -16649,7 +16649,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L642",
       "id": "harness_generate_writegeneratedharnessdocs",
-      "community": 13
+      "community": 11
     },
     {
       "label": "harness-review.test.ts",
@@ -16788,6 +16788,38 @@
       "community": 18
     },
     {
+      "label": "pre-push-review.test.ts",
+      "file_type": "code",
+      "source_file": "scripts/pre-push-review.test.ts",
+      "source_location": "L1",
+      "id": "pre_push_review_test",
+      "community": 18
+    },
+    {
+      "label": "log()",
+      "file_type": "code",
+      "source_file": "scripts/pre-push-review.test.ts",
+      "source_location": "L81",
+      "id": "pre_push_review_test_log",
+      "community": 18
+    },
+    {
+      "label": "warn()",
+      "file_type": "code",
+      "source_file": "scripts/pre-push-review.test.ts",
+      "source_location": "L82",
+      "id": "pre_push_review_test_warn",
+      "community": 18
+    },
+    {
+      "label": "error()",
+      "file_type": "code",
+      "source_file": "scripts/pre-push-review.test.ts",
+      "source_location": "L83",
+      "id": "pre_push_review_test_error",
+      "community": 18
+    },
+    {
       "label": "pre-push-review.ts",
       "file_type": "code",
       "source_file": "scripts/pre-push-review.ts",
@@ -16799,7 +16831,7 @@
       "label": "getChangedFilesVsOriginMain()",
       "file_type": "code",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L6",
+      "source_location": "L24",
       "id": "pre_push_review_getchangedfilesvsoriginmain",
       "community": 18
     },
@@ -16807,16 +16839,16 @@
       "label": "runArchitectureCheck()",
       "file_type": "code",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L44",
+      "source_location": "L65",
       "id": "pre_push_review_runarchitecturecheck",
       "community": 18
     },
     {
-      "label": "main()",
+      "label": "runPrePushReview()",
       "file_type": "code",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L56",
-      "id": "pre_push_review_main",
+      "source_location": "L77",
+      "id": "pre_push_review_runprepushreview",
       "community": 18
     }
   ],
@@ -74278,10 +74310,58 @@
       "confidence_score": 0.5
     },
     {
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/pre-push-review.test.ts",
+      "source_location": "L5",
+      "weight": 1.0,
+      "_src": "pre_push_review_test",
+      "_tgt": "pre_push_review",
+      "source": "pre_push_review_test",
+      "target": "pre_push_review",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/pre-push-review.test.ts",
+      "source_location": "L81",
+      "weight": 1.0,
+      "_src": "pre_push_review_test",
+      "_tgt": "pre_push_review_test_log",
+      "source": "pre_push_review_test",
+      "target": "pre_push_review_test_log",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/pre-push-review.test.ts",
+      "source_location": "L82",
+      "weight": 1.0,
+      "_src": "pre_push_review_test",
+      "_tgt": "pre_push_review_test_warn",
+      "source": "pre_push_review_test",
+      "target": "pre_push_review_test_warn",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/pre-push-review.test.ts",
+      "source_location": "L83",
+      "weight": 1.0,
+      "_src": "pre_push_review_test",
+      "_tgt": "pre_push_review_test_error",
+      "source": "pre_push_review_test",
+      "target": "pre_push_review_test_error",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L6",
+      "source_location": "L24",
       "weight": 1.0,
       "_src": "pre_push_review",
       "_tgt": "pre_push_review_getchangedfilesvsoriginmain",
@@ -74293,7 +74373,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L44",
+      "source_location": "L65",
       "weight": 1.0,
       "_src": "pre_push_review",
       "_tgt": "pre_push_review_runarchitecturecheck",
@@ -74305,25 +74385,13 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L56",
+      "source_location": "L77",
       "weight": 1.0,
       "_src": "pre_push_review",
-      "_tgt": "pre_push_review_main",
+      "_tgt": "pre_push_review_runprepushreview",
       "source": "pre_push_review",
-      "target": "pre_push_review_main",
+      "target": "pre_push_review_runprepushreview",
       "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L60",
-      "weight": 0.8,
-      "_src": "pre_push_review_main",
-      "_tgt": "pre_push_review_runarchitecturecheck",
-      "source": "pre_push_review_runarchitecturecheck",
-      "target": "pre_push_review_main",
-      "confidence_score": 0.5
     }
   ],
   "hyperedges": []

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "harness:generate": "bun scripts/harness-generate.ts",
     "harness:review": "bun scripts/harness-review.ts",
     "pre-push:review": "bun scripts/pre-push-review.ts",
-    "pr:athena": "bun run --filter '@athena/webapp' audit:convex && bun run --filter '@athena/webapp' lint:convex:changed && bun run architecture:check && bun run --filter '@athena/webapp' test && bun run --filter '@athena/storefront-webapp' test && bun run harness:check",
+    "pr:athena": "bun run --filter '@athena/webapp' audit:convex && bun run --filter '@athena/webapp' lint:convex:changed && bun run architecture:check && bun run --filter '@athena/webapp' test && bun run --filter '@athena/storefront-webapp' test && bun run harness:check && bun run harness:audit",
     "test": "bun run --filter '@athena/webapp' test && bun run --filter '@athena/storefront-webapp' test",
     "test:coverage": "bun run --filter '@athena/webapp' test:coverage && bun run --filter '@athena/storefront-webapp' test:coverage && bun scripts/coverage-summary.mjs"
   },

--- a/scripts/pre-push-review.test.ts
+++ b/scripts/pre-push-review.test.ts
@@ -1,0 +1,142 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import * as prePushReview from "./pre-push-review";
+
+const ROOT_DIR = path.resolve(import.meta.dirname, "..");
+
+describe("pre-push review wiring", () => {
+  it("exports testable helpers for pre-push orchestration", () => {
+    expect(typeof prePushReview.getChangedFilesVsOriginMain).toBe("function");
+    expect(typeof prePushReview.runPrePushReview).toBe("function");
+  });
+
+  it("returns changed files from origin/main diff output", async () => {
+    const commands: string[][] = [];
+
+    const files = await prePushReview.getChangedFilesVsOriginMain(
+      ROOT_DIR,
+      (command) => {
+        commands.push(command);
+
+        if (command[1] === "rev-parse") {
+          return {
+            exited: Promise.resolve(0),
+            stdout: new Response("").body,
+            stderr: new Response("").body,
+          };
+        }
+
+        return {
+          exited: Promise.resolve(0),
+          stdout: new Response(
+            "packages/athena-webapp/src/main.tsx\npackages/storefront-webapp/src/router.tsx\n"
+          ).body,
+          stderr: new Response("").body,
+        };
+      }
+    );
+
+    expect(files).toEqual([
+      "packages/athena-webapp/src/main.tsx",
+      "packages/storefront-webapp/src/router.tsx",
+    ]);
+    expect(commands).toEqual([
+      ["git", "rev-parse", "--verify", "origin/main"],
+      ["git", "diff", "--name-only", "origin/main...HEAD"],
+    ]);
+  });
+
+  it("falls back cleanly when origin/main is not reachable", async () => {
+    const files = await prePushReview.getChangedFilesVsOriginMain(
+      ROOT_DIR,
+      () => ({
+        exited: Promise.resolve(1),
+        stdout: new Response("").body,
+        stderr: new Response("missing ref").body,
+      })
+    );
+
+    expect(files).toEqual([]);
+  });
+
+  it("runs architecture checks before harness review", async () => {
+    const steps: string[] = [];
+
+    await prePushReview.runPrePushReview(ROOT_DIR, {
+      getChangedFiles: async () => {
+        steps.push("changed-files");
+        return ["packages/athena-webapp/src/main.tsx"];
+      },
+      runArchitectureCheck: async () => {
+        steps.push("architecture:check");
+      },
+      runHarnessReview: async (_rootDir, options) => {
+        steps.push("harness:review");
+        const files = await options.getChangedFiles(ROOT_DIR);
+        steps.push(`files:${files.join(",")}`);
+      },
+      logger: {
+        log() {},
+        warn() {},
+        error() {},
+      },
+    });
+
+    expect(steps).toEqual([
+      "architecture:check",
+      "harness:review",
+      "changed-files",
+      "files:packages/athena-webapp/src/main.tsx",
+    ]);
+  });
+
+  it("keeps the husky pre-push hook pointed at the repo review script", async () => {
+    const hookContents = await readFile(
+      path.join(ROOT_DIR, ".husky/pre-push"),
+      "utf8"
+    );
+
+    expect(hookContents).toContain("bun run pre-push:review");
+  });
+});
+
+describe("repo harness ergonomics", () => {
+  it("schedules a recurring harness drift check in GitHub Actions", async () => {
+    const workflow = await readFile(
+      path.join(ROOT_DIR, ".github/workflows/athena-pr-tests.yml"),
+      "utf8"
+    );
+
+    expect(workflow).toContain("schedule:");
+    expect(workflow).toContain("- cron:");
+    expect(workflow).toContain("workflow_dispatch:");
+    expect(workflow).toContain("run: bun run harness:audit");
+  });
+
+  it("includes harness audit in the local pr:athena command", async () => {
+    const packageJson = JSON.parse(
+      await readFile(path.join(ROOT_DIR, "package.json"), "utf8")
+    ) as {
+      scripts?: Record<string, string>;
+    };
+
+    expect(packageJson.scripts?.["pr:athena"]).toContain("bun run harness:audit");
+  });
+
+  it("documents graphify setup and tracked artifact policy in the README", async () => {
+    const readme = await readFile(path.join(ROOT_DIR, "README.md"), "utf8");
+
+    expect(readme).toContain(".graphify_python");
+    expect(readme).toContain("graphify-out/GRAPH_REPORT.md");
+    expect(readme).toContain("graphify-out/graph.json");
+    expect(readme).toContain("graphify-out/cache");
+  });
+
+  it("ignores the generated graphify cache directory", async () => {
+    const gitignore = await readFile(path.join(ROOT_DIR, ".gitignore"), "utf8");
+
+    expect(gitignore).toContain("graphify-out/cache/");
+  });
+});

--- a/scripts/pre-push-review.ts
+++ b/scripts/pre-push-review.ts
@@ -3,8 +3,29 @@ import { runHarnessReview } from "./harness-review";
 const ROOT_DIR = process.cwd();
 const BASE_REF = "origin/main";
 
-async function getChangedFilesVsOriginMain(rootDir: string): Promise<string[]> {
-  const refCheck = Bun.spawn(["git", "rev-parse", "--verify", BASE_REF], {
+type SpawnedProcess = {
+  exited: Promise<number>;
+  stdout?: ReadableStream | null;
+  stderr?: ReadableStream | null;
+};
+
+type PrePushReviewLogger = Pick<Console, "log" | "warn" | "error">;
+
+type PrePushReviewOptions = {
+  getChangedFiles?: (rootDir: string) => Promise<string[]>;
+  runArchitectureCheck?: (rootDir: string) => Promise<void>;
+  runHarnessReview?: (
+    rootDir: string,
+    options: { getChangedFiles: (rootDir: string) => Promise<string[]> }
+  ) => Promise<void>;
+  logger?: PrePushReviewLogger;
+};
+
+export async function getChangedFilesVsOriginMain(
+  rootDir: string,
+  spawn: (command: string[], options: { cwd: string; stdout: "pipe"; stderr: "pipe" }) => SpawnedProcess = Bun.spawn
+): Promise<string[]> {
+  const refCheck = spawn(["git", "rev-parse", "--verify", BASE_REF], {
     cwd: rootDir,
     stdout: "pipe",
     stderr: "pipe",
@@ -18,7 +39,7 @@ async function getChangedFilesVsOriginMain(rootDir: string): Promise<string[]> {
     return [];
   }
 
-  const proc = Bun.spawn(
+  const proc = spawn(
     ["git", "diff", "--name-only", `${BASE_REF}...HEAD`],
     { cwd: rootDir, stdout: "pipe", stderr: "pipe" }
   );
@@ -41,7 +62,7 @@ async function getChangedFilesVsOriginMain(rootDir: string): Promise<string[]> {
     .filter(Boolean);
 }
 
-async function runArchitectureCheck(rootDir: string): Promise<void> {
+export async function runArchitectureCheck(rootDir: string): Promise<void> {
   const proc = Bun.spawn(["bun", "run", "architecture:check"], {
     cwd: rootDir,
     stdout: "inherit",
@@ -53,23 +74,33 @@ async function runArchitectureCheck(rootDir: string): Promise<void> {
   }
 }
 
-async function main() {
-  console.log("[pre-push] Running pre-push validation suite...\n");
+export async function runPrePushReview(
+  rootDir: string,
+  options: PrePushReviewOptions = {}
+) {
+  const logger = options.logger ?? console;
+  const getChangedFiles = options.getChangedFiles ?? getChangedFilesVsOriginMain;
+  const runArchitecture = options.runArchitectureCheck ?? runArchitectureCheck;
+  const review = options.runHarnessReview ?? runHarnessReview;
 
-  console.log("[pre-push] Step 1/2: architecture:check");
-  await runArchitectureCheck(ROOT_DIR);
+  logger.log("[pre-push] Running pre-push validation suite...\n");
+
+  logger.log("[pre-push] Step 1/2: architecture:check");
+  await runArchitecture(rootDir);
 
   // runHarnessReview internally runs harness:check first, then targeted per-surface scripts
-  console.log("[pre-push] Step 2/2: harness:review (vs origin/main)");
-  await runHarnessReview(ROOT_DIR, {
-    getChangedFiles: getChangedFilesVsOriginMain,
+  logger.log("[pre-push] Step 2/2: harness:review (vs origin/main)");
+  await review(rootDir, {
+    getChangedFiles,
   });
 
-  console.log("\n[pre-push] All checks passed.");
+  logger.log("\n[pre-push] All checks passed.");
 }
 
-main().catch((error: unknown) => {
-  const message = error instanceof Error ? error.message : String(error);
-  console.error(`\n[pre-push] BLOCKED: ${message}`);
-  process.exit(1);
-});
+if (import.meta.main) {
+  runPrePushReview(ROOT_DIR).catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`\n[pre-push] BLOCKED: ${message}`);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- add test coverage for the local pre-push review flow and lock in the expected hook/wiring ergonomics
- document the repo harness and graphify setup in the README, ignore the local graphify cache, and align `pr:athena` with the current harness audit expectations
- add a scheduled GitHub Actions run for recurring harness drift detection and refresh the tracked graphify outputs

## Why
The harness foundation was already healthy, but a few operational gaps remained: the new pre-push flow was lightly tested, local graphify expectations were not documented in the repo itself, `pr:athena` lagged behind the current CI harness checks, and drift detection only ran on PR activity. This change closes those ergonomics and maintenance gaps so the harness is easier to trust day to day.

## Validation
- `bun test /Users/kwamina/athena/scripts/pre-push-review.test.ts /Users/kwamina/athena/scripts/graphify-rebuild.test.ts /Users/kwamina/athena/scripts/harness-audit.test.ts /Users/kwamina/athena/scripts/harness-check.test.ts /Users/kwamina/athena/scripts/harness-generate.test.ts /Users/kwamina/athena/scripts/harness-review.test.ts`
- `bun run pre-push:review && bun run graphify:rebuild && bun run harness:check && bun run harness:audit && bun run architecture:check`

https://linear.app/v26-labs/issue/V26-194/add-bun-run-harnessaudit-for-stale-doc-and-uncovered-validation
