### PR TITLE
[V26-195]: unify harness validation source of truth

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,8 +5,8 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 2106 nodes · 4795 edges · 72 communities detected
-- Extraction: 92% EXTRACTED · 8% INFERRED · 0% AMBIGUOUS · INFERRED: 400 edges (avg confidence: 0.5)
+- 2112 nodes · 4804 edges · 72 communities detected
+- Extraction: 92% EXTRACTED · 8% INFERRED · 0% AMBIGUOUS · INFERRED: 403 edges (avg confidence: 0.5)
 - Token cost: 0 input · 0 output
 
 ## God Nodes (most connected - your core abstractions)
@@ -19,7 +19,7 @@
 7. `Logger` - 8 edges
 8. `asRecord()` - 8 edges
 9. `buildTestIndex()` - 8 edges
-10. `collectAllPages()` - 7 edges
+10. `generateHarnessDocs()` - 8 edges
 
 ## Surprising Connections (you probably didn't know these)
 - `getAmountPaidForOrder()` --calls--> `getDiscountValue()`  [INFERRED]
@@ -37,43 +37,43 @@
 
 ### Community 0 - "Community 0"
 Cohesion: 0.01
-Nodes (6): handleKeyDown(), handleRedeemPromoCode(), getPromoAlertCopy(), PromoAlert(), clearFilters(), onMobileFiltersCloseClick()
+Nodes (14): AnalyticsCombinedUsers(), processAnalyticsToUsers(), AnalyticsTopUsers(), processAnalyticsToUsers(), handleFileSelect(), validateFile(), capitalizeWords(), countGroupedAnalytics() (+6 more)
 
 ### Community 1 - "Community 1"
 Cohesion: 0.01
-Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
+Nodes (13): buildUsername(), normalizeNameSegment(), getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold(), handleKeyDown() (+5 more)
 
 ### Community 2 - "Community 2"
 Cohesion: 0.02
-Nodes (19): AnalyticsCombinedUsers(), processAnalyticsToUsers(), AnalyticsTopUsers(), processAnalyticsToUsers(), handleSave(), hasReceivingAccountDetails(), normalizePrimaryAccounts(), toPatchReceivingAccounts() (+11 more)
+Nodes (41): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory(), getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore(), expectIndex() (+33 more)
 
 ### Community 3 - "Community 3"
 Cohesion: 0.02
-Nodes (49): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory(), getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore(), expectIndex() (+41 more)
-
-### Community 4 - "Community 4"
-Cohesion: 0.02
 Nodes (16): handleNewSession(), resetAutoSessionInitialized(), handleNewSession(), resetAutoSessionInitialized(), usePOSActiveSession(), usePOSSessionComplete(), usePOSSessionCreate(), usePOSSessionHold() (+8 more)
 
+### Community 4 - "Community 4"
+Cohesion: 0.03
+Nodes (15): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource(), buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus() (+7 more)
+
 ### Community 5 - "Community 5"
-Cohesion: 0.02
-Nodes (15): buildUsername(), normalizeNameSegment(), getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold(), onSubmit() (+7 more)
+Cohesion: 0.03
+Nodes (33): checkIfItemsHaveChanged(), CheckoutSessionError, createCheckoutSession(), createOnlineOrder(), defaultCheckoutActionMessage(), findBestValuePromoCode(), getActiveCheckoutSession(), getBaseUrl() (+25 more)
 
 ### Community 6 - "Community 6"
 Cohesion: 0.03
-Nodes (56): bootstrapCheckout(), createBootstrapToken(), createMarker(), createOffer(), getBaseUrl(), getUserRedeemedOffers(), isDuplicate(), submitOffer() (+48 more)
+Nodes (10): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction(), cancelOrder(), getErrorMessage() (+2 more)
 
 ### Community 7 - "Community 7"
-Cohesion: 0.03
-Nodes (9): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource(), modifyProduct(), onSubmit(), saveProduct(), onSubmit() (+1 more)
+Cohesion: 0.07
+Nodes (56): addGroupedError(), collectLiveSurfaceEntries(), fileExists(), formatGroupedErrors(), inferGroupFromError(), loadAuditTarget(), matchesPathPrefix(), normalizeRepoPath() (+48 more)
 
 ### Community 8 - "Community 8"
 Cohesion: 0.04
-Nodes (37): checkIfItemsHaveChanged(), CheckoutSessionError, createCheckoutSession(), createOnlineOrder(), defaultCheckoutActionMessage(), findBestValuePromoCode(), getActiveCheckoutSession(), getBaseUrl() (+29 more)
+Nodes (14): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins(), getDeliveryAddress(), getLocationDetails(), getPickupLocation() (+6 more)
 
 ### Community 9 - "Community 9"
-Cohesion: 0.03
-Nodes (2): isSkuReserved(), shouldDisable()
+Cohesion: 0.04
+Nodes (12): createReview(), deleteReview(), getBaseUrl(), getReviewByOrderItem(), getReviewsByProductId(), getReviewsByProductSkuId(), getUserReviews(), getUserReviewsForProduct() (+4 more)
 
 ### Community 10 - "Community 10"
 Cohesion: 0.05
@@ -81,67 +81,67 @@ Nodes (21): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventor
 
 ### Community 11 - "Community 11"
 Cohesion: 0.07
-Nodes (53): addGroupedError(), collectLiveSurfaceEntries(), fileExists(), formatGroupedErrors(), inferGroupFromError(), loadAuditTarget(), matchesPathPrefix(), normalizeRepoPath() (+45 more)
+Nodes (47): getPromoAlertCopy(), PromoAlert(), compactContext(), createAuthEntryViewedEvent(), createAuthRequestStartedEvent(), createAuthVerificationSucceededEvent(), createAuthVerificationViewedEvent(), createBagAddSucceededEvent() (+39 more)
 
 ### Community 12 - "Community 12"
-Cohesion: 0.06
-Nodes (20): getAllColors(), getBaseUrl(), buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct() (+12 more)
-
-### Community 13 - "Community 13"
-Cohesion: 0.08
-Nodes (27): asArray(), asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), assignOrDelete(), asString() (+19 more)
-
-### Community 14 - "Community 14"
 Cohesion: 0.05
 Nodes (7): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile(), MockImage
+
+### Community 13 - "Community 13"
+Cohesion: 0.05
+Nodes (13): getAllColors(), getBaseUrl(), getNonEmptyString(), isFailureStatus(), normalizeEvent(), buildQueryString(), getAllProducts(), getBaseUrl() (+5 more)
+
+### Community 14 - "Community 14"
+Cohesion: 0.07
+Nodes (9): bootstrapCheckout(), createBootstrapToken(), createMarker(), createOffer(), getBaseUrl(), getUserRedeemedOffers(), isDuplicate(), submitOffer() (+1 more)
 
 ### Community 15 - "Community 15"
 Cohesion: 0.08
 Nodes (27): onSubmit(), reportAuthFailure(), resendVerificationCode(), addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), listBagItems() (+19 more)
 
 ### Community 16 - "Community 16"
-Cohesion: 0.1
-Nodes (26): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction(), asBoolean(), asMtnMomoSetupStatus() (+18 more)
+Cohesion: 0.09
+Nodes (25): handleSave(), hasReceivingAccountDetails(), normalizePrimaryAccounts(), toPatchReceivingAccounts(), trimToUndefined(), asBoolean(), asMtnMomoSetupStatus(), asNumber() (+17 more)
 
 ### Community 17 - "Community 17"
-Cohesion: 0.08
-Nodes (5): getNonEmptyString(), isFailureStatus(), normalizeEvent(), getNonEmptyString(), normalizeStorefrontObservabilityEvent()
+Cohesion: 0.06
+Nodes (0): 
 
 ### Community 18 - "Community 18"
-Cohesion: 0.11
-Nodes (10): collectScriptsForChangedFiles(), fileExists(), loadReviewTarget(), loadReviewTargets(), matchesPathPrefix(), normalizeRepoPath(), runHarnessReview(), createFixtureRepo() (+2 more)
+Cohesion: 0.06
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 19 - "Community 19"
-Cohesion: 0.1
-Nodes (0): 
+Cohesion: 0.16
+Nodes (25): asArray(), asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), assignOrDelete(), asString() (+17 more)
 
 ### Community 20 - "Community 20"
-Cohesion: 0.17
-Nodes (0): 
+Cohesion: 0.08
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 21 - "Community 21"
+Cohesion: 0.1
+Nodes (9): collectCommandsForChangedFiles(), fileExists(), loadReviewTarget(), loadReviewTargets(), matchesPathPrefix(), normalizeRepoPath(), runHarnessReview(), createFixtureRepo() (+1 more)
+
+### Community 22 - "Community 22"
 Cohesion: 0.18
 Nodes (0): 
 
-### Community 22 - "Community 22"
+### Community 23 - "Community 23"
 Cohesion: 0.2
 Nodes (0): 
 
-### Community 23 - "Community 23"
+### Community 24 - "Community 24"
 Cohesion: 0.39
 Nodes (7): calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock(), validateRefund()
 
-### Community 24 - "Community 24"
+### Community 25 - "Community 25"
 Cohesion: 0.54
 Nodes (1): Logger
 
-### Community 25 - "Community 25"
+### Community 26 - "Community 26"
 Cohesion: 0.32
 Nodes (3): fileExists(), resolveGraphifyPython(), runGraphifyRebuild()
-
-### Community 26 - "Community 26"
-Cohesion: 0.4
-Nodes (1): ValkeyClient
 
 ### Community 27 - "Community 27"
 Cohesion: 0.7
@@ -414,10 +414,8 @@ Nodes (0):
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `Logger` connect `Community 24` to `Community 4`?**
+- **Why does `Logger` connect `Community 25` to `Community 3`?**
   _High betweenness centrality (0.006) - this node is a cross-community bridge._
-- **Why does `ValkeyClient` connect `Community 26` to `Community 1`?**
-  _High betweenness centrality (0.003) - this node is a cross-community bridge._
 - **Are the 39 inferred relationships involving `createJourneyEvent()` (e.g. with `compactContext()` and `createLandingPageViewedEvent()`) actually correct?**
   _`createJourneyEvent()` has 39 INFERRED edges - model-reasoned connections that need verification._
 - **Are the 15 inferred relationships involving `getStoreConfigV2()` (e.g. with `getRawConfig()` and `asRecord()`) actually correct?**
@@ -428,3 +426,5 @@ _Questions this graph is uniquely positioned to answer:_
   _`getBaseUrl()` has 11 INFERRED edges - model-reasoned connections that need verification._
 - **Are the 8 inferred relationships involving `usePOSSessionManager()` (e.g. with `usePOSSessionCreate()` and `usePOSSessionUpdate()`) actually correct?**
   _`usePOSSessionManager()` has 8 INFERRED edges - model-reasoned connections that need verification._
+- **Should `Community 0` be split into smaller, more focused modules?**
+  _Cohesion score 0.01 - nodes in this community are weakly interconnected._

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -9,7 +9,7 @@
       "source_file": "packages/athena-webapp/convex/_generated/api.d.ts",
       "source_location": "L1",
       "id": "api_d",
-      "community": 3
+      "community": 2
     },
     {
       "label": "api.js",
@@ -17,7 +17,7 @@
       "source_file": "packages/athena-webapp/convex/_generated/api.js",
       "source_location": "L1",
       "id": "api",
-      "community": 3
+      "community": 0
     },
     {
       "label": "dataModel.d.ts",
@@ -25,7 +25,7 @@
       "source_file": "packages/athena-webapp/convex/_generated/dataModel.d.ts",
       "source_location": "L1",
       "id": "datamodel_d",
-      "community": 3
+      "community": 2
     },
     {
       "label": "server.d.ts",
@@ -33,7 +33,7 @@
       "source_file": "packages/athena-webapp/convex/_generated/server.d.ts",
       "source_location": "L1",
       "id": "server_d",
-      "community": 3
+      "community": 2
     },
     {
       "label": "server.js",
@@ -41,7 +41,7 @@
       "source_file": "packages/athena-webapp/convex/_generated/server.js",
       "source_location": "L1",
       "id": "server",
-      "community": 3
+      "community": 2
     },
     {
       "label": "app.ts",
@@ -49,7 +49,7 @@
       "source_file": "packages/athena-webapp/convex/app.ts",
       "source_location": "L1",
       "id": "app",
-      "community": 3
+      "community": 2
     },
     {
       "label": "auth.config.js",
@@ -65,7 +65,7 @@
       "source_file": "packages/storefront-webapp/src/components/auth/Auth.tsx",
       "source_location": "L1",
       "id": "auth",
-      "community": 3
+      "community": 2
     },
     {
       "label": "index.js",
@@ -73,7 +73,7 @@
       "source_file": "packages/valkey-proxy-server/index.js",
       "source_location": "L1",
       "id": "index",
-      "community": 1
+      "community": 6
     },
     {
       "label": "ValkeyClient",
@@ -81,7 +81,7 @@
       "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L4",
       "id": "index_valkeyclient",
-      "community": 26
+      "community": 6
     },
     {
       "label": ".constructor()",
@@ -89,7 +89,7 @@
       "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L11",
       "id": "index_valkeyclient_constructor",
-      "community": 26
+      "community": 6
     },
     {
       "label": ".get()",
@@ -97,7 +97,7 @@
       "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L20",
       "id": "index_valkeyclient_get",
-      "community": 26
+      "community": 6
     },
     {
       "label": ".set()",
@@ -105,7 +105,7 @@
       "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L48",
       "id": "index_valkeyclient_set",
-      "community": 26
+      "community": 6
     },
     {
       "label": ".invalidate()",
@@ -113,7 +113,7 @@
       "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L75",
       "id": "index_valkeyclient_invalidate",
-      "community": 26
+      "community": 6
     },
     {
       "label": "r2.ts",
@@ -121,7 +121,7 @@
       "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
       "source_location": "L1",
       "id": "r2",
-      "community": 3
+      "community": 2
     },
     {
       "label": "uploadFileToR2()",
@@ -129,7 +129,7 @@
       "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
       "source_location": "L21",
       "id": "r2_uploadfiletor2",
-      "community": 3
+      "community": 2
     },
     {
       "label": "deleteFileInR2()",
@@ -137,7 +137,7 @@
       "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
       "source_location": "L40",
       "id": "r2_deletefileinr2",
-      "community": 3
+      "community": 2
     },
     {
       "label": "deleteDirectoryInR2()",
@@ -145,7 +145,7 @@
       "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
       "source_location": "L62",
       "id": "r2_deletedirectoryinr2",
-      "community": 3
+      "community": 2
     },
     {
       "label": "listItemsInR2Directory()",
@@ -153,7 +153,7 @@
       "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
       "source_location": "L106",
       "id": "r2_listitemsinr2directory",
-      "community": 3
+      "community": 2
     },
     {
       "label": "stream.ts",
@@ -161,7 +161,7 @@
       "source_file": "packages/athena-webapp/convex/cloudflare/stream.ts",
       "source_location": "L1",
       "id": "stream",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getCloudflareConfig()",
@@ -169,7 +169,7 @@
       "source_file": "packages/athena-webapp/convex/cloudflare/stream.ts",
       "source_location": "L8",
       "id": "stream_getcloudflareconfig",
-      "community": 3
+      "community": 2
     },
     {
       "label": "countries.ts",
@@ -177,7 +177,7 @@
       "source_file": "packages/storefront-webapp/src/lib/countries.ts",
       "source_location": "L1",
       "id": "countries",
-      "community": 5
+      "community": 1
     },
     {
       "label": "email.ts",
@@ -185,7 +185,7 @@
       "source_file": "packages/storefront-webapp/src/lib/validations/email.ts",
       "source_location": "L1",
       "id": "email",
-      "community": 6
+      "community": 14
     },
     {
       "label": "ghana.ts",
@@ -193,7 +193,7 @@
       "source_file": "packages/storefront-webapp/src/lib/ghana.ts",
       "source_location": "L1",
       "id": "ghana",
-      "community": 5
+      "community": 1
     },
     {
       "label": "payment.ts",
@@ -201,7 +201,7 @@
       "source_file": "packages/athena-webapp/convex/types/payment.ts",
       "source_location": "L1",
       "id": "payment",
-      "community": 3
+      "community": 2
     },
     {
       "label": "crons.ts",
@@ -209,7 +209,7 @@
       "source_file": "packages/athena-webapp/convex/crons.ts",
       "source_location": "L1",
       "id": "crons",
-      "community": 3
+      "community": 2
     },
     {
       "label": "DiscountCode.tsx",
@@ -217,7 +217,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
       "source_location": "L1",
       "id": "discountcode",
-      "community": 1
+      "community": 6
     },
     {
       "label": "ProductCard()",
@@ -225,7 +225,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
       "source_location": "L33",
       "id": "discountcode_productcard",
-      "community": 1
+      "community": 6
     },
     {
       "label": "chunkProducts()",
@@ -233,7 +233,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
       "source_location": "L98",
       "id": "discountcode_chunkproducts",
-      "community": 1
+      "community": 6
     },
     {
       "label": "DiscountReminder.tsx",
@@ -241,7 +241,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
       "source_location": "L1",
       "id": "discountreminder",
-      "community": 1
+      "community": 6
     },
     {
       "label": "ProductCard()",
@@ -249,7 +249,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
       "source_location": "L31",
       "id": "discountreminder_productcard",
-      "community": 1
+      "community": 6
     },
     {
       "label": "chunkProducts()",
@@ -257,7 +257,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
       "source_location": "L85",
       "id": "discountreminder_chunkproducts",
-      "community": 1
+      "community": 6
     },
     {
       "label": "FeedbackRequest.tsx",
@@ -265,7 +265,7 @@
       "source_file": "packages/athena-webapp/convex/emails/FeedbackRequest.tsx",
       "source_location": "L1",
       "id": "feedbackrequest",
-      "community": 1
+      "community": 6
     },
     {
       "label": "NewOrderAdmin.tsx",
@@ -273,7 +273,7 @@
       "source_file": "packages/athena-webapp/convex/emails/NewOrderAdmin.tsx",
       "source_location": "L1",
       "id": "neworderadmin",
-      "community": 1
+      "community": 6
     },
     {
       "label": "OrderEmail.tsx",
@@ -281,7 +281,7 @@
       "source_file": "packages/athena-webapp/convex/emails/OrderEmail.tsx",
       "source_location": "L1",
       "id": "orderemail",
-      "community": 1
+      "community": 6
     },
     {
       "label": "PosReceiptEmail.tsx",
@@ -289,7 +289,7 @@
       "source_file": "packages/athena-webapp/convex/emails/PosReceiptEmail.tsx",
       "source_location": "L1",
       "id": "posreceiptemail",
-      "community": 4
+      "community": 3
     },
     {
       "label": "VerificationCode.tsx",
@@ -297,7 +297,7 @@
       "source_file": "packages/athena-webapp/convex/emails/VerificationCode.tsx",
       "source_location": "L1",
       "id": "verificationcode",
-      "community": 1
+      "community": 6
     },
     {
       "label": "VerificationCode()",
@@ -305,7 +305,7 @@
       "source_file": "packages/athena-webapp/convex/emails/VerificationCode.tsx",
       "source_location": "L18",
       "id": "verificationcode_verificationcode",
-      "community": 1
+      "community": 6
     },
     {
       "label": "env.ts",
@@ -313,7 +313,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
       "source_location": "L1",
       "id": "env",
-      "community": 6
+      "community": 14
     },
     {
       "label": "analytics.ts",
@@ -321,7 +321,7 @@
       "source_file": "packages/storefront-webapp/src/lib/mutations.ts/analytics.ts",
       "source_location": "L1",
       "id": "analytics",
-      "community": 17
+      "community": 13
     },
     {
       "label": "bannerMessage.ts",
@@ -329,7 +329,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/bannerMessage.ts",
       "source_location": "L1",
       "id": "bannermessage",
-      "community": 3
+      "community": 2
     },
     {
       "label": "categories.ts",
@@ -337,7 +337,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/categories.ts",
       "source_location": "L1",
       "id": "categories",
-      "community": 3
+      "community": 2
     },
     {
       "label": "colors.ts",
@@ -345,7 +345,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/colors.ts",
       "source_location": "L1",
       "id": "colors",
-      "community": 3
+      "community": 2
     },
     {
       "label": "organizations.ts",
@@ -353,7 +353,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/organizations.ts",
       "source_location": "L1",
       "id": "organizations",
-      "community": 3
+      "community": 2
     },
     {
       "label": "Products.tsx",
@@ -361,7 +361,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/Products.tsx",
       "source_location": "L1",
       "id": "products",
-      "community": 2
+      "community": 0
     },
     {
       "label": "stores.ts",
@@ -369,7 +369,7 @@
       "source_file": "packages/storefront-webapp/src/api/stores.ts",
       "source_location": "L1",
       "id": "stores",
-      "community": 3
+      "community": 2
     },
     {
       "label": "subcategories.ts",
@@ -377,7 +377,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/subcategories.ts",
       "source_location": "L1",
       "id": "subcategories",
-      "community": 3
+      "community": 2
     },
     {
       "label": "mtnMomo.ts",
@@ -385,7 +385,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/mtnMomo.ts",
       "source_location": "L1",
       "id": "mtnmomo",
-      "community": 3
+      "community": 2
     },
     {
       "label": "handleCollectionNotification()",
@@ -393,7 +393,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/mtnMomo.ts",
       "source_location": "L10",
       "id": "mtnmomo_handlecollectionnotification",
-      "community": 3
+      "community": 2
     },
     {
       "label": "bag.ts",
@@ -409,7 +409,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/checkout.ts",
       "source_location": "L1",
       "id": "checkout",
-      "community": 0
+      "community": 1
     },
     {
       "label": "hasValidCanonicalBagItem()",
@@ -417,7 +417,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/checkout.ts",
       "source_location": "L84",
       "id": "checkout_hasvalidcanonicalbagitem",
-      "community": 0
+      "community": 1
     },
     {
       "label": "hasValidSessionItems()",
@@ -425,7 +425,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/checkout.ts",
       "source_location": "L95",
       "id": "checkout_hasvalidsessionitems",
-      "community": 0
+      "community": 1
     },
     {
       "label": "hasAllVisibileSessionItems()",
@@ -433,7 +433,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/checkout.ts",
       "source_location": "L109",
       "id": "checkout_hasallvisibilesessionitems",
-      "community": 0
+      "community": 1
     },
     {
       "label": "guest.ts",
@@ -441,7 +441,7 @@
       "source_file": "packages/storefront-webapp/src/api/guest.ts",
       "source_location": "L1",
       "id": "guest",
-      "community": 3
+      "community": 2
     },
     {
       "label": "me.ts",
@@ -449,7 +449,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/me.ts",
       "source_location": "L1",
       "id": "me",
-      "community": 3
+      "community": 2
     },
     {
       "label": "offers.ts",
@@ -457,7 +457,7 @@
       "source_file": "packages/storefront-webapp/src/api/offers.ts",
       "source_location": "L1",
       "id": "offers",
-      "community": 6
+      "community": 14
     },
     {
       "label": "onlineOrder.ts",
@@ -465,7 +465,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/onlineOrder.ts",
       "source_location": "L1",
       "id": "onlineorder",
-      "community": 3
+      "community": 2
     },
     {
       "label": "paystack.ts",
@@ -473,7 +473,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/paystack.ts",
       "source_location": "L1",
       "id": "paystack",
-      "community": 3
+      "community": 2
     },
     {
       "label": "reviews.ts",
@@ -481,7 +481,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/reviews.ts",
       "source_location": "L1",
       "id": "reviews",
-      "community": 12
+      "community": 9
     },
     {
       "label": "rewards.ts",
@@ -505,7 +505,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.test.ts",
       "source_location": "L1",
       "id": "security_test",
-      "community": 3
+      "community": 2
     },
     {
       "label": "security.ts",
@@ -513,7 +513,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
       "source_location": "L1",
       "id": "security",
-      "community": 3
+      "community": 2
     },
     {
       "label": "hasValidPositiveQuantity()",
@@ -521,7 +521,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
       "source_location": "L27",
       "id": "security_hasvalidpositivequantity",
-      "community": 3
+      "community": 2
     },
     {
       "label": "isAuthorizedResourceOwner()",
@@ -529,7 +529,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
       "source_location": "L31",
       "id": "security_isauthorizedresourceowner",
-      "community": 3
+      "community": 2
     },
     {
       "label": "buildCanonicalCheckoutProducts()",
@@ -537,7 +537,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
       "source_location": "L42",
       "id": "security_buildcanonicalcheckoutproducts",
-      "community": 3
+      "community": 2
     },
     {
       "label": "isAmountTampered()",
@@ -545,7 +545,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
       "source_location": "L65",
       "id": "security_isamounttampered",
-      "community": 3
+      "community": 2
     },
     {
       "label": "isDuplicateChargeSuccess()",
@@ -553,7 +553,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
       "source_location": "L76",
       "id": "security_isduplicatechargesuccess",
-      "community": 3
+      "community": 2
     },
     {
       "label": "storefront.ts",
@@ -561,7 +561,7 @@
       "source_file": "packages/storefront-webapp/src/api/storefront.ts",
       "source_location": "L1",
       "id": "storefront",
-      "community": 3
+      "community": 2
     },
     {
       "label": "upsells.ts",
@@ -569,7 +569,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/upsells.ts",
       "source_location": "L1",
       "id": "upsells",
-      "community": 3
+      "community": 2
     },
     {
       "label": "user.ts",
@@ -577,7 +577,7 @@
       "source_file": "packages/storefront-webapp/src/lib/schemas/user.ts",
       "source_location": "L1",
       "id": "user",
-      "community": 3
+      "community": 2
     },
     {
       "label": "userOffers.ts",
@@ -585,7 +585,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/userOffers.ts",
       "source_location": "L1",
       "id": "useroffers",
-      "community": 6
+      "community": 2
     },
     {
       "label": "routerComposition.test.ts",
@@ -609,7 +609,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L1",
       "id": "utils",
-      "community": 2
+      "community": 0
     },
     {
       "label": "getStoreDataFromRequest()",
@@ -617,7 +617,7 @@
       "source_file": "packages/athena-webapp/convex/http/utils.ts",
       "source_location": "L5",
       "id": "utils_getstoredatafromrequest",
-      "community": 2
+      "community": 0
     },
     {
       "label": "getStorefrontUserFromRequest()",
@@ -625,7 +625,7 @@
       "source_file": "packages/athena-webapp/convex/http/utils.ts",
       "source_location": "L12",
       "id": "utils_getstorefrontuserfromrequest",
-      "community": 2
+      "community": 0
     },
     {
       "label": "http.ts",
@@ -633,7 +633,7 @@
       "source_file": "packages/athena-webapp/convex/http.ts",
       "source_location": "L1",
       "id": "http",
-      "community": 3
+      "community": 2
     },
     {
       "label": "athenaUser.ts",
@@ -641,7 +641,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/athenaUser.ts",
       "source_location": "L1",
       "id": "athenauser",
-      "community": 3
+      "community": 2
     },
     {
       "label": "bestSeller.ts",
@@ -649,7 +649,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/bestSeller.ts",
       "source_location": "L1",
       "id": "bestseller",
-      "community": 3
+      "community": 2
     },
     {
       "label": "cashier.ts",
@@ -657,7 +657,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/cashier.ts",
       "source_location": "L1",
       "id": "cashier",
-      "community": 3
+      "community": 2
     },
     {
       "label": "authenticateHandler()",
@@ -665,7 +665,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/cashier.ts",
       "source_location": "L239",
       "id": "cashier_authenticatehandler",
-      "community": 3
+      "community": 2
     },
     {
       "label": "complimentaryProduct.ts",
@@ -673,7 +673,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/complimentaryProduct.ts",
       "source_location": "L1",
       "id": "complimentaryproduct",
-      "community": 3
+      "community": 2
     },
     {
       "label": "expenseSessionItems.ts",
@@ -729,7 +729,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/featuredItem.ts",
       "source_location": "L1",
       "id": "featureditem",
-      "community": 3
+      "community": 2
     },
     {
       "label": "expenseSessionExpiration.ts",
@@ -1057,7 +1057,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/inviteCode.ts",
       "source_location": "L1",
       "id": "invitecode",
-      "community": 3
+      "community": 2
     },
     {
       "label": "organizationMembers.ts",
@@ -1065,7 +1065,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/organizationMembers.ts",
       "source_location": "L1",
       "id": "organizationmembers",
-      "community": 3
+      "community": 2
     },
     {
       "label": "pos.ts",
@@ -1153,7 +1153,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posCustomers.ts",
       "source_location": "L1",
       "id": "poscustomers",
-      "community": 3
+      "community": 2
     },
     {
       "label": "posQueryCleanup.test.ts",
@@ -1225,7 +1225,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/pos/posTerminal.ts",
       "source_location": "L1",
       "id": "posterminal",
-      "community": 3
+      "community": 2
     },
     {
       "label": "productSku.ts",
@@ -1233,7 +1233,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/productSku.ts",
       "source_location": "L1",
       "id": "productsku",
-      "community": 3
+      "community": 2
     },
     {
       "label": "productUtil.ts",
@@ -1241,7 +1241,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/productUtil.ts",
       "source_location": "L1",
       "id": "productutil",
-      "community": 3
+      "community": 2
     },
     {
       "label": "generateSKU()",
@@ -1249,7 +1249,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/products.ts",
       "source_location": "L18",
       "id": "products_generatesku",
-      "community": 2
+      "community": 0
     },
     {
       "label": "generateBarcode()",
@@ -1257,7 +1257,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/products.ts",
       "source_location": "L42",
       "id": "products_generatebarcode",
-      "community": 2
+      "community": 0
     },
     {
       "label": "calculateTotalInventoryCount()",
@@ -1265,7 +1265,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/products.ts",
       "source_location": "L65",
       "id": "products_calculatetotalinventorycount",
-      "community": 2
+      "community": 0
     },
     {
       "label": "calculateTotalAvailableCount()",
@@ -1273,7 +1273,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/products.ts",
       "source_location": "L70",
       "id": "products_calculatetotalavailablecount",
-      "community": 2
+      "community": 0
     },
     {
       "label": "promoCode.ts",
@@ -1281,7 +1281,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/promoCode.ts",
       "source_location": "L1",
       "id": "promocode",
-      "community": 3
+      "community": 2
     },
     {
       "label": "sessionQueryIndexes.test.ts",
@@ -1305,7 +1305,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/stockValidation.ts",
       "source_location": "L1",
       "id": "stockvalidation",
-      "community": 3
+      "community": 2
     },
     {
       "label": "storeConfigV2.test.ts",
@@ -1313,7 +1313,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.test.ts",
       "source_location": "L1",
       "id": "storeconfigv2_test",
-      "community": 13
+      "community": 19
     },
     {
       "label": "storeConfigV2.ts",
@@ -1321,7 +1321,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L1",
       "id": "storeconfigv2",
-      "community": 13
+      "community": 19
     },
     {
       "label": "isPlainObject()",
@@ -1329,7 +1329,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L53",
       "id": "storeconfigv2_isplainobject",
-      "community": 13
+      "community": 19
     },
     {
       "label": "asRecord()",
@@ -1337,7 +1337,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L57",
       "id": "storeconfigv2_asrecord",
-      "community": 13
+      "community": 19
     },
     {
       "label": "asNumber()",
@@ -1345,7 +1345,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L61",
       "id": "storeconfigv2_asnumber",
-      "community": 13
+      "community": 19
     },
     {
       "label": "asString()",
@@ -1353,7 +1353,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L65",
       "id": "storeconfigv2_asstring",
-      "community": 13
+      "community": 19
     },
     {
       "label": "asBoolean()",
@@ -1361,7 +1361,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L69",
       "id": "storeconfigv2_asboolean",
-      "community": 13
+      "community": 19
     },
     {
       "label": "asArray()",
@@ -1369,7 +1369,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L77",
       "id": "storeconfigv2_asarray",
-      "community": 13
+      "community": 19
     },
     {
       "label": "asOptionalArray()",
@@ -1377,7 +1377,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L90",
       "id": "storeconfigv2_asoptionalarray",
-      "community": 13
+      "community": 19
     },
     {
       "label": "firstDefined()",
@@ -1385,7 +1385,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L101",
       "id": "storeconfigv2_firstdefined",
-      "community": 13
+      "community": 19
     },
     {
       "label": "mapPromotion()",
@@ -1393,7 +1393,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L111",
       "id": "storeconfigv2_mappromotion",
-      "community": 13
+      "community": 19
     },
     {
       "label": "mapStreamReel()",
@@ -1401,7 +1401,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L115",
       "id": "storeconfigv2_mapstreamreel",
-      "community": 13
+      "community": 19
     },
     {
       "label": "normalizeWaiveDeliveryFees()",
@@ -1409,7 +1409,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L135",
       "id": "storeconfigv2_normalizewaivedeliveryfees",
-      "community": 13
+      "community": 19
     },
     {
       "label": "cleanUndefined()",
@@ -1417,7 +1417,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L153",
       "id": "storeconfigv2_cleanundefined",
-      "community": 13
+      "community": 19
     },
     {
       "label": "asMtnMomoSetupStatus()",
@@ -1425,7 +1425,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L165",
       "id": "storeconfigv2_asmtnmomosetupstatus",
-      "community": 13
+      "community": 19
     },
     {
       "label": "hasMtnMomoReceivingAccountDetails()",
@@ -1433,7 +1433,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L178",
       "id": "storeconfigv2_hasmtnmomoreceivingaccountdetails",
-      "community": 13
+      "community": 19
     },
     {
       "label": "mapMtnMomoReceivingAccount()",
@@ -1441,7 +1441,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L191",
       "id": "storeconfigv2_mapmtnmomoreceivingaccount",
-      "community": 13
+      "community": 19
     },
     {
       "label": "normalizeMtnMomoReceivingAccounts()",
@@ -1449,7 +1449,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L214",
       "id": "storeconfigv2_normalizemtnmomoreceivingaccounts",
-      "community": 13
+      "community": 19
     },
     {
       "label": "toV2Config()",
@@ -1457,7 +1457,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L231",
       "id": "storeconfigv2_tov2config",
-      "community": 13
+      "community": 19
     },
     {
       "label": "normalizeStoreConfig()",
@@ -1465,7 +1465,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L474",
       "id": "storeconfigv2_normalizestoreconfig",
-      "community": 13
+      "community": 19
     },
     {
       "label": "deepMerge()",
@@ -1473,7 +1473,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L478",
       "id": "storeconfigv2_deepmerge",
-      "community": 13
+      "community": 19
     },
     {
       "label": "patchV2Config()",
@@ -1481,7 +1481,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L498",
       "id": "storeconfigv2_patchv2config",
-      "community": 13
+      "community": 19
     },
     {
       "label": "assignOrDelete()",
@@ -1489,7 +1489,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L507",
       "id": "storeconfigv2_assignordelete",
-      "community": 13
+      "community": 19
     },
     {
       "label": "mirrorLegacyKeys()",
@@ -1497,7 +1497,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L520",
       "id": "storeconfigv2_mirrorlegacykeys",
-      "community": 13
+      "community": 19
     },
     {
       "label": "getUnknownStoreConfigRootKeys()",
@@ -1505,7 +1505,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L591",
       "id": "storeconfigv2_getunknownstoreconfigrootkeys",
-      "community": 13
+      "community": 19
     },
     {
       "label": "isStoreCheckoutDisabled()",
@@ -1513,7 +1513,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L597",
       "id": "storeconfigv2_isstorecheckoutdisabled",
-      "community": 13
+      "community": 19
     },
     {
       "label": "removeLegacyRootKeysFromConfig()",
@@ -1521,7 +1521,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L606",
       "id": "storeconfigv2_removelegacyrootkeysfromconfig",
-      "community": 13
+      "community": 19
     },
     {
       "label": "isLegacyRootKey()",
@@ -1529,7 +1529,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L623",
       "id": "storeconfigv2_islegacyrootkey",
-      "community": 13
+      "community": 19
     },
     {
       "label": "isV2RootKey()",
@@ -1537,7 +1537,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L627",
       "id": "storeconfigv2_isv2rootkey",
-      "community": 13
+      "community": 19
     },
     {
       "label": "toV2OnlyConfig()",
@@ -1545,7 +1545,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/stores.ts",
       "source_location": "L27",
       "id": "stores_tov2onlyconfig",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getDiscountValue()",
@@ -1553,7 +1553,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L17",
       "id": "utils_getdiscountvalue",
-      "community": 2
+      "community": 0
     },
     {
       "label": "getProductDiscountValue()",
@@ -1561,7 +1561,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
       "source_location": "L75",
       "id": "utils_getproductdiscountvalue",
-      "community": 2
+      "community": 0
     },
     {
       "label": "getOrderAmount()",
@@ -1569,7 +1569,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L51",
       "id": "utils_getorderamount",
-      "community": 2
+      "community": 0
     },
     {
       "label": "formatDeliveryAddress()",
@@ -1577,7 +1577,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L74",
       "id": "utils_formatdeliveryaddress",
-      "community": 2
+      "community": 0
     },
     {
       "label": "currency.test.ts",
@@ -1585,7 +1585,7 @@
       "source_file": "packages/athena-webapp/convex/lib/currency.test.ts",
       "source_location": "L1",
       "id": "currency_test",
-      "community": 13
+      "community": 8
     },
     {
       "label": "currency.ts",
@@ -1593,7 +1593,7 @@
       "source_file": "packages/storefront-webapp/src/lib/currency.ts",
       "source_location": "L1",
       "id": "currency",
-      "community": 13
+      "community": 8
     },
     {
       "label": "toPesewas()",
@@ -1601,7 +1601,7 @@
       "source_file": "packages/storefront-webapp/src/lib/currency.ts",
       "source_location": "L1",
       "id": "currency_topesewas",
-      "community": 13
+      "community": 8
     },
     {
       "label": "toDisplayAmount()",
@@ -1609,7 +1609,7 @@
       "source_file": "packages/storefront-webapp/src/lib/currency.ts",
       "source_location": "L5",
       "id": "currency_todisplayamount",
-      "community": 13
+      "community": 8
     },
     {
       "label": "callLlmProvider.ts",
@@ -1617,7 +1617,7 @@
       "source_file": "packages/athena-webapp/convex/llm/callLlmProvider.ts",
       "source_location": "L1",
       "id": "callllmprovider",
-      "community": 3
+      "community": 2
     },
     {
       "label": "callLlmProvider()",
@@ -1625,7 +1625,7 @@
       "source_file": "packages/athena-webapp/convex/llm/callLlmProvider.ts",
       "source_location": "L4",
       "id": "callllmprovider_callllmprovider",
-      "community": 3
+      "community": 2
     },
     {
       "label": "anthropic.ts",
@@ -1633,7 +1633,7 @@
       "source_file": "packages/athena-webapp/convex/llm/providers/anthropic.ts",
       "source_location": "L1",
       "id": "anthropic",
-      "community": 3
+      "community": 2
     },
     {
       "label": "callAnthropic()",
@@ -1641,7 +1641,7 @@
       "source_file": "packages/athena-webapp/convex/llm/providers/anthropic.ts",
       "source_location": "L3",
       "id": "anthropic_callanthropic",
-      "community": 3
+      "community": 2
     },
     {
       "label": "openai.ts",
@@ -1649,7 +1649,7 @@
       "source_file": "packages/athena-webapp/convex/llm/providers/openai.ts",
       "source_location": "L1",
       "id": "openai",
-      "community": 3
+      "community": 2
     },
     {
       "label": "callOpenAi()",
@@ -1657,7 +1657,7 @@
       "source_file": "packages/athena-webapp/convex/llm/providers/openai.ts",
       "source_location": "L3",
       "id": "openai_callopenai",
-      "community": 3
+      "community": 2
     },
     {
       "label": "StoreInsights.tsx",
@@ -1665,7 +1665,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/StoreInsights.tsx",
       "source_location": "L1",
       "id": "storeinsights",
-      "community": 3
+      "community": 2
     },
     {
       "label": "userInsights.ts",
@@ -1673,7 +1673,7 @@
       "source_file": "packages/athena-webapp/convex/llm/userInsights.ts",
       "source_location": "L1",
       "id": "userinsights",
-      "community": 3
+      "community": 2
     },
     {
       "label": "analyticsUtils.ts",
@@ -1681,7 +1681,7 @@
       "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
       "source_location": "L1",
       "id": "analyticsutils",
-      "community": 3
+      "community": 2
     },
     {
       "label": "calculateDeviceDistribution()",
@@ -1689,7 +1689,7 @@
       "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
       "source_location": "L11",
       "id": "analyticsutils_calculatedevicedistribution",
-      "community": 3
+      "community": 2
     },
     {
       "label": "calculateActivityTrend()",
@@ -1697,7 +1697,7 @@
       "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
       "source_location": "L43",
       "id": "analyticsutils_calculateactivitytrend",
-      "community": 3
+      "community": 2
     },
     {
       "label": "sendVerificationCode()",
@@ -1705,7 +1705,7 @@
       "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L3",
       "id": "index_sendverificationcode",
-      "community": 1
+      "community": 6
     },
     {
       "label": "sendOrderEmail()",
@@ -1713,7 +1713,7 @@
       "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L43",
       "id": "index_sendorderemail",
-      "community": 1
+      "community": 6
     },
     {
       "label": "sendNewOrderEmail()",
@@ -1721,7 +1721,7 @@
       "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L117",
       "id": "index_sendneworderemail",
-      "community": 1
+      "community": 6
     },
     {
       "label": "sendFeedbackRequestEmail()",
@@ -1729,7 +1729,7 @@
       "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L167",
       "id": "index_sendfeedbackrequestemail",
-      "community": 1
+      "community": 6
     },
     {
       "label": "sendDiscountCodeEmail()",
@@ -1737,7 +1737,7 @@
       "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L255",
       "id": "index_senddiscountcodeemail",
-      "community": 1
+      "community": 6
     },
     {
       "label": "sendDiscountReminderEmail()",
@@ -1745,7 +1745,7 @@
       "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L334",
       "id": "index_senddiscountreminderemail",
-      "community": 1
+      "community": 6
     },
     {
       "label": "migrateAmountsToPesewas.ts",
@@ -1753,7 +1753,7 @@
       "source_file": "packages/athena-webapp/convex/migrations/migrateAmountsToPesewas.ts",
       "source_location": "L1",
       "id": "migrateamountstopesewas",
-      "community": 13
+      "community": 8
     },
     {
       "label": "client.test.ts",
@@ -1761,7 +1761,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.test.ts",
       "source_location": "L1",
       "id": "client_test",
-      "community": 8
+      "community": 4
     },
     {
       "label": "client.tsx",
@@ -1769,7 +1769,7 @@
       "source_file": "packages/storefront-webapp/src/client.tsx",
       "source_location": "L1",
       "id": "client",
-      "community": 8
+      "community": 4
     },
     {
       "label": "encodeBasicAuth()",
@@ -1777,7 +1777,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L9",
       "id": "client_encodebasicauth",
-      "community": 8
+      "community": 4
     },
     {
       "label": "toError()",
@@ -1785,7 +1785,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L13",
       "id": "client_toerror",
-      "community": 8
+      "community": 4
     },
     {
       "label": "buildHeaders()",
@@ -1793,7 +1793,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L20",
       "id": "client_buildheaders",
-      "community": 8
+      "community": 4
     },
     {
       "label": "createCollectionsAccessToken()",
@@ -1801,7 +1801,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L30",
       "id": "client_createcollectionsaccesstoken",
-      "community": 8
+      "community": 4
     },
     {
       "label": "requestToPay()",
@@ -1809,7 +1809,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L65",
       "id": "client_requesttopay",
-      "community": 8
+      "community": 4
     },
     {
       "label": "getRequestToPayStatus()",
@@ -1817,7 +1817,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L115",
       "id": "client_getrequesttopaystatus",
-      "community": 8
+      "community": 4
     },
     {
       "label": "collections.ts",
@@ -1825,7 +1825,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
       "source_location": "L1",
       "id": "collections",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getCachedTokenRecord()",
@@ -1833,7 +1833,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
       "source_location": "L26",
       "id": "collections_getcachedtokenrecord",
-      "community": 3
+      "community": 2
     },
     {
       "label": "resolveConfigForStore()",
@@ -1841,7 +1841,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
       "source_location": "L33",
       "id": "collections_resolveconfigforstore",
-      "community": 3
+      "community": 2
     },
     {
       "label": "resolveAccessTokenForStore()",
@@ -1849,7 +1849,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
       "source_location": "L79",
       "id": "collections_resolveaccesstokenforstore",
-      "community": 3
+      "community": 2
     },
     {
       "label": "config.test.ts",
@@ -1857,7 +1857,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.test.ts",
       "source_location": "L1",
       "id": "config_test",
-      "community": 3
+      "community": 2
     },
     {
       "label": "config.ts",
@@ -1865,7 +1865,7 @@
       "source_file": "packages/storefront-webapp/src/config.ts",
       "source_location": "L1",
       "id": "config",
-      "community": 3
+      "community": 2
     },
     {
       "label": "toEnvSegment()",
@@ -1873,7 +1873,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L29",
       "id": "config_toenvsegment",
-      "community": 3
+      "community": 2
     },
     {
       "label": "buildMtnCollectionsLookupPrefixes()",
@@ -1881,7 +1881,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L43",
       "id": "config_buildmtncollectionslookupprefixes",
-      "community": 3
+      "community": 2
     },
     {
       "label": "readScopedValue()",
@@ -1889,7 +1889,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L56",
       "id": "config_readscopedvalue",
-      "community": 3
+      "community": 2
     },
     {
       "label": "isTargetEnvironment()",
@@ -1897,7 +1897,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L67",
       "id": "config_istargetenvironment",
-      "community": 3
+      "community": 2
     },
     {
       "label": "resolveConfigForPrefix()",
@@ -1905,7 +1905,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L73",
       "id": "config_resolveconfigforprefix",
-      "community": 3
+      "community": 2
     },
     {
       "label": "resolveMtnCollectionsConfigFromEnv()",
@@ -1913,7 +1913,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L108",
       "id": "config_resolvemtncollectionsconfigfromenv",
-      "community": 3
+      "community": 2
     },
     {
       "label": "buildMtnCollectionsCallbackUrl()",
@@ -1921,7 +1921,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L135",
       "id": "config_buildmtncollectionscallbackurl",
-      "community": 3
+      "community": 2
     },
     {
       "label": "foundation.test.ts",
@@ -1945,7 +1945,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/normalize.test.ts",
       "source_location": "L1",
       "id": "normalize_test",
-      "community": 3
+      "community": 2
     },
     {
       "label": "normalize.ts",
@@ -1953,7 +1953,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
       "source_location": "L1",
       "id": "normalize",
-      "community": 3
+      "community": 2
     },
     {
       "label": "maskMtnPartyId()",
@@ -1961,7 +1961,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
       "source_location": "L10",
       "id": "normalize_maskmtnpartyid",
-      "community": 3
+      "community": 2
     },
     {
       "label": "normalizeCollectionsTransaction()",
@@ -1969,7 +1969,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
       "source_location": "L18",
       "id": "normalize_normalizecollectionstransaction",
-      "community": 3
+      "community": 2
     },
     {
       "label": "parseCollectionsNotificationRequest()",
@@ -1977,7 +1977,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
       "source_location": "L52",
       "id": "normalize_parsecollectionsnotificationrequest",
-      "community": 3
+      "community": 2
     },
     {
       "label": "types.ts",
@@ -1985,7 +1985,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/types.ts",
       "source_location": "L1",
       "id": "types",
-      "community": 4
+      "community": 3
     },
     {
       "label": "ResendOTP.ts",
@@ -1993,7 +1993,7 @@
       "source_file": "packages/athena-webapp/convex/otp/ResendOTP.ts",
       "source_location": "L1",
       "id": "resendotp",
-      "community": 6
+      "community": 14
     },
     {
       "label": "VerificationCodeEmail.tsx",
@@ -2001,7 +2001,7 @@
       "source_file": "packages/athena-webapp/convex/otp/VerificationCodeEmail.tsx",
       "source_location": "L1",
       "id": "verificationcodeemail",
-      "community": 6
+      "community": 14
     },
     {
       "label": "VerificationCodeEmail()",
@@ -2009,7 +2009,7 @@
       "source_file": "packages/athena-webapp/convex/otp/VerificationCodeEmail.tsx",
       "source_location": "L11",
       "id": "verificationcodeemail_verificationcodeemail",
-      "community": 6
+      "community": 14
     },
     {
       "label": "listTransactions()",
@@ -2017,7 +2017,7 @@
       "source_file": "packages/athena-webapp/convex/paystack/index.ts",
       "source_location": "L7",
       "id": "index_listtransactions",
-      "community": 1
+      "community": 6
     },
     {
       "label": "verifyTransaction()",
@@ -2025,7 +2025,7 @@
       "source_file": "packages/athena-webapp/convex/paystack/index.ts",
       "source_location": "L109",
       "id": "index_verifytransaction",
-      "community": 1
+      "community": 6
     },
     {
       "label": "schema.ts",
@@ -2033,7 +2033,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/schema.ts",
       "source_location": "L1",
       "id": "schema",
-      "community": 3
+      "community": 2
     },
     {
       "label": "appVerificationCode.ts",
@@ -2049,7 +2049,7 @@
       "source_file": "packages/storefront-webapp/src/lib/schemas/category.ts",
       "source_location": "L1",
       "id": "category",
-      "community": 3
+      "community": 2
     },
     {
       "label": "color.ts",
@@ -2057,7 +2057,7 @@
       "source_file": "packages/storefront-webapp/src/api/color.ts",
       "source_location": "L1",
       "id": "color",
-      "community": 12
+      "community": 13
     },
     {
       "label": "organization.ts",
@@ -2065,7 +2065,7 @@
       "source_file": "packages/storefront-webapp/src/lib/schemas/organization.ts",
       "source_location": "L1",
       "id": "organization",
-      "community": 3
+      "community": 2
     },
     {
       "label": "organizationMember.ts",
@@ -2081,7 +2081,7 @@
       "source_file": "packages/storefront-webapp/src/lib/schemas/product.ts",
       "source_location": "L1",
       "id": "product",
-      "community": 12
+      "community": 13
     },
     {
       "label": "redeemedPromoCode.ts",
@@ -2097,7 +2097,7 @@
       "source_file": "packages/storefront-webapp/src/lib/schemas/store.ts",
       "source_location": "L1",
       "id": "store",
-      "community": 3
+      "community": 2
     },
     {
       "label": "subcategory.ts",
@@ -2105,7 +2105,7 @@
       "source_file": "packages/storefront-webapp/src/lib/schemas/subcategory.ts",
       "source_location": "L1",
       "id": "subcategory",
-      "community": 3
+      "community": 2
     },
     {
       "label": "mtnCollections.ts",
@@ -2113,7 +2113,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/payments/mtnCollections.ts",
       "source_location": "L1",
       "id": "mtncollections",
-      "community": 3
+      "community": 2
     },
     {
       "label": "customer.ts",
@@ -2161,7 +2161,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/pos/posSession.ts",
       "source_location": "L1",
       "id": "possession",
-      "community": 3
+      "community": 2
     },
     {
       "label": "posSessionItem.ts",
@@ -2201,7 +2201,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L1",
       "id": "checkoutsession",
-      "community": 8
+      "community": 5
     },
     {
       "label": "checkoutSessionItem.ts",
@@ -2225,7 +2225,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderItem.ts",
       "source_location": "L1",
       "id": "onlineorderitem",
-      "community": 3
+      "community": 2
     },
     {
       "label": "review.tsx",
@@ -2233,7 +2233,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
       "source_location": "L1",
       "id": "review",
-      "community": 0
+      "community": 1
     },
     {
       "label": "savedBagItem.ts",
@@ -2241,7 +2241,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/savedBagItem.ts",
       "source_location": "L1",
       "id": "savedbagitem",
-      "community": 3
+      "community": 2
     },
     {
       "label": "storeFrontSession.ts",
@@ -2257,7 +2257,7 @@
       "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
       "source_location": "L1",
       "id": "storefrontuser",
-      "community": 5
+      "community": 1
     },
     {
       "label": "storeFrontVerificationCode.ts",
@@ -2273,7 +2273,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/supportTicket.ts",
       "source_location": "L1",
       "id": "supportticket",
-      "community": 3
+      "community": 2
     },
     {
       "label": "orderEmailService.ts",
@@ -2281,7 +2281,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L1",
       "id": "orderemailservice",
-      "community": 3
+      "community": 8
     },
     {
       "label": "shouldSendToAdmins()",
@@ -2289,7 +2289,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L42",
       "id": "orderemailservice_shouldsendtoadmins",
-      "community": 3
+      "community": 8
     },
     {
       "label": "buildOrderStatusMessage()",
@@ -2297,7 +2297,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L49",
       "id": "orderemailservice_buildorderstatusmessage",
-      "community": 3
+      "community": 8
     },
     {
       "label": "buildPickupDetails()",
@@ -2305,7 +2305,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L77",
       "id": "orderemailservice_buildpickupdetails",
-      "community": 3
+      "community": 8
     },
     {
       "label": "sendPODOrderEmails()",
@@ -2313,7 +2313,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L96",
       "id": "orderemailservice_sendpodorderemails",
-      "community": 3
+      "community": 8
     },
     {
       "label": "sendPaymentVerificationEmails()",
@@ -2321,7 +2321,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L217",
       "id": "orderemailservice_sendpaymentverificationemails",
-      "community": 3
+      "community": 8
     },
     {
       "label": "paystackService.ts",
@@ -2329,7 +2329,7 @@
       "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
       "source_location": "L1",
       "id": "paystackservice",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getPaystackHeaders()",
@@ -2337,7 +2337,7 @@
       "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
       "source_location": "L11",
       "id": "paystackservice_getpaystackheaders",
-      "community": 3
+      "community": 2
     },
     {
       "label": "initializeTransaction()",
@@ -2345,7 +2345,7 @@
       "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
       "source_location": "L21",
       "id": "paystackservice_initializetransaction",
-      "community": 3
+      "community": 2
     },
     {
       "label": "verifyTransaction()",
@@ -2353,7 +2353,7 @@
       "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
       "source_location": "L65",
       "id": "paystackservice_verifytransaction",
-      "community": 3
+      "community": 2
     },
     {
       "label": "initiateRefund()",
@@ -2361,7 +2361,7 @@
       "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
       "source_location": "L87",
       "id": "paystackservice_initiaterefund",
-      "community": 3
+      "community": 2
     },
     {
       "label": "extractPromoCodeId()",
@@ -2369,7 +2369,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L18",
       "id": "analytics_extractpromocodeid",
-      "community": 17
+      "community": 13
     },
     {
       "label": "getAnalyticsByStoreQuery()",
@@ -2377,7 +2377,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L28",
       "id": "analytics_getanalyticsbystorequery",
-      "community": 17
+      "community": 13
     },
     {
       "label": "getCompletedOrdersQuery()",
@@ -2385,7 +2385,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L59",
       "id": "analytics_getcompletedordersquery",
-      "community": 17
+      "community": 13
     },
     {
       "label": "getAnalyticsByStoreAndActionQuery()",
@@ -2393,7 +2393,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L97",
       "id": "analytics_getanalyticsbystoreandactionquery",
-      "community": 17
+      "community": 13
     },
     {
       "label": "getSkuMapForProducts()",
@@ -2401,7 +2401,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L132",
       "id": "analytics_getskumapforproducts",
-      "community": 17
+      "community": 13
     },
     {
       "label": "getStoreFrontActorById()",
@@ -2409,7 +2409,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/auth.ts",
       "source_location": "L15",
       "id": "auth_getstorefrontactorbyid",
-      "community": 3
+      "community": 2
     },
     {
       "label": "listSessionItems()",
@@ -2417,7 +2417,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L40",
       "id": "checkoutsession_listsessionitems",
-      "community": 8
+      "community": 5
     },
     {
       "label": "checkIfItemsHaveChanged()",
@@ -2425,7 +2425,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L50",
       "id": "checkoutsession_checkifitemshavechanged",
-      "community": 8
+      "community": 5
     },
     {
       "label": "createPatchObject()",
@@ -2433,7 +2433,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L651",
       "id": "checkoutsession_createpatchobject",
-      "community": 8
+      "community": 5
     },
     {
       "label": "handlePlaceOrder()",
@@ -2441,7 +2441,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L698",
       "id": "checkoutsession_handleplaceorder",
-      "community": 8
+      "community": 5
     },
     {
       "label": "handleOrderCreation()",
@@ -2449,7 +2449,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L734",
       "id": "checkoutsession_handleordercreation",
-      "community": 8
+      "community": 5
     },
     {
       "label": "createOnlineOrder()",
@@ -2457,7 +2457,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L765",
       "id": "checkoutsession_createonlineorder",
-      "community": 8
+      "community": 5
     },
     {
       "label": "retrieveActiveCheckoutSession()",
@@ -2465,7 +2465,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L951",
       "id": "checkoutsession_retrieveactivecheckoutsession",
-      "community": 8
+      "community": 5
     },
     {
       "label": "fetchProductSkus()",
@@ -2473,7 +2473,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L979",
       "id": "checkoutsession_fetchproductskus",
-      "community": 8
+      "community": 5
     },
     {
       "label": "checkAdjustedAvailability()",
@@ -2481,7 +2481,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L990",
       "id": "checkoutsession_checkadjustedavailability",
-      "community": 8
+      "community": 5
     },
     {
       "label": "updateExistingSession()",
@@ -2489,7 +2489,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1020",
       "id": "checkoutsession_updateexistingsession",
-      "community": 8
+      "community": 5
     },
     {
       "label": "createSessionItems()",
@@ -2497,7 +2497,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1102",
       "id": "checkoutsession_createsessionitems",
-      "community": 8
+      "community": 5
     },
     {
       "label": "updateProductAvailability()",
@@ -2505,7 +2505,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1123",
       "id": "checkoutsession_updateproductavailability",
-      "community": 8
+      "community": 5
     },
     {
       "label": "updateAvailability()",
@@ -2513,7 +2513,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1140",
       "id": "checkoutsession_updateavailability",
-      "community": 8
+      "community": 5
     },
     {
       "label": "handleExistingSession()",
@@ -2521,7 +2521,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1161",
       "id": "checkoutsession_handleexistingsession",
-      "community": 8
+      "community": 5
     },
     {
       "label": "validateExistingDiscount()",
@@ -2529,7 +2529,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1321",
       "id": "checkoutsession_validateexistingdiscount",
-      "community": 8
+      "community": 5
     },
     {
       "label": "calculatePromoCodeValue()",
@@ -2537,7 +2537,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1447",
       "id": "checkoutsession_calculatepromocodevalue",
-      "community": 8
+      "community": 5
     },
     {
       "label": "findBestValuePromoCode()",
@@ -2545,7 +2545,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1495",
       "id": "checkoutsession_findbestvaluepromocode",
-      "community": 8
+      "community": 5
     },
     {
       "label": "commerceQueryIndexes.test.ts",
@@ -2553,7 +2553,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
       "source_location": "L1",
       "id": "commercequeryindexes_test",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getTableIndexes()",
@@ -2561,7 +2561,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
       "source_location": "L12",
       "id": "commercequeryindexes_test_gettableindexes",
-      "community": 3
+      "community": 2
     },
     {
       "label": "expectIndex()",
@@ -2569,7 +2569,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
       "source_location": "L19",
       "id": "commercequeryindexes_test_expectindex",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getSource()",
@@ -2577,7 +2577,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
       "source_location": "L26",
       "id": "commercequeryindexes_test_getsource",
-      "community": 3
+      "community": 2
     },
     {
       "label": "CustomerBehaviorTimeline.tsx",
@@ -2585,7 +2585,7 @@
       "source_file": "packages/athena-webapp/src/components/users/CustomerBehaviorTimeline.tsx",
       "source_location": "L1",
       "id": "customerbehaviortimeline",
-      "community": 2
+      "community": 18
     },
     {
       "label": "getTimeFilterForRange()",
@@ -2593,7 +2593,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
       "source_location": "L11",
       "id": "customerbehaviortimeline_gettimefilterforrange",
-      "community": 2
+      "community": 18
     },
     {
       "label": "getCustomerAnalyticsQuery()",
@@ -2601,7 +2601,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
       "source_location": "L26",
       "id": "customerbehaviortimeline_getcustomeranalyticsquery",
-      "community": 2
+      "community": 18
     },
     {
       "label": "getTimelineUserData()",
@@ -2609,7 +2609,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
       "source_location": "L42",
       "id": "customerbehaviortimeline_gettimelineuserdata",
-      "community": 2
+      "community": 18
     },
     {
       "label": "getProductInfoMaps()",
@@ -2617,7 +2617,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
       "source_location": "L66",
       "id": "customerbehaviortimeline_getproductinfomaps",
-      "community": 2
+      "community": 18
     },
     {
       "label": "customerObservabilityTimeline.test.ts",
@@ -2625,7 +2625,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimeline.test.ts",
       "source_location": "L1",
       "id": "customerobservabilitytimeline_test",
-      "community": 17
+      "community": 13
     },
     {
       "label": "createAnalyticsEvent()",
@@ -2633,7 +2633,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimeline.test.ts",
       "source_location": "L17",
       "id": "customerobservabilitytimeline_test_createanalyticsevent",
-      "community": 17
+      "community": 13
     },
     {
       "label": "customerObservabilityTimelineData.ts",
@@ -2641,7 +2641,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L1",
       "id": "customerobservabilitytimelinedata",
-      "community": 17
+      "community": 13
     },
     {
       "label": "getNonEmptyString()",
@@ -2649,7 +2649,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L64",
       "id": "customerobservabilitytimelinedata_getnonemptystring",
-      "community": 17
+      "community": 13
     },
     {
       "label": "isFailureStatus()",
@@ -2657,7 +2657,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L68",
       "id": "customerobservabilitytimelinedata_isfailurestatus",
-      "community": 17
+      "community": 13
     },
     {
       "label": "normalizeEvent()",
@@ -2665,7 +2665,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L72",
       "id": "customerobservabilitytimelinedata_normalizeevent",
-      "community": 17
+      "community": 13
     },
     {
       "label": "buildCustomerObservabilityTimeline()",
@@ -2673,7 +2673,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L118",
       "id": "customerobservabilitytimelinedata_buildcustomerobservabilitytimeline",
-      "community": 17
+      "community": 13
     },
     {
       "label": "helperOrchestration.test.ts",
@@ -2713,7 +2713,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
       "source_location": "L8",
       "id": "onlineorder_generateordernumber",
-      "community": 3
+      "community": 2
     },
     {
       "label": "findOrderByExternalReference()",
@@ -2721,7 +2721,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
       "source_location": "L15",
       "id": "onlineorder_findorderbyexternalreference",
-      "community": 3
+      "community": 2
     },
     {
       "label": "clearBagItems()",
@@ -2729,7 +2729,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
       "source_location": "L27",
       "id": "onlineorder_clearbagitems",
-      "community": 3
+      "community": 2
     },
     {
       "label": "returnOrderItemsToStock()",
@@ -2737,7 +2737,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
       "source_location": "L39",
       "id": "onlineorder_returnorderitemstostock",
-      "community": 3
+      "community": 2
     },
     {
       "label": "createOrderFromCheckoutSession()",
@@ -2745,7 +2745,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
       "source_location": "L75",
       "id": "onlineorder_createorderfromcheckoutsession",
-      "community": 3
+      "community": 2
     },
     {
       "label": "orderUpdateEmails.ts",
@@ -2753,7 +2753,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L1",
       "id": "orderupdateemails",
-      "community": 3
+      "community": 8
     },
     {
       "label": "getPickupLocation()",
@@ -2761,7 +2761,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L52",
       "id": "orderupdateemails_getpickuplocation",
-      "community": 3
+      "community": 8
     },
     {
       "label": "getDeliveryAddress()",
@@ -2769,7 +2769,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L55",
       "id": "orderupdateemails_getdeliveryaddress",
-      "community": 3
+      "community": 8
     },
     {
       "label": "getLocationDetails()",
@@ -2777,7 +2777,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L58",
       "id": "orderupdateemails_getlocationdetails",
-      "community": 3
+      "community": 8
     },
     {
       "label": "formatOrderItems()",
@@ -2785,7 +2785,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L64",
       "id": "orderupdateemails_formatorderitems",
-      "community": 3
+      "community": 8
     },
     {
       "label": "handleOrderStatusUpdate()",
@@ -2793,7 +2793,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L118",
       "id": "orderupdateemails_handleorderstatusupdate",
-      "community": 3
+      "community": 8
     },
     {
       "label": "processOrderUpdateEmail()",
@@ -2801,7 +2801,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L293",
       "id": "orderupdateemails_processorderupdateemail",
-      "community": 3
+      "community": 8
     },
     {
       "label": "paymentHelpers.ts",
@@ -2809,7 +2809,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
       "source_location": "L1",
       "id": "paymenthelpers",
-      "community": 3
+      "community": 2
     },
     {
       "label": "generatePODReference()",
@@ -2817,7 +2817,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
       "source_location": "L9",
       "id": "paymenthelpers_generatepodreference",
-      "community": 3
+      "community": 2
     },
     {
       "label": "extractOrderItems()",
@@ -2825,7 +2825,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
       "source_location": "L18",
       "id": "paymenthelpers_extractorderitems",
-      "community": 3
+      "community": 2
     },
     {
       "label": "calculateOrderAmount()",
@@ -2833,7 +2833,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
       "source_location": "L35",
       "id": "paymenthelpers_calculateorderamount",
-      "community": 3
+      "community": 2
     },
     {
       "label": "calculateRewardPoints()",
@@ -2841,7 +2841,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
       "source_location": "L53",
       "id": "paymenthelpers_calculaterewardpoints",
-      "community": 3
+      "community": 2
     },
     {
       "label": "validatePaymentAmount()",
@@ -2849,7 +2849,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
       "source_location": "L61",
       "id": "paymenthelpers_validatepaymentamount",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getOrderDiscountValue()",
@@ -2857,7 +2857,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
       "source_location": "L75",
       "id": "paymenthelpers_getorderdiscountvalue",
-      "community": 3
+      "community": 2
     },
     {
       "label": "isDuplicate()",
@@ -2865,7 +2865,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
       "source_location": "L36",
       "id": "offers_isduplicate",
-      "community": 6
+      "community": 14
     },
     {
       "label": "updateStoreFrontActorEmail()",
@@ -2873,7 +2873,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
       "source_location": "L59",
       "id": "offers_updatestorefrontactoremail",
-      "community": 6
+      "community": 14
     },
     {
       "label": "createOffer()",
@@ -2881,7 +2881,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
       "source_location": "L88",
       "id": "offers_createoffer",
-      "community": 6
+      "community": 14
     },
     {
       "label": "getUpsellProducts()",
@@ -2889,7 +2889,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
       "source_location": "L685",
       "id": "offers_getupsellproducts",
-      "community": 6
+      "community": 14
     },
     {
       "label": "listOrderItems()",
@@ -2897,7 +2897,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
       "source_location": "L27",
       "id": "onlineorder_listorderitems",
-      "community": 3
+      "community": 2
     },
     {
       "label": "updateOnlineOrderItem()",
@@ -2905,7 +2905,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderItem.ts",
       "source_location": "L21",
       "id": "onlineorderitem_updateonlineorderitem",
-      "community": 3
+      "community": 2
     },
     {
       "label": "onlineOrderUtilFns.ts",
@@ -2913,7 +2913,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderUtilFns.ts",
       "source_location": "L1",
       "id": "onlineorderutilfns",
-      "community": 3
+      "community": 8
     },
     {
       "label": "paystackActions.ts",
@@ -2921,7 +2921,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/paystackActions.ts",
       "source_location": "L1",
       "id": "paystackactions",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getStoreFrontActorById()",
@@ -2929,7 +2929,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/reviews.ts",
       "source_location": "L17",
       "id": "reviews_getstorefrontactorbyid",
-      "community": 12
+      "community": 9
     },
     {
       "label": "listSavedBagItems()",
@@ -2945,7 +2945,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.test.ts",
       "source_location": "L1",
       "id": "storefrontobservabilityreport_test",
-      "community": 17
+      "community": 13
     },
     {
       "label": "createAnalyticsEvent()",
@@ -2953,7 +2953,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.test.ts",
       "source_location": "L7",
       "id": "storefrontobservabilityreport_test_createanalyticsevent",
-      "community": 17
+      "community": 13
     },
     {
       "label": "storefrontObservabilityReport.ts",
@@ -2961,7 +2961,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
       "source_location": "L1",
       "id": "storefrontobservabilityreport",
-      "community": 17
+      "community": 13
     },
     {
       "label": "getNonEmptyString()",
@@ -2969,7 +2969,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
       "source_location": "L59",
       "id": "storefrontobservabilityreport_getnonemptystring",
-      "community": 17
+      "community": 13
     },
     {
       "label": "normalizeStorefrontObservabilityEvent()",
@@ -2977,7 +2977,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
       "source_location": "L63",
       "id": "storefrontobservabilityreport_normalizestorefrontobservabilityevent",
-      "community": 17
+      "community": 13
     },
     {
       "label": "buildStorefrontObservabilityReport()",
@@ -2985,7 +2985,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
       "source_location": "L95",
       "id": "storefrontobservabilityreport_buildstorefrontobservabilityreport",
-      "community": 17
+      "community": 13
     },
     {
       "label": "timeQueryRefactors.test.ts",
@@ -3009,7 +3009,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/user.ts",
       "source_location": "L15",
       "id": "user_getstorefrontactorbyid",
-      "community": 3
+      "community": 2
     },
     {
       "label": "determineOfferEligibility()",
@@ -3017,7 +3017,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/userOffers.ts",
       "source_location": "L30",
       "id": "useroffers_determineoffereligibility",
-      "community": 6
+      "community": 2
     },
     {
       "label": "users.ts",
@@ -3025,7 +3025,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/users.ts",
       "source_location": "L1",
       "id": "users",
-      "community": 3
+      "community": 2
     },
     {
       "label": "toSlug()",
@@ -3033,7 +3033,7 @@
       "source_file": "packages/athena-webapp/src/lib/utils.ts",
       "source_location": "L37",
       "id": "utils_toslug",
-      "community": 2
+      "community": 0
     },
     {
       "label": "getAddressString()",
@@ -3041,7 +3041,7 @@
       "source_file": "packages/athena-webapp/convex/utils.ts",
       "source_location": "L14",
       "id": "utils_getaddressstring",
-      "community": 2
+      "community": 0
     },
     {
       "label": "capitalizeWords()",
@@ -3049,7 +3049,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L23",
       "id": "utils_capitalizewords",
-      "community": 2
+      "community": 0
     },
     {
       "label": "currencyFormatter()",
@@ -3057,7 +3057,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L35",
       "id": "utils_currencyformatter",
-      "community": 2
+      "community": 0
     },
     {
       "label": "formatDate()",
@@ -3065,7 +3065,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L44",
       "id": "utils_formatdate",
-      "community": 2
+      "community": 0
     },
     {
       "label": "getProductName()",
@@ -3073,7 +3073,7 @@
       "source_file": "packages/athena-webapp/convex/utils.ts",
       "source_location": "L64",
       "id": "utils_getproductname",
-      "community": 2
+      "community": 0
     },
     {
       "label": "generateTransactionNumber()",
@@ -3081,7 +3081,7 @@
       "source_file": "packages/athena-webapp/convex/utils.ts",
       "source_location": "L77",
       "id": "utils_generatetransactionnumber",
-      "community": 2
+      "community": 0
     },
     {
       "label": "eslint.config.js",
@@ -3113,7 +3113,7 @@
       "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
       "source_location": "L1",
       "id": "navbar",
-      "community": 1
+      "community": 0
     },
     {
       "label": "SettingsHeader()",
@@ -3121,7 +3121,7 @@
       "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
       "source_location": "L20",
       "id": "navbar_settingsheader",
-      "community": 1
+      "community": 0
     },
     {
       "label": "AppHeader()",
@@ -3129,7 +3129,7 @@
       "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
       "source_location": "L61",
       "id": "navbar_appheader",
-      "community": 1
+      "community": 0
     },
     {
       "label": "Header()",
@@ -3137,7 +3137,7 @@
       "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
       "source_location": "L75",
       "id": "navbar_header",
-      "community": 1
+      "community": 0
     },
     {
       "label": "Navbar()",
@@ -3145,7 +3145,7 @@
       "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
       "source_location": "L116",
       "id": "navbar_navbar",
-      "community": 1
+      "community": 0
     },
     {
       "label": "OrganizationView.tsx",
@@ -3153,7 +3153,7 @@
       "source_file": "packages/athena-webapp/src/components/OrganizationView.tsx",
       "source_location": "L1",
       "id": "organizationview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "Navigation()",
@@ -3161,7 +3161,7 @@
       "source_file": "packages/athena-webapp/src/components/OrganizationView.tsx",
       "source_location": "L7",
       "id": "organizationview_navigation",
-      "community": 1
+      "community": 0
     },
     {
       "label": "OrganizationsView.tsx",
@@ -3169,7 +3169,7 @@
       "source_file": "packages/athena-webapp/src/components/OrganizationsView.tsx",
       "source_location": "L1",
       "id": "organizationsview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "Navigation()",
@@ -3177,7 +3177,7 @@
       "source_file": "packages/athena-webapp/src/components/OrganizationsView.tsx",
       "source_location": "L12",
       "id": "organizationsview_navigation",
-      "community": 1
+      "community": 0
     },
     {
       "label": "PermissionGate.tsx",
@@ -3185,7 +3185,7 @@
       "source_file": "packages/athena-webapp/src/components/PermissionGate.tsx",
       "source_location": "L1",
       "id": "permissiongate",
-      "community": 1
+      "community": 0
     },
     {
       "label": "PermissionGate()",
@@ -3193,7 +3193,7 @@
       "source_file": "packages/athena-webapp/src/components/PermissionGate.tsx",
       "source_location": "L11",
       "id": "permissiongate_permissiongate",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ProtectedRoute.tsx",
@@ -3201,7 +3201,7 @@
       "source_file": "packages/athena-webapp/src/components/ProtectedRoute.tsx",
       "source_location": "L1",
       "id": "protectedroute",
-      "community": 7
+      "community": 4
     },
     {
       "label": "ProtectedRoute()",
@@ -3209,7 +3209,7 @@
       "source_file": "packages/athena-webapp/src/components/ProtectedRoute.tsx",
       "source_location": "L11",
       "id": "protectedroute_protectedroute",
-      "community": 7
+      "community": 4
     },
     {
       "label": "SettingsView.tsx",
@@ -3217,7 +3217,7 @@
       "source_file": "packages/athena-webapp/src/components/SettingsView.tsx",
       "source_location": "L1",
       "id": "settingsview",
-      "community": 1
+      "community": 6
     },
     {
       "label": "SettingsView()",
@@ -3225,7 +3225,7 @@
       "source_file": "packages/athena-webapp/src/components/SettingsView.tsx",
       "source_location": "L3",
       "id": "settingsview_settingsview",
-      "community": 1
+      "community": 6
     },
     {
       "label": "StoreAccordion.tsx",
@@ -3241,7 +3241,7 @@
       "source_file": "packages/athena-webapp/src/components/StoreActions.tsx",
       "source_location": "L1",
       "id": "storeactions",
-      "community": 0
+      "community": 17
     },
     {
       "label": "StoreActions()",
@@ -3249,7 +3249,7 @@
       "source_file": "packages/athena-webapp/src/components/StoreActions.tsx",
       "source_location": "L12",
       "id": "storeactions_storeactions",
-      "community": 0
+      "community": 17
     },
     {
       "label": "StoreDropdown.tsx",
@@ -3257,7 +3257,7 @@
       "source_file": "packages/athena-webapp/src/components/StoreDropdown.tsx",
       "source_location": "L1",
       "id": "storedropdown",
-      "community": 0
+      "community": 17
     },
     {
       "label": "StoreDropdown()",
@@ -3265,7 +3265,7 @@
       "source_file": "packages/athena-webapp/src/components/StoreDropdown.tsx",
       "source_location": "L42",
       "id": "storedropdown_storedropdown",
-      "community": 0
+      "community": 17
     },
     {
       "label": "StoreView.tsx",
@@ -3273,7 +3273,7 @@
       "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
       "source_location": "L1",
       "id": "storeview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "Navigation()",
@@ -3281,7 +3281,7 @@
       "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
       "source_location": "L13",
       "id": "storeview_navigation",
-      "community": 1
+      "community": 0
     },
     {
       "label": "StoresAccordion.tsx",
@@ -3289,7 +3289,7 @@
       "source_file": "packages/athena-webapp/src/components/StoresAccordion.tsx",
       "source_location": "L1",
       "id": "storesaccordion",
-      "community": 0
+      "community": 17
     },
     {
       "label": "StoresDropdown.tsx",
@@ -3297,7 +3297,7 @@
       "source_file": "packages/athena-webapp/src/components/StoresDropdown.tsx",
       "source_location": "L1",
       "id": "storesdropdown",
-      "community": 0
+      "community": 17
     },
     {
       "label": "StoresDropdown()",
@@ -3305,7 +3305,7 @@
       "source_file": "packages/athena-webapp/src/components/StoresDropdown.tsx",
       "source_location": "L42",
       "id": "storesdropdown_storesdropdown",
-      "community": 0
+      "community": 17
     },
     {
       "label": "ThemeToggle.tsx",
@@ -3321,7 +3321,7 @@
       "source_file": "packages/storefront-webapp/src/components/View.tsx",
       "source_location": "L1",
       "id": "view",
-      "community": 1
+      "community": 0
     },
     {
       "label": "View()",
@@ -3329,7 +3329,7 @@
       "source_file": "packages/storefront-webapp/src/components/View.tsx",
       "source_location": "L4",
       "id": "view_view",
-      "community": 1
+      "community": 0
     },
     {
       "label": "AttributesManager.tsx",
@@ -3337,7 +3337,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
       "source_location": "L1",
       "id": "attributesmanager",
-      "community": 5
+      "community": 1
     },
     {
       "label": "Sidebar()",
@@ -3345,7 +3345,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
       "source_location": "L26",
       "id": "attributesmanager_sidebar",
-      "community": 5
+      "community": 1
     },
     {
       "label": "ColorManager()",
@@ -3353,7 +3353,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
       "source_location": "L45",
       "id": "attributesmanager_colormanager",
-      "community": 5
+      "community": 1
     },
     {
       "label": "AttributesManager()",
@@ -3361,7 +3361,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
       "source_location": "L228",
       "id": "attributesmanager_attributesmanager",
-      "community": 5
+      "community": 1
     },
     {
       "label": "AttributesTable.tsx",
@@ -3369,7 +3369,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
       "source_location": "L1",
       "id": "attributestable",
-      "community": 1
+      "community": 8
     },
     {
       "label": "handleChange()",
@@ -3377,7 +3377,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
       "source_location": "L32",
       "id": "attributestable_handlechange",
-      "community": 1
+      "community": 8
     },
     {
       "label": "getProductAttribute()",
@@ -3385,7 +3385,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
       "source_location": "L55",
       "id": "attributestable_getproductattribute",
-      "community": 1
+      "community": 8
     },
     {
       "label": "onSubmit()",
@@ -3393,7 +3393,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
       "source_location": "L210",
       "id": "attributestable_onsubmit",
-      "community": 1
+      "community": 8
     },
     {
       "label": "BarcodeQRViewer.tsx",
@@ -3417,7 +3417,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
       "source_location": "L1",
       "id": "categorysubcategorymanager",
-      "community": 5
+      "community": 20
     },
     {
       "label": "Sidebar()",
@@ -3425,7 +3425,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
       "source_location": "L26",
       "id": "categorysubcategorymanager_sidebar",
-      "community": 5
+      "community": 20
     },
     {
       "label": "CategoryManager()",
@@ -3433,7 +3433,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
       "source_location": "L51",
       "id": "categorysubcategorymanager_categorymanager",
-      "community": 5
+      "community": 20
     },
     {
       "label": "SubcategoryManager()",
@@ -3441,7 +3441,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
       "source_location": "L290",
       "id": "categorysubcategorymanager_subcategorymanager",
-      "community": 5
+      "community": 20
     },
     {
       "label": "DefaultAttributesToggleGroup.tsx",
@@ -3449,7 +3449,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/DefaultAttributesToggleGroup.tsx",
       "source_location": "L1",
       "id": "defaultattributestogglegroup",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ProcessingFees.tsx",
@@ -3457,7 +3457,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProcessingFees.tsx",
       "source_location": "L1",
       "id": "processingfees",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ProcessingFeesView()",
@@ -3465,7 +3465,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProcessingFees.tsx",
       "source_location": "L10",
       "id": "processingfees_processingfeesview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ProductAttributes.tsx",
@@ -3473,7 +3473,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttributes.tsx",
       "source_location": "L1",
       "id": "productattributes",
-      "community": 1
+      "community": 0
     },
     {
       "label": "isAllowedAttribute()",
@@ -3481,7 +3481,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAttributes.tsx",
       "source_location": "L14",
       "id": "productattributes_isallowedattribute",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ProductAttributesView.tsx",
@@ -3497,7 +3497,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
       "source_location": "L1",
       "id": "productavailability",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ProductAvailabilityView()",
@@ -3505,7 +3505,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
       "source_location": "L5",
       "id": "productavailability_productavailabilityview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ProductAvailability()",
@@ -3513,7 +3513,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
       "source_location": "L18",
       "id": "productavailability_productavailability",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ProductAvailabilityToggleGroup.tsx",
@@ -3521,7 +3521,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailabilityToggleGroup.tsx",
       "source_location": "L1",
       "id": "productavailabilitytogglegroup",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ProductAvailabilityToggleGroup()",
@@ -3529,7 +3529,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailabilityToggleGroup.tsx",
       "source_location": "L5",
       "id": "productavailabilitytogglegroup_productavailabilitytogglegroup",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ProductCategorization.tsx",
@@ -3537,7 +3537,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
       "source_location": "L1",
       "id": "productcategorization",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleClose()",
@@ -3545,7 +3545,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
       "source_location": "L203",
       "id": "productcategorization_handleclose",
-      "community": 1
+      "community": 0
     },
     {
       "label": "setInitialSelectedOption()",
@@ -3553,7 +3553,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
       "source_location": "L230",
       "id": "productcategorization_setinitialselectedoption",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleProductVisibility()",
@@ -3561,7 +3561,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
       "source_location": "L243",
       "id": "productcategorization_handleproductvisibility",
-      "community": 1
+      "community": 0
     },
     {
       "label": "getProductName()",
@@ -3569,7 +3569,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
       "source_location": "L286",
       "id": "productcategorization_getproductname",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ProductDetails.tsx",
@@ -3577,7 +3577,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
       "source_location": "L1",
       "id": "productdetails",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleNameChange()",
@@ -3585,7 +3585,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductDetails.tsx",
       "source_location": "L10",
       "id": "productdetails_handlenamechange",
-      "community": 0
+      "community": 1
     },
     {
       "label": "ProductImages.tsx",
@@ -3593,7 +3593,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductImages.tsx",
       "source_location": "L1",
       "id": "productimages",
-      "community": 1
+      "community": 0
     },
     {
       "label": "Header()",
@@ -3601,7 +3601,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductImages.tsx",
       "source_location": "L15",
       "id": "productimages_header",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ProductPage.tsx",
@@ -3625,7 +3625,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
       "source_location": "L1",
       "id": "productstock",
-      "community": 9
+      "community": 8
     },
     {
       "label": "restock()",
@@ -3633,7 +3633,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L107",
       "id": "productstock_restock",
-      "community": 9
+      "community": 8
     },
     {
       "label": "isSkuReserved()",
@@ -3641,7 +3641,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L174",
       "id": "productstock_isskureserved",
-      "community": 9
+      "community": 8
     },
     {
       "label": "getReservationType()",
@@ -3649,7 +3649,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L178",
       "id": "productstock_getreservationtype",
-      "community": 9
+      "community": 8
     },
     {
       "label": "handleGenerateBarcode()",
@@ -3657,7 +3657,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L239",
       "id": "productstock_handlegeneratebarcode",
-      "community": 9
+      "community": 8
     },
     {
       "label": "handleSaveBarcode()",
@@ -3665,7 +3665,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L285",
       "id": "productstock_handlesavebarcode",
-      "community": 9
+      "community": 8
     },
     {
       "label": "handleViewBarcode()",
@@ -3673,7 +3673,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L300",
       "id": "productstock_handleviewbarcode",
-      "community": 9
+      "community": 8
     },
     {
       "label": "handleClearBarcodeClick()",
@@ -3681,7 +3681,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L308",
       "id": "productstock_handleclearbarcodeclick",
-      "community": 9
+      "community": 8
     },
     {
       "label": "handleClearBarcodeConfirm()",
@@ -3689,7 +3689,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L313",
       "id": "productstock_handleclearbarcodeconfirm",
-      "community": 9
+      "community": 8
     },
     {
       "label": "handleClearBarcodeCancel()",
@@ -3697,7 +3697,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L379",
       "id": "productstock_handleclearbarcodecancel",
-      "community": 9
+      "community": 8
     },
     {
       "label": "handleChange()",
@@ -3705,7 +3705,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L384",
       "id": "productstock_handlechange",
-      "community": 9
+      "community": 8
     },
     {
       "label": "addRow()",
@@ -3713,7 +3713,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L430",
       "id": "productstock_addrow",
-      "community": 9
+      "community": 8
     },
     {
       "label": "handleDeleteAction()",
@@ -3721,7 +3721,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L445",
       "id": "productstock_handledeleteaction",
-      "community": 9
+      "community": 8
     },
     {
       "label": "setOutOfStock()",
@@ -3729,7 +3729,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L462",
       "id": "productstock_setoutofstock",
-      "community": 9
+      "community": 8
     },
     {
       "label": "setVisibility()",
@@ -3737,7 +3737,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L472",
       "id": "productstock_setvisibility",
-      "community": 9
+      "community": 8
     },
     {
       "label": "isLastActiveVariant()",
@@ -3745,7 +3745,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L486",
       "id": "productstock_islastactivevariant",
-      "community": 9
+      "community": 8
     },
     {
       "label": "isLastVisibleVariant()",
@@ -3753,7 +3753,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L492",
       "id": "productstock_islastvisiblevariant",
-      "community": 9
+      "community": 8
     },
     {
       "label": "shouldDisable()",
@@ -3761,7 +3761,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L498",
       "id": "productstock_shoulddisable",
-      "community": 9
+      "community": 8
     },
     {
       "label": "hasQuantityError()",
@@ -3769,7 +3769,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L506",
       "id": "productstock_hasquantityerror",
-      "community": 9
+      "community": 8
     },
     {
       "label": "hasPriceError()",
@@ -3777,7 +3777,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L514",
       "id": "productstock_haspriceerror",
-      "community": 9
+      "community": 8
     },
     {
       "label": "ProductView.tsx",
@@ -3785,7 +3785,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L1",
       "id": "productview",
-      "community": 7
+      "community": 4
     },
     {
       "label": "deleteActiveProduct()",
@@ -3793,7 +3793,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L82",
       "id": "productview_deleteactiveproduct",
-      "community": 7
+      "community": 4
     },
     {
       "label": "saveProduct()",
@@ -3801,7 +3801,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L115",
       "id": "productview_saveproduct",
-      "community": 7
+      "community": 4
     },
     {
       "label": "modifyProduct()",
@@ -3809,7 +3809,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L170",
       "id": "productview_modifyproduct",
-      "community": 7
+      "community": 4
     },
     {
       "label": "createVariantSku()",
@@ -3817,7 +3817,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L245",
       "id": "productview_createvariantsku",
-      "community": 7
+      "community": 4
     },
     {
       "label": "updateVariantSku()",
@@ -3825,7 +3825,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L300",
       "id": "productview_updatevariantsku",
-      "community": 7
+      "community": 4
     },
     {
       "label": "onSubmit()",
@@ -3833,7 +3833,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L369",
       "id": "productview_onsubmit",
-      "community": 7
+      "community": 4
     },
     {
       "label": "handleKeyDown()",
@@ -3841,7 +3841,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L380",
       "id": "productview_handlekeydown",
-      "community": 7
+      "community": 4
     },
     {
       "label": "updateProductVisibility()",
@@ -3849,7 +3849,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L431",
       "id": "productview_updateproductvisibility",
-      "community": 7
+      "community": 4
     },
     {
       "label": "SheetProvider.tsx",
@@ -3881,7 +3881,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
       "source_location": "L1",
       "id": "wigtype",
-      "community": 1
+      "community": 0
     },
     {
       "label": "WigTypeView()",
@@ -3889,7 +3889,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
       "source_location": "L8",
       "id": "wigtype_wigtypeview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "WigType()",
@@ -3897,7 +3897,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
       "source_location": "L21",
       "id": "wigtype_wigtype",
-      "community": 1
+      "community": 0
     },
     {
       "label": "CopyImagesProvider.tsx",
@@ -3905,7 +3905,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
       "source_location": "L1",
       "id": "copyimagesprovider",
-      "community": 9
+      "community": 8
     },
     {
       "label": "useCopyImages()",
@@ -3913,7 +3913,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
       "source_location": "L13",
       "id": "copyimagesprovider_usecopyimages",
-      "community": 9
+      "community": 8
     },
     {
       "label": "CopyImagesProvider()",
@@ -3921,7 +3921,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
       "source_location": "L21",
       "id": "copyimagesprovider_copyimagesprovider",
-      "community": 9
+      "community": 8
     },
     {
       "label": "CopyImagesView.tsx",
@@ -3929,7 +3929,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesView.tsx",
       "source_location": "L1",
       "id": "copyimagesview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "setIsUpdatingSku()",
@@ -3937,7 +3937,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesView.tsx",
       "source_location": "L116",
       "id": "copyimagesview_setisupdatingsku",
-      "community": 1
+      "community": 0
     },
     {
       "label": "constants.ts",
@@ -3945,7 +3945,7 @@
       "source_file": "packages/storefront-webapp/src/lib/constants.ts",
       "source_location": "L1",
       "id": "constants",
-      "community": 0
+      "community": 1
     },
     {
       "label": "data-table-column-header.tsx",
@@ -3953,7 +3953,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "data_table_column_header",
-      "community": 2
+      "community": 0
     },
     {
       "label": "DataTableColumnHeader()",
@@ -3961,7 +3961,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-column-header.tsx",
       "source_location": "L20",
       "id": "data_table_column_header_datatablecolumnheader",
-      "community": 2
+      "community": 0
     },
     {
       "label": "data-table-faceted-filter.tsx",
@@ -3969,7 +3969,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-faceted-filter.tsx",
       "source_location": "L1",
       "id": "data_table_faceted_filter",
-      "community": 0
+      "community": 17
     },
     {
       "label": "data-table-pagination.tsx",
@@ -3977,7 +3977,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "data_table_pagination",
-      "community": 2
+      "community": 0
     },
     {
       "label": "data-table-toolbar-provider.tsx",
@@ -3985,7 +3985,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
       "source_location": "L1",
       "id": "data_table_toolbar_provider",
-      "community": 0
+      "community": 17
     },
     {
       "label": "OrdersTableToolbarProvider()",
@@ -3993,7 +3993,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
       "source_location": "L16",
       "id": "data_table_toolbar_provider_orderstabletoolbarprovider",
-      "community": 0
+      "community": 17
     },
     {
       "label": "useOrdersTableToolbar()",
@@ -4001,7 +4001,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
       "source_location": "L46",
       "id": "data_table_toolbar_provider_useorderstabletoolbar",
-      "community": 0
+      "community": 17
     },
     {
       "label": "data-table-toolbar.tsx",
@@ -4009,7 +4009,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-toolbar.tsx",
       "source_location": "L1",
       "id": "data_table_toolbar",
-      "community": 0
+      "community": 17
     },
     {
       "label": "DataTableToolbar()",
@@ -4017,7 +4017,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
       "source_location": "L23",
       "id": "data_table_toolbar_datatabletoolbar",
-      "community": 0
+      "community": 17
     },
     {
       "label": "data-table-view-options.tsx",
@@ -4025,7 +4025,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
       "source_location": "L1",
       "id": "data_table_view_options",
-      "community": 0
+      "community": 17
     },
     {
       "label": "DataTableViewOptions()",
@@ -4033,7 +4033,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
       "source_location": "L18",
       "id": "data_table_view_options_datatableviewoptions",
-      "community": 0
+      "community": 17
     },
     {
       "label": "data-table.tsx",
@@ -4041,7 +4041,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table.tsx",
       "source_location": "L1",
       "id": "data_table",
-      "community": 2
+      "community": 0
     },
     {
       "label": "product-variant-columns.tsx",
@@ -4049,7 +4049,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
       "source_location": "L1",
       "id": "product_variant_columns",
-      "community": 9
+      "community": 8
     },
     {
       "label": "setSourceVariant()",
@@ -4057,7 +4057,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
       "source_location": "L47",
       "id": "product_variant_columns_setsourcevariant",
-      "community": 9
+      "community": 8
     },
     {
       "label": "ActivityTimeline.tsx",
@@ -4065,7 +4065,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/ActivityTimeline.tsx",
       "source_location": "L1",
       "id": "activitytimeline",
-      "community": 2
+      "community": 0
     },
     {
       "label": "capitalizeFirstLetter()",
@@ -4073,7 +4073,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/ActivityTimeline.tsx",
       "source_location": "L151",
       "id": "activitytimeline_capitalizefirstletter",
-      "community": 2
+      "community": 0
     },
     {
       "label": "AnalyticsCombinedUsers.tsx",
@@ -4081,7 +4081,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
       "source_location": "L1",
       "id": "analyticscombinedusers",
-      "community": 2
+      "community": 0
     },
     {
       "label": "processAnalyticsToUsers()",
@@ -4089,7 +4089,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
       "source_location": "L10",
       "id": "analyticscombinedusers_processanalyticstousers",
-      "community": 2
+      "community": 0
     },
     {
       "label": "AnalyticsCombinedUsers()",
@@ -4097,7 +4097,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
       "source_location": "L100",
       "id": "analyticscombinedusers_analyticscombinedusers",
-      "community": 2
+      "community": 0
     },
     {
       "label": "AnalyticsItems.tsx",
@@ -4105,7 +4105,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsItems.tsx",
       "source_location": "L1",
       "id": "analyticsitems",
-      "community": 2
+      "community": 0
     },
     {
       "label": "AnalyticsItems()",
@@ -4113,7 +4113,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsItems.tsx",
       "source_location": "L6",
       "id": "analyticsitems_analyticsitems",
-      "community": 2
+      "community": 0
     },
     {
       "label": "AnalyticsProducts.tsx",
@@ -4121,7 +4121,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsProducts.tsx",
       "source_location": "L1",
       "id": "analyticsproducts",
-      "community": 2
+      "community": 0
     },
     {
       "label": "AnalyticsProducts()",
@@ -4129,7 +4129,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsProducts.tsx",
       "source_location": "L19",
       "id": "analyticsproducts_analyticsproducts",
-      "community": 2
+      "community": 0
     },
     {
       "label": "AnalyticsTopUsers.tsx",
@@ -4137,7 +4137,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsTopUsers.tsx",
       "source_location": "L1",
       "id": "analyticstopusers",
-      "community": 2
+      "community": 0
     },
     {
       "label": "processAnalyticsToUsers()",
@@ -4145,7 +4145,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsTopUsers.tsx",
       "source_location": "L10",
       "id": "analyticstopusers_processanalyticstousers",
-      "community": 2
+      "community": 0
     },
     {
       "label": "AnalyticsTopUsers()",
@@ -4153,7 +4153,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsTopUsers.tsx",
       "source_location": "L100",
       "id": "analyticstopusers_analyticstopusers",
-      "community": 2
+      "community": 0
     },
     {
       "label": "AnalyticsUsers.tsx",
@@ -4161,7 +4161,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsUsers.tsx",
       "source_location": "L1",
       "id": "analyticsusers",
-      "community": 2
+      "community": 0
     },
     {
       "label": "AnalyticsUsers()",
@@ -4169,7 +4169,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsUsers.tsx",
       "source_location": "L7",
       "id": "analyticsusers_analyticsusers",
-      "community": 2
+      "community": 0
     },
     {
       "label": "AnalyticsView.tsx",
@@ -4177,7 +4177,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
       "source_location": "L1",
       "id": "analyticsview",
-      "community": 2
+      "community": 0
     },
     {
       "label": "StoreVisitors()",
@@ -4185,7 +4185,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
       "source_location": "L14",
       "id": "analyticsview_storevisitors",
-      "community": 2
+      "community": 0
     },
     {
       "label": "ActiveCheckoutSessions()",
@@ -4193,7 +4193,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
       "source_location": "L44",
       "id": "analyticsview_activecheckoutsessions",
-      "community": 2
+      "community": 0
     },
     {
       "label": "AnalyticsView()",
@@ -4201,7 +4201,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
       "source_location": "L84",
       "id": "analyticsview_analyticsview",
-      "community": 2
+      "community": 0
     },
     {
       "label": "ConversionFunnelChart.tsx",
@@ -4209,7 +4209,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/ConversionFunnelChart.tsx",
       "source_location": "L1",
       "id": "conversionfunnelchart",
-      "community": 2
+      "community": 0
     },
     {
       "label": "EnhancedAnalyticsView.tsx",
@@ -4217,7 +4217,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/EnhancedAnalyticsView.tsx",
       "source_location": "L1",
       "id": "enhancedanalyticsview",
-      "community": 2
+      "community": 0
     },
     {
       "label": "getDateRangeMilliseconds()",
@@ -4225,7 +4225,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/EnhancedAnalyticsView.tsx",
       "source_location": "L42",
       "id": "enhancedanalyticsview_getdaterangemilliseconds",
-      "community": 2
+      "community": 0
     },
     {
       "label": "RevenueChart.tsx",
@@ -4233,7 +4233,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/RevenueChart.tsx",
       "source_location": "L1",
       "id": "revenuechart",
-      "community": 2
+      "community": 0
     },
     {
       "label": "getTrendIcon()",
@@ -4241,7 +4241,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/StoreInsights.tsx",
       "source_location": "L66",
       "id": "storeinsights_gettrendicon",
-      "community": 3
+      "community": 2
     },
     {
       "label": "StorefrontObservabilityPanel.tsx",
@@ -4249,7 +4249,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
       "source_location": "L1",
       "id": "storefrontobservabilitypanel",
-      "community": 2
+      "community": 0
     },
     {
       "label": "formatLabel()",
@@ -4257,7 +4257,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
       "source_location": "L15",
       "id": "storefrontobservabilitypanel_formatlabel",
-      "community": 2
+      "community": 0
     },
     {
       "label": "SummaryCard()",
@@ -4265,7 +4265,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
       "source_location": "L19",
       "id": "storefrontobservabilitypanel_summarycard",
-      "community": 2
+      "community": 0
     },
     {
       "label": "VisitorChart.tsx",
@@ -4273,7 +4273,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/VisitorChart.tsx",
       "source_location": "L1",
       "id": "visitorchart",
-      "community": 2
+      "community": 0
     },
     {
       "label": "formatHour()",
@@ -4281,7 +4281,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/VisitorChart.tsx",
       "source_location": "L18",
       "id": "visitorchart_formathour",
-      "community": 2
+      "community": 0
     },
     {
       "label": "analytics-columns.tsx",
@@ -4289,7 +4289,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/analytics-columns.tsx",
       "source_location": "L1",
       "id": "analytics_columns",
-      "community": 2
+      "community": 0
     },
     {
       "label": "data-table-row-actions.tsx",
@@ -4297,7 +4297,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-row-actions.tsx",
       "source_location": "L1",
       "id": "data_table_row_actions",
-      "community": 0
+      "community": 1
     },
     {
       "label": "DataTableRowActions()",
@@ -4305,7 +4305,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-row-actions.tsx",
       "source_location": "L25",
       "id": "data_table_row_actions_datatablerowactions",
-      "community": 0
+      "community": 1
     },
     {
       "label": "selectable-data-provider.tsx",
@@ -4313,7 +4313,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
       "source_location": "L1",
       "id": "selectable_data_provider",
-      "community": 7
+      "community": 0
     },
     {
       "label": "SelectedProductsProvider()",
@@ -4321,7 +4321,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
       "source_location": "L16",
       "id": "selectable_data_provider_selectedproductsprovider",
-      "community": 7
+      "community": 0
     },
     {
       "label": "useSelectedProducts()",
@@ -4329,7 +4329,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
       "source_location": "L37",
       "id": "selectable_data_provider_useselectedproducts",
-      "community": 7
+      "community": 0
     },
     {
       "label": "columns.tsx",
@@ -4337,7 +4337,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/columns.tsx",
       "source_location": "L1",
       "id": "columns",
-      "community": 2
+      "community": 0
     },
     {
       "label": "chart.tsx",
@@ -4345,7 +4345,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/chart.tsx",
       "source_location": "L1",
       "id": "chart",
-      "community": 2
+      "community": 3
     },
     {
       "label": "data.ts",
@@ -4353,7 +4353,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data.ts",
       "source_location": "L1",
       "id": "data",
-      "community": 0
+      "community": 17
     },
     {
       "label": "groupAnalytics()",
@@ -4361,7 +4361,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
       "source_location": "L3",
       "id": "utils_groupanalytics",
-      "community": 2
+      "community": 0
     },
     {
       "label": "countGroupedAnalytics()",
@@ -4369,7 +4369,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
       "source_location": "L52",
       "id": "utils_countgroupedanalytics",
-      "community": 2
+      "community": 0
     },
     {
       "label": "groupProductViewsByDay()",
@@ -4377,7 +4377,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
       "source_location": "L90",
       "id": "utils_groupproductviewsbyday",
-      "community": 2
+      "community": 0
     },
     {
       "label": "LogItems.tsx",
@@ -4385,7 +4385,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/LogItems.tsx",
       "source_location": "L1",
       "id": "logitems",
-      "community": 2
+      "community": 0
     },
     {
       "label": "LogItems()",
@@ -4393,7 +4393,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/LogItems.tsx",
       "source_location": "L6",
       "id": "logitems_logitems",
-      "community": 2
+      "community": 0
     },
     {
       "label": "LogView.tsx",
@@ -4401,7 +4401,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/LogView.tsx",
       "source_location": "L1",
       "id": "logview",
-      "community": 7
+      "community": 4
     },
     {
       "label": "Header()",
@@ -4409,7 +4409,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/LogView.tsx",
       "source_location": "L10",
       "id": "logview_header",
-      "community": 7
+      "community": 4
     },
     {
       "label": "LogsView.tsx",
@@ -4417,7 +4417,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
       "source_location": "L1",
       "id": "logsview",
-      "community": 9
+      "community": 0
     },
     {
       "label": "Navigation()",
@@ -4425,7 +4425,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
       "source_location": "L27",
       "id": "logsview_navigation",
-      "community": 9
+      "community": 0
     },
     {
       "label": "log-items-provider.tsx",
@@ -4433,7 +4433,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
       "source_location": "L1",
       "id": "log_items_provider",
-      "community": 2
+      "community": 0
     },
     {
       "label": "LogItemsProvider()",
@@ -4441,7 +4441,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
       "source_location": "L15",
       "id": "log_items_provider_logitemsprovider",
-      "community": 2
+      "community": 0
     },
     {
       "label": "useLogItems()",
@@ -4449,7 +4449,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
       "source_location": "L39",
       "id": "log_items_provider_uselogitems",
-      "community": 2
+      "community": 0
     },
     {
       "label": "useLoadLogItems.ts",
@@ -4457,7 +4457,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/hooks/useLoadLogItems.ts",
       "source_location": "L1",
       "id": "useloadlogitems",
-      "community": 3
+      "community": 0
     },
     {
       "label": "useLoadLogItems()",
@@ -4465,7 +4465,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/hooks/useLoadLogItems.ts",
       "source_location": "L12",
       "id": "useloadlogitems_useloadlogitems",
-      "community": 3
+      "community": 0
     },
     {
       "label": "app-sidebar.tsx",
@@ -4473,7 +4473,7 @@
       "source_file": "packages/athena-webapp/src/components/app-sidebar.tsx",
       "source_location": "L1",
       "id": "app_sidebar",
-      "community": 1
+      "community": 0
     },
     {
       "label": "assetsColumns.tsx",
@@ -4481,7 +4481,7 @@
       "source_file": "packages/athena-webapp/src/components/assets/assets-table/assetsColumns.tsx",
       "source_location": "L1",
       "id": "assetscolumns",
-      "community": 2
+      "community": 0
     },
     {
       "label": "Header()",
@@ -4489,7 +4489,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
       "source_location": "L42",
       "id": "index_header",
-      "community": 1
+      "community": 6
     },
     {
       "label": "FeesView()",
@@ -4497,7 +4497,7 @@
       "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
       "source_location": "L29",
       "id": "index_feesview",
-      "community": 1
+      "community": 6
     },
     {
       "label": "Auth()",
@@ -4505,7 +4505,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Auth.tsx",
       "source_location": "L3",
       "id": "auth_auth",
-      "community": 3
+      "community": 2
     },
     {
       "label": "DefaultCatchBoundary.tsx",
@@ -4513,7 +4513,7 @@
       "source_file": "packages/storefront-webapp/src/components/DefaultCatchBoundary.tsx",
       "source_location": "L1",
       "id": "defaultcatchboundary",
-      "community": 8
+      "community": 5
     },
     {
       "label": "InputOTP.tsx",
@@ -4521,7 +4521,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
       "source_location": "L1",
       "id": "inputotp",
-      "community": 5
+      "community": 1
     },
     {
       "label": "handlePinChange()",
@@ -4529,7 +4529,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
       "source_location": "L48",
       "id": "inputotp_handlepinchange",
-      "community": 5
+      "community": 1
     },
     {
       "label": "onSubmit()",
@@ -4537,7 +4537,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
       "source_location": "L56",
       "id": "inputotp_onsubmit",
-      "community": 5
+      "community": 1
     },
     {
       "label": "LoginForm.tsx",
@@ -4545,7 +4545,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Login/LoginForm.tsx",
       "source_location": "L1",
       "id": "loginform",
-      "community": 5
+      "community": 1
     },
     {
       "label": "Login()",
@@ -4553,7 +4553,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Login/index.tsx",
       "source_location": "L5",
       "id": "index_login",
-      "community": 1
+      "community": 6
     },
     {
       "label": "BulkOperationsFilters.tsx",
@@ -4577,7 +4577,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPage.tsx",
       "source_location": "L1",
       "id": "bulkoperationspage",
-      "community": 1
+      "community": 0
     },
     {
       "label": "BulkOperationsPreview.test.tsx",
@@ -4585,7 +4585,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.test.tsx",
       "source_location": "L1",
       "id": "bulkoperationspreview_test",
-      "community": 13
+      "community": 8
     },
     {
       "label": "makeRow()",
@@ -4593,7 +4593,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.test.tsx",
       "source_location": "L23",
       "id": "bulkoperationspreview_test_makerow",
-      "community": 13
+      "community": 8
     },
     {
       "label": "BulkOperationsPreview.tsx",
@@ -4601,7 +4601,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.tsx",
       "source_location": "L1",
       "id": "bulkoperationspreview",
-      "community": 13
+      "community": 8
     },
     {
       "label": "formatPrice()",
@@ -4609,7 +4609,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.tsx",
       "source_location": "L50",
       "id": "bulkoperationspreview_formatprice",
-      "community": 13
+      "community": 8
     },
     {
       "label": "CashierManagement.tsx",
@@ -4617,7 +4617,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L1",
       "id": "cashiermanagement",
-      "community": 5
+      "community": 1
     },
     {
       "label": "normalizeNameSegment()",
@@ -4625,7 +4625,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L42",
       "id": "cashiermanagement_normalizenamesegment",
-      "community": 5
+      "community": 1
     },
     {
       "label": "buildUsername()",
@@ -4633,7 +4633,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L50",
       "id": "cashiermanagement_buildusername",
-      "community": 5
+      "community": 1
     },
     {
       "label": "handleSubmit()",
@@ -4641,7 +4641,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L109",
       "id": "cashiermanagement_handlesubmit",
-      "community": 5
+      "community": 1
     },
     {
       "label": "handlePinKeyDown()",
@@ -4649,7 +4649,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L169",
       "id": "cashiermanagement_handlepinkeydown",
-      "community": 5
+      "community": 1
     },
     {
       "label": "handleDelete()",
@@ -4657,7 +4657,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L320",
       "id": "cashiermanagement_handledelete",
-      "community": 5
+      "community": 1
     },
     {
       "label": "CheckoutSessionsTable.tsx",
@@ -4665,7 +4665,7 @@
       "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSessionsTable.tsx",
       "source_location": "L1",
       "id": "checkoutsessionstable",
-      "community": 1
+      "community": 0
     },
     {
       "label": "CheckoutSessionsTable()",
@@ -4673,7 +4673,7 @@
       "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSessionsTable.tsx",
       "source_location": "L13",
       "id": "checkoutsessionstable_checkoutsessionstable",
-      "community": 1
+      "community": 0
     },
     {
       "label": "CheckoutSesssionsView.tsx",
@@ -4681,7 +4681,7 @@
       "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSesssionsView.tsx",
       "source_location": "L1",
       "id": "checkoutsesssionsview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "Navigation()",
@@ -4689,7 +4689,7 @@
       "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSesssionsView.tsx",
       "source_location": "L11",
       "id": "checkoutsesssionsview_navigation",
-      "community": 1
+      "community": 0
     },
     {
       "label": "FadeIn.tsx",
@@ -4697,7 +4697,7 @@
       "source_file": "packages/storefront-webapp/src/components/common/FadeIn.tsx",
       "source_location": "L1",
       "id": "fadein",
-      "community": 1
+      "community": 0
     },
     {
       "label": "FadeIn()",
@@ -4705,7 +4705,7 @@
       "source_file": "packages/storefront-webapp/src/components/common/FadeIn.tsx",
       "source_location": "L3",
       "id": "fadein_fadein",
-      "community": 1
+      "community": 0
     },
     {
       "label": "PageHeader.tsx",
@@ -4713,7 +4713,7 @@
       "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
       "source_location": "L1",
       "id": "pageheader",
-      "community": 1
+      "community": 0
     },
     {
       "label": "PageHeader()",
@@ -4721,7 +4721,7 @@
       "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
       "source_location": "L7",
       "id": "pageheader_pageheader",
-      "community": 1
+      "community": 0
     },
     {
       "label": "Dashboard.tsx",
@@ -4729,7 +4729,7 @@
       "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
       "source_location": "L1",
       "id": "dashboard",
-      "community": 2
+      "community": 4
     },
     {
       "label": "getPeriodRange()",
@@ -4737,7 +4737,7 @@
       "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
       "source_location": "L20",
       "id": "dashboard_getperiodrange",
-      "community": 2
+      "community": 4
     },
     {
       "label": "LoadingSection()",
@@ -4745,7 +4745,7 @@
       "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
       "source_location": "L50",
       "id": "dashboard_loadingsection",
-      "community": 2
+      "community": 4
     },
     {
       "label": "renderSalesSection()",
@@ -4753,7 +4753,7 @@
       "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
       "source_location": "L322",
       "id": "dashboard_rendersalessection",
-      "community": 2
+      "community": 4
     },
     {
       "label": "renderProductsSection()",
@@ -4761,7 +4761,7 @@
       "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
       "source_location": "L342",
       "id": "dashboard_renderproductssection",
-      "community": 2
+      "community": 4
     },
     {
       "label": "MetricCard.tsx",
@@ -4769,7 +4769,7 @@
       "source_file": "packages/athena-webapp/src/components/dashboard/MetricCard.tsx",
       "source_location": "L1",
       "id": "metriccard",
-      "community": 2
+      "community": 4
     },
     {
       "label": "ExpenseCompletion.tsx",
@@ -4777,7 +4777,7 @@
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseCompletion.tsx",
       "source_location": "L1",
       "id": "expensecompletion",
-      "community": 4
+      "community": 3
     },
     {
       "label": "ExpenseView.tsx",
@@ -4785,7 +4785,7 @@
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
       "source_location": "L1",
       "id": "expenseview",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleSessionLoaded()",
@@ -4793,7 +4793,7 @@
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
       "source_location": "L60",
       "id": "expenseview_handlesessionloaded",
-      "community": 4
+      "community": 3
     },
     {
       "label": "resetAutoSessionInitialized()",
@@ -4801,7 +4801,7 @@
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
       "source_location": "L64",
       "id": "expenseview_resetautosessioninitialized",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleNewSession()",
@@ -4809,7 +4809,7 @@
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
       "source_location": "L68",
       "id": "expenseview_handlenewsession",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleCashierAuthenticated()",
@@ -4817,7 +4817,7 @@
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
       "source_location": "L86",
       "id": "expenseview_handlecashierauthenticated",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleBarcodeSubmit()",
@@ -4825,7 +4825,7 @@
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
       "source_location": "L295",
       "id": "expenseview_handlebarcodesubmit",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleClearCart()",
@@ -4833,7 +4833,7 @@
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
       "source_location": "L322",
       "id": "expenseview_handleclearcart",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleCompleteExpense()",
@@ -4841,7 +4841,7 @@
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
       "source_location": "L335",
       "id": "expenseview_handlecompleteexpense",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleNavigateBack()",
@@ -4849,7 +4849,7 @@
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
       "source_location": "L383",
       "id": "expenseview_handlenavigateback",
-      "community": 4
+      "community": 3
     },
     {
       "label": "BannerMessageEditor.tsx",
@@ -4857,7 +4857,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L1",
       "id": "bannermessageeditor",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleSave()",
@@ -4865,7 +4865,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L46",
       "id": "bannermessageeditor_handlesave",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleClear()",
@@ -4873,7 +4873,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L66",
       "id": "bannermessageeditor_handleclear",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleActiveToggle()",
@@ -4881,7 +4881,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L91",
       "id": "bannermessageeditor_handleactivetoggle",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleCountdownChange()",
@@ -4889,7 +4889,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L113",
       "id": "bannermessageeditor_handlecountdownchange",
-      "community": 1
+      "community": 0
     },
     {
       "label": "getCountdownStatus()",
@@ -4897,7 +4897,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L123",
       "id": "bannermessageeditor_getcountdownstatus",
-      "community": 1
+      "community": 0
     },
     {
       "label": "BestSellers.tsx",
@@ -4905,7 +4905,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
       "source_location": "L1",
       "id": "bestsellers",
-      "community": 4
+      "community": 0
     },
     {
       "label": "handleRemoveBestSeller()",
@@ -4913,7 +4913,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
       "source_location": "L53",
       "id": "bestsellers_handleremovebestseller",
-      "community": 4
+      "community": 0
     },
     {
       "label": "onDragEnd()",
@@ -4921,7 +4921,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
       "source_location": "L65",
       "id": "bestsellers_ondragend",
-      "community": 4
+      "community": 0
     },
     {
       "label": "BestSellersDialog.tsx",
@@ -4929,7 +4929,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BestSellersDialog.tsx",
       "source_location": "L1",
       "id": "bestsellersdialog",
-      "community": 4
+      "community": 0
     },
     {
       "label": "handleAddBestSeller()",
@@ -4937,7 +4937,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BestSellersDialog.tsx",
       "source_location": "L29",
       "id": "bestsellersdialog_handleaddbestseller",
-      "community": 4
+      "community": 0
     },
     {
       "label": "FeaturedSection.tsx",
@@ -4945,7 +4945,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
       "source_location": "L1",
       "id": "featuredsection",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleHighlightedItem()",
@@ -4953,7 +4953,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
       "source_location": "L47",
       "id": "featuredsection_handlehighlighteditem",
-      "community": 1
+      "community": 0
     },
     {
       "label": "onDragEnd()",
@@ -4961,7 +4961,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
       "source_location": "L53",
       "id": "featuredsection_ondragend",
-      "community": 1
+      "community": 0
     },
     {
       "label": "FeaturedSectionDialog.tsx",
@@ -4969,7 +4969,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSectionDialog.tsx",
       "source_location": "L1",
       "id": "featuredsectiondialog",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleAddFeaturedItem()",
@@ -4977,7 +4977,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSectionDialog.tsx",
       "source_location": "L37",
       "id": "featuredsectiondialog_handleaddfeatureditem",
-      "community": 1
+      "community": 0
     },
     {
       "label": "HeroHeaderImageUploader.tsx",
@@ -4985,7 +4985,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L1",
       "id": "heroheaderimageuploader",
-      "community": 14
+      "community": 12
     },
     {
       "label": "validateFile()",
@@ -4993,7 +4993,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L50",
       "id": "heroheaderimageuploader_validatefile",
-      "community": 14
+      "community": 12
     },
     {
       "label": "uploadImage()",
@@ -5001,7 +5001,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L67",
       "id": "heroheaderimageuploader_uploadimage",
-      "community": 14
+      "community": 12
     },
     {
       "label": "resetEditState()",
@@ -5009,7 +5009,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L95",
       "id": "heroheaderimageuploader_reseteditstate",
-      "community": 14
+      "community": 12
     },
     {
       "label": "handleEditClick()",
@@ -5017,7 +5017,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L108",
       "id": "heroheaderimageuploader_handleeditclick",
-      "community": 14
+      "community": 12
     },
     {
       "label": "handleFileSelect()",
@@ -5025,7 +5025,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L113",
       "id": "heroheaderimageuploader_handlefileselect",
-      "community": 14
+      "community": 12
     },
     {
       "label": "handleUpload()",
@@ -5033,7 +5033,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L127",
       "id": "heroheaderimageuploader_handleupload",
-      "community": 14
+      "community": 12
     },
     {
       "label": "handleRevert()",
@@ -5041,7 +5041,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L163",
       "id": "heroheaderimageuploader_handlerevert",
-      "community": 14
+      "community": 12
     },
     {
       "label": "EditModeButtons()",
@@ -5049,7 +5049,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L179",
       "id": "heroheaderimageuploader_editmodebuttons",
-      "community": 14
+      "community": 12
     },
     {
       "label": "ViewModeButton()",
@@ -5057,7 +5057,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L205",
       "id": "heroheaderimageuploader_viewmodebutton",
-      "community": 14
+      "community": 12
     },
     {
       "label": "HeroSectionTabs.tsx",
@@ -5065,7 +5065,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
       "source_location": "L1",
       "id": "herosectiontabs",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleImageUpdate()",
@@ -5073,7 +5073,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
       "source_location": "L57",
       "id": "herosectiontabs_handleimageupdate",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleDisplayTypeChange()",
@@ -5081,7 +5081,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
       "source_location": "L61",
       "id": "herosectiontabs_handledisplaytypechange",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleOverlayToggle()",
@@ -5089,7 +5089,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
       "source_location": "L98",
       "id": "herosectiontabs_handleoverlaytoggle",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleTextToggle()",
@@ -5097,7 +5097,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
       "source_location": "L134",
       "id": "herosectiontabs_handletexttoggle",
-      "community": 1
+      "community": 0
     },
     {
       "label": "home.tsx",
@@ -5105,7 +5105,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/home.tsx",
       "source_location": "L1",
       "id": "home",
-      "community": 1
+      "community": 0
     },
     {
       "label": "Navigation()",
@@ -5113,7 +5113,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/Home.tsx",
       "source_location": "L25",
       "id": "home_navigation",
-      "community": 1
+      "community": 0
     },
     {
       "label": "LandingPageReelVersion.tsx",
@@ -5121,7 +5121,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/LandingPageReelVersion.tsx",
       "source_location": "L1",
       "id": "landingpagereelversion",
-      "community": 16
+      "community": 0
     },
     {
       "label": "handleUpdateConfig()",
@@ -5129,7 +5129,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/LandingPageReelVersion.tsx",
       "source_location": "L83",
       "id": "landingpagereelversion_handleupdateconfig",
-      "community": 16
+      "community": 0
     },
     {
       "label": "MaintenanceMessageEditor.tsx",
@@ -5137,7 +5137,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
       "source_location": "L1",
       "id": "maintenancemessageeditor",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleSave()",
@@ -5145,7 +5145,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
       "source_location": "L52",
       "id": "maintenancemessageeditor_handlesave",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleCountdownChange()",
@@ -5153,7 +5153,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
       "source_location": "L76",
       "id": "maintenancemessageeditor_handlecountdownchange",
-      "community": 1
+      "community": 0
     },
     {
       "label": "getCountdownStatus()",
@@ -5161,7 +5161,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
       "source_location": "L86",
       "id": "maintenancemessageeditor_getcountdownstatus",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ReelUploader.tsx",
@@ -5169,7 +5169,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
       "source_location": "L1",
       "id": "reeluploader",
-      "community": 5
+      "community": 0
     },
     {
       "label": "formatFileSize()",
@@ -5177,7 +5177,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
       "source_location": "L38",
       "id": "reeluploader_formatfilesize",
-      "community": 5
+      "community": 0
     },
     {
       "label": "validateFile()",
@@ -5185,7 +5185,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
       "source_location": "L43",
       "id": "reeluploader_validatefile",
-      "community": 5
+      "community": 0
     },
     {
       "label": "handleFileSelect()",
@@ -5193,7 +5193,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
       "source_location": "L64",
       "id": "reeluploader_handlefileselect",
-      "community": 5
+      "community": 0
     },
     {
       "label": "handleUpload()",
@@ -5201,7 +5201,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
       "source_location": "L135",
       "id": "reeluploader_handleupload",
-      "community": 5
+      "community": 0
     },
     {
       "label": "ShopLook.tsx",
@@ -5209,7 +5209,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
       "source_location": "L1",
       "id": "shoplook",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleHighlightedItem()",
@@ -5217,7 +5217,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
       "source_location": "L67",
       "id": "shoplook_handlehighlighteditem",
-      "community": 1
+      "community": 0
     },
     {
       "label": "onDragEnd()",
@@ -5225,7 +5225,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
       "source_location": "L73",
       "id": "shoplook_ondragend",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleImageUpdate()",
@@ -5233,7 +5233,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
       "source_location": "L90",
       "id": "shoplook_handleimageupdate",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ShopLookDialog.tsx",
@@ -5241,7 +5241,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ShopLookDialog.tsx",
       "source_location": "L1",
       "id": "shoplookdialog",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleAddFeaturedItem()",
@@ -5249,7 +5249,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ShopLookDialog.tsx",
       "source_location": "L35",
       "id": "shoplookdialog_handleaddfeatureditem",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ShopLookImageUploader.tsx",
@@ -5257,7 +5257,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
       "source_location": "L1",
       "id": "shoplookimageuploader",
-      "community": 14
+      "community": 0
     },
     {
       "label": "ShopLookImageUploader()",
@@ -5265,7 +5265,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
       "source_location": "L28",
       "id": "shoplookimageuploader_shoplookimageuploader",
-      "community": 14
+      "community": 0
     },
     {
       "label": "VideoPlayer.tsx",
@@ -5273,7 +5273,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
       "source_location": "L1",
       "id": "videoplayer",
-      "community": 16
+      "community": 1
     },
     {
       "label": "VideoPlayer()",
@@ -5281,7 +5281,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
       "source_location": "L9",
       "id": "videoplayer_videoplayer",
-      "community": 16
+      "community": 1
     },
     {
       "label": "JoinTeam()",
@@ -5289,7 +5289,7 @@
       "source_file": "packages/athena-webapp/src/components/join-team/index.tsx",
       "source_location": "L11",
       "id": "index_jointeam",
-      "community": 1
+      "community": 6
     },
     {
       "label": "ActivityView.tsx",
@@ -5297,7 +5297,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
       "source_location": "L1",
       "id": "activityview",
-      "community": 19
+      "community": 0
     },
     {
       "label": "isRefundAction()",
@@ -5305,7 +5305,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
       "source_location": "L50",
       "id": "activityview_isrefundaction",
-      "community": 19
+      "community": 0
     },
     {
       "label": "isTransitionAction()",
@@ -5313,7 +5313,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
       "source_location": "L53",
       "id": "activityview_istransitionaction",
-      "community": 19
+      "community": 0
     },
     {
       "label": "isCreatedAction()",
@@ -5321,7 +5321,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
       "source_location": "L58",
       "id": "activityview_iscreatedaction",
-      "community": 19
+      "community": 0
     },
     {
       "label": "isFeedbackRequestAction()",
@@ -5329,7 +5329,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
       "source_location": "L63",
       "id": "activityview_isfeedbackrequestaction",
-      "community": 19
+      "community": 0
     },
     {
       "label": "CustomerDetailsView.tsx",
@@ -5337,7 +5337,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/CustomerDetailsView.tsx",
       "source_location": "L1",
       "id": "customerdetailsview",
-      "community": 2
+      "community": 0
     },
     {
       "label": "CustomerDetailsView()",
@@ -5345,7 +5345,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/CustomerDetailsView.tsx",
       "source_location": "L13",
       "id": "customerdetailsview_customerdetailsview",
-      "community": 2
+      "community": 0
     },
     {
       "label": "EmailStatusView.tsx",
@@ -5353,7 +5353,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/EmailStatusView.tsx",
       "source_location": "L1",
       "id": "emailstatusview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleSendOrderEmail()",
@@ -5361,7 +5361,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/EmailStatusView.tsx",
       "source_location": "L41",
       "id": "emailstatusview_handlesendorderemail",
-      "community": 1
+      "community": 0
     },
     {
       "label": "OrderDetailsView.tsx",
@@ -5369,7 +5369,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
       "source_location": "L1",
       "id": "orderdetailsview",
-      "community": 19
+      "community": 0
     },
     {
       "label": "VerifiedBadge()",
@@ -5377,7 +5377,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
       "source_location": "L41",
       "id": "orderdetailsview_verifiedbadge",
-      "community": 19
+      "community": 0
     },
     {
       "label": "fetchTransactions()",
@@ -5385,7 +5385,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
       "source_location": "L136",
       "id": "orderdetailsview_fetchtransactions",
-      "community": 19
+      "community": 0
     },
     {
       "label": "handleMarkAsVerified()",
@@ -5393,7 +5393,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
       "source_location": "L173",
       "id": "orderdetailsview_handlemarkasverified",
-      "community": 19
+      "community": 0
     },
     {
       "label": "handleMarkPaymentCollected()",
@@ -5401,7 +5401,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
       "source_location": "L187",
       "id": "orderdetailsview_handlemarkpaymentcollected",
-      "community": 19
+      "community": 0
     },
     {
       "label": "OrderItemsView.tsx",
@@ -5409,7 +5409,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
       "source_location": "L1",
       "id": "orderitemsview",
-      "community": 19
+      "community": 0
     },
     {
       "label": "handleUpdateOrderItem()",
@@ -5417,7 +5417,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
       "source_location": "L47",
       "id": "orderitemsview_handleupdateorderitem",
-      "community": 19
+      "community": 0
     },
     {
       "label": "handleReturnItemToStock()",
@@ -5425,7 +5425,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
       "source_location": "L61",
       "id": "orderitemsview_handlereturnitemtostock",
-      "community": 19
+      "community": 0
     },
     {
       "label": "handleRequestFeedback()",
@@ -5433,7 +5433,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
       "source_location": "L77",
       "id": "orderitemsview_handlerequestfeedback",
-      "community": 19
+      "community": 0
     },
     {
       "label": "handleRestockAll()",
@@ -5441,7 +5441,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
       "source_location": "L295",
       "id": "orderitemsview_handlerestockall",
-      "community": 19
+      "community": 0
     },
     {
       "label": "OrderMetricsPanel.tsx",
@@ -5449,7 +5449,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
       "source_location": "L1",
       "id": "ordermetricspanel",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleTimeRangeChange()",
@@ -5457,7 +5457,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
       "source_location": "L33",
       "id": "ordermetricspanel_handletimerangechange",
-      "community": 1
+      "community": 0
     },
     {
       "label": "OrderStatus.tsx",
@@ -5465,7 +5465,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderStatus.tsx",
       "source_location": "L1",
       "id": "orderstatus",
-      "community": 2
+      "community": 0
     },
     {
       "label": "OrderSummary.tsx",
@@ -5473,7 +5473,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/OrderSummary.tsx",
       "source_location": "L1",
       "id": "ordersummary",
-      "community": 4
+      "community": 3
     },
     {
       "label": "OrderView.tsx",
@@ -5505,7 +5505,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/Orders.tsx",
       "source_location": "L1",
       "id": "orders",
-      "community": 2
+      "community": 0
     },
     {
       "label": "OrdersView.tsx",
@@ -5513,7 +5513,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
       "source_location": "L1",
       "id": "ordersview",
-      "community": 7
+      "community": 4
     },
     {
       "label": "getTimeFilter()",
@@ -5521,7 +5521,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
       "source_location": "L35",
       "id": "ordersview_gettimefilter",
-      "community": 7
+      "community": 4
     },
     {
       "label": "PickupDetailsView.tsx",
@@ -5529,7 +5529,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/PickupDetailsView.tsx",
       "source_location": "L1",
       "id": "pickupdetailsview",
-      "community": 5
+      "community": 0
     },
     {
       "label": "PickupDetailsView()",
@@ -5537,7 +5537,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/PickupDetailsView.tsx",
       "source_location": "L9",
       "id": "pickupdetailsview_pickupdetailsview",
-      "community": 5
+      "community": 0
     },
     {
       "label": "DeliveryDetails()",
@@ -5545,7 +5545,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/PickupDetailsView.tsx",
       "source_location": "L67",
       "id": "pickupdetailsview_deliverydetails",
-      "community": 5
+      "community": 0
     },
     {
       "label": "RefundsView.tsx",
@@ -5569,7 +5569,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/hooks/useGetActiveOnlineOrder.ts",
       "source_location": "L1",
       "id": "usegetactiveonlineorder",
-      "community": 19
+      "community": 0
     },
     {
       "label": "useGetActiveOnlineOrder()",
@@ -5577,7 +5577,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/hooks/useGetActiveOnlineOrder.ts",
       "source_location": "L6",
       "id": "usegetactiveonlineorder_usegetactiveonlineorder",
-      "community": 19
+      "community": 0
     },
     {
       "label": "handleClearFilters()",
@@ -5585,7 +5585,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar.tsx",
       "source_location": "L34",
       "id": "data_table_toolbar_handleclearfilters",
-      "community": 0
+      "community": 17
     },
     {
       "label": "orderColumns.tsx",
@@ -5593,7 +5593,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/orderColumns.tsx",
       "source_location": "L1",
       "id": "ordercolumns",
-      "community": 2
+      "community": 0
     },
     {
       "label": "if()",
@@ -5601,7 +5601,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/orderColumns.tsx",
       "source_location": "L89",
       "id": "ordercolumns_if",
-      "community": 2
+      "community": 0
     },
     {
       "label": "refundUtils.ts",
@@ -5609,7 +5609,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L1",
       "id": "refundutils",
-      "community": 23
+      "community": 24
     },
     {
       "label": "refundReducer()",
@@ -5617,7 +5617,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L31",
       "id": "refundutils_refundreducer",
-      "community": 23
+      "community": 24
     },
     {
       "label": "getAmountRefunded()",
@@ -5625,7 +5625,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L98",
       "id": "refundutils_getamountrefunded",
-      "community": 23
+      "community": 24
     },
     {
       "label": "getNetAmount()",
@@ -5633,7 +5633,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L106",
       "id": "refundutils_getnetamount",
-      "community": 23
+      "community": 24
     },
     {
       "label": "getAvailableItems()",
@@ -5641,7 +5641,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L115",
       "id": "refundutils_getavailableitems",
-      "community": 23
+      "community": 24
     },
     {
       "label": "calculateRefundAmount()",
@@ -5649,7 +5649,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L124",
       "id": "refundutils_calculaterefundamount",
-      "community": 23
+      "community": 24
     },
     {
       "label": "getItemsToRefund()",
@@ -5657,7 +5657,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L174",
       "id": "refundutils_getitemstorefund",
-      "community": 23
+      "community": 24
     },
     {
       "label": "validateRefund()",
@@ -5665,7 +5665,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L199",
       "id": "refundutils_validaterefund",
-      "community": 23
+      "community": 24
     },
     {
       "label": "shouldShowReturnToStock()",
@@ -5673,7 +5673,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L255",
       "id": "refundutils_shouldshowreturntostock",
-      "community": 23
+      "community": 24
     },
     {
       "label": "getOrderState()",
@@ -5681,7 +5681,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
       "source_location": "L1",
       "id": "utils_getorderstate",
-      "community": 2
+      "community": 0
     },
     {
       "label": "getAmountPaidForOrder()",
@@ -5689,7 +5689,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
       "source_location": "L108",
       "id": "utils_getamountpaidfororder",
-      "community": 2
+      "community": 0
     },
     {
       "label": "onSubmit()",
@@ -5697,7 +5697,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
       "source_location": "L105",
       "id": "index_onsubmit",
-      "community": 1
+      "community": 6
     },
     {
       "label": "inviteColumns.tsx",
@@ -5705,7 +5705,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/inviteColumns.tsx",
       "source_location": "L1",
       "id": "invitecolumns",
-      "community": 2
+      "community": 0
     },
     {
       "label": "membersColumns.tsx",
@@ -5713,7 +5713,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/membersColumns.tsx",
       "source_location": "L1",
       "id": "memberscolumns",
-      "community": 2
+      "community": 0
     },
     {
       "label": "organization-switcher.tsx",
@@ -5721,7 +5721,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-switcher.tsx",
       "source_location": "L1",
       "id": "organization_switcher",
-      "community": 0
+      "community": 17
     },
     {
       "label": "onOrganizationSelect()",
@@ -5729,7 +5729,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-switcher.tsx",
       "source_location": "L94",
       "id": "organization_switcher_onorganizationselect",
-      "community": 0
+      "community": 17
     },
     {
       "label": "handleSignOut()",
@@ -5737,7 +5737,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-switcher.tsx",
       "source_location": "L99",
       "id": "organization_switcher_handlesignout",
-      "community": 0
+      "community": 17
     },
     {
       "label": "CartItems.tsx",
@@ -5745,7 +5745,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CartItems.tsx",
       "source_location": "L1",
       "id": "cartitems",
-      "community": 1
+      "community": 0
     },
     {
       "label": "CashierAuthDialog.tsx",
@@ -5753,7 +5753,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx",
       "source_location": "L1",
       "id": "cashierauthdialog",
-      "community": 5
+      "community": 1
     },
     {
       "label": "CashierView.tsx",
@@ -5761,7 +5761,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CashierView.tsx",
       "source_location": "L1",
       "id": "cashierview",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleSignOut()",
@@ -5769,7 +5769,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CashierView.tsx",
       "source_location": "L63",
       "id": "cashierview_handlesignout",
-      "community": 4
+      "community": 3
     },
     {
       "label": "CustomerInfoPanel.tsx",
@@ -5777,7 +5777,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
       "source_location": "L1",
       "id": "customerinfopanel",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleSelectCustomer()",
@@ -5785,7 +5785,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
       "source_location": "L59",
       "id": "customerinfopanel_handleselectcustomer",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleCreateCustomer()",
@@ -5793,7 +5793,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
       "source_location": "L77",
       "id": "customerinfopanel_handlecreatecustomer",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleStartEdit()",
@@ -5801,7 +5801,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
       "source_location": "L105",
       "id": "customerinfopanel_handlestartedit",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleSaveEdit()",
@@ -5809,7 +5809,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
       "source_location": "L115",
       "id": "customerinfopanel_handlesaveedit",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleCancelEdit()",
@@ -5817,7 +5817,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
       "source_location": "L146",
       "id": "customerinfopanel_handlecanceledit",
-      "community": 4
+      "community": 3
     },
     {
       "label": "clearCustomer()",
@@ -5825,7 +5825,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
       "source_location": "L155",
       "id": "customerinfopanel_clearcustomer",
-      "community": 4
+      "community": 3
     },
     {
       "label": "DebugProducts.tsx",
@@ -5833,7 +5833,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/DebugProducts.tsx",
       "source_location": "L1",
       "id": "debugproducts",
-      "community": 3
+      "community": 0
     },
     {
       "label": "DebugProducts()",
@@ -5841,7 +5841,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/DebugProducts.tsx",
       "source_location": "L5",
       "id": "debugproducts_debugproducts",
-      "community": 3
+      "community": 0
     },
     {
       "label": "NewTransactionView.tsx",
@@ -5849,7 +5849,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
       "source_location": "L1",
       "id": "newtransactionview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "Navigation()",
@@ -5857,7 +5857,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
       "source_location": "L22",
       "id": "newtransactionview_navigation",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleStartTransaction()",
@@ -5865,7 +5865,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
       "source_location": "L68",
       "id": "newtransactionview_handlestarttransaction",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleQuickStart()",
@@ -5873,7 +5873,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
       "source_location": "L91",
       "id": "newtransactionview_handlequickstart",
-      "community": 1
+      "community": 0
     },
     {
       "label": "NoResultsMessage.tsx",
@@ -5897,7 +5897,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
       "source_location": "L128",
       "id": "ordersummary_handlecompletetransaction",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleSelectedPaymentMethod()",
@@ -5905,7 +5905,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
       "source_location": "L150",
       "id": "ordersummary_handleselectedpaymentmethod",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleNewTransaction()",
@@ -5913,7 +5913,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
       "source_location": "L162",
       "id": "ordersummary_handlenewtransaction",
-      "community": 4
+      "community": 3
     },
     {
       "label": "POSRegisterView.tsx",
@@ -5921,7 +5921,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/POSRegisterView.tsx",
       "source_location": "L1",
       "id": "posregisterview",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleSessionLoaded()",
@@ -5929,7 +5929,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/POSRegisterView.tsx",
       "source_location": "L83",
       "id": "posregisterview_handlesessionloaded",
-      "community": 4
+      "community": 3
     },
     {
       "label": "resetAutoSessionInitialized()",
@@ -5937,7 +5937,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/POSRegisterView.tsx",
       "source_location": "L87",
       "id": "posregisterview_resetautosessioninitialized",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleNewSession()",
@@ -5945,7 +5945,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/POSRegisterView.tsx",
       "source_location": "L92",
       "id": "posregisterview_handlenewsession",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleCashierAuthenticated()",
@@ -5953,7 +5953,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/POSRegisterView.tsx",
       "source_location": "L133",
       "id": "posregisterview_handlecashierauthenticated",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleBarcodeSubmit()",
@@ -5961,7 +5961,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/POSRegisterView.tsx",
       "source_location": "L606",
       "id": "posregisterview_handlebarcodesubmit",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleClearCart()",
@@ -5969,7 +5969,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/POSRegisterView.tsx",
       "source_location": "L678",
       "id": "posregisterview_handleclearcart",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleNavigateBack()",
@@ -5977,7 +5977,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/POSRegisterView.tsx",
       "source_location": "L709",
       "id": "posregisterview_handlenavigateback",
-      "community": 4
+      "community": 3
     },
     {
       "label": "PaymentView.tsx",
@@ -5985,7 +5985,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
       "source_location": "L1",
       "id": "paymentview",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleAddPayment()",
@@ -5993,7 +5993,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
       "source_location": "L178",
       "id": "paymentview_handleaddpayment",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleClearAll()",
@@ -6001,7 +6001,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
       "source_location": "L219",
       "id": "paymentview_handleclearall",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleAmountChange()",
@@ -6009,7 +6009,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
       "source_location": "L224",
       "id": "paymentview_handleamountchange",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleAmountBlur()",
@@ -6017,7 +6017,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
       "source_location": "L253",
       "id": "paymentview_handleamountblur",
-      "community": 4
+      "community": 3
     },
     {
       "label": "PaymentsAddedList.tsx",
@@ -6025,7 +6025,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L1",
       "id": "paymentsaddedlist",
-      "community": 4
+      "community": 3
     },
     {
       "label": "getPaymentMethodLabel()",
@@ -6033,7 +6033,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L18",
       "id": "paymentsaddedlist_getpaymentmethodlabel",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleStartEdit()",
@@ -6041,7 +6041,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L57",
       "id": "paymentsaddedlist_handlestartedit",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleSaveEdit()",
@@ -6049,7 +6049,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L62",
       "id": "paymentsaddedlist_handlesaveedit",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleCancelEdit()",
@@ -6057,7 +6057,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L93",
       "id": "paymentsaddedlist_handlecanceledit",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleRemovePayment()",
@@ -6065,7 +6065,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L98",
       "id": "paymentsaddedlist_handleremovepayment",
-      "community": 4
+      "community": 3
     },
     {
       "label": "PinInput.tsx",
@@ -6073,7 +6073,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
       "source_location": "L1",
       "id": "pininput",
-      "community": 5
+      "community": 1
     },
     {
       "label": "PinInput()",
@@ -6081,7 +6081,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
       "source_location": "L13",
       "id": "pininput_pininput",
-      "community": 5
+      "community": 1
     },
     {
       "label": "PointOfSaleView.tsx",
@@ -6089,7 +6089,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
       "source_location": "L1",
       "id": "pointofsaleview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "Navigation()",
@@ -6097,7 +6097,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
       "source_location": "L34",
       "id": "pointofsaleview_navigation",
-      "community": 1
+      "community": 0
     },
     {
       "label": "PrintInstructions.tsx",
@@ -6121,7 +6121,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductCard.tsx",
       "source_location": "L1",
       "id": "productcard",
-      "community": 4
+      "community": 9
     },
     {
       "label": "ProductCard()",
@@ -6129,7 +6129,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/ProductCard.tsx",
       "source_location": "L14",
       "id": "productcard_productcard",
-      "community": 4
+      "community": 9
     },
     {
       "label": "ProductEntry.tsx",
@@ -6137,7 +6137,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
       "source_location": "L1",
       "id": "productentry",
-      "community": 4
+      "community": 1
     },
     {
       "label": "handleClearSearch()",
@@ -6145,7 +6145,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
       "source_location": "L86",
       "id": "productentry_handleclearsearch",
-      "community": 4
+      "community": 1
     },
     {
       "label": "ProductLookup.tsx",
@@ -6153,7 +6153,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/ProductLookup.tsx",
       "source_location": "L1",
       "id": "productlookup",
-      "community": 4
+      "community": 1
     },
     {
       "label": "QuickActionsBar.tsx",
@@ -6161,7 +6161,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/QuickActionsBar.tsx",
       "source_location": "L1",
       "id": "quickactionsbar",
-      "community": 4
+      "community": 3
     },
     {
       "label": "QuickActionsBar()",
@@ -6169,7 +6169,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/QuickActionsBar.tsx",
       "source_location": "L11",
       "id": "quickactionsbar_quickactionsbar",
-      "community": 4
+      "community": 3
     },
     {
       "label": "RegisterActions.tsx",
@@ -6177,7 +6177,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/RegisterActions.tsx",
       "source_location": "L1",
       "id": "registeractions",
-      "community": 4
+      "community": 3
     },
     {
       "label": "SearchResultsSection.tsx",
@@ -6185,7 +6185,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SearchResultsSection.tsx",
       "source_location": "L1",
       "id": "searchresultssection",
-      "community": 4
+      "community": 9
     },
     {
       "label": "SessionDemo.tsx",
@@ -6193,7 +6193,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionDemo.tsx",
       "source_location": "L1",
       "id": "sessiondemo",
-      "community": 2
+      "community": 0
     },
     {
       "label": "SessionDemo()",
@@ -6201,7 +6201,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionDemo.tsx",
       "source_location": "L15",
       "id": "sessiondemo_sessiondemo",
-      "community": 2
+      "community": 0
     },
     {
       "label": "SessionManager.tsx",
@@ -6209,7 +6209,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
       "source_location": "L1",
       "id": "sessionmanager",
-      "community": 4
+      "community": 3
     },
     {
       "label": "onHoldConfirm()",
@@ -6217,7 +6217,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
       "source_location": "L72",
       "id": "sessionmanager_onholdconfirm",
-      "community": 4
+      "community": 3
     },
     {
       "label": "onResumeSession()",
@@ -6225,7 +6225,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
       "source_location": "L77",
       "id": "sessionmanager_onresumesession",
-      "community": 4
+      "community": 3
     },
     {
       "label": "onVoidConfirm()",
@@ -6233,7 +6233,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
       "source_location": "L90",
       "id": "sessionmanager_onvoidconfirm",
-      "community": 4
+      "community": 3
     },
     {
       "label": "onNewSessionClick()",
@@ -6241,7 +6241,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
       "source_location": "L96",
       "id": "sessionmanager_onnewsessionclick",
-      "community": 4
+      "community": 3
     },
     {
       "label": "TotalsDisplay.tsx",
@@ -6249,7 +6249,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.tsx",
       "source_location": "L1",
       "id": "totalsdisplay",
-      "community": 4
+      "community": 3
     },
     {
       "label": "TotalsDisplay()",
@@ -6257,7 +6257,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.tsx",
       "source_location": "L12",
       "id": "totalsdisplay_totalsdisplay",
-      "community": 4
+      "community": 3
     },
     {
       "label": "ExpenseReportView.tsx",
@@ -6265,7 +6265,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportView.tsx",
       "source_location": "L1",
       "id": "expensereportview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ExpenseReportsView.tsx",
@@ -6273,7 +6273,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
       "source_location": "L1",
       "id": "expensereportsview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "isToday()",
@@ -6281,7 +6281,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
       "source_location": "L17",
       "id": "expensereportsview_istoday",
-      "community": 1
+      "community": 0
     },
     {
       "label": "expenseReportColumns.tsx",
@@ -6289,7 +6289,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/expense-reports/expenseReportColumns.tsx",
       "source_location": "L1",
       "id": "expensereportcolumns",
-      "community": 2
+      "community": 0
     },
     {
       "label": "hooks.ts",
@@ -6297,7 +6297,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
       "source_location": "L1",
       "id": "hooks",
-      "community": 0
+      "community": 5
     },
     {
       "label": "usePOSCashier()",
@@ -6305,7 +6305,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/hooks.ts",
       "source_location": "L5",
       "id": "hooks_useposcashier",
-      "community": 0
+      "community": 5
     },
     {
       "label": "HeldSessionsList.tsx",
@@ -6313,7 +6313,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx",
       "source_location": "L1",
       "id": "heldsessionslist",
-      "community": 4
+      "community": 3
     },
     {
       "label": "hasExpired()",
@@ -6321,7 +6321,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx",
       "source_location": "L54",
       "id": "heldsessionslist_hasexpired",
-      "community": 4
+      "community": 3
     },
     {
       "label": "getSessionCartItemsCount()",
@@ -6329,7 +6329,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx",
       "source_location": "L58",
       "id": "heldsessionslist_getsessioncartitemscount",
-      "community": 4
+      "community": 3
     },
     {
       "label": "HoldSessionDialog.tsx",
@@ -6337,7 +6337,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/HoldSessionDialog.tsx",
       "source_location": "L1",
       "id": "holdsessiondialog",
-      "community": 5
+      "community": 1
     },
     {
       "label": "HoldSessionDialog()",
@@ -6345,7 +6345,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/HoldSessionDialog.tsx",
       "source_location": "L19",
       "id": "holdsessiondialog_holdsessiondialog",
-      "community": 5
+      "community": 1
     },
     {
       "label": "VoidSessionDialog.tsx",
@@ -6353,7 +6353,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/VoidSessionDialog.tsx",
       "source_location": "L1",
       "id": "voidsessiondialog",
-      "community": 5
+      "community": 1
     },
     {
       "label": "VoidSessionDialog()",
@@ -6361,7 +6361,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/VoidSessionDialog.tsx",
       "source_location": "L19",
       "id": "voidsessiondialog_voidsessiondialog",
-      "community": 5
+      "community": 1
     },
     {
       "label": "POSSettingsView.tsx",
@@ -6369,7 +6369,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
       "source_location": "L1",
       "id": "possettingsview",
-      "community": 7
+      "community": 4
     },
     {
       "label": "loadFingerprint()",
@@ -6377,7 +6377,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
       "source_location": "L166",
       "id": "possettingsview_loadfingerprint",
-      "community": 7
+      "community": 4
     },
     {
       "label": "handleRegisterTerminal()",
@@ -6385,7 +6385,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
       "source_location": "L247",
       "id": "possettingsview_handleregisterterminal",
-      "community": 7
+      "community": 4
     },
     {
       "label": "handleUpdateExistingTerminal()",
@@ -6393,7 +6393,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
       "source_location": "L284",
       "id": "possettingsview_handleupdateexistingterminal",
-      "community": 7
+      "community": 4
     },
     {
       "label": "TransactionView.tsx",
@@ -6401,7 +6401,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
       "source_location": "L1",
       "id": "transactionview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "TransactionsView.tsx",
@@ -6409,7 +6409,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
       "source_location": "L1",
       "id": "transactionsview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "formatPaymentMethod()",
@@ -6417,7 +6417,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
       "source_location": "L19",
       "id": "transactionsview_formatpaymentmethod",
-      "community": 1
+      "community": 0
     },
     {
       "label": "isToday()",
@@ -6425,7 +6425,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
       "source_location": "L25",
       "id": "transactionsview_istoday",
-      "community": 1
+      "community": 0
     },
     {
       "label": "transactionColumns.tsx",
@@ -6433,7 +6433,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
       "source_location": "L1",
       "id": "transactioncolumns",
-      "community": 2
+      "community": 0
     },
     {
       "label": "getPaymentMethodIcon()",
@@ -6441,7 +6441,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
       "source_location": "L22",
       "id": "transactioncolumns_getpaymentmethodicon",
-      "community": 2
+      "community": 0
     },
     {
       "label": "AnalyticsInsights.tsx",
@@ -6449,7 +6449,7 @@
       "source_file": "packages/athena-webapp/src/components/product/AnalyticsInsights.tsx",
       "source_location": "L1",
       "id": "analyticsinsights",
-      "community": 1
+      "community": 0
     },
     {
       "label": "AttributesView.tsx",
@@ -6457,7 +6457,7 @@
       "source_file": "packages/athena-webapp/src/components/product/AttributesView.tsx",
       "source_location": "L1",
       "id": "attributesview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "BarcodeView.tsx",
@@ -6465,7 +6465,7 @@
       "source_file": "packages/athena-webapp/src/components/product/BarcodeView.tsx",
       "source_location": "L1",
       "id": "barcodeview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "BarcodeView()",
@@ -6473,7 +6473,7 @@
       "source_file": "packages/athena-webapp/src/components/product/BarcodeView.tsx",
       "source_location": "L14",
       "id": "barcodeview_barcodeview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "CategorizationView.tsx",
@@ -6481,7 +6481,7 @@
       "source_file": "packages/athena-webapp/src/components/product/CategorizationView.tsx",
       "source_location": "L1",
       "id": "categorizationview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "CategorizationView()",
@@ -6489,7 +6489,7 @@
       "source_file": "packages/athena-webapp/src/components/product/CategorizationView.tsx",
       "source_location": "L6",
       "id": "categorizationview_categorizationview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "DetailsView.tsx",
@@ -6497,7 +6497,7 @@
       "source_file": "packages/athena-webapp/src/components/product/DetailsView.tsx",
       "source_location": "L1",
       "id": "detailsview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ImagesView.tsx",
@@ -6505,7 +6505,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ImagesView.tsx",
       "source_location": "L1",
       "id": "imagesview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleKeyDown()",
@@ -6513,7 +6513,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ImagesView.tsx",
       "source_location": "L36",
       "id": "imagesview_handlekeydown",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ProductDetailView.tsx",
@@ -6521,7 +6521,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ProductDetailView.tsx",
       "source_location": "L1",
       "id": "productdetailview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ProductStatus.tsx",
@@ -6529,7 +6529,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ProductStatus.tsx",
       "source_location": "L1",
       "id": "productstatus",
-      "community": 2
+      "community": 0
     },
     {
       "label": "ProductStockStatus()",
@@ -6537,7 +6537,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
       "source_location": "L4",
       "id": "productstock_productstockstatus",
-      "community": 9
+      "community": 8
     },
     {
       "label": "OutOfStockStatus()",
@@ -6545,7 +6545,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
       "source_location": "L38",
       "id": "productstock_outofstockstatus",
-      "community": 9
+      "community": 8
     },
     {
       "label": "LowStockStatus()",
@@ -6553,7 +6553,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
       "source_location": "L47",
       "id": "productstock_lowstockstatus",
-      "community": 9
+      "community": 8
     },
     {
       "label": "SKUSelector.tsx",
@@ -6561,7 +6561,7 @@
       "source_file": "packages/athena-webapp/src/components/product/SKUSelector.tsx",
       "source_location": "L1",
       "id": "skuselector",
-      "community": 1
+      "community": 0
     },
     {
       "label": "SKUSelector()",
@@ -6569,7 +6569,7 @@
       "source_file": "packages/athena-webapp/src/components/product/SKUSelector.tsx",
       "source_location": "L10",
       "id": "skuselector_skuselector",
-      "community": 1
+      "community": 0
     },
     {
       "label": "product-actions.tsx",
@@ -6577,7 +6577,7 @@
       "source_file": "packages/athena-webapp/src/components/product-actions.tsx",
       "source_location": "L1",
       "id": "product_actions",
-      "community": 3
+      "community": 0
     },
     {
       "label": "useDeleteProduct()",
@@ -6585,7 +6585,7 @@
       "source_file": "packages/athena-webapp/src/components/product-actions.tsx",
       "source_location": "L6",
       "id": "product_actions_usedeleteproduct",
-      "community": 3
+      "community": 0
     },
     {
       "label": "CategoryListView.tsx",
@@ -6593,7 +6593,7 @@
       "source_file": "packages/athena-webapp/src/components/products/CategoryListView.tsx",
       "source_location": "L1",
       "id": "categorylistview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ProductSubcategoryToggleGroup.tsx",
@@ -6601,7 +6601,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductSubcategoryToggleGroup.tsx",
       "source_location": "L1",
       "id": "productsubcategorytogglegroup",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ProductsListView.tsx",
@@ -6609,7 +6609,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsListView.tsx",
       "source_location": "L1",
       "id": "productslistview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ProductActionsToggleGroup()",
@@ -6617,7 +6617,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsListView.tsx",
       "source_location": "L20",
       "id": "productslistview_productactionstogglegroup",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleClearCache()",
@@ -6625,7 +6625,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsListView.tsx",
       "source_location": "L65",
       "id": "productslistview_handleclearcache",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ProductsTableContext.tsx",
@@ -6633,7 +6633,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsTableContext.tsx",
       "source_location": "L1",
       "id": "productstablecontext",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ProductsTableProvider()",
@@ -6641,7 +6641,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsTableContext.tsx",
       "source_location": "L16",
       "id": "productstablecontext_productstableprovider",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useProductsTableState()",
@@ -6649,7 +6649,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsTableContext.tsx",
       "source_location": "L60",
       "id": "productstablecontext_useproductstablestate",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ProductsView.tsx",
@@ -6657,7 +6657,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsView.tsx",
       "source_location": "L1",
       "id": "productsview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ProductsView()",
@@ -6665,7 +6665,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsView.tsx",
       "source_location": "L5",
       "id": "productsview_productsview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "StoreProducts.tsx",
@@ -6673,7 +6673,7 @@
       "source_file": "packages/athena-webapp/src/components/products/StoreProducts.tsx",
       "source_location": "L1",
       "id": "storeproducts",
-      "community": 1
+      "community": 0
     },
     {
       "label": "StoreProductsView.tsx",
@@ -6681,7 +6681,7 @@
       "source_file": "packages/athena-webapp/src/components/products/StoreProductsView.tsx",
       "source_location": "L1",
       "id": "storeproductsview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ProductActionsToggleGroup()",
@@ -6689,7 +6689,7 @@
       "source_file": "packages/athena-webapp/src/components/products/StoreProductsView.tsx",
       "source_location": "L19",
       "id": "storeproductsview_productactionstogglegroup",
-      "community": 1
+      "community": 0
     },
     {
       "label": "Navigation()",
@@ -6697,7 +6697,7 @@
       "source_file": "packages/athena-webapp/src/components/products/StoreProductsView.tsx",
       "source_location": "L45",
       "id": "storeproductsview_navigation",
-      "community": 1
+      "community": 0
     },
     {
       "label": "UnresolvedProducts.tsx",
@@ -6705,7 +6705,7 @@
       "source_file": "packages/athena-webapp/src/components/products/UnresolvedProducts.tsx",
       "source_location": "L1",
       "id": "unresolvedproducts",
-      "community": 1
+      "community": 0
     },
     {
       "label": "AddComplimentaryProduct.tsx",
@@ -6713,7 +6713,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/AddComplimentaryProduct.tsx",
       "source_location": "L1",
       "id": "addcomplimentaryproduct",
-      "community": 7
+      "community": 0
     },
     {
       "label": "handleAddComplimentaryProducts()",
@@ -6721,7 +6721,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/AddComplimentaryProduct.tsx",
       "source_location": "L40",
       "id": "addcomplimentaryproduct_handleaddcomplimentaryproducts",
-      "community": 7
+      "community": 0
     },
     {
       "label": "AddComplimentaryProduct()",
@@ -6729,7 +6729,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/AddComplimentaryProduct.tsx",
       "source_location": "L128",
       "id": "addcomplimentaryproduct_addcomplimentaryproduct",
-      "community": 7
+      "community": 0
     },
     {
       "label": "ComplimentaryProducts.tsx",
@@ -6737,7 +6737,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProducts.tsx",
       "source_location": "L1",
       "id": "complimentaryproducts",
-      "community": 2
+      "community": 0
     },
     {
       "label": "ComplimentaryProductsView.tsx",
@@ -6745,7 +6745,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
       "source_location": "L1",
       "id": "complimentaryproductsview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "Navigation()",
@@ -6753,7 +6753,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
       "source_location": "L6",
       "id": "complimentaryproductsview_navigation",
-      "community": 1
+      "community": 0
     },
     {
       "label": "Body()",
@@ -6761,7 +6761,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
       "source_location": "L16",
       "id": "complimentaryproductsview_body",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ComplimentaryProductsView()",
@@ -6769,7 +6769,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
       "source_location": "L35",
       "id": "complimentaryproductsview_complimentaryproductsview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "complimentaryProductsColumn.tsx",
@@ -6777,7 +6777,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/complimentaryProductsColumn.tsx",
       "source_location": "L1",
       "id": "complimentaryproductscolumn",
-      "community": 2
+      "community": 0
     },
     {
       "label": "add-product-command.tsx",
@@ -6785,7 +6785,7 @@
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/add-product-command.tsx",
       "source_location": "L1",
       "id": "add_product_command",
-      "community": 2
+      "community": 0
     },
     {
       "label": "AddProductCommand()",
@@ -6793,7 +6793,7 @@
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/add-product-command.tsx",
       "source_location": "L17",
       "id": "add_product_command_addproductcommand",
-      "community": 2
+      "community": 0
     },
     {
       "label": "productColumns.tsx",
@@ -6801,7 +6801,7 @@
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/productColumns.tsx",
       "source_location": "L1",
       "id": "productcolumns",
-      "community": 2
+      "community": 0
     },
     {
       "label": "Products()",
@@ -6809,7 +6809,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/Products.tsx",
       "source_location": "L4",
       "id": "products_products",
-      "community": 2
+      "community": 0
     },
     {
       "label": "PromoCodeForm.tsx",
@@ -6817,7 +6817,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeForm.tsx",
       "source_location": "L1",
       "id": "promocodeform",
-      "community": 0
+      "community": 1
     },
     {
       "label": "toggleDiscountType()",
@@ -6825,7 +6825,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeForm.tsx",
       "source_location": "L84",
       "id": "promocodeform_togglediscounttype",
-      "community": 0
+      "community": 1
     },
     {
       "label": "PromoCodeHeader.tsx",
@@ -6833,7 +6833,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
       "source_location": "L1",
       "id": "promocodeheader",
-      "community": 7
+      "community": 0
     },
     {
       "label": "handleDeletePromoCode()",
@@ -6841,7 +6841,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
       "source_location": "L22",
       "id": "promocodeheader_handledeletepromocode",
-      "community": 7
+      "community": 0
     },
     {
       "label": "PromoCodePreview.tsx",
@@ -6849,7 +6849,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodePreview.tsx",
       "source_location": "L1",
       "id": "promocodepreview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "PromoCodeView.tsx",
@@ -6857,7 +6857,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
       "source_location": "L1",
       "id": "promocodeview",
-      "community": 7
+      "community": 0
     },
     {
       "label": "handleAddPromoCode()",
@@ -6865,7 +6865,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
       "source_location": "L146",
       "id": "promocodeview_handleaddpromocode",
-      "community": 7
+      "community": 0
     },
     {
       "label": "handleUpdatePromoCode()",
@@ -6873,7 +6873,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
       "source_location": "L213",
       "id": "promocodeview_handleupdatepromocode",
-      "community": 7
+      "community": 0
     },
     {
       "label": "updateHomepageDiscountCode()",
@@ -6881,7 +6881,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
       "source_location": "L299",
       "id": "promocodeview_updatehomepagediscountcode",
-      "community": 7
+      "community": 0
     },
     {
       "label": "updateLeaveAReviewDiscountCode()",
@@ -6889,7 +6889,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
       "source_location": "L351",
       "id": "promocodeview_updateleaveareviewdiscountcode",
-      "community": 7
+      "community": 0
     },
     {
       "label": "promoCodes.ts",
@@ -6897,7 +6897,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L1",
       "id": "promocodes",
-      "community": 3
+      "community": 2
     },
     {
       "label": "PromoCodesView.tsx",
@@ -6905,7 +6905,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodesView.tsx",
       "source_location": "L1",
       "id": "promocodesview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "PromoCodesView()",
@@ -6913,7 +6913,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodesView.tsx",
       "source_location": "L9",
       "id": "promocodesview_promocodesview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "SelectableCategories.tsx",
@@ -6921,7 +6921,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/SelectableCategories.tsx",
       "source_location": "L1",
       "id": "selectablecategories",
-      "community": 5
+      "community": 20
     },
     {
       "label": "toggle()",
@@ -6929,7 +6929,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/SelectableCategories.tsx",
       "source_location": "L23",
       "id": "selectablecategories_toggle",
-      "community": 5
+      "community": 20
     },
     {
       "label": "DiscountTypeToggleGroup.tsx",
@@ -6937,7 +6937,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/DiscountTypeToggleGroup.tsx",
       "source_location": "L1",
       "id": "discounttypetogglegroup",
-      "community": 4
+      "community": 3
     },
     {
       "label": "DiscountTypeToggleGroup()",
@@ -6945,7 +6945,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/DiscountTypeToggleGroup.tsx",
       "source_location": "L5",
       "id": "discounttypetogglegroup_discounttypetogglegroup",
-      "community": 4
+      "community": 3
     },
     {
       "label": "PromoCodeSpanToggleGroup.tsx",
@@ -6953,7 +6953,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/PromoCodeSpanToggleGroup.tsx",
       "source_location": "L1",
       "id": "promocodespantogglegroup",
-      "community": 4
+      "community": 3
     },
     {
       "label": "PromoCodeSpanToggleGroup()",
@@ -6961,7 +6961,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/PromoCodeSpanToggleGroup.tsx",
       "source_location": "L4",
       "id": "promocodespantogglegroup_promocodespantogglegroup",
-      "community": 4
+      "community": 3
     },
     {
       "label": "PromoCodeAnalytics.tsx",
@@ -6969,7 +6969,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/analytics/PromoCodeAnalytics.tsx",
       "source_location": "L1",
       "id": "promocodeanalytics",
-      "community": 2
+      "community": 0
     },
     {
       "label": "CapturedEmails.tsx",
@@ -6977,7 +6977,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/captured/CapturedEmails.tsx",
       "source_location": "L1",
       "id": "capturedemails",
-      "community": 2
+      "community": 0
     },
     {
       "label": "CapturedEmails()",
@@ -6985,7 +6985,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/captured/CapturedEmails.tsx",
       "source_location": "L13",
       "id": "capturedemails_capturedemails",
-      "community": 2
+      "community": 0
     },
     {
       "label": "captured-emails-columns.tsx",
@@ -6993,7 +6993,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/captured/captured-emails-columns.tsx",
       "source_location": "L1",
       "id": "captured_emails_columns",
-      "community": 2
+      "community": 0
     },
     {
       "label": "color-picker.tsx",
@@ -7001,7 +7001,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
       "source_location": "L1",
       "id": "color_picker",
-      "community": 5
+      "community": 17
     },
     {
       "label": "handleInputChange()",
@@ -7009,7 +7009,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
       "source_location": "L20",
       "id": "color_picker_handleinputchange",
-      "community": 5
+      "community": 17
     },
     {
       "label": "handleBlur()",
@@ -7017,7 +7017,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
       "source_location": "L24",
       "id": "color_picker_handleblur",
-      "community": 5
+      "community": 17
     },
     {
       "label": "promo-code-modal.tsx",
@@ -7025,7 +7025,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/promo-code-modal.tsx",
       "source_location": "L1",
       "id": "promo_code_modal",
-      "community": 14
+      "community": 12
     },
     {
       "label": "PromoCodeModal()",
@@ -7033,7 +7033,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/promo-code-modal.tsx",
       "source_location": "L29",
       "id": "promo_code_modal_promocodemodal",
-      "community": 14
+      "community": 12
     },
     {
       "label": "welcome-offer-modal.tsx",
@@ -7041,7 +7041,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L1",
       "id": "welcome_offer_modal",
-      "community": 5
+      "community": 12
     },
     {
       "label": "handleChange()",
@@ -7049,7 +7049,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L76",
       "id": "welcome_offer_modal_handlechange",
-      "community": 5
+      "community": 12
     },
     {
       "label": "handleNumberChange()",
@@ -7057,7 +7057,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L83",
       "id": "welcome_offer_modal_handlenumberchange",
-      "community": 5
+      "community": 12
     },
     {
       "label": "handleSwitchChange()",
@@ -7065,7 +7065,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L88",
       "id": "welcome_offer_modal_handleswitchchange",
-      "community": 5
+      "community": 12
     },
     {
       "label": "handleColorChange()",
@@ -7073,7 +7073,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L92",
       "id": "welcome_offer_modal_handlecolorchange",
-      "community": 5
+      "community": 12
     },
     {
       "label": "handleSelectChange()",
@@ -7081,7 +7081,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L96",
       "id": "welcome_offer_modal_handleselectchange",
-      "community": 5
+      "community": 12
     },
     {
       "label": "updateImages()",
@@ -7089,7 +7089,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L100",
       "id": "welcome_offer_modal_updateimages",
-      "community": 5
+      "community": 12
     },
     {
       "label": "handleSubmit()",
@@ -7097,7 +7097,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L104",
       "id": "welcome_offer_modal_handlesubmit",
-      "community": 5
+      "community": 12
     },
     {
       "label": "welcome-offer-card.tsx",
@@ -7105,7 +7105,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/welcome-offer-card.tsx",
       "source_location": "L1",
       "id": "welcome_offer_card",
-      "community": 0
+      "community": 17
     },
     {
       "label": "currency-provider.tsx",
@@ -7113,7 +7113,7 @@
       "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
       "source_location": "L1",
       "id": "currency_provider",
-      "community": 0
+      "community": 17
     },
     {
       "label": "useStoreCurrency()",
@@ -7121,7 +7121,7 @@
       "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
       "source_location": "L17",
       "id": "currency_provider_usestorecurrency",
-      "community": 0
+      "community": 17
     },
     {
       "label": "CurrencyProvider()",
@@ -7129,7 +7129,7 @@
       "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
       "source_location": "L25",
       "id": "currency_provider_currencyprovider",
-      "community": 0
+      "community": 17
     },
     {
       "label": "RatingStars.tsx",
@@ -7137,7 +7137,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/RatingStars.tsx",
       "source_location": "L1",
       "id": "ratingstars",
-      "community": 2
+      "community": 6
     },
     {
       "label": "ReviewActions.tsx",
@@ -7145,7 +7145,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewActions.tsx",
       "source_location": "L1",
       "id": "reviewactions",
-      "community": 4
+      "community": 6
     },
     {
       "label": "ReviewActions()",
@@ -7153,7 +7153,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewActions.tsx",
       "source_location": "L20",
       "id": "reviewactions_reviewactions",
-      "community": 4
+      "community": 6
     },
     {
       "label": "ReviewCard.tsx",
@@ -7161,7 +7161,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewCard.tsx",
       "source_location": "L1",
       "id": "reviewcard",
-      "community": 2
+      "community": 6
     },
     {
       "label": "ReviewMetadata.tsx",
@@ -7169,7 +7169,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewMetadata.tsx",
       "source_location": "L1",
       "id": "reviewmetadata",
-      "community": 2
+      "community": 6
     },
     {
       "label": "ReviewsView.tsx",
@@ -7177,7 +7177,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L1",
       "id": "reviewsview",
-      "community": 1
+      "community": 6
     },
     {
       "label": "Header()",
@@ -7185,7 +7185,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L13",
       "id": "reviewsview_header",
-      "community": 1
+      "community": 6
     },
     {
       "label": "handleApprove()",
@@ -7193,7 +7193,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L42",
       "id": "reviewsview_handleapprove",
-      "community": 1
+      "community": 6
     },
     {
       "label": "handleReject()",
@@ -7201,7 +7201,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L58",
       "id": "reviewsview_handlereject",
-      "community": 1
+      "community": 6
     },
     {
       "label": "handlePublish()",
@@ -7209,7 +7209,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L74",
       "id": "reviewsview_handlepublish",
-      "community": 1
+      "community": 6
     },
     {
       "label": "handleUnpublish()",
@@ -7217,7 +7217,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L90",
       "id": "reviewsview_handleunpublish",
-      "community": 1
+      "community": 6
     },
     {
       "label": "empty-state.tsx",
@@ -7225,7 +7225,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/empty/empty-state.tsx",
       "source_location": "L1",
       "id": "empty_state",
-      "community": 1
+      "community": 0
     },
     {
       "label": "onClick()",
@@ -7233,7 +7233,7 @@
       "source_file": "packages/athena-webapp/src/components/states/empty/empty-state.tsx",
       "source_location": "L29",
       "id": "empty_state_onclick",
-      "community": 1
+      "community": 0
     },
     {
       "label": "SingleLineError.tsx",
@@ -7257,7 +7257,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/error/index.tsx",
       "source_location": "L9",
       "id": "index_errorpage",
-      "community": 1
+      "community": 6
     },
     {
       "label": "app-skeleton.tsx",
@@ -7265,7 +7265,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/app-skeleton.tsx",
       "source_location": "L1",
       "id": "app_skeleton",
-      "community": 1
+      "community": 0
     },
     {
       "label": "AppSkeleton()",
@@ -7273,7 +7273,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/app-skeleton.tsx",
       "source_location": "L3",
       "id": "app_skeleton_appskeleton",
-      "community": 1
+      "community": 0
     },
     {
       "label": "dashboard-skeleton.tsx",
@@ -7281,7 +7281,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/dashboard-skeleton.tsx",
       "source_location": "L1",
       "id": "dashboard_skeleton",
-      "community": 1
+      "community": 0
     },
     {
       "label": "DashboardSkeleton()",
@@ -7289,7 +7289,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/dashboard-skeleton.tsx",
       "source_location": "L3",
       "id": "dashboard_skeleton_dashboardskeleton",
-      "community": 1
+      "community": 0
     },
     {
       "label": "table-skeleton.tsx",
@@ -7297,7 +7297,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/table-skeleton.tsx",
       "source_location": "L1",
       "id": "table_skeleton",
-      "community": 1
+      "community": 0
     },
     {
       "label": "TableSkeleton()",
@@ -7305,7 +7305,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/table-skeleton.tsx",
       "source_location": "L3",
       "id": "table_skeleton_tableskeleton",
-      "community": 1
+      "community": 0
     },
     {
       "label": "transactions-skeleton.tsx",
@@ -7313,7 +7313,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/transactions-skeleton.tsx",
       "source_location": "L1",
       "id": "transactions_skeleton",
-      "community": 1
+      "community": 0
     },
     {
       "label": "TransactionsSkeleton()",
@@ -7321,7 +7321,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/transactions-skeleton.tsx",
       "source_location": "L3",
       "id": "transactions_skeleton_transactionsskeleton",
-      "community": 1
+      "community": 0
     },
     {
       "label": "NoPermission.tsx",
@@ -7329,7 +7329,7 @@
       "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermission.tsx",
       "source_location": "L1",
       "id": "nopermission",
-      "community": 7
+      "community": 4
     },
     {
       "label": "NoPermission()",
@@ -7337,7 +7337,7 @@
       "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermission.tsx",
       "source_location": "L3",
       "id": "nopermission_nopermission",
-      "community": 7
+      "community": 4
     },
     {
       "label": "NoPermissionView.tsx",
@@ -7345,7 +7345,7 @@
       "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermissionView.tsx",
       "source_location": "L1",
       "id": "nopermissionview",
-      "community": 7
+      "community": 4
     },
     {
       "label": "NoPermissionView()",
@@ -7353,7 +7353,7 @@
       "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermissionView.tsx",
       "source_location": "L4",
       "id": "nopermissionview_nopermissionview",
-      "community": 7
+      "community": 4
     },
     {
       "label": "NotFound.tsx",
@@ -7361,7 +7361,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/not-found/NotFound.tsx",
       "source_location": "L1",
       "id": "notfound",
-      "community": 0
+      "community": 1
     },
     {
       "label": "NotFound()",
@@ -7369,7 +7369,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/not-found/NotFound.tsx",
       "source_location": "L4",
       "id": "notfound_notfound",
-      "community": 0
+      "community": 1
     },
     {
       "label": "NotFoundView.tsx",
@@ -7377,7 +7377,7 @@
       "source_file": "packages/athena-webapp/src/components/states/not-found/NotFoundView.tsx",
       "source_location": "L1",
       "id": "notfoundview",
-      "community": 7
+      "community": 4
     },
     {
       "label": "NotFoundView()",
@@ -7385,7 +7385,7 @@
       "source_file": "packages/athena-webapp/src/components/states/not-found/NotFoundView.tsx",
       "source_location": "L4",
       "id": "notfoundview_notfoundview",
-      "community": 7
+      "community": 4
     },
     {
       "label": "ContactView.tsx",
@@ -7393,7 +7393,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/ContactView.tsx",
       "source_location": "L1",
       "id": "contactview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ContactView()",
@@ -7401,7 +7401,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/ContactView.tsx",
       "source_location": "L9",
       "id": "contactview_contactview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "FeesView.tsx",
@@ -7409,7 +7409,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FeesView.tsx",
       "source_location": "L1",
       "id": "feesview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleUpdateFees()",
@@ -7417,7 +7417,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FeesView.tsx",
       "source_location": "L36",
       "id": "feesview_handleupdatefees",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleToggleAllFees()",
@@ -7425,7 +7425,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FeesView.tsx",
       "source_location": "L104",
       "id": "feesview_handletoggleallfees",
-      "community": 1
+      "community": 0
     },
     {
       "label": "FulfillmentView.tsx",
@@ -7433,7 +7433,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L1",
       "id": "fulfillmentview",
-      "community": 16
+      "community": 6
     },
     {
       "label": "saveEnableStorePickupChanges()",
@@ -7441,7 +7441,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L43",
       "id": "fulfillmentview_saveenablestorepickupchanges",
-      "community": 16
+      "community": 6
     },
     {
       "label": "saveEnableDeliveryChanges()",
@@ -7449,7 +7449,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L75",
       "id": "fulfillmentview_saveenabledeliverychanges",
-      "community": 16
+      "community": 6
     },
     {
       "label": "savePickupRestriction()",
@@ -7457,7 +7457,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L107",
       "id": "fulfillmentview_savepickuprestriction",
-      "community": 16
+      "community": 6
     },
     {
       "label": "saveDeliveryRestriction()",
@@ -7465,7 +7465,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L132",
       "id": "fulfillmentview_savedeliveryrestriction",
-      "community": 16
+      "community": 6
     },
     {
       "label": "handlePickupRestrictionToggle()",
@@ -7473,7 +7473,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L157",
       "id": "fulfillmentview_handlepickuprestrictiontoggle",
-      "community": 16
+      "community": 6
     },
     {
       "label": "handleDeliveryRestrictionToggle()",
@@ -7481,7 +7481,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L196",
       "id": "fulfillmentview_handledeliveryrestrictiontoggle",
-      "community": 16
+      "community": 6
     },
     {
       "label": "handleSavePickupRestriction()",
@@ -7489,7 +7489,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L235",
       "id": "fulfillmentview_handlesavepickuprestriction",
-      "community": 16
+      "community": 6
     },
     {
       "label": "handleSaveDeliveryRestriction()",
@@ -7497,7 +7497,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L244",
       "id": "fulfillmentview_handlesavedeliveryrestriction",
-      "community": 16
+      "community": 6
     },
     {
       "label": "Header.tsx",
@@ -7505,7 +7505,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
       "source_location": "L1",
       "id": "header",
-      "community": 1
+      "community": 6
     },
     {
       "label": "Header()",
@@ -7513,7 +7513,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
       "source_location": "L1",
       "id": "header_header",
-      "community": 1
+      "community": 6
     },
     {
       "label": "MaintenanceView.tsx",
@@ -7521,7 +7521,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.tsx",
       "source_location": "L1",
       "id": "maintenanceview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "MaintenanceView()",
@@ -7529,7 +7529,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.tsx",
       "source_location": "L13",
       "id": "maintenanceview_maintenanceview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "MtnMomoView.test.tsx",
@@ -7537,7 +7537,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.test.tsx",
       "source_location": "L1",
       "id": "mtnmomoview_test",
-      "community": 2
+      "community": 16
     },
     {
       "label": "MtnMomoView.tsx",
@@ -7545,7 +7545,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L1",
       "id": "mtnmomoview",
-      "community": 2
+      "community": 16
     },
     {
       "label": "cloneReceivingAccount()",
@@ -7553,7 +7553,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L27",
       "id": "mtnmomoview_clonereceivingaccount",
-      "community": 2
+      "community": 16
     },
     {
       "label": "createEmptyReceivingAccount()",
@@ -7561,7 +7561,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L35",
       "id": "mtnmomoview_createemptyreceivingaccount",
-      "community": 2
+      "community": 16
     },
     {
       "label": "trimToUndefined()",
@@ -7569,7 +7569,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L47",
       "id": "mtnmomoview_trimtoundefined",
-      "community": 2
+      "community": 16
     },
     {
       "label": "cleanUndefinedFields()",
@@ -7577,7 +7577,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L52",
       "id": "mtnmomoview_cleanundefinedfields",
-      "community": 2
+      "community": 16
     },
     {
       "label": "hasReceivingAccountDetails()",
@@ -7585,7 +7585,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L64",
       "id": "mtnmomoview_hasreceivingaccountdetails",
-      "community": 2
+      "community": 16
     },
     {
       "label": "normalizePrimaryAccounts()",
@@ -7593,7 +7593,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L77",
       "id": "mtnmomoview_normalizeprimaryaccounts",
-      "community": 2
+      "community": 16
     },
     {
       "label": "toPatchReceivingAccounts()",
@@ -7601,7 +7601,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L93",
       "id": "mtnmomoview_topatchreceivingaccounts",
-      "community": 2
+      "community": 16
     },
     {
       "label": "getStatusBadgeVariant()",
@@ -7609,7 +7609,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L114",
       "id": "mtnmomoview_getstatusbadgevariant",
-      "community": 2
+      "community": 16
     },
     {
       "label": "updateAccount()",
@@ -7617,7 +7617,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L141",
       "id": "mtnmomoview_updateaccount",
-      "community": 2
+      "community": 16
     },
     {
       "label": "handleAddAccount()",
@@ -7625,7 +7625,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L152",
       "id": "mtnmomoview_handleaddaccount",
-      "community": 2
+      "community": 16
     },
     {
       "label": "handleMakePrimary()",
@@ -7633,7 +7633,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L159",
       "id": "mtnmomoview_handlemakeprimary",
-      "community": 2
+      "community": 16
     },
     {
       "label": "handleRemoveAccount()",
@@ -7641,7 +7641,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L168",
       "id": "mtnmomoview_handleremoveaccount",
-      "community": 2
+      "community": 16
     },
     {
       "label": "handleSave()",
@@ -7649,7 +7649,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L188",
       "id": "mtnmomoview_handlesave",
-      "community": 2
+      "community": 16
     },
     {
       "label": "TaxView.tsx",
@@ -7657,7 +7657,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/TaxView.tsx",
       "source_location": "L1",
       "id": "taxview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleUpdateTaxSettings()",
@@ -7665,7 +7665,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/TaxView.tsx",
       "source_location": "L25",
       "id": "taxview_handleupdatetaxsettings",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useStoreConfigUpdate.ts",
@@ -7673,7 +7673,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/hooks/useStoreConfigUpdate.ts",
       "source_location": "L1",
       "id": "usestoreconfigupdate",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useStoreConfigUpdate()",
@@ -7681,7 +7681,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/hooks/useStoreConfigUpdate.ts",
       "source_location": "L19",
       "id": "usestoreconfigupdate_usestoreconfigupdate",
-      "community": 1
+      "community": 0
     },
     {
       "label": "store-switcher.tsx",
@@ -7689,7 +7689,7 @@
       "source_file": "packages/athena-webapp/src/components/store-switcher.tsx",
       "source_location": "L1",
       "id": "store_switcher",
-      "community": 0
+      "community": 17
     },
     {
       "label": "onStoreSelect()",
@@ -7697,7 +7697,7 @@
       "source_file": "packages/athena-webapp/src/components/store-switcher.tsx",
       "source_location": "L63",
       "id": "store_switcher_onstoreselect",
-      "community": 0
+      "community": 17
     },
     {
       "label": "accordion.tsx",
@@ -7713,7 +7713,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/app-context-menu.tsx",
       "source_location": "L1",
       "id": "app_context_menu",
-      "community": 14
+      "community": 12
     },
     {
       "label": "AppContextMenu()",
@@ -7721,7 +7721,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/app-context-menu.tsx",
       "source_location": "L20",
       "id": "app_context_menu_appcontextmenu",
-      "community": 14
+      "community": 12
     },
     {
       "label": "badge.tsx",
@@ -7729,7 +7729,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/badge.tsx",
       "source_location": "L1",
       "id": "badge",
-      "community": 2
+      "community": 0
     },
     {
       "label": "Badge()",
@@ -7737,7 +7737,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/badge.tsx",
       "source_location": "L30",
       "id": "badge_badge",
-      "community": 2
+      "community": 0
     },
     {
       "label": "button.test.tsx",
@@ -7745,7 +7745,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/button.test.tsx",
       "source_location": "L1",
       "id": "button_test",
-      "community": 0
+      "community": 1
     },
     {
       "label": "button.tsx",
@@ -7753,7 +7753,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/button.tsx",
       "source_location": "L1",
       "id": "button",
-      "community": 0
+      "community": 1
     },
     {
       "label": "calendar.test.tsx",
@@ -7761,7 +7761,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/calendar.test.tsx",
       "source_location": "L1",
       "id": "calendar_test",
-      "community": 0
+      "community": 1
     },
     {
       "label": "calendar.tsx",
@@ -7769,7 +7769,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/calendar.tsx",
       "source_location": "L1",
       "id": "calendar",
-      "community": 0
+      "community": 1
     },
     {
       "label": "card.tsx",
@@ -7777,7 +7777,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/card.tsx",
       "source_location": "L1",
       "id": "card",
-      "community": 2
+      "community": 0
     },
     {
       "label": "useChart()",
@@ -7785,7 +7785,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/chart.tsx",
       "source_location": "L25",
       "id": "chart_usechart",
-      "community": 2
+      "community": 3
     },
     {
       "label": "checkbox.tsx",
@@ -7793,7 +7793,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/checkbox.tsx",
       "source_location": "L1",
       "id": "checkbox",
-      "community": 5
+      "community": 20
     },
     {
       "label": "collapsible.tsx",
@@ -7817,7 +7817,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/context-menu.tsx",
       "source_location": "L1",
       "id": "context_menu",
-      "community": 14
+      "community": 12
     },
     {
       "label": "copy-button.tsx",
@@ -7825,7 +7825,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/copy-button.tsx",
       "source_location": "L1",
       "id": "copy_button",
-      "community": 2
+      "community": 0
     },
     {
       "label": "handleCopy()",
@@ -7833,7 +7833,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/copy-button.tsx",
       "source_location": "L15",
       "id": "copy_button_handlecopy",
-      "community": 2
+      "community": 0
     },
     {
       "label": "copy-wrapper.tsx",
@@ -7841,7 +7841,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/copy-wrapper.tsx",
       "source_location": "L1",
       "id": "copy_wrapper",
-      "community": 2
+      "community": 0
     },
     {
       "label": "handleCopy()",
@@ -7849,7 +7849,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/copy-wrapper.tsx",
       "source_location": "L21",
       "id": "copy_wrapper_handlecopy",
-      "community": 2
+      "community": 0
     },
     {
       "label": "date-time-picker.tsx",
@@ -7857,7 +7857,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/date-time-picker.tsx",
       "source_location": "L1",
       "id": "date_time_picker",
-      "community": 0
+      "community": 1
     },
     {
       "label": "DateTimePicker()",
@@ -7865,7 +7865,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/date-time-picker.tsx",
       "source_location": "L21",
       "id": "date_time_picker_datetimepicker",
-      "community": 0
+      "community": 1
     },
     {
       "label": "dialog.tsx",
@@ -7873,7 +7873,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/dialog.tsx",
       "source_location": "L1",
       "id": "dialog",
-      "community": 5
+      "community": 1
     },
     {
       "label": "dropdown-menu.tsx",
@@ -7881,7 +7881,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/dropdown-menu.tsx",
       "source_location": "L1",
       "id": "dropdown_menu",
-      "community": 0
+      "community": 17
     },
     {
       "label": "form.tsx",
@@ -7889,7 +7889,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/form.tsx",
       "source_location": "L1",
       "id": "form",
-      "community": 5
+      "community": 1
     },
     {
       "label": "icons.tsx",
@@ -7897,7 +7897,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/icons.tsx",
       "source_location": "L1",
       "id": "icons",
-      "community": 0
+      "community": 1
     },
     {
       "label": "image-uploader.tsx",
@@ -7905,7 +7905,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1",
       "id": "image_uploader",
-      "community": 14
+      "community": 12
     },
     {
       "label": "onDrop()",
@@ -7913,7 +7913,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L20",
       "id": "image_uploader_ondrop",
-      "community": 14
+      "community": 12
     },
     {
       "label": "removeImage()",
@@ -7921,7 +7921,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L31",
       "id": "image_uploader_removeimage",
-      "community": 14
+      "community": 12
     },
     {
       "label": "unmarkForDeletion()",
@@ -7929,7 +7929,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L46",
       "id": "image_uploader_unmarkfordeletion",
-      "community": 14
+      "community": 12
     },
     {
       "label": "onDragEnd()",
@@ -7937,7 +7937,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L100",
       "id": "image_uploader_ondragend",
-      "community": 14
+      "community": 12
     },
     {
       "label": "input-otp.tsx",
@@ -7945,7 +7945,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/input-otp.tsx",
       "source_location": "L1",
       "id": "input_otp",
-      "community": 5
+      "community": 1
     },
     {
       "label": "input.tsx",
@@ -7953,7 +7953,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/input.tsx",
       "source_location": "L1",
       "id": "input",
-      "community": 5
+      "community": 1
     },
     {
       "label": "label.tsx",
@@ -7961,7 +7961,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/label.tsx",
       "source_location": "L1",
       "id": "label",
-      "community": 1
+      "community": 0
     },
     {
       "label": "Label()",
@@ -7969,7 +7969,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/label.tsx",
       "source_location": "L6",
       "id": "label_label",
-      "community": 1
+      "community": 0
     },
     {
       "label": "loading-button.tsx",
@@ -7977,7 +7977,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/loading-button.tsx",
       "source_location": "L1",
       "id": "loading_button",
-      "community": 5
+      "community": 1
     },
     {
       "label": "LoadingButton()",
@@ -7985,7 +7985,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/loading-button.tsx",
       "source_location": "L9",
       "id": "loading_button_loadingbutton",
-      "community": 5
+      "community": 1
     },
     {
       "label": "modal.tsx",
@@ -7993,7 +7993,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modal.tsx",
       "source_location": "L1",
       "id": "modal",
-      "community": 5
+      "community": 1
     },
     {
       "label": "onChange()",
@@ -8001,7 +8001,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modal.tsx",
       "source_location": "L38",
       "id": "modal_onchange",
-      "community": 5
+      "community": 1
     },
     {
       "label": "action-modal.tsx",
@@ -8009,7 +8009,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/action-modal.tsx",
       "source_location": "L1",
       "id": "action_modal",
-      "community": 0
+      "community": 1
     },
     {
       "label": "alert-modal.tsx",
@@ -8017,7 +8017,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/alert-modal.tsx",
       "source_location": "L1",
       "id": "alert_modal",
-      "community": 0
+      "community": 1
     },
     {
       "label": "AlertModal()",
@@ -8025,7 +8025,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/alert-modal.tsx",
       "source_location": "L20",
       "id": "alert_modal_alertmodal",
-      "community": 0
+      "community": 1
     },
     {
       "label": "custom-modal-example.tsx",
@@ -8033,7 +8033,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
       "source_location": "L1",
       "id": "custom_modal_example",
-      "community": 14
+      "community": 12
     },
     {
       "label": "BasicModalExample()",
@@ -8041,7 +8041,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
       "source_location": "L7",
       "id": "custom_modal_example_basicmodalexample",
-      "community": 14
+      "community": 12
     },
     {
       "label": "CustomPositionModalExample()",
@@ -8049,7 +8049,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
       "source_location": "L44",
       "id": "custom_modal_example_custompositionmodalexample",
-      "community": 14
+      "community": 12
     },
     {
       "label": "CustomCloseButtonExample()",
@@ -8057,7 +8057,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
       "source_location": "L69",
       "id": "custom_modal_example_customclosebuttonexample",
-      "community": 14
+      "community": 12
     },
     {
       "label": "FullScreenModalExample()",
@@ -8065,7 +8065,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
       "source_location": "L103",
       "id": "custom_modal_example_fullscreenmodalexample",
-      "community": 14
+      "community": 12
     },
     {
       "label": "custom-modal.tsx",
@@ -8073,7 +8073,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
       "source_location": "L1",
       "id": "custom_modal",
-      "community": 14
+      "community": 12
     },
     {
       "label": "CustomModal()",
@@ -8081,7 +8081,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
       "source_location": "L25",
       "id": "custom_modal_custommodal",
-      "community": 14
+      "community": 12
     },
     {
       "label": "organization-modal.tsx",
@@ -8089,7 +8089,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/organization-modal.tsx",
       "source_location": "L1",
       "id": "organization_modal",
-      "community": 5
+      "community": 1
     },
     {
       "label": "onSubmit()",
@@ -8097,7 +8097,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/organization-modal.tsx",
       "source_location": "L49",
       "id": "organization_modal_onsubmit",
-      "community": 5
+      "community": 1
     },
     {
       "label": "overlay-modal.tsx",
@@ -8105,7 +8105,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/overlay-modal.tsx",
       "source_location": "L1",
       "id": "overlay_modal",
-      "community": 0
+      "community": 17
     },
     {
       "label": "OverlayModal()",
@@ -8113,7 +8113,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/overlay-modal.tsx",
       "source_location": "L12",
       "id": "overlay_modal_overlaymodal",
-      "community": 0
+      "community": 17
     },
     {
       "label": "store-modal.tsx",
@@ -8121,7 +8121,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/store-modal.tsx",
       "source_location": "L1",
       "id": "store_modal",
-      "community": 5
+      "community": 1
     },
     {
       "label": "onSubmit()",
@@ -8129,7 +8129,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/store-modal.tsx",
       "source_location": "L63",
       "id": "store_modal_onsubmit",
-      "community": 5
+      "community": 1
     },
     {
       "label": "welcome-back-modal-example.tsx",
@@ -8137,7 +8137,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal-example.tsx",
       "source_location": "L1",
       "id": "welcome_back_modal_example",
-      "community": 14
+      "community": 12
     },
     {
       "label": "WelcomeBackModalExample()",
@@ -8145,7 +8145,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal-example.tsx",
       "source_location": "L5",
       "id": "welcome_back_modal_example_welcomebackmodalexample",
-      "community": 14
+      "community": 12
     },
     {
       "label": "welcome-back-modal.tsx",
@@ -8153,7 +8153,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal.tsx",
       "source_location": "L1",
       "id": "welcome_back_modal",
-      "community": 14
+      "community": 12
     },
     {
       "label": "WelcomeBackModal()",
@@ -8161,7 +8161,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal.tsx",
       "source_location": "L12",
       "id": "welcome_back_modal_welcomebackmodal",
-      "community": 14
+      "community": 12
     },
     {
       "label": "popover.tsx",
@@ -8169,7 +8169,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/popover.tsx",
       "source_location": "L1",
       "id": "popover",
-      "community": 0
+      "community": 17
     },
     {
       "label": "radio-group.tsx",
@@ -8177,7 +8177,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/radio-group.tsx",
       "source_location": "L1",
       "id": "radio_group",
-      "community": 5
+      "community": 0
     },
     {
       "label": "scroll-area.tsx",
@@ -8193,7 +8193,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/select-native.tsx",
       "source_location": "L1",
       "id": "select_native",
-      "community": 16
+      "community": 0
     },
     {
       "label": "cn()",
@@ -8201,7 +8201,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/select-native.tsx",
       "source_location": "L15",
       "id": "select_native_cn",
-      "community": 16
+      "community": 0
     },
     {
       "label": "select.tsx",
@@ -8209,7 +8209,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/select.tsx",
       "source_location": "L1",
       "id": "select",
-      "community": 5
+      "community": 1
     },
     {
       "label": "separator.tsx",
@@ -8217,7 +8217,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/separator.tsx",
       "source_location": "L1",
       "id": "separator",
-      "community": 0
+      "community": 20
     },
     {
       "label": "sheet.tsx",
@@ -8233,7 +8233,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L1",
       "id": "sidebar",
-      "community": 9
+      "community": 20
     },
     {
       "label": "useSidebar()",
@@ -8241,7 +8241,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L45",
       "id": "sidebar_usesidebar",
-      "community": 9
+      "community": 20
     },
     {
       "label": "handleKeyDown()",
@@ -8249,7 +8249,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L105",
       "id": "sidebar_handlekeydown",
-      "community": 9
+      "community": 20
     },
     {
       "label": "cn()",
@@ -8257,7 +8257,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L147",
       "id": "sidebar_cn",
-      "community": 9
+      "community": 20
     },
     {
       "label": "handleOnHover()",
@@ -8265,7 +8265,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L224",
       "id": "sidebar_handleonhover",
-      "community": 9
+      "community": 20
     },
     {
       "label": "handleOnMouseLeave()",
@@ -8273,7 +8273,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L228",
       "id": "sidebar_handleonmouseleave",
-      "community": 9
+      "community": 20
     },
     {
       "label": "skeleton.tsx",
@@ -8281,7 +8281,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/skeleton.tsx",
       "source_location": "L1",
       "id": "skeleton",
-      "community": 1
+      "community": 0
     },
     {
       "label": "Skeleton()",
@@ -8289,7 +8289,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/skeleton.tsx",
       "source_location": "L3",
       "id": "skeleton_skeleton",
-      "community": 1
+      "community": 0
     },
     {
       "label": "sonner.tsx",
@@ -8297,7 +8297,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/sonner.tsx",
       "source_location": "L1",
       "id": "sonner",
-      "community": 4
+      "community": 0
     },
     {
       "label": "Toaster()",
@@ -8305,7 +8305,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/sonner.tsx",
       "source_location": "L6",
       "id": "sonner_toaster",
-      "community": 4
+      "community": 0
     },
     {
       "label": "spinner.tsx",
@@ -8313,7 +8313,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/spinner.tsx",
       "source_location": "L1",
       "id": "spinner",
-      "community": 0
+      "community": 1
     },
     {
       "label": "Spinner()",
@@ -8321,7 +8321,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/spinner.tsx",
       "source_location": "L3",
       "id": "spinner_spinner",
-      "community": 0
+      "community": 1
     },
     {
       "label": "switch.tsx",
@@ -8329,7 +8329,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/switch.tsx",
       "source_location": "L1",
       "id": "switch",
-      "community": 1
+      "community": 0
     },
     {
       "label": "table.tsx",
@@ -8337,7 +8337,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/table.tsx",
       "source_location": "L1",
       "id": "table",
-      "community": 13
+      "community": 8
     },
     {
       "label": "tabs.tsx",
@@ -8345,7 +8345,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/tabs.tsx",
       "source_location": "L1",
       "id": "tabs",
-      "community": 1
+      "community": 0
     },
     {
       "label": "textarea.tsx",
@@ -8353,7 +8353,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/textarea.tsx",
       "source_location": "L1",
       "id": "textarea",
-      "community": 5
+      "community": 1
     },
     {
       "label": "timeline-item.tsx",
@@ -8377,7 +8377,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/toggle-group.tsx",
       "source_location": "L1",
       "id": "toggle_group",
-      "community": 1
+      "community": 0
     },
     {
       "label": "toggle.tsx",
@@ -8385,7 +8385,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/toggle.tsx",
       "source_location": "L1",
       "id": "toggle",
-      "community": 1
+      "community": 0
     },
     {
       "label": "tooltip.tsx",
@@ -8393,7 +8393,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/tooltip.tsx",
       "source_location": "L1",
       "id": "tooltip",
-      "community": 2
+      "community": 0
     },
     {
       "label": "webp-image.tsx",
@@ -8417,7 +8417,7 @@
       "source_file": "packages/athena-webapp/src/components/upload-button.tsx",
       "source_location": "L1",
       "id": "upload_button",
-      "community": 0
+      "community": 6
     },
     {
       "label": "BagItems.tsx",
@@ -8425,7 +8425,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/BagItems.tsx",
       "source_location": "L1",
       "id": "bagitems",
-      "community": 2
+      "community": 0
     },
     {
       "label": "BagItems()",
@@ -8433,7 +8433,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/BagItems.tsx",
       "source_location": "L5",
       "id": "bagitems_bagitems",
-      "community": 2
+      "community": 0
     },
     {
       "label": "BagItemsView.tsx",
@@ -8441,7 +8441,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/BagItemsView.tsx",
       "source_location": "L1",
       "id": "bagitemsview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "BagItemsView()",
@@ -8449,7 +8449,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/BagItemsView.tsx",
       "source_location": "L11",
       "id": "bagitemsview_bagitemsview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "BagView.tsx",
@@ -8457,7 +8457,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/BagView.tsx",
       "source_location": "L1",
       "id": "bagview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "Bags.tsx",
@@ -8465,7 +8465,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
       "source_location": "L1",
       "id": "bags",
-      "community": 2
+      "community": 0
     },
     {
       "label": "Bags()",
@@ -8473,7 +8473,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
       "source_location": "L4",
       "id": "bags_bags",
-      "community": 2
+      "community": 0
     },
     {
       "label": "bag-columns.tsx",
@@ -8481,7 +8481,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bag-columns.tsx",
       "source_location": "L1",
       "id": "bag_columns",
-      "community": 2
+      "community": 0
     },
     {
       "label": "bags-table.tsx",
@@ -8489,7 +8489,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bags-table.tsx",
       "source_location": "L1",
       "id": "bags_table",
-      "community": 2
+      "community": 0
     },
     {
       "label": "ActivitySummaryCards.tsx",
@@ -8497,7 +8497,7 @@
       "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
       "source_location": "L1",
       "id": "activitysummarycards",
-      "community": 2
+      "community": 3
     },
     {
       "label": "SummaryCard()",
@@ -8505,7 +8505,7 @@
       "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
       "source_location": "L19",
       "id": "activitysummarycards_summarycard",
-      "community": 2
+      "community": 3
     },
     {
       "label": "ActivitySummaryCards()",
@@ -8513,7 +8513,7 @@
       "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
       "source_location": "L44",
       "id": "activitysummarycards_activitysummarycards",
-      "community": 2
+      "community": 3
     },
     {
       "label": "String()",
@@ -8521,7 +8521,7 @@
       "source_file": "packages/athena-webapp/src/components/users/CustomerBehaviorTimeline.tsx",
       "source_location": "L110",
       "id": "customerbehaviortimeline_string",
-      "community": 2
+      "community": 18
     },
     {
       "label": "LinkedAccounts.tsx",
@@ -8529,7 +8529,7 @@
       "source_file": "packages/athena-webapp/src/components/users/LinkedAccounts.tsx",
       "source_location": "L1",
       "id": "linkedaccounts",
-      "community": 2
+      "community": 0
     },
     {
       "label": "TimelineEventCard.test.tsx",
@@ -8537,7 +8537,7 @@
       "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.test.tsx",
       "source_location": "L1",
       "id": "timelineeventcard_test",
-      "community": 2
+      "community": 18
     },
     {
       "label": "TimelineEventCard.tsx",
@@ -8545,7 +8545,7 @@
       "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
       "source_location": "L1",
       "id": "timelineeventcard",
-      "community": 2
+      "community": 18
     },
     {
       "label": "formatObservabilityLabel()",
@@ -8553,7 +8553,7 @@
       "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
       "source_location": "L139",
       "id": "timelineeventcard_formatobservabilitylabel",
-      "community": 2
+      "community": 18
     },
     {
       "label": "loadMore()",
@@ -8561,7 +8561,7 @@
       "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
       "source_location": "L175",
       "id": "timelineeventcard_loadmore",
-      "community": 2
+      "community": 18
     },
     {
       "label": "UserActivity.tsx",
@@ -8569,7 +8569,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
       "source_location": "L1",
       "id": "useractivity",
-      "community": 2
+      "community": 0
     },
     {
       "label": "ActivityHeader()",
@@ -8577,7 +8577,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
       "source_location": "L22",
       "id": "useractivity_activityheader",
-      "community": 2
+      "community": 0
     },
     {
       "label": "UserActivity()",
@@ -8585,7 +8585,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
       "source_location": "L45",
       "id": "useractivity_useractivity",
-      "community": 2
+      "community": 0
     },
     {
       "label": "UserAnalyticsName.tsx",
@@ -8593,7 +8593,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserAnalyticsName.tsx",
       "source_location": "L1",
       "id": "useranalyticsname",
-      "community": 2
+      "community": 0
     },
     {
       "label": "UserAnalyticsName()",
@@ -8601,7 +8601,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserAnalyticsName.tsx",
       "source_location": "L13",
       "id": "useranalyticsname_useranalyticsname",
-      "community": 2
+      "community": 0
     },
     {
       "label": "UserBag.tsx",
@@ -8609,7 +8609,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserBag.tsx",
       "source_location": "L1",
       "id": "userbag",
-      "community": 3
+      "community": 0
     },
     {
       "label": "UserBag()",
@@ -8617,7 +8617,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserBag.tsx",
       "source_location": "L7",
       "id": "userbag_userbag",
-      "community": 3
+      "community": 0
     },
     {
       "label": "UserCheckoutSession.tsx",
@@ -8625,7 +8625,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserCheckoutSession.tsx",
       "source_location": "L1",
       "id": "usercheckoutsession",
-      "community": 1
+      "community": 0
     },
     {
       "label": "UserInsightsSection.tsx",
@@ -8633,7 +8633,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserInsightsSection.tsx",
       "source_location": "L1",
       "id": "userinsightssection",
-      "community": 2
+      "community": 0
     },
     {
       "label": "UserOnlineOrders.tsx",
@@ -8641,7 +8641,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserOnlineOrders.tsx",
       "source_location": "L1",
       "id": "useronlineorders",
-      "community": 2
+      "community": 0
     },
     {
       "label": "UserOnlineOrders()",
@@ -8649,7 +8649,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserOnlineOrders.tsx",
       "source_location": "L11",
       "id": "useronlineorders_useronlineorders",
-      "community": 2
+      "community": 0
     },
     {
       "label": "UserStatus.tsx",
@@ -8657,7 +8657,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserStatus.tsx",
       "source_location": "L1",
       "id": "userstatus",
-      "community": 2
+      "community": 0
     },
     {
       "label": "UserStatus()",
@@ -8665,7 +8665,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserStatus.tsx",
       "source_location": "L7",
       "id": "userstatus_userstatus",
-      "community": 2
+      "community": 0
     },
     {
       "label": "UserView.tsx",
@@ -8673,7 +8673,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserView.tsx",
       "source_location": "L1",
       "id": "userview",
-      "community": 2
+      "community": 0
     },
     {
       "label": "UserActions()",
@@ -8681,7 +8681,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserView.tsx",
       "source_location": "L45",
       "id": "userview_useractions",
-      "community": 2
+      "community": 0
     },
     {
       "label": "CustomerJourneyStage.tsx",
@@ -8689,7 +8689,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/CustomerJourneyStage.tsx",
       "source_location": "L1",
       "id": "customerjourneystage",
-      "community": 2
+      "community": 18
     },
     {
       "label": "CustomerJourneyStageCard()",
@@ -8697,7 +8697,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/CustomerJourneyStage.tsx",
       "source_location": "L13",
       "id": "customerjourneystage_customerjourneystagecard",
-      "community": 2
+      "community": 18
     },
     {
       "label": "EngagementMetrics.tsx",
@@ -8705,7 +8705,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
       "source_location": "L1",
       "id": "engagementmetrics",
-      "community": 2
+      "community": 18
     },
     {
       "label": "formatLastActivity()",
@@ -8713,7 +8713,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
       "source_location": "L75",
       "id": "engagementmetrics_formatlastactivity",
-      "community": 2
+      "community": 18
     },
     {
       "label": "getDeviceIcon()",
@@ -8721,7 +8721,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
       "source_location": "L82",
       "id": "engagementmetrics_getdeviceicon",
-      "community": 2
+      "community": 18
     },
     {
       "label": "getDeviceLabel()",
@@ -8729,7 +8729,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
       "source_location": "L93",
       "id": "engagementmetrics_getdevicelabel",
-      "community": 2
+      "community": 18
     },
     {
       "label": "RiskIndicators.tsx",
@@ -8737,7 +8737,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
       "source_location": "L1",
       "id": "riskindicators",
-      "community": 2
+      "community": 18
     },
     {
       "label": "getRiskIcon()",
@@ -8745,7 +8745,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
       "source_location": "L15",
       "id": "riskindicators_getriskicon",
-      "community": 2
+      "community": 18
     },
     {
       "label": "getRiskStyles()",
@@ -8753,7 +8753,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
       "source_location": "L28",
       "id": "riskindicators_getriskstyles",
-      "community": 2
+      "community": 18
     },
     {
       "label": "RiskIndicators()",
@@ -8761,7 +8761,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
       "source_location": "L54",
       "id": "riskindicators_riskindicators",
-      "community": 2
+      "community": 18
     },
     {
       "label": "UserBehaviorInsights.tsx",
@@ -8769,7 +8769,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/UserBehaviorInsights.tsx",
       "source_location": "L1",
       "id": "userbehaviorinsights",
-      "community": 2
+      "community": 18
     },
     {
       "label": "OnlineOrderContext.tsx",
@@ -8777,7 +8777,7 @@
       "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
       "source_location": "L1",
       "id": "onlineordercontext",
-      "community": 19
+      "community": 0
     },
     {
       "label": "OnlineOrderProvider()",
@@ -8785,7 +8785,7 @@
       "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
       "source_location": "L24",
       "id": "onlineordercontext_onlineorderprovider",
-      "community": 19
+      "community": 0
     },
     {
       "label": "useOnlineOrder()",
@@ -8793,7 +8793,7 @@
       "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
       "source_location": "L38",
       "id": "onlineordercontext_useonlineorder",
-      "community": 19
+      "community": 0
     },
     {
       "label": "PermissionsContext.tsx",
@@ -8801,7 +8801,7 @@
       "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
       "source_location": "L1",
       "id": "permissionscontext",
-      "community": 1
+      "community": 3
     },
     {
       "label": "PermissionsProvider()",
@@ -8809,7 +8809,7 @@
       "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
       "source_location": "L23",
       "id": "permissionscontext_permissionsprovider",
-      "community": 1
+      "community": 3
     },
     {
       "label": "usePermissionsContext()",
@@ -8817,7 +8817,7 @@
       "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
       "source_location": "L51",
       "id": "permissionscontext_usepermissionscontext",
-      "community": 1
+      "community": 3
     },
     {
       "label": "ProductContext.tsx",
@@ -8825,7 +8825,7 @@
       "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
       "source_location": "L1",
       "id": "productcontext",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ProductProvider()",
@@ -8833,7 +8833,7 @@
       "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
       "source_location": "L54",
       "id": "productcontext_productprovider",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useProduct()",
@@ -8841,7 +8841,7 @@
       "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
       "source_location": "L282",
       "id": "productcontext_useproduct",
-      "community": 1
+      "community": 0
     },
     {
       "label": "ThemeContext.tsx",
@@ -8857,7 +8857,7 @@
       "source_file": "packages/athena-webapp/src/contexts/UserContext.tsx",
       "source_location": "L1",
       "id": "usercontext",
-      "community": 0
+      "community": 17
     },
     {
       "label": "UserProvider()",
@@ -8865,7 +8865,7 @@
       "source_file": "packages/athena-webapp/src/contexts/UserContext.tsx",
       "source_location": "L12",
       "id": "usercontext_userprovider",
-      "community": 0
+      "community": 17
     },
     {
       "label": "useUserContext()",
@@ -8873,7 +8873,7 @@
       "source_file": "packages/athena-webapp/src/contexts/UserContext.tsx",
       "source_location": "L37",
       "id": "usercontext_useusercontext",
-      "community": 0
+      "community": 17
     },
     {
       "label": "use-image-upload.ts",
@@ -8881,7 +8881,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-image-upload.ts",
       "source_location": "L1",
       "id": "use_image_upload",
-      "community": 0
+      "community": 6
     },
     {
       "label": "useImageUpload()",
@@ -8889,7 +8889,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-image-upload.ts",
       "source_location": "L7",
       "id": "use_image_upload_useimageupload",
-      "community": 0
+      "community": 6
     },
     {
       "label": "use-mobile.tsx",
@@ -8897,7 +8897,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
       "source_location": "L1",
       "id": "use_mobile",
-      "community": 9
+      "community": 20
     },
     {
       "label": "useIsMobile()",
@@ -8905,7 +8905,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
       "source_location": "L5",
       "id": "use_mobile_useismobile",
-      "community": 9
+      "community": 20
     },
     {
       "label": "use-navigate-back.ts",
@@ -8913,7 +8913,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
       "source_location": "L1",
       "id": "use_navigate_back",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useNavigateBack()",
@@ -8921,7 +8921,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
       "source_location": "L5",
       "id": "use_navigate_back_usenavigateback",
-      "community": 1
+      "community": 0
     },
     {
       "label": "use-navigation-keyboard-shortcuts.ts",
@@ -8929,7 +8929,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-navigation-keyboard-shortcuts.ts",
       "source_location": "L1",
       "id": "use_navigation_keyboard_shortcuts",
-      "community": 0
+      "community": 5
     },
     {
       "label": "useNavigationKeyboardShortcuts()",
@@ -8937,7 +8937,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-navigation-keyboard-shortcuts.ts",
       "source_location": "L7",
       "id": "use_navigation_keyboard_shortcuts_usenavigationkeyboardshortcuts",
-      "community": 0
+      "community": 5
     },
     {
       "label": "use-pagination-persistence.ts",
@@ -8945,7 +8945,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-pagination-persistence.ts",
       "source_location": "L1",
       "id": "use_pagination_persistence",
-      "community": 2
+      "community": 0
     },
     {
       "label": "usePaginationPersistence()",
@@ -8953,7 +8953,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-pagination-persistence.ts",
       "source_location": "L9",
       "id": "use_pagination_persistence_usepaginationpersistence",
-      "community": 2
+      "community": 0
     },
     {
       "label": "use-store-modal.tsx",
@@ -8961,7 +8961,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/use-store-modal.tsx",
       "source_location": "L1",
       "id": "use_store_modal",
-      "community": 0
+      "community": 17
     },
     {
       "label": "use-table-keyboard-pagination.ts",
@@ -8969,7 +8969,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-table-keyboard-pagination.ts",
       "source_location": "L1",
       "id": "use_table_keyboard_pagination",
-      "community": 2
+      "community": 0
     },
     {
       "label": "useTableKeyboardPagination()",
@@ -8977,7 +8977,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-table-keyboard-pagination.ts",
       "source_location": "L6",
       "id": "use_table_keyboard_pagination_usetablekeyboardpagination",
-      "community": 2
+      "community": 0
     },
     {
       "label": "useAuth.ts",
@@ -8985,7 +8985,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useAuth.ts",
       "source_location": "L1",
       "id": "useauth",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useAuth()",
@@ -8993,7 +8993,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useAuth.ts",
       "source_location": "L4",
       "id": "useauth_useauth",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useBulkOperations.test.ts",
@@ -9001,7 +9001,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.test.ts",
       "source_location": "L1",
       "id": "usebulkoperations_test",
-      "community": 13
+      "community": 8
     },
     {
       "label": "makeSku()",
@@ -9009,7 +9009,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.test.ts",
       "source_location": "L168",
       "id": "usebulkoperations_test_makesku",
-      "community": 13
+      "community": 8
     },
     {
       "label": "useBulkOperations.ts",
@@ -9017,7 +9017,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L1",
       "id": "usebulkoperations",
-      "community": 13
+      "community": 8
     },
     {
       "label": "applyOperation()",
@@ -9025,7 +9025,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L56",
       "id": "usebulkoperations_applyoperation",
-      "community": 13
+      "community": 8
     },
     {
       "label": "calculatePriceWithFee()",
@@ -9033,7 +9033,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L87",
       "id": "usebulkoperations_calculatepricewithfee",
-      "community": 13
+      "community": 8
     },
     {
       "label": "computePreview()",
@@ -9041,7 +9041,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L101",
       "id": "usebulkoperations_computepreview",
-      "community": 13
+      "community": 8
     },
     {
       "label": "validateOperationValue()",
@@ -9049,7 +9049,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L139",
       "id": "usebulkoperations_validateoperationvalue",
-      "community": 13
+      "community": 8
     },
     {
       "label": "useBulkOperations()",
@@ -9057,7 +9057,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L158",
       "id": "usebulkoperations_usebulkoperations",
-      "community": 13
+      "community": 8
     },
     {
       "label": "useCartOperations.ts",
@@ -9065,7 +9065,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useCartOperations.ts",
       "source_location": "L1",
       "id": "usecartoperations",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useCartOperations()",
@@ -9073,7 +9073,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useCartOperations.ts",
       "source_location": "L23",
       "id": "usecartoperations_usecartoperations",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useCopyText.ts",
@@ -9081,7 +9081,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useCopyText.ts",
       "source_location": "L1",
       "id": "usecopytext",
-      "community": 2
+      "community": 0
     },
     {
       "label": "useCopyText()",
@@ -9089,7 +9089,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useCopyText.ts",
       "source_location": "L1",
       "id": "usecopytext_usecopytext",
-      "community": 2
+      "community": 0
     },
     {
       "label": "useCreateComplimentaryProduct.ts",
@@ -9097,7 +9097,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useCreateComplimentaryProduct.ts",
       "source_location": "L1",
       "id": "usecreatecomplimentaryproduct",
-      "community": 3
+      "community": 0
     },
     {
       "label": "useCreateComplimentaryProduct()",
@@ -9105,7 +9105,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useCreateComplimentaryProduct.ts",
       "source_location": "L6",
       "id": "usecreatecomplimentaryproduct_usecreatecomplimentaryproduct",
-      "community": 3
+      "community": 0
     },
     {
       "label": "useCustomerOperations.ts",
@@ -9113,7 +9113,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useCustomerOperations.ts",
       "source_location": "L1",
       "id": "usecustomeroperations",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useCustomerOperations()",
@@ -9121,7 +9121,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useCustomerOperations.ts",
       "source_location": "L21",
       "id": "usecustomeroperations_usecustomeroperations",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useDebounce.ts",
@@ -9129,7 +9129,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useDebounce.ts",
       "source_location": "L1",
       "id": "usedebounce",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useDebounce()",
@@ -9137,7 +9137,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useDebounce.ts",
       "source_location": "L12",
       "id": "usedebounce_usedebounce",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useExpenseOperations.ts",
@@ -9145,7 +9145,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
       "source_location": "L1",
       "id": "useexpenseoperations",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useExpenseOperations()",
@@ -9153,7 +9153,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
       "source_location": "L23",
       "id": "useexpenseoperations_useexpenseoperations",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useExpenseSessions.ts",
@@ -9161,7 +9161,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L1",
       "id": "useexpensesessions",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useExpenseStoreSessions()",
@@ -9169,7 +9169,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L7",
       "id": "useexpensesessions_useexpensestoresessions",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useExpenseSession()",
@@ -9177,7 +9177,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L23",
       "id": "useexpensesessions_useexpensesession",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useExpenseActiveSession()",
@@ -9185,7 +9185,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L33",
       "id": "useexpensesessions_useexpenseactivesession",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useExpenseSessionCreate()",
@@ -9193,7 +9193,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L48",
       "id": "useexpensesessions_useexpensesessioncreate",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useExpenseSessionUpdate()",
@@ -9201,7 +9201,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L85",
       "id": "useexpensesessions_useexpensesessionupdate",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useGetActiveProduct.ts",
@@ -9209,7 +9209,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
       "source_location": "L1",
       "id": "usegetactiveproduct",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useGetActiveProduct()",
@@ -9217,7 +9217,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
       "source_location": "L6",
       "id": "usegetactiveproduct_usegetactiveproduct",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useGetActiveStore.ts",
@@ -9225,7 +9225,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetActiveStore.ts",
       "source_location": "L1",
       "id": "usegetactivestore",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useGetActiveStore()",
@@ -9233,7 +9233,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetActiveStore.ts",
       "source_location": "L9",
       "id": "usegetactivestore_usegetactivestore",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useGetStores()",
@@ -9241,7 +9241,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetActiveStore.ts",
       "source_location": "L50",
       "id": "usegetactivestore_usegetstores",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useGetAuthedUser.ts",
@@ -9249,7 +9249,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetAuthedUser.ts",
       "source_location": "L1",
       "id": "usegetautheduser",
-      "community": 3
+      "community": 0
     },
     {
       "label": "useGetAuthedUser()",
@@ -9257,7 +9257,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetAuthedUser.ts",
       "source_location": "L4",
       "id": "usegetautheduser_usegetautheduser",
-      "community": 3
+      "community": 0
     },
     {
       "label": "useGetCategories.ts",
@@ -9265,7 +9265,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetCategories.ts",
       "source_location": "L1",
       "id": "usegetcategories",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useGetCategories()",
@@ -9273,7 +9273,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetCategories.ts",
       "source_location": "L5",
       "id": "usegetcategories_usegetcategories",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useGetComplimentaryProducts.ts",
@@ -9281,7 +9281,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetComplimentaryProducts.ts",
       "source_location": "L1",
       "id": "usegetcomplimentaryproducts",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useGetComplimentaryProducts()",
@@ -9289,7 +9289,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetComplimentaryProducts.ts",
       "source_location": "L5",
       "id": "usegetcomplimentaryproducts_usegetcomplimentaryproducts",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useGetCurrencyFormatter.ts",
@@ -9297,7 +9297,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetCurrencyFormatter.ts",
       "source_location": "L1",
       "id": "usegetcurrencyformatter",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useGetCurrencyFormatter()",
@@ -9305,7 +9305,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetCurrencyFormatter.ts",
       "source_location": "L4",
       "id": "usegetcurrencyformatter_usegetcurrencyformatter",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useGetOrganizations.ts",
@@ -9313,7 +9313,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
       "source_location": "L1",
       "id": "usegetorganizations",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useGetActiveOrganization()",
@@ -9321,7 +9321,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
       "source_location": "L6",
       "id": "usegetorganizations_usegetactiveorganization",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useGetOrganizations()",
@@ -9329,7 +9329,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
       "source_location": "L31",
       "id": "usegetorganizations_usegetorganizations",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useGetProducts.ts",
@@ -9337,7 +9337,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
       "source_location": "L1",
       "id": "usegetproducts",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useGetProducts()",
@@ -9345,7 +9345,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
       "source_location": "L5",
       "id": "usegetproducts_usegetproducts",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useGetUnresolvedProducts()",
@@ -9353,7 +9353,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
       "source_location": "L31",
       "id": "usegetproducts_usegetunresolvedproducts",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useGetSubcategories.ts",
@@ -9361,7 +9361,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetSubcategories.ts",
       "source_location": "L1",
       "id": "usegetsubcategories",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useGetSubcategories()",
@@ -9369,7 +9369,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetSubcategories.ts",
       "source_location": "L5",
       "id": "usegetsubcategories_usegetsubcategories",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useGetTerminal.ts",
@@ -9377,7 +9377,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetTerminal.ts",
       "source_location": "L1",
       "id": "usegetterminal",
-      "community": 1
+      "community": 3
     },
     {
       "label": "useGetTerminal()",
@@ -9385,7 +9385,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetTerminal.ts",
       "source_location": "L6",
       "id": "usegetterminal_usegetterminal",
-      "community": 1
+      "community": 3
     },
     {
       "label": "useNewOrderNotification.ts",
@@ -9393,7 +9393,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useNewOrderNotification.ts",
       "source_location": "L1",
       "id": "usenewordernotification",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useNewOrderNotification()",
@@ -9401,7 +9401,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useNewOrderNotification.ts",
       "source_location": "L8",
       "id": "usenewordernotification_usenewordernotification",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useOrganizationModal.tsx",
@@ -9409,7 +9409,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useOrganizationModal.tsx",
       "source_location": "L1",
       "id": "useorganizationmodal",
-      "community": 5
+      "community": 17
     },
     {
       "label": "usePOSCustomers.ts",
@@ -9417,7 +9417,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L1",
       "id": "useposcustomers",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSCustomerSearch()",
@@ -9425,7 +9425,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L7",
       "id": "useposcustomers_useposcustomersearch",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSCustomer()",
@@ -9433,7 +9433,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L18",
       "id": "useposcustomers_useposcustomer",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSCustomerCreate()",
@@ -9441,7 +9441,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L26",
       "id": "useposcustomers_useposcustomercreate",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSCustomerUpdate()",
@@ -9449,7 +9449,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L57",
       "id": "useposcustomers_useposcustomerupdate",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSCustomerTransactions()",
@@ -9457,7 +9457,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L90",
       "id": "useposcustomers_useposcustomertransactions",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSOperations.ts",
@@ -9465,7 +9465,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSOperations.ts",
       "source_location": "L1",
       "id": "useposoperations",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSOperations()",
@@ -9473,7 +9473,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSOperations.ts",
       "source_location": "L30",
       "id": "useposoperations_useposoperations",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSState()",
@@ -9481,7 +9481,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSOperations.ts",
       "source_location": "L580",
       "id": "useposoperations_useposstate",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSProducts.ts",
@@ -9489,7 +9489,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L1",
       "id": "useposproducts",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSProductSearch()",
@@ -9497,7 +9497,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L10",
       "id": "useposproducts_useposproductsearch",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSBarcodeSearch()",
@@ -9505,7 +9505,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L30",
       "id": "useposproducts_useposbarcodesearch",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSProductIdSearch()",
@@ -9513,7 +9513,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L41",
       "id": "useposproducts_useposproductidsearch",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSTransactionComplete()",
@@ -9521,7 +9521,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L100",
       "id": "useposproducts_usepostransactioncomplete",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSSessions.ts",
@@ -9529,7 +9529,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L1",
       "id": "usepossessions",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSStoreSessions()",
@@ -9537,7 +9537,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L8",
       "id": "usepossessions_useposstoresessions",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSSession()",
@@ -9545,7 +9545,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L24",
       "id": "usepossessions_usepossession",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSActiveSession()",
@@ -9553,7 +9553,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L32",
       "id": "usepossessions_useposactivesession",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSSessionCreate()",
@@ -9561,7 +9561,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L47",
       "id": "usepossessions_usepossessioncreate",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSSessionUpdate()",
@@ -9569,7 +9569,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L82",
       "id": "usepossessions_usepossessionupdate",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSSessionHold()",
@@ -9577,7 +9577,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L117",
       "id": "usepossessions_usepossessionhold",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSSessionResume()",
@@ -9585,7 +9585,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L137",
       "id": "usepossessions_usepossessionresume",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSSessionComplete()",
@@ -9593,7 +9593,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L157",
       "id": "usepossessions_usepossessioncomplete",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSSessionVoid()",
@@ -9601,7 +9601,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L191",
       "id": "usepossessions_usepossessionvoid",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSSessionManager()",
@@ -9609,7 +9609,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L207",
       "id": "usepossessions_usepossessionmanager",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePermissions.ts",
@@ -9617,7 +9617,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePermissions.ts",
       "source_location": "L1",
       "id": "usepermissions",
-      "community": 1
+      "community": 0
     },
     {
       "label": "usePermissions()",
@@ -9625,7 +9625,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePermissions.ts",
       "source_location": "L12",
       "id": "usepermissions_usepermissions",
-      "community": 1
+      "community": 0
     },
     {
       "label": "usePrint.ts",
@@ -9633,7 +9633,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
       "source_location": "L1",
       "id": "useprint",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePrint()",
@@ -9641,7 +9641,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
       "source_location": "L3",
       "id": "useprint_useprint",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useProductSearchResults.ts",
@@ -9649,7 +9649,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
       "source_location": "L1",
       "id": "useproductsearchresults",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useProductSearchResults()",
@@ -9657,7 +9657,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
       "source_location": "L26",
       "id": "useproductsearchresults_useproductsearchresults",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useProductWithNoImagesNotification.tsx",
@@ -9665,7 +9665,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useProductWithNoImagesNotification.tsx",
       "source_location": "L1",
       "id": "useproductwithnoimagesnotification",
-      "community": 4
+      "community": 0
     },
     {
       "label": "useProductWithNoImagesNotification()",
@@ -9673,7 +9673,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useProductWithNoImagesNotification.tsx",
       "source_location": "L7",
       "id": "useproductwithnoimagesnotification_useproductwithnoimagesnotification",
-      "community": 4
+      "community": 0
     },
     {
       "label": "useSessionManagement.ts",
@@ -9681,7 +9681,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSessionManagement.ts",
       "source_location": "L1",
       "id": "usesessionmanagement",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useSessionManagement()",
@@ -9689,7 +9689,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSessionManagement.ts",
       "source_location": "L17",
       "id": "usesessionmanagement_usesessionmanagement",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useSessionManagementExpense.ts",
@@ -9697,7 +9697,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSessionManagementExpense.ts",
       "source_location": "L1",
       "id": "usesessionmanagementexpense",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useSessionManagementExpense()",
@@ -9705,7 +9705,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSessionManagementExpense.ts",
       "source_location": "L17",
       "id": "usesessionmanagementexpense_usesessionmanagementexpense",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useSessionManagerOperations.ts",
@@ -9713,7 +9713,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSessionManagerOperations.ts",
       "source_location": "L1",
       "id": "usesessionmanageroperations",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useSessionManagerOperations()",
@@ -9721,7 +9721,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSessionManagerOperations.ts",
       "source_location": "L16",
       "id": "usesessionmanageroperations_usesessionmanageroperations",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useSkusReservedInCheckout.ts",
@@ -9729,7 +9729,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSkusReservedInCheckout.ts",
       "source_location": "L1",
       "id": "useskusreservedincheckout",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useSkusReservedInCheckout()",
@@ -9737,7 +9737,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSkusReservedInCheckout.ts",
       "source_location": "L12",
       "id": "useskusreservedincheckout_useskusreservedincheckout",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useSkusReservedInPosSession.ts",
@@ -9745,7 +9745,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSkusReservedInPosSession.ts",
       "source_location": "L1",
       "id": "useskusreservedinpossession",
-      "community": 9
+      "community": 0
     },
     {
       "label": "useSkusReservedInPosSession()",
@@ -9753,7 +9753,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSkusReservedInPosSession.ts",
       "source_location": "L12",
       "id": "useskusreservedinpossession_useskusreservedinpossession",
-      "community": 9
+      "community": 0
     },
     {
       "label": "useToggleComplimentaryProductActive.ts",
@@ -9761,7 +9761,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useToggleComplimentaryProductActive.ts",
       "source_location": "L1",
       "id": "usetogglecomplimentaryproductactive",
-      "community": 2
+      "community": 0
     },
     {
       "label": "useToggleComplimentaryProductActive()",
@@ -9769,7 +9769,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useToggleComplimentaryProductActive.ts",
       "source_location": "L5",
       "id": "usetogglecomplimentaryproductactive_usetogglecomplimentaryproductactive",
-      "community": 2
+      "community": 0
     },
     {
       "label": "aws.ts",
@@ -9785,7 +9785,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L1",
       "id": "behaviorutils",
-      "community": 2
+      "community": 18
     },
     {
       "label": "getCustomerJourneyStage()",
@@ -9793,7 +9793,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L36",
       "id": "behaviorutils_getcustomerjourneystage",
-      "community": 2
+      "community": 18
     },
     {
       "label": "calculateRiskIndicators()",
@@ -9801,7 +9801,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L71",
       "id": "behaviorutils_calculateriskindicators",
-      "community": 2
+      "community": 18
     },
     {
       "label": "calculateEngagementMetrics()",
@@ -9809,7 +9809,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L173",
       "id": "behaviorutils_calculateengagementmetrics",
-      "community": 2
+      "community": 18
     },
     {
       "label": "getActivityPriority()",
@@ -9817,7 +9817,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L251",
       "id": "behaviorutils_getactivitypriority",
-      "community": 2
+      "community": 18
     },
     {
       "label": "getJourneyStageInfo()",
@@ -9825,7 +9825,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L277",
       "id": "behaviorutils_getjourneystageinfo",
-      "community": 2
+      "community": 18
     },
     {
       "label": "browserFingerprint.ts",
@@ -9833,7 +9833,7 @@
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
       "source_location": "L1",
       "id": "browserfingerprint",
-      "community": 7
+      "community": 4
     },
     {
       "label": "bufferToHex()",
@@ -9841,7 +9841,7 @@
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
       "source_location": "L18",
       "id": "browserfingerprint_buffertohex",
-      "community": 7
+      "community": 4
     },
     {
       "label": "collectBrowserInfo()",
@@ -9849,7 +9849,7 @@
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
       "source_location": "L23",
       "id": "browserfingerprint_collectbrowserinfo",
-      "community": 7
+      "community": 4
     },
     {
       "label": "hashFingerprintSource()",
@@ -9857,7 +9857,7 @@
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
       "source_location": "L45",
       "id": "browserfingerprint_hashfingerprintsource",
-      "community": 7
+      "community": 4
     },
     {
       "label": "generateBrowserFingerprint()",
@@ -9865,7 +9865,7 @@
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
       "source_location": "L65",
       "id": "browserfingerprint_generatebrowserfingerprint",
-      "community": 7
+      "community": 4
     },
     {
       "label": "customerObservabilityTimeline.ts",
@@ -9873,7 +9873,7 @@
       "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
       "source_location": "L1",
       "id": "customerobservabilitytimeline",
-      "community": 2
+      "community": 18
     },
     {
       "label": "formatObservabilityLabel()",
@@ -9881,7 +9881,7 @@
       "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
       "source_location": "L59",
       "id": "customerobservabilitytimeline_formatobservabilitylabel",
-      "community": 2
+      "community": 18
     },
     {
       "label": "getObservabilityStatusStyles()",
@@ -9889,7 +9889,7 @@
       "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
       "source_location": "L67",
       "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
-      "community": 2
+      "community": 18
     },
     {
       "label": "getDeviceIcon()",
@@ -9897,7 +9897,7 @@
       "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
       "source_location": "L114",
       "id": "customerobservabilitytimeline_getdeviceicon",
-      "community": 2
+      "community": 18
     },
     {
       "label": "ghanaRegions.ts",
@@ -9905,7 +9905,7 @@
       "source_file": "packages/storefront-webapp/src/lib/ghanaRegions.ts",
       "source_location": "L1",
       "id": "ghanaregions",
-      "community": 5
+      "community": 1
     },
     {
       "label": "imageUtils.test.ts",
@@ -9913,7 +9913,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
       "source_location": "L1",
       "id": "imageutils_test",
-      "community": 14
+      "community": 12
     },
     {
       "label": "constructor()",
@@ -9921,7 +9921,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
       "source_location": "L74",
       "id": "imageutils_test_constructor",
-      "community": 14
+      "community": 12
     },
     {
       "label": "arrayBuffer()",
@@ -9929,7 +9929,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
       "source_location": "L78",
       "id": "imageutils_test_arraybuffer",
-      "community": 14
+      "community": 12
     },
     {
       "label": "MockImage",
@@ -9937,7 +9937,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
       "source_location": "L103",
       "id": "imageutils_test_mockimage",
-      "community": 14
+      "community": 12
     },
     {
       "label": ".src()",
@@ -9945,7 +9945,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
       "source_location": "L109",
       "id": "imageutils_test_mockimage_src",
-      "community": 14
+      "community": 12
     },
     {
       "label": "imageUtils.ts",
@@ -9953,7 +9953,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
       "source_location": "L1",
       "id": "imageutils",
-      "community": 14
+      "community": 12
     },
     {
       "label": "getUploadImagesData()",
@@ -9961,7 +9961,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
       "source_location": "L4",
       "id": "imageutils_getuploadimagesdata",
-      "community": 14
+      "community": 12
     },
     {
       "label": "convertImagesToWebp()",
@@ -9969,7 +9969,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
       "source_location": "L26",
       "id": "imageutils_convertimagestowebp",
-      "community": 14
+      "community": 12
     },
     {
       "label": "convertToJpg()",
@@ -9977,7 +9977,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
       "source_location": "L38",
       "id": "imageutils_converttojpg",
-      "community": 14
+      "community": 12
     },
     {
       "label": "convertImagesToJpg()",
@@ -9985,7 +9985,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
       "source_location": "L75",
       "id": "imageutils_convertimagestojpg",
-      "community": 14
+      "community": 12
     },
     {
       "label": "logger.ts",
@@ -9993,7 +9993,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L1",
       "id": "logger",
-      "community": 4
+      "community": 3
     },
     {
       "label": "Logger",
@@ -10001,7 +10001,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L12",
       "id": "logger_logger",
-      "community": 24
+      "community": 25
     },
     {
       "label": ".constructor()",
@@ -10009,7 +10009,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L15",
       "id": "logger_logger_constructor",
-      "community": 24
+      "community": 25
     },
     {
       "label": ".shouldLog()",
@@ -10017,7 +10017,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L20",
       "id": "logger_logger_shouldlog",
-      "community": 24
+      "community": 25
     },
     {
       "label": ".formatMessage()",
@@ -10025,7 +10025,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L30",
       "id": "logger_logger_formatmessage",
-      "community": 24
+      "community": 25
     },
     {
       "label": ".debug()",
@@ -10033,7 +10033,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L45",
       "id": "logger_logger_debug",
-      "community": 24
+      "community": 25
     },
     {
       "label": ".info()",
@@ -10041,7 +10041,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L51",
       "id": "logger_logger_info",
-      "community": 24
+      "community": 25
     },
     {
       "label": ".warn()",
@@ -10049,7 +10049,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L57",
       "id": "logger_logger_warn",
-      "community": 24
+      "community": 25
     },
     {
       "label": ".error()",
@@ -10057,7 +10057,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L63",
       "id": "logger_logger_error",
-      "community": 24
+      "community": 25
     },
     {
       "label": "maintenanceUtils.ts",
@@ -10081,7 +10081,7 @@
       "source_file": "packages/athena-webapp/src/lib/navigationUtils.ts",
       "source_location": "L1",
       "id": "navigationutils",
-      "community": 2
+      "community": 0
     },
     {
       "label": "getOrigin()",
@@ -10089,7 +10089,7 @@
       "source_file": "packages/athena-webapp/src/lib/navigationUtils.ts",
       "source_location": "L1",
       "id": "navigationutils_getorigin",
-      "community": 2
+      "community": 0
     },
     {
       "label": "barcodeUtils.ts",
@@ -10097,7 +10097,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
       "source_location": "L1",
       "id": "barcodeutils",
-      "community": 4
+      "community": 3
     },
     {
       "label": "isValidConvexId()",
@@ -10105,7 +10105,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
       "source_location": "L16",
       "id": "barcodeutils_isvalidconvexid",
-      "community": 4
+      "community": 3
     },
     {
       "label": "extractBarcodeFromInput()",
@@ -10113,7 +10113,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
       "source_location": "L51",
       "id": "barcodeutils_extractbarcodefrominput",
-      "community": 4
+      "community": 3
     },
     {
       "label": "isUrlOrBarcode()",
@@ -10121,7 +10121,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
       "source_location": "L92",
       "id": "barcodeutils_isurlorbarcode",
-      "community": 4
+      "community": 3
     },
     {
       "label": "calculations.ts",
@@ -10129,7 +10129,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/calculations.ts",
       "source_location": "L1",
       "id": "calculations",
-      "community": 4
+      "community": 3
     },
     {
       "label": "calculateCartTotals()",
@@ -10137,7 +10137,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/calculations.ts",
       "source_location": "L10",
       "id": "calculations_calculatecarttotals",
-      "community": 4
+      "community": 3
     },
     {
       "label": "calculationService.ts",
@@ -10145,7 +10145,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
       "source_location": "L1",
       "id": "calculationservice",
-      "community": 4
+      "community": 3
     },
     {
       "label": "calculateCartTotals()",
@@ -10153,7 +10153,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
       "source_location": "L30",
       "id": "calculationservice_calculatecarttotals",
-      "community": 4
+      "community": 3
     },
     {
       "label": "calculateItemTotal()",
@@ -10161,7 +10161,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
       "source_location": "L61",
       "id": "calculationservice_calculateitemtotal",
-      "community": 4
+      "community": 3
     },
     {
       "label": "calculateChange()",
@@ -10169,7 +10169,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
       "source_location": "L68",
       "id": "calculationservice_calculatechange",
-      "community": 4
+      "community": 3
     },
     {
       "label": "formatCurrency()",
@@ -10177,7 +10177,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
       "source_location": "L75",
       "id": "calculationservice_formatcurrency",
-      "community": 4
+      "community": 3
     },
     {
       "label": "isPaymentSufficient()",
@@ -10185,7 +10185,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
       "source_location": "L85",
       "id": "calculationservice_ispaymentsufficient",
-      "community": 4
+      "community": 3
     },
     {
       "label": "getEffectivePrice()",
@@ -10193,7 +10193,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
       "source_location": "L96",
       "id": "calculationservice_geteffectiveprice",
-      "community": 4
+      "community": 3
     },
     {
       "label": "toastService.ts",
@@ -10201,7 +10201,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L1",
       "id": "toastservice",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handlePOSOperation()",
@@ -10209,7 +10209,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L171",
       "id": "toastservice_handleposoperation",
-      "community": 4
+      "community": 3
     },
     {
       "label": "showValidationError()",
@@ -10217,7 +10217,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L293",
       "id": "toastservice_showvalidationerror",
-      "community": 4
+      "community": 3
     },
     {
       "label": "showInventoryError()",
@@ -10225,7 +10225,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L302",
       "id": "toastservice_showinventoryerror",
-      "community": 4
+      "community": 3
     },
     {
       "label": "showSessionExpiredError()",
@@ -10233,7 +10233,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L312",
       "id": "toastservice_showsessionexpirederror",
-      "community": 4
+      "community": 3
     },
     {
       "label": "showNoActiveSessionError()",
@@ -10241,7 +10241,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L319",
       "id": "toastservice_shownoactivesessionerror",
-      "community": 4
+      "community": 3
     },
     {
       "label": "transactionUtils.ts",
@@ -10249,7 +10249,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
       "source_location": "L1",
       "id": "transactionutils",
-      "community": 4
+      "community": 3
     },
     {
       "label": "generateTransactionNumber()",
@@ -10257,7 +10257,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
       "source_location": "L14",
       "id": "transactionutils_generatetransactionnumber",
-      "community": 4
+      "community": 3
     },
     {
       "label": "formatCurrency()",
@@ -10265,7 +10265,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
       "source_location": "L29",
       "id": "transactionutils_formatcurrency",
-      "community": 4
+      "community": 3
     },
     {
       "label": "calculateChange()",
@@ -10273,7 +10273,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
       "source_location": "L42",
       "id": "transactionutils_calculatechange",
-      "community": 4
+      "community": 3
     },
     {
       "label": "formatTimestamp()",
@@ -10281,7 +10281,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
       "source_location": "L49",
       "id": "transactionutils_formattimestamp",
-      "community": 4
+      "community": 3
     },
     {
       "label": "validation.ts",
@@ -10289,7 +10289,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L1",
       "id": "validation",
-      "community": 4
+      "community": 3
     },
     {
       "label": "validateCart()",
@@ -10297,7 +10297,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L21",
       "id": "validation_validatecart",
-      "community": 4
+      "community": 3
     },
     {
       "label": "validateProduct()",
@@ -10305,7 +10305,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L68",
       "id": "validation_validateproduct",
-      "community": 4
+      "community": 3
     },
     {
       "label": "validateCustomer()",
@@ -10313,7 +10313,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L108",
       "id": "validation_validatecustomer",
-      "community": 4
+      "community": 3
     },
     {
       "label": "validatePayment()",
@@ -10321,7 +10321,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L146",
       "id": "validation_validatepayment",
-      "community": 4
+      "community": 3
     },
     {
       "label": "validateBarcode()",
@@ -10329,7 +10329,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L185",
       "id": "validation_validatebarcode",
-      "community": 4
+      "community": 3
     },
     {
       "label": "validateQuantity()",
@@ -10337,7 +10337,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L213",
       "id": "validation_validatequantity",
-      "community": 4
+      "community": 3
     },
     {
       "label": "isValidEmail()",
@@ -10345,7 +10345,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L244",
       "id": "validation_isvalidemail",
-      "community": 4
+      "community": 3
     },
     {
       "label": "validateSession()",
@@ -10353,7 +10353,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L252",
       "id": "validation_validatesession",
-      "community": 4
+      "community": 3
     },
     {
       "label": "isValidPhone()",
@@ -10361,7 +10361,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L304",
       "id": "validation_isvalidphone",
-      "community": 4
+      "community": 3
     },
     {
       "label": "validatePaymentAmount()",
@@ -10369,7 +10369,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L317",
       "id": "validation_validatepaymentamount",
-      "community": 4
+      "community": 3
     },
     {
       "label": "validatePayments()",
@@ -10377,7 +10377,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L359",
       "id": "validation_validatepayments",
-      "community": 4
+      "community": 3
     },
     {
       "label": "canCompleteTransaction()",
@@ -10385,7 +10385,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L404",
       "id": "validation_cancompletetransaction",
-      "community": 4
+      "community": 3
     },
     {
       "label": "productUtils.test.ts",
@@ -10393,7 +10393,7 @@
       "source_file": "packages/athena-webapp/src/lib/productUtils.test.ts",
       "source_location": "L1",
       "id": "productutils_test",
-      "community": 0
+      "community": 1
     },
     {
       "label": "productUtils.ts",
@@ -10401,7 +10401,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L1",
       "id": "productutils",
-      "community": 0
+      "community": 1
     },
     {
       "label": "getProductName()",
@@ -10409,7 +10409,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L18",
       "id": "productutils_getproductname",
-      "community": 0
+      "community": 1
     },
     {
       "label": "sortProduct()",
@@ -10417,7 +10417,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L66",
       "id": "productutils_sortproduct",
-      "community": 0
+      "community": 1
     },
     {
       "label": "pinHash.ts",
@@ -10425,7 +10425,7 @@
       "source_file": "packages/athena-webapp/src/lib/security/pinHash.ts",
       "source_location": "L1",
       "id": "pinhash",
-      "community": 5
+      "community": 1
     },
     {
       "label": "hashPin()",
@@ -10433,7 +10433,7 @@
       "source_file": "packages/athena-webapp/src/lib/security/pinHash.ts",
       "source_location": "L12",
       "id": "pinhash_hashpin",
-      "community": 5
+      "community": 1
     },
     {
       "label": "storeConfig.test.ts",
@@ -10585,7 +10585,7 @@
       "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
       "source_location": "L1",
       "id": "timelineutils",
-      "community": 2
+      "community": 18
     },
     {
       "label": "enrichTimelineEvent()",
@@ -10593,7 +10593,7 @@
       "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
       "source_location": "L184",
       "id": "timelineutils_enrichtimelineevent",
-      "community": 2
+      "community": 18
     },
     {
       "label": "enrichTimelineEvents()",
@@ -10601,7 +10601,7 @@
       "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
       "source_location": "L200",
       "id": "timelineutils_enrichtimelineevents",
-      "community": 2
+      "community": 18
     },
     {
       "label": "groupEventsByTimeframe()",
@@ -10609,7 +10609,7 @@
       "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
       "source_location": "L206",
       "id": "timelineutils_groupeventsbytimeframe",
-      "community": 2
+      "community": 18
     },
     {
       "label": "getTimeRangeLabel()",
@@ -10617,7 +10617,7 @@
       "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
       "source_location": "L244",
       "id": "timelineutils_gettimerangelabel",
-      "community": 2
+      "community": 18
     },
     {
       "label": "utils.test.ts",
@@ -10625,7 +10625,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.test.ts",
       "source_location": "L1",
       "id": "utils_test",
-      "community": 4
+      "community": 0
     },
     {
       "label": "cn()",
@@ -10633,7 +10633,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L9",
       "id": "utils_cn",
-      "community": 2
+      "community": 0
     },
     {
       "label": "getErrorForField()",
@@ -10641,7 +10641,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L14",
       "id": "utils_geterrorforfield",
-      "community": 2
+      "community": 0
     },
     {
       "label": "capitalizeFirstLetter()",
@@ -10649,7 +10649,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L18",
       "id": "utils_capitalizefirstletter",
-      "community": 2
+      "community": 0
     },
     {
       "label": "slugToWords()",
@@ -10657,7 +10657,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L31",
       "id": "utils_slugtowords",
-      "community": 2
+      "community": 0
     },
     {
       "label": "snakeCaseToWords()",
@@ -10665,7 +10665,7 @@
       "source_file": "packages/athena-webapp/src/lib/utils.ts",
       "source_location": "L50",
       "id": "utils_snakecasetowords",
-      "community": 2
+      "community": 0
     },
     {
       "label": "getRelativeTime()",
@@ -10673,7 +10673,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L67",
       "id": "utils_getrelativetime",
-      "community": 2
+      "community": 0
     },
     {
       "label": "getTimeRemaining()",
@@ -10681,7 +10681,7 @@
       "source_file": "packages/athena-webapp/src/lib/utils.ts",
       "source_location": "L71",
       "id": "utils_gettimeremaining",
-      "community": 2
+      "community": 0
     },
     {
       "label": "formatUserId()",
@@ -10689,7 +10689,7 @@
       "source_file": "packages/athena-webapp/src/lib/utils.ts",
       "source_location": "L91",
       "id": "utils_formatuserid",
-      "community": 2
+      "community": 0
     },
     {
       "label": "main.tsx",
@@ -10697,7 +10697,7 @@
       "source_file": "packages/storefront-webapp/src/main.tsx",
       "source_location": "L1",
       "id": "main",
-      "community": 8
+      "community": 4
     },
     {
       "label": "App()",
@@ -10705,7 +10705,7 @@
       "source_file": "packages/storefront-webapp/src/main.tsx",
       "source_location": "L38",
       "id": "main_app",
-      "community": 8
+      "community": 4
     },
     {
       "label": "routeTree.gen.ts",
@@ -10713,7 +10713,7 @@
       "source_file": "packages/storefront-webapp/src/routeTree.gen.ts",
       "source_location": "L1",
       "id": "routetree_gen",
-      "community": 7
+      "community": 4
     },
     {
       "label": "__root.tsx",
@@ -10721,7 +10721,7 @@
       "source_file": "packages/storefront-webapp/src/routes/__root.tsx",
       "source_location": "L1",
       "id": "root",
-      "community": 0
+      "community": 5
     },
     {
       "label": "$storeUrlSlug.tsx",
@@ -10729,7 +10729,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/stores/$storeUrlSlug.tsx",
       "source_location": "L1",
       "id": "storeurlslug",
-      "community": 7
+      "community": 4
     },
     {
       "label": "assets.index.tsx",
@@ -10737,7 +10737,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/assets.index.tsx",
       "source_location": "L1",
       "id": "assets_index",
-      "community": 7
+      "community": 4
     },
     {
       "label": "bags.$bagId.tsx",
@@ -10745,7 +10745,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.$bagId.tsx",
       "source_location": "L1",
       "id": "bags_bagid",
-      "community": 7
+      "community": 4
     },
     {
       "label": "bags.index.tsx",
@@ -10753,7 +10753,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.index.tsx",
       "source_location": "L1",
       "id": "bags_index",
-      "community": 7
+      "community": 4
     },
     {
       "label": "checkout-sessions.index.tsx",
@@ -10761,7 +10761,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/checkout-sessions.index.tsx",
       "source_location": "L1",
       "id": "checkout_sessions_index",
-      "community": 7
+      "community": 4
     },
     {
       "label": "configuration.index.tsx",
@@ -10769,7 +10769,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/configuration.index.tsx",
       "source_location": "L1",
       "id": "configuration_index",
-      "community": 7
+      "community": 4
     },
     {
       "label": "dashboard.index.tsx",
@@ -10777,7 +10777,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/dashboard.index.tsx",
       "source_location": "L1",
       "id": "dashboard_index",
-      "community": 2
+      "community": 4
     },
     {
       "label": "StoreRootRedirect()",
@@ -10785,7 +10785,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/index.tsx",
       "source_location": "L13",
       "id": "index_storerootredirect",
-      "community": 1
+      "community": 6
     },
     {
       "label": "logs.$logId.tsx",
@@ -10793,7 +10793,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.$logId.tsx",
       "source_location": "L1",
       "id": "logs_logid",
-      "community": 7
+      "community": 4
     },
     {
       "label": "logs.index.tsx",
@@ -10801,7 +10801,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.index.tsx",
       "source_location": "L1",
       "id": "logs_index",
-      "community": 9
+      "community": 4
     },
     {
       "label": "members.index.tsx",
@@ -10809,7 +10809,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/members.index.tsx",
       "source_location": "L1",
       "id": "members_index",
-      "community": 7
+      "community": 4
     },
     {
       "label": "all.index.tsx",
@@ -10817,7 +10817,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/all.index.tsx",
       "source_location": "L1",
       "id": "all_index",
-      "community": 7
+      "community": 4
     },
     {
       "label": "cancelled.index.tsx",
@@ -10825,7 +10825,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/cancelled.index.tsx",
       "source_location": "L1",
       "id": "cancelled_index",
-      "community": 7
+      "community": 4
     },
     {
       "label": "completed.index.tsx",
@@ -10833,7 +10833,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/completed.index.tsx",
       "source_location": "L1",
       "id": "completed_index",
-      "community": 7
+      "community": 4
     },
     {
       "label": "open.index.tsx",
@@ -10841,7 +10841,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/open.index.tsx",
       "source_location": "L1",
       "id": "open_index",
-      "community": 7
+      "community": 4
     },
     {
       "label": "out-for-delivery.index.tsx",
@@ -10849,7 +10849,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/out-for-delivery.index.tsx",
       "source_location": "L1",
       "id": "out_for_delivery_index",
-      "community": 7
+      "community": 4
     },
     {
       "label": "ready.index.tsx",
@@ -10857,7 +10857,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/ready.index.tsx",
       "source_location": "L1",
       "id": "ready_index",
-      "community": 7
+      "community": 4
     },
     {
       "label": "refunded.index.tsx",
@@ -10865,7 +10865,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/refunded.index.tsx",
       "source_location": "L1",
       "id": "refunded_index",
-      "community": 7
+      "community": 4
     },
     {
       "label": "$reportId.tsx",
@@ -10873,7 +10873,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports/$reportId.tsx",
       "source_location": "L1",
       "id": "reportid",
-      "community": 7
+      "community": 4
     },
     {
       "label": "expense-reports.index.tsx",
@@ -10881,7 +10881,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports.index.tsx",
       "source_location": "L1",
       "id": "expense_reports_index",
-      "community": 7
+      "community": 4
     },
     {
       "label": "expense.index.tsx",
@@ -10889,7 +10889,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense.index.tsx",
       "source_location": "L1",
       "id": "expense_index",
-      "community": 7
+      "community": 4
     },
     {
       "label": "register.index.tsx",
@@ -10897,7 +10897,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/register.index.tsx",
       "source_location": "L1",
       "id": "register_index",
-      "community": 7
+      "community": 4
     },
     {
       "label": "settings.index.tsx",
@@ -10905,7 +10905,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/settings.index.tsx",
       "source_location": "L1",
       "id": "settings_index",
-      "community": 7
+      "community": 4
     },
     {
       "label": "$transactionId.tsx",
@@ -10913,7 +10913,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId.tsx",
       "source_location": "L1",
       "id": "transactionid",
-      "community": 7
+      "community": 4
     },
     {
       "label": "transactions.index.tsx",
@@ -10921,7 +10921,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions.index.tsx",
       "source_location": "L1",
       "id": "transactions_index",
-      "community": 7
+      "community": 4
     },
     {
       "label": "edit.tsx",
@@ -10929,7 +10929,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/edit.tsx",
       "source_location": "L1",
       "id": "edit",
-      "community": 7
+      "community": 4
     },
     {
       "label": "new.tsx",
@@ -10937,7 +10937,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/new.tsx",
       "source_location": "L1",
       "id": "new",
-      "community": 7
+      "community": 0
     },
     {
       "label": "unresolved.tsx",
@@ -10945,7 +10945,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/unresolved.tsx",
       "source_location": "L1",
       "id": "unresolved",
-      "community": 7
+      "community": 4
     },
     {
       "label": "$promoCodeSlug.tsx",
@@ -10953,7 +10953,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/$promoCodeSlug.tsx",
       "source_location": "L1",
       "id": "promocodeslug",
-      "community": 7
+      "community": 0
     },
     {
       "label": "new.index.tsx",
@@ -10961,7 +10961,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/new.index.tsx",
       "source_location": "L1",
       "id": "new_index",
-      "community": 1
+      "community": 6
     },
     {
       "label": "published.index.tsx",
@@ -10969,7 +10969,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/published.index.tsx",
       "source_location": "L1",
       "id": "published_index",
-      "community": 7
+      "community": 4
     },
     {
       "label": "RouteComponent()",
@@ -10977,7 +10977,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/published.index.tsx",
       "source_location": "L9",
       "id": "published_index_routecomponent",
-      "community": 7
+      "community": 4
     },
     {
       "label": "users.$userId.tsx",
@@ -10985,7 +10985,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/users.$userId.tsx",
       "source_location": "L1",
       "id": "users_userid",
-      "community": 2
+      "community": 4
     },
     {
       "label": "_authed.tsx",
@@ -10993,7 +10993,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed.tsx",
       "source_location": "L1",
       "id": "authed",
-      "community": 5
+      "community": 1
     },
     {
       "label": "AuthedComponent()",
@@ -11001,7 +11001,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed.tsx",
       "source_location": "L18",
       "id": "authed_authedcomponent",
-      "community": 5
+      "community": 1
     },
     {
       "label": "Layout()",
@@ -11009,7 +11009,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed.tsx",
       "source_location": "L38",
       "id": "authed_layout",
-      "community": 5
+      "community": 1
     },
     {
       "label": "Index()",
@@ -11017,7 +11017,7 @@
       "source_file": "packages/athena-webapp/src/routes/index.tsx",
       "source_location": "L13",
       "id": "index_index",
-      "community": 1
+      "community": 6
     },
     {
       "label": "join-team.index.tsx",
@@ -11025,7 +11025,7 @@
       "source_file": "packages/athena-webapp/src/routes/join-team.index.tsx",
       "source_location": "L1",
       "id": "join_team_index",
-      "community": 7
+      "community": 4
     },
     {
       "label": "_layout.index.tsx",
@@ -11033,7 +11033,7 @@
       "source_file": "packages/athena-webapp/src/routes/login/_layout.index.tsx",
       "source_location": "L1",
       "id": "layout_index",
-      "community": 5
+      "community": 4
     },
     {
       "label": "_layout.tsx",
@@ -11041,7 +11041,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout.tsx",
       "source_location": "L1",
       "id": "layout",
-      "community": 0
+      "community": 5
     },
     {
       "label": "LoginLayout()",
@@ -11049,7 +11049,7 @@
       "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
       "source_location": "L36",
       "id": "layout_loginlayout",
-      "community": 0
+      "community": 5
     },
     {
       "label": "OrganizationSettingsView.tsx",
@@ -11057,7 +11057,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L1",
       "id": "organizationsettingsview",
-      "community": 5
+      "community": 20
     },
     {
       "label": "OrganizationSettings()",
@@ -11065,7 +11065,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L24",
       "id": "organizationsettingsview_organizationsettings",
-      "community": 5
+      "community": 20
     },
     {
       "label": "saveStoreChanges()",
@@ -11073,7 +11073,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L71",
       "id": "organizationsettingsview_savestorechanges",
-      "community": 5
+      "community": 20
     },
     {
       "label": "onSubmit()",
@@ -11081,7 +11081,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L105",
       "id": "organizationsettingsview_onsubmit",
-      "community": 5
+      "community": 20
     },
     {
       "label": "handleDeleteStore()",
@@ -11089,7 +11089,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L156",
       "id": "organizationsettingsview_handledeletestore",
-      "community": 5
+      "community": 20
     },
     {
       "label": "Navigation()",
@@ -11097,7 +11097,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L198",
       "id": "organizationsettingsview_navigation",
-      "community": 5
+      "community": 20
     },
     {
       "label": "OrganizationsSettingsAccordion.tsx",
@@ -11121,7 +11121,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L1",
       "id": "storesettingsview",
-      "community": 7
+      "community": 4
     },
     {
       "label": "StoreSettings()",
@@ -11129,7 +11129,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L28",
       "id": "storesettingsview_storesettings",
-      "community": 7
+      "community": 4
     },
     {
       "label": "saveStoreChanges()",
@@ -11137,7 +11137,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L82",
       "id": "storesettingsview_savestorechanges",
-      "community": 7
+      "community": 4
     },
     {
       "label": "onSubmit()",
@@ -11145,7 +11145,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L116",
       "id": "storesettingsview_onsubmit",
-      "community": 7
+      "community": 4
     },
     {
       "label": "handleDeleteStore()",
@@ -11153,7 +11153,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L167",
       "id": "storesettingsview_handledeletestore",
-      "community": 7
+      "community": 4
     },
     {
       "label": "handleDeleteAllProductsInStore()",
@@ -11161,7 +11161,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L232",
       "id": "storesettingsview_handledeleteallproductsinstore",
-      "community": 7
+      "community": 4
     },
     {
       "label": "StoresSettingsAccordion.tsx",
@@ -11177,7 +11177,7 @@
       "source_file": "packages/athena-webapp/src/stores/expenseStore.ts",
       "source_location": "L1",
       "id": "expensestore",
-      "community": 4
+      "community": 3
     },
     {
       "label": "posStore.ts",
@@ -11185,7 +11185,7 @@
       "source_file": "packages/athena-webapp/src/stores/posStore.ts",
       "source_location": "L1",
       "id": "posstore",
-      "community": 4
+      "community": 3
     },
     {
       "label": "setup.ts",
@@ -11201,7 +11201,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L1",
       "id": "backend_test",
-      "community": 21
+      "community": 22
     },
     {
       "label": "validateInventory()",
@@ -11209,7 +11209,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L58",
       "id": "backend_test_validateinventory",
-      "community": 21
+      "community": 22
     },
     {
       "label": "generateTransactionNumber()",
@@ -11217,7 +11217,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L374",
       "id": "backend_test_generatetransactionnumber",
-      "community": 21
+      "community": 22
     },
     {
       "label": "createTransaction()",
@@ -11225,7 +11225,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L391",
       "id": "backend_test_createtransaction",
-      "community": 21
+      "community": 22
     },
     {
       "label": "updateInventory()",
@@ -11233,7 +11233,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L422",
       "id": "backend_test_updateinventory",
-      "community": 21
+      "community": 22
     },
     {
       "label": "createTransactionItems()",
@@ -11241,7 +11241,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L467",
       "id": "backend_test_createtransactionitems",
-      "community": 21
+      "community": 22
     },
     {
       "label": "validateSession()",
@@ -11249,7 +11249,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L553",
       "id": "backend_test_validatesession",
-      "community": 21
+      "community": 22
     },
     {
       "label": "validateSessionInventory()",
@@ -11257,7 +11257,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L593",
       "id": "backend_test_validatesessioninventory",
-      "community": 21
+      "community": 22
     },
     {
       "label": "completeSession()",
@@ -11265,7 +11265,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L629",
       "id": "backend_test_completesession",
-      "community": 21
+      "community": 22
     },
     {
       "label": "handleDatabaseError()",
@@ -11273,7 +11273,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L671",
       "id": "backend_test_handledatabaseerror",
-      "community": 21
+      "community": 22
     },
     {
       "label": "rollbackInventory()",
@@ -11281,7 +11281,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L692",
       "id": "backend_test_rollbackinventory",
-      "community": 21
+      "community": 22
     },
     {
       "label": "inventoryValidationLogic.test.ts",
@@ -11313,7 +11313,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L1",
       "id": "simple_test",
-      "community": 22
+      "community": 23
     },
     {
       "label": "generateTransactionNumber()",
@@ -11321,7 +11321,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L38",
       "id": "simple_test_generatetransactionnumber",
-      "community": 22
+      "community": 23
     },
     {
       "label": "validateInventory()",
@@ -11329,7 +11329,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L77",
       "id": "simple_test_validateinventory",
-      "community": 22
+      "community": 23
     },
     {
       "label": "validateInventoryWithAggregation()",
@@ -11337,7 +11337,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L130",
       "id": "simple_test_validateinventorywithaggregation",
-      "community": 22
+      "community": 23
     },
     {
       "label": "formatCurrency()",
@@ -11345,7 +11345,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L173",
       "id": "simple_test_formatcurrency",
-      "community": 22
+      "community": 23
     },
     {
       "label": "formatPaymentMethod()",
@@ -11353,7 +11353,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L201",
       "id": "simple_test_formatpaymentmethod",
-      "community": 22
+      "community": 23
     },
     {
       "label": "formatReceiptDate()",
@@ -11361,7 +11361,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L225",
       "id": "simple_test_formatreceiptdate",
-      "community": 22
+      "community": 23
     },
     {
       "label": "addToCart()",
@@ -11369,7 +11369,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L249",
       "id": "simple_test_addtocart",
-      "community": 22
+      "community": 23
     },
     {
       "label": "removeFromCart()",
@@ -11377,7 +11377,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L288",
       "id": "simple_test_removefromcart",
-      "community": 22
+      "community": 23
     },
     {
       "label": "updateQuantity()",
@@ -11385,7 +11385,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L311",
       "id": "simple_test_updatequantity",
-      "community": 22
+      "community": 23
     },
     {
       "label": "usePrint.test.ts",
@@ -11393,7 +11393,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/usePrint.test.ts",
       "source_location": "L1",
       "id": "useprint_test",
-      "community": 4
+      "community": 3
     },
     {
       "label": "formatNumber.ts",
@@ -11401,7 +11401,7 @@
       "source_file": "packages/athena-webapp/src/utils/formatNumber.ts",
       "source_location": "L1",
       "id": "formatnumber",
-      "community": 2
+      "community": 0
     },
     {
       "label": "formatNumber()",
@@ -11409,7 +11409,7 @@
       "source_file": "packages/athena-webapp/src/utils/formatNumber.ts",
       "source_location": "L1",
       "id": "formatnumber_formatnumber",
-      "community": 2
+      "community": 0
     },
     {
       "label": "hashPassword()",
@@ -11417,7 +11417,7 @@
       "source_file": "packages/storefront-webapp/src/utils/index.ts",
       "source_location": "L1",
       "id": "index_hashpassword",
-      "community": 1
+      "community": 6
     },
     {
       "label": "session.ts",
@@ -11425,7 +11425,7 @@
       "source_file": "packages/storefront-webapp/src/utils/session.ts",
       "source_location": "L1",
       "id": "session",
-      "community": 3
+      "community": 2
     },
     {
       "label": "useAppSession()",
@@ -11433,7 +11433,7 @@
       "source_file": "packages/storefront-webapp/src/utils/session.ts",
       "source_location": "L8",
       "id": "session_useappsession",
-      "community": 3
+      "community": 2
     },
     {
       "label": "versionChecker.ts",
@@ -11441,7 +11441,7 @@
       "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
       "source_location": "L1",
       "id": "versionchecker",
-      "community": 8
+      "community": 4
     },
     {
       "label": "createVersionChecker()",
@@ -11449,7 +11449,7 @@
       "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
       "source_location": "L16",
       "id": "versionchecker_createversionchecker",
-      "community": 8
+      "community": 4
     },
     {
       "label": "tailwind.config.js",
@@ -11465,7 +11465,7 @@
       "source_file": "packages/storefront-webapp/vite.config.ts",
       "source_location": "L1",
       "id": "vite_config",
-      "community": 3
+      "community": 2
     },
     {
       "label": "manualChunks()",
@@ -11473,7 +11473,7 @@
       "source_file": "packages/storefront-webapp/vite.config.ts",
       "source_location": "L19",
       "id": "vite_config_manualchunks",
-      "community": 3
+      "community": 2
     },
     {
       "label": "vitest.config.ts",
@@ -11481,7 +11481,7 @@
       "source_file": "packages/storefront-webapp/vitest.config.ts",
       "source_location": "L1",
       "id": "vitest_config",
-      "community": 3
+      "community": 2
     },
     {
       "label": "vitest.setup.ts",
@@ -11513,7 +11513,7 @@
       "source_file": "packages/storefront-webapp/src/api/analytics.ts",
       "source_location": "L3",
       "id": "analytics_postanalytics",
-      "community": 17
+      "community": 13
     },
     {
       "label": "updateAnalyticsOwner()",
@@ -11521,7 +11521,7 @@
       "source_file": "packages/storefront-webapp/src/api/analytics.ts",
       "source_location": "L32",
       "id": "analytics_updateanalyticsowner",
-      "community": 17
+      "community": 13
     },
     {
       "label": "logout()",
@@ -11529,7 +11529,7 @@
       "source_file": "packages/storefront-webapp/src/api/analytics.ts",
       "source_location": "L60",
       "id": "analytics_logout",
-      "community": 17
+      "community": 13
     },
     {
       "label": "getProductViewCount()",
@@ -11537,7 +11537,7 @@
       "source_file": "packages/storefront-webapp/src/api/analytics.ts",
       "source_location": "L78",
       "id": "analytics_getproductviewcount",
-      "community": 17
+      "community": 13
     },
     {
       "label": "verifyUserAccount()",
@@ -11545,7 +11545,7 @@
       "source_file": "packages/storefront-webapp/src/api/auth.ts",
       "source_location": "L3",
       "id": "auth_verifyuseraccount",
-      "community": 3
+      "community": 2
     },
     {
       "label": "logout()",
@@ -11553,7 +11553,7 @@
       "source_file": "packages/storefront-webapp/src/api/auth.ts",
       "source_location": "L32",
       "id": "auth_logout",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getBaseUrl()",
@@ -11617,7 +11617,7 @@
       "source_file": "packages/storefront-webapp/src/api/bannerMessage.ts",
       "source_location": "L4",
       "id": "bannermessage_getbannermessage",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getBaseUrl()",
@@ -11625,7 +11625,7 @@
       "source_file": "packages/storefront-webapp/src/api/category.ts",
       "source_location": "L9",
       "id": "category_getbaseurl",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getAllCategories()",
@@ -11633,7 +11633,7 @@
       "source_file": "packages/storefront-webapp/src/api/category.ts",
       "source_location": "L11",
       "id": "category_getallcategories",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getAllCategoriesWithSubcategories()",
@@ -11641,7 +11641,7 @@
       "source_file": "packages/storefront-webapp/src/api/category.ts",
       "source_location": "L25",
       "id": "category_getallcategorieswithsubcategories",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getCategory()",
@@ -11649,7 +11649,7 @@
       "source_file": "packages/storefront-webapp/src/api/category.ts",
       "source_location": "L39",
       "id": "category_getcategory",
-      "community": 3
+      "community": 2
     },
     {
       "label": "checkoutSession.test.ts",
@@ -11657,7 +11657,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.test.ts",
       "source_location": "L1",
       "id": "checkoutsession_test",
-      "community": 8
+      "community": 5
     },
     {
       "label": "jsonResponse()",
@@ -11665,7 +11665,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.test.ts",
       "source_location": "L27",
       "id": "checkoutsession_test_jsonresponse",
-      "community": 8
+      "community": 5
     },
     {
       "label": "getBaseUrl()",
@@ -11673,7 +11673,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L5",
       "id": "checkoutsession_getbaseurl",
-      "community": 8
+      "community": 5
     },
     {
       "label": "CheckoutSessionError",
@@ -11681,7 +11681,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L64",
       "id": "checkoutsession_checkoutsessionerror",
-      "community": 8
+      "community": 5
     },
     {
       "label": ".constructor()",
@@ -11689,7 +11689,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L69",
       "id": "checkoutsession_checkoutsessionerror_constructor",
-      "community": 8
+      "community": 5
     },
     {
       "label": "isRecord()",
@@ -11697,7 +11697,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L78",
       "id": "checkoutsession_isrecord",
-      "community": 8
+      "community": 5
     },
     {
       "label": "parseJson()",
@@ -11705,7 +11705,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L81",
       "id": "checkoutsession_parsejson",
-      "community": 8
+      "community": 5
     },
     {
       "label": "getCheckoutErrorMessageFromPayload()",
@@ -11713,7 +11713,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L98",
       "id": "checkoutsession_getcheckouterrormessagefrompayload",
-      "community": 8
+      "community": 5
     },
     {
       "label": "parseCheckoutResponse()",
@@ -11721,7 +11721,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L115",
       "id": "checkoutsession_parsecheckoutresponse",
-      "community": 8
+      "community": 5
     },
     {
       "label": "defaultCheckoutActionMessage()",
@@ -11729,7 +11729,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L135",
       "id": "checkoutsession_defaultcheckoutactionmessage",
-      "community": 8
+      "community": 5
     },
     {
       "label": "getCheckoutActionErrorMessage()",
@@ -11737,7 +11737,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L147",
       "id": "checkoutsession_getcheckoutactionerrormessage",
-      "community": 8
+      "community": 5
     },
     {
       "label": "createCheckoutSession()",
@@ -11745,7 +11745,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L184",
       "id": "checkoutsession_createcheckoutsession",
-      "community": 8
+      "community": 5
     },
     {
       "label": "getActiveCheckoutSession()",
@@ -11753,7 +11753,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L204",
       "id": "checkoutsession_getactivecheckoutsession",
-      "community": 8
+      "community": 5
     },
     {
       "label": "getPendingCheckoutSessions()",
@@ -11761,7 +11761,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L215",
       "id": "checkoutsession_getpendingcheckoutsessions",
-      "community": 8
+      "community": 5
     },
     {
       "label": "getCheckoutSession()",
@@ -11769,7 +11769,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L226",
       "id": "checkoutsession_getcheckoutsession",
-      "community": 8
+      "community": 5
     },
     {
       "label": "updateCheckoutSession()",
@@ -11777,7 +11777,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L239",
       "id": "checkoutsession_updatecheckoutsession",
-      "community": 8
+      "community": 5
     },
     {
       "label": "verifyCheckoutSessionPayment()",
@@ -11785,7 +11785,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L274",
       "id": "checkoutsession_verifycheckoutsessionpayment",
-      "community": 8
+      "community": 5
     },
     {
       "label": "getBaseUrl()",
@@ -11793,7 +11793,7 @@
       "source_file": "packages/storefront-webapp/src/api/color.ts",
       "source_location": "L5",
       "id": "color_getbaseurl",
-      "community": 12
+      "community": 13
     },
     {
       "label": "getAllColors()",
@@ -11801,7 +11801,7 @@
       "source_file": "packages/storefront-webapp/src/api/color.ts",
       "source_location": "L7",
       "id": "color_getallcolors",
-      "community": 12
+      "community": 13
     },
     {
       "label": "updateGuest()",
@@ -11809,7 +11809,7 @@
       "source_file": "packages/storefront-webapp/src/api/guest.ts",
       "source_location": "L4",
       "id": "guest_updateguest",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getBaseUrl()",
@@ -11817,7 +11817,7 @@
       "source_file": "packages/storefront-webapp/src/api/offers.ts",
       "source_location": "L13",
       "id": "offers_getbaseurl",
-      "community": 6
+      "community": 14
     },
     {
       "label": "submitOffer()",
@@ -11825,7 +11825,7 @@
       "source_file": "packages/storefront-webapp/src/api/offers.ts",
       "source_location": "L21",
       "id": "offers_submitoffer",
-      "community": 6
+      "community": 14
     },
     {
       "label": "getUserRedeemedOffers()",
@@ -11833,7 +11833,7 @@
       "source_file": "packages/storefront-webapp/src/api/offers.ts",
       "source_location": "L46",
       "id": "offers_getuserredeemedoffers",
-      "community": 6
+      "community": 14
     },
     {
       "label": "getBaseUrl()",
@@ -11841,7 +11841,7 @@
       "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
       "source_location": "L4",
       "id": "onlineorder_getbaseurl",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getOrders()",
@@ -11849,7 +11849,7 @@
       "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
       "source_location": "L6",
       "id": "onlineorder_getorders",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getOrder()",
@@ -11857,7 +11857,7 @@
       "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
       "source_location": "L24",
       "id": "onlineorder_getorder",
-      "community": 3
+      "community": 2
     },
     {
       "label": "updateOrdersOwner()",
@@ -11865,7 +11865,7 @@
       "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
       "source_location": "L42",
       "id": "onlineorder_updateordersowner",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getAllOrganizations()",
@@ -11873,7 +11873,7 @@
       "source_file": "packages/storefront-webapp/src/api/organization.ts",
       "source_location": "L6",
       "id": "organization_getallorganizations",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getOrganization()",
@@ -11881,7 +11881,7 @@
       "source_file": "packages/storefront-webapp/src/api/organization.ts",
       "source_location": "L18",
       "id": "organization_getorganization",
-      "community": 3
+      "community": 2
     },
     {
       "label": "buildQueryString()",
@@ -11889,7 +11889,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L5",
       "id": "product_buildquerystring",
-      "community": 12
+      "community": 13
     },
     {
       "label": "getBaseUrl()",
@@ -11897,7 +11897,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L18",
       "id": "product_getbaseurl",
-      "community": 12
+      "community": 13
     },
     {
       "label": "getAllProducts()",
@@ -11905,7 +11905,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L20",
       "id": "product_getallproducts",
-      "community": 12
+      "community": 13
     },
     {
       "label": "getProduct()",
@@ -11913,7 +11913,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L40",
       "id": "product_getproduct",
-      "community": 12
+      "community": 13
     },
     {
       "label": "getBestSellers()",
@@ -11921,7 +11921,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L59",
       "id": "product_getbestsellers",
-      "community": 12
+      "community": 13
     },
     {
       "label": "getFeatured()",
@@ -11929,7 +11929,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L73",
       "id": "product_getfeatured",
-      "community": 12
+      "community": 13
     },
     {
       "label": "getInventoryBySkuIds()",
@@ -11937,7 +11937,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L93",
       "id": "product_getinventorybyskuids",
-      "community": 12
+      "community": 13
     },
     {
       "label": "getBaseUrl()",
@@ -11945,7 +11945,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L4",
       "id": "promocodes_getbaseurl",
-      "community": 3
+      "community": 2
     },
     {
       "label": "redeemPromoCode()",
@@ -11953,7 +11953,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L6",
       "id": "promocodes_redeempromocode",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getPromoCodes()",
@@ -11961,7 +11961,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L34",
       "id": "promocodes_getpromocodes",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getPromoCodeItems()",
@@ -11969,7 +11969,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L49",
       "id": "promocodes_getpromocodeitems",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getRedeemedPromoCodes()",
@@ -11977,7 +11977,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L74",
       "id": "promocodes_getredeemedpromocodes",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getBaseUrl()",
@@ -11985,7 +11985,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L4",
       "id": "reviews_getbaseurl",
-      "community": 12
+      "community": 9
     },
     {
       "label": "createReview()",
@@ -11993,7 +11993,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L13",
       "id": "reviews_createreview",
-      "community": 12
+      "community": 9
     },
     {
       "label": "getReviewByOrderItem()",
@@ -12001,7 +12001,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L32",
       "id": "reviews_getreviewbyorderitem",
-      "community": 12
+      "community": 9
     },
     {
       "label": "updateReview()",
@@ -12009,7 +12009,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L48",
       "id": "reviews_updatereview",
-      "community": 12
+      "community": 9
     },
     {
       "label": "deleteReview()",
@@ -12017,7 +12017,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L69",
       "id": "reviews_deletereview",
-      "community": 12
+      "community": 9
     },
     {
       "label": "getReviewsByProductSkuId()",
@@ -12025,7 +12025,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L83",
       "id": "reviews_getreviewsbyproductskuid",
-      "community": 12
+      "community": 9
     },
     {
       "label": "getUserReviews()",
@@ -12033,7 +12033,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L99",
       "id": "reviews_getuserreviews",
-      "community": 12
+      "community": 9
     },
     {
       "label": "getUserReviewsForProduct()",
@@ -12041,7 +12041,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L113",
       "id": "reviews_getuserreviewsforproduct",
-      "community": 12
+      "community": 9
     },
     {
       "label": "getReviewsByProductId()",
@@ -12049,7 +12049,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L132",
       "id": "reviews_getreviewsbyproductid",
-      "community": 12
+      "community": 9
     },
     {
       "label": "markReviewHelpful()",
@@ -12057,7 +12057,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L148",
       "id": "reviews_markreviewhelpful",
-      "community": 12
+      "community": 9
     },
     {
       "label": "hasReviewForOrderItem()",
@@ -12065,7 +12065,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L164",
       "id": "reviews_hasreviewfororderitem",
-      "community": 12
+      "community": 9
     },
     {
       "label": "hasUserReviewForOrderItem()",
@@ -12073,7 +12073,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L183",
       "id": "reviews_hasuserreviewfororderitem",
-      "community": 12
+      "community": 9
     },
     {
       "label": "getBaseUrl()",
@@ -12201,7 +12201,7 @@
       "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
       "source_location": "L5",
       "id": "storefrontuser_getbaseurl",
-      "community": 5
+      "community": 1
     },
     {
       "label": "getGuest()",
@@ -12209,7 +12209,7 @@
       "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
       "source_location": "L7",
       "id": "storefrontuser_getguest",
-      "community": 5
+      "community": 1
     },
     {
       "label": "getActiveUser()",
@@ -12217,7 +12217,7 @@
       "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
       "source_location": "L28",
       "id": "storefrontuser_getactiveuser",
-      "community": 5
+      "community": 1
     },
     {
       "label": "updateUser()",
@@ -12225,7 +12225,7 @@
       "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
       "source_location": "L46",
       "id": "storefrontuser_updateuser",
-      "community": 5
+      "community": 1
     },
     {
       "label": "getStore()",
@@ -12233,7 +12233,7 @@
       "source_file": "packages/storefront-webapp/src/api/storefront.ts",
       "source_location": "L5",
       "id": "storefront_getstore",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getBaseUrl()",
@@ -12241,7 +12241,7 @@
       "source_file": "packages/storefront-webapp/src/api/stores.ts",
       "source_location": "L5",
       "id": "stores_getbaseurl",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getAllStores()",
@@ -12249,7 +12249,7 @@
       "source_file": "packages/storefront-webapp/src/api/stores.ts",
       "source_location": "L8",
       "id": "stores_getallstores",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getStore()",
@@ -12257,7 +12257,7 @@
       "source_file": "packages/storefront-webapp/src/api/stores.ts",
       "source_location": "L20",
       "id": "stores_getstore",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getBaseUrl()",
@@ -12265,7 +12265,7 @@
       "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
       "source_location": "L9",
       "id": "subcategory_getbaseurl",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getAllSubcategories()",
@@ -12273,7 +12273,7 @@
       "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
       "source_location": "L11",
       "id": "subcategory_getallsubcategories",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getSubategory()",
@@ -12281,7 +12281,7 @@
       "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
       "source_location": "L25",
       "id": "subcategory_getsubategory",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getBaseUrl()",
@@ -12289,7 +12289,7 @@
       "source_file": "packages/storefront-webapp/src/api/upsells.ts",
       "source_location": "L3",
       "id": "upsells_getbaseurl",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getLastViewedProduct()",
@@ -12297,7 +12297,7 @@
       "source_file": "packages/storefront-webapp/src/api/upsells.ts",
       "source_location": "L5",
       "id": "upsells_getlastviewedproduct",
-      "community": 3
+      "community": 2
     },
     {
       "label": "getBaseUrl()",
@@ -12305,7 +12305,7 @@
       "source_file": "packages/storefront-webapp/src/api/userOffers.ts",
       "source_location": "L18",
       "id": "useroffers_getbaseurl",
-      "community": 6
+      "community": 2
     },
     {
       "label": "getUserOffersEligibility()",
@@ -12313,7 +12313,7 @@
       "source_file": "packages/storefront-webapp/src/api/userOffers.ts",
       "source_location": "L23",
       "id": "useroffers_getuserofferseligibility",
-      "community": 6
+      "community": 2
     },
     {
       "label": "HeartIconFilled.tsx",
@@ -12321,7 +12321,7 @@
       "source_file": "packages/storefront-webapp/src/assets/icons/HeartIconFilled.tsx",
       "source_location": "L1",
       "id": "hearticonfilled",
-      "community": 0
+      "community": 1
     },
     {
       "label": "EntityPage.tsx",
@@ -12329,7 +12329,7 @@
       "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
       "source_location": "L1",
       "id": "entitypage",
-      "community": 12
+      "community": 13
     },
     {
       "label": "EntityPage()",
@@ -12337,7 +12337,7 @@
       "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
       "source_location": "L10",
       "id": "entitypage_entitypage",
-      "community": 12
+      "community": 13
     },
     {
       "label": "HomePage.tsx",
@@ -12345,7 +12345,7 @@
       "source_file": "packages/storefront-webapp/src/components/HomePage.tsx",
       "source_location": "L1",
       "id": "homepage",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleScroll()",
@@ -12353,7 +12353,7 @@
       "source_file": "packages/storefront-webapp/src/components/HomePage.tsx",
       "source_location": "L106",
       "id": "homepage_handlescroll",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleClickOnDiscountCode()",
@@ -12361,7 +12361,7 @@
       "source_file": "packages/storefront-webapp/src/components/HomePage.tsx",
       "source_location": "L155",
       "id": "homepage_handleclickondiscountcode",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleClickOnLeaveReviewButton()",
@@ -12369,7 +12369,7 @@
       "source_file": "packages/storefront-webapp/src/components/HomePage.tsx",
       "source_location": "L167",
       "id": "homepage_handleclickonleavereviewbutton",
-      "community": 0
+      "community": 1
     },
     {
       "label": "ProductActionBar.tsx",
@@ -12377,7 +12377,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
       "source_location": "L1",
       "id": "productactionbar",
-      "community": 0
+      "community": 1
     },
     {
       "label": "checkScroll()",
@@ -12385,7 +12385,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
       "source_location": "L50",
       "id": "productactionbar_checkscroll",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleDismiss()",
@@ -12393,7 +12393,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
       "source_location": "L74",
       "id": "productactionbar_handledismiss",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleAction()",
@@ -12401,7 +12401,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
       "source_location": "L92",
       "id": "productactionbar_handleaction",
-      "community": 0
+      "community": 1
     },
     {
       "label": "ProductReminderBar.tsx",
@@ -12409,7 +12409,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
       "source_location": "L1",
       "id": "productreminderbar",
-      "community": 0
+      "community": 1
     },
     {
       "label": "checkScroll()",
@@ -12417,7 +12417,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
       "source_location": "L62",
       "id": "productreminderbar_checkscroll",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleAddToBag()",
@@ -12425,7 +12425,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
       "source_location": "L109",
       "id": "productreminderbar_handleaddtobag",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleDismiss()",
@@ -12433,7 +12433,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
       "source_location": "L177",
       "id": "productreminderbar_handledismiss",
-      "community": 0
+      "community": 1
     },
     {
       "label": "ProductsPage.tsx",
@@ -12441,7 +12441,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductsPage.tsx",
       "source_location": "L1",
       "id": "productspage",
-      "community": 12
+      "community": 13
     },
     {
       "label": "ProductCardLoadingSkeleton()",
@@ -12449,7 +12449,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductsPage.tsx",
       "source_location": "L10",
       "id": "productspage_productcardloadingskeleton",
-      "community": 12
+      "community": 13
     },
     {
       "label": "Upsell.tsx",
@@ -12457,7 +12457,7 @@
       "source_file": "packages/storefront-webapp/src/components/Upsell.tsx",
       "source_location": "L1",
       "id": "upsell",
-      "community": 0
+      "community": 1
     },
     {
       "label": "AuthComponent()",
@@ -12465,7 +12465,7 @@
       "source_file": "packages/storefront-webapp/src/components/auth/Auth.tsx",
       "source_location": "L4",
       "id": "auth_authcomponent",
-      "community": 3
+      "community": 2
     },
     {
       "label": "BagSummary.tsx",
@@ -12473,7 +12473,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BagSummary.tsx",
       "source_location": "L1",
       "id": "bagsummary",
-      "community": 0
+      "community": 1
     },
     {
       "label": "toBagSummaryItems()",
@@ -12481,7 +12481,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BagSummary.tsx",
       "source_location": "L39",
       "id": "bagsummary_tobagsummaryitems",
-      "community": 0
+      "community": 1
     },
     {
       "label": "BillingDetails.tsx",
@@ -12489,7 +12489,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L1",
       "id": "billingdetails",
-      "community": 5
+      "community": 1
     },
     {
       "label": "EnteredBillingAddressDetails()",
@@ -12497,7 +12497,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L102",
       "id": "billingdetails_enteredbillingaddressdetails",
-      "community": 5
+      "community": 1
     },
     {
       "label": "onSubmit()",
@@ -12505,7 +12505,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L150",
       "id": "billingdetails_onsubmit",
-      "community": 5
+      "community": 1
     },
     {
       "label": "toggleSameAsDelivery()",
@@ -12513,7 +12513,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L155",
       "id": "billingdetails_togglesameasdelivery",
-      "community": 5
+      "community": 1
     },
     {
       "label": "clearForm()",
@@ -12521,7 +12521,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L173",
       "id": "billingdetails_clearform",
-      "community": 5
+      "community": 1
     },
     {
       "label": "handleUseBillingAddressOnFile()",
@@ -12529,7 +12529,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L201",
       "id": "billingdetails_handleusebillingaddressonfile",
-      "community": 5
+      "community": 1
     },
     {
       "label": "BillingDetailsSection.tsx",
@@ -12537,7 +12537,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
       "source_location": "L1",
       "id": "billingdetailssection",
-      "community": 5
+      "community": 1
     },
     {
       "label": "clearForm()",
@@ -12545,7 +12545,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
       "source_location": "L18",
       "id": "billingdetailssection_clearform",
-      "community": 5
+      "community": 1
     },
     {
       "label": "handleUseBillingAddressOnFile()",
@@ -12553,7 +12553,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
       "source_location": "L52",
       "id": "billingdetailssection_handleusebillingaddressonfile",
-      "community": 5
+      "community": 1
     },
     {
       "label": "toggleSameAsDelivery()",
@@ -12561,7 +12561,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
       "source_location": "L68",
       "id": "billingdetailssection_togglesameasdelivery",
-      "community": 5
+      "community": 1
     },
     {
       "label": "CheckoutForm.tsx",
@@ -12569,7 +12569,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/CheckoutForm.tsx",
       "source_location": "L1",
       "id": "checkoutform",
-      "community": 5
+      "community": 1
     },
     {
       "label": "CheckoutForm()",
@@ -12577,7 +12577,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/CheckoutForm.tsx",
       "source_location": "L18",
       "id": "checkoutform_checkoutform",
-      "community": 5
+      "community": 1
     },
     {
       "label": "CheckoutProvider.tsx",
@@ -12585,7 +12585,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/CheckoutProvider.tsx",
       "source_location": "L1",
       "id": "checkoutprovider",
-      "community": 0
+      "community": 1
     },
     {
       "label": "CheckoutProvider()",
@@ -12593,7 +12593,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/CheckoutProvider.tsx",
       "source_location": "L71",
       "id": "checkoutprovider_checkoutprovider",
-      "community": 0
+      "community": 1
     },
     {
       "label": "CustomerDetails.tsx",
@@ -12601,7 +12601,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/CustomerDetails.tsx",
       "source_location": "L1",
       "id": "customerdetails",
-      "community": 5
+      "community": 1
     },
     {
       "label": "EnteredCustomerDetails()",
@@ -12609,7 +12609,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/CustomerDetails.tsx",
       "source_location": "L22",
       "id": "customerdetails_enteredcustomerdetails",
-      "community": 5
+      "community": 1
     },
     {
       "label": "onSubmit()",
@@ -12617,7 +12617,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/CustomerDetails.tsx",
       "source_location": "L55",
       "id": "customerdetails_onsubmit",
-      "community": 5
+      "community": 1
     },
     {
       "label": "CustomerInfoSection.tsx",
@@ -12625,7 +12625,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/CustomerInfoSection.tsx",
       "source_location": "L1",
       "id": "customerinfosection",
-      "community": 5
+      "community": 1
     },
     {
       "label": "DeliveryOptionsSelector.tsx",
@@ -12633,7 +12633,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
       "source_location": "L1",
       "id": "deliveryoptionsselector",
-      "community": 5
+      "community": 1
     },
     {
       "label": "StoreSelector()",
@@ -12641,7 +12641,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
       "source_location": "L11",
       "id": "deliveryoptionsselector_storeselector",
-      "community": 5
+      "community": 1
     },
     {
       "label": "handleChange()",
@@ -12649,7 +12649,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
       "source_location": "L77",
       "id": "deliveryoptionsselector_handlechange",
-      "community": 5
+      "community": 1
     },
     {
       "label": "DeliverySection.tsx",
@@ -12657,7 +12657,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
       "source_location": "L1",
       "id": "deliverysection",
-      "community": 5
+      "community": 1
     },
     {
       "label": "DeliveryDetails()",
@@ -12665,7 +12665,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
       "source_location": "L11",
       "id": "deliverysection_deliverydetails",
-      "community": 5
+      "community": 1
     },
     {
       "label": "DeliveryOptions()",
@@ -12673,7 +12673,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
       "source_location": "L22",
       "id": "deliverysection_deliveryoptions",
-      "community": 5
+      "community": 1
     },
     {
       "label": "PickupOptions.tsx",
@@ -12681,7 +12681,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/PickupOptions.tsx",
       "source_location": "L1",
       "id": "pickupoptions",
-      "community": 5
+      "community": 1
     },
     {
       "label": "isWithinRestrictionTime()",
@@ -12689,7 +12689,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/PickupOptions.tsx",
       "source_location": "L12",
       "id": "pickupoptions_iswithinrestrictiontime",
-      "community": 5
+      "community": 1
     },
     {
       "label": "DeliveryDetailsSection.tsx",
@@ -12697,7 +12697,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetailsSection.tsx",
       "source_location": "L1",
       "id": "deliverydetailssection",
-      "community": 5
+      "community": 1
     },
     {
       "label": "EnteredBillingAddressDetails.tsx",
@@ -12705,7 +12705,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/EnteredBillingAddressDetails.tsx",
       "source_location": "L1",
       "id": "enteredbillingaddressdetails",
-      "community": 5
+      "community": 1
     },
     {
       "label": "EnteredBillingAddressDetails()",
@@ -12713,7 +12713,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/EnteredBillingAddressDetails.tsx",
       "source_location": "L6",
       "id": "enteredbillingaddressdetails_enteredbillingaddressdetails",
-      "community": 5
+      "community": 1
     },
     {
       "label": "MobileBagSummary.tsx",
@@ -12721,7 +12721,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
       "source_location": "L1",
       "id": "mobilebagsummary",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleRedeemPromoCode()",
@@ -12729,7 +12729,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
       "source_location": "L89",
       "id": "mobilebagsummary_handleredeempromocode",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleKeyDown()",
@@ -12737,7 +12737,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
       "source_location": "L110",
       "id": "mobilebagsummary_handlekeydown",
-      "community": 0
+      "community": 1
     },
     {
       "label": "OrderSummary()",
@@ -12745,7 +12745,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/OrderSummary.tsx",
       "source_location": "L18",
       "id": "ordersummary_ordersummary",
-      "community": 4
+      "community": 3
     },
     {
       "label": "PickupDetails()",
@@ -12753,7 +12753,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/index.tsx",
       "source_location": "L10",
       "id": "index_pickupdetails",
-      "community": 1
+      "community": 6
     },
     {
       "label": "PaymentMethodSection.tsx",
@@ -12761,7 +12761,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/PaymentMethodSection.tsx",
       "source_location": "L1",
       "id": "paymentmethodsection",
-      "community": 5
+      "community": 1
     },
     {
       "label": "PaymentMethodSection()",
@@ -12769,7 +12769,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/PaymentMethodSection.tsx",
       "source_location": "L8",
       "id": "paymentmethodsection_paymentmethodsection",
-      "community": 5
+      "community": 1
     },
     {
       "label": "PaymentSection.tsx",
@@ -12777,7 +12777,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/PaymentSection.tsx",
       "source_location": "L1",
       "id": "paymentsection",
-      "community": 5
+      "community": 1
     },
     {
       "label": "PaymentSection()",
@@ -12785,7 +12785,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/PaymentSection.tsx",
       "source_location": "L27",
       "id": "paymentsection_paymentsection",
-      "community": 5
+      "community": 1
     },
     {
       "label": "checkoutStorage.test.ts",
@@ -12793,7 +12793,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.test.ts",
       "source_location": "L1",
       "id": "checkoutstorage_test",
-      "community": 0
+      "community": 1
     },
     {
       "label": "checkoutStorage.ts",
@@ -12801,7 +12801,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
       "source_location": "L1",
       "id": "checkoutstorage",
-      "community": 0
+      "community": 1
     },
     {
       "label": "loadCheckoutState()",
@@ -12809,7 +12809,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
       "source_location": "L4",
       "id": "checkoutstorage_loadcheckoutstate",
-      "community": 0
+      "community": 1
     },
     {
       "label": "saveCheckoutState()",
@@ -12817,7 +12817,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
       "source_location": "L24",
       "id": "checkoutstorage_savecheckoutstate",
-      "community": 0
+      "community": 1
     },
     {
       "label": "deliveryFees.test.ts",
@@ -12825,7 +12825,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.test.ts",
       "source_location": "L1",
       "id": "deliveryfees_test",
-      "community": 5
+      "community": 1
     },
     {
       "label": "deliveryFees.ts",
@@ -12833,7 +12833,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.ts",
       "source_location": "L1",
       "id": "deliveryfees",
-      "community": 5
+      "community": 1
     },
     {
       "label": "calculateDeliveryFee()",
@@ -12841,7 +12841,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.ts",
       "source_location": "L40",
       "id": "deliveryfees_calculatedeliveryfee",
-      "community": 5
+      "community": 1
     },
     {
       "label": "deriveCheckoutState.test.ts",
@@ -12849,7 +12849,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.test.ts",
       "source_location": "L1",
       "id": "derivecheckoutstate_test",
-      "community": 4
+      "community": 3
     },
     {
       "label": "deriveCheckoutState.ts",
@@ -12857,7 +12857,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
       "source_location": "L1",
       "id": "derivecheckoutstate",
-      "community": 4
+      "community": 3
     },
     {
       "label": "deriveCheckoutState()",
@@ -12865,7 +12865,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
       "source_location": "L3",
       "id": "derivecheckoutstate_derivecheckoutstate",
-      "community": 4
+      "community": 3
     },
     {
       "label": "billingDetailsSchema.ts",
@@ -12873,7 +12873,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/billingDetailsSchema.ts",
       "source_location": "L1",
       "id": "billingdetailsschema",
-      "community": 5
+      "community": 1
     },
     {
       "label": "checkoutFormSchema.ts",
@@ -12881,7 +12881,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutFormSchema.ts",
       "source_location": "L1",
       "id": "checkoutformschema",
-      "community": 5
+      "community": 1
     },
     {
       "label": "checkoutSchemas.test.ts",
@@ -12889,7 +12889,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutSchemas.test.ts",
       "source_location": "L1",
       "id": "checkoutschemas_test",
-      "community": 5
+      "community": 1
     },
     {
       "label": "getIssueMap()",
@@ -12897,7 +12897,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutSchemas.test.ts",
       "source_location": "L8",
       "id": "checkoutschemas_test_getissuemap",
-      "community": 5
+      "community": 1
     },
     {
       "label": "customerDetailsSchema.ts",
@@ -12905,7 +12905,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/customerDetailsSchema.ts",
       "source_location": "L1",
       "id": "customerdetailsschema",
-      "community": 5
+      "community": 1
     },
     {
       "label": "deliveryDetailsSchema.ts",
@@ -12913,7 +12913,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/deliveryDetailsSchema.ts",
       "source_location": "L1",
       "id": "deliverydetailsschema",
-      "community": 5
+      "community": 1
     },
     {
       "label": "webOrderSchema.test.ts",
@@ -12921,7 +12921,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.test.ts",
       "source_location": "L1",
       "id": "weborderschema_test",
-      "community": 5
+      "community": 1
     },
     {
       "label": "getIssueMap()",
@@ -12929,7 +12929,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.test.ts",
       "source_location": "L12",
       "id": "weborderschema_test_getissuemap",
-      "community": 5
+      "community": 1
     },
     {
       "label": "webOrderSchema.ts",
@@ -12937,7 +12937,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.ts",
       "source_location": "L1",
       "id": "weborderschema",
-      "community": 5
+      "community": 1
     },
     {
       "label": "getPotentialPoints()",
@@ -12945,7 +12945,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L107",
       "id": "utils_getpotentialpoints",
-      "community": 2
+      "community": 0
     },
     {
       "label": "CustomerDetailsForm.tsx",
@@ -12953,7 +12953,7 @@
       "source_file": "packages/storefront-webapp/src/components/common/forms/CustomerDetailsForm.tsx",
       "source_location": "L1",
       "id": "customerdetailsform",
-      "community": 5
+      "community": 1
     },
     {
       "label": "onSubmit()",
@@ -12961,7 +12961,7 @@
       "source_file": "packages/storefront-webapp/src/components/common/forms/CustomerDetailsForm.tsx",
       "source_location": "L77",
       "id": "customerdetailsform_onsubmit",
-      "community": 5
+      "community": 1
     },
     {
       "label": "DeliveryDetailsForm.tsx",
@@ -12969,7 +12969,7 @@
       "source_file": "packages/storefront-webapp/src/components/common/forms/DeliveryDetailsForm.tsx",
       "source_location": "L1",
       "id": "deliverydetailsform",
-      "community": 5
+      "community": 1
     },
     {
       "label": "onSubmit()",
@@ -12977,7 +12977,7 @@
       "source_file": "packages/storefront-webapp/src/components/common/forms/DeliveryDetailsForm.tsx",
       "source_location": "L161",
       "id": "deliverydetailsform_onsubmit",
-      "community": 5
+      "community": 1
     },
     {
       "label": "useCountdown()",
@@ -12985,7 +12985,7 @@
       "source_file": "packages/storefront-webapp/src/components/common/hooks.ts",
       "source_location": "L3",
       "id": "hooks_usecountdown",
-      "community": 0
+      "community": 5
     },
     {
       "label": "TrustSignals.tsx",
@@ -13009,7 +13009,7 @@
       "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
       "source_location": "L1",
       "id": "productfilter",
-      "community": 0
+      "community": 20
     },
     {
       "label": "ProductFilter()",
@@ -13017,7 +13017,7 @@
       "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
       "source_location": "L14",
       "id": "productfilter_productfilter",
-      "community": 0
+      "community": 20
     },
     {
       "label": "ProductFilterBar.tsx",
@@ -13025,7 +13025,7 @@
       "source_file": "packages/storefront-webapp/src/components/filter/ProductFilterBar.tsx",
       "source_location": "L1",
       "id": "productfilterbar",
-      "community": 0
+      "community": 5
     },
     {
       "label": "Filter.tsx",
@@ -13033,7 +13033,7 @@
       "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
       "source_location": "L1",
       "id": "filter",
-      "community": 5
+      "community": 20
     },
     {
       "label": "handleCheckboxChange()",
@@ -13041,7 +13041,7 @@
       "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
       "source_location": "L27",
       "id": "filter_handlecheckboxchange",
-      "community": 5
+      "community": 20
     },
     {
       "label": "Footer.tsx",
@@ -13049,7 +13049,7 @@
       "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
       "source_location": "L1",
       "id": "footer",
-      "community": 0
+      "community": 5
     },
     {
       "label": "LinkGroup()",
@@ -13057,7 +13057,7 @@
       "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
       "source_location": "L13",
       "id": "footer_linkgroup",
-      "community": 0
+      "community": 5
     },
     {
       "label": "BestSellersSection.tsx",
@@ -13065,7 +13065,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.tsx",
       "source_location": "L1",
       "id": "bestsellerssection",
-      "community": 0
+      "community": 1
     },
     {
       "label": "BestSellersSection()",
@@ -13073,7 +13073,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.tsx",
       "source_location": "L17",
       "id": "bestsellerssection_bestsellerssection",
-      "community": 0
+      "community": 1
     },
     {
       "label": "FeaturedProductsSection.tsx",
@@ -13081,7 +13081,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
       "source_location": "L1",
       "id": "featuredproductssection",
-      "community": 0
+      "community": 1
     },
     {
       "label": "FeaturedProductsSection()",
@@ -13089,7 +13089,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
       "source_location": "L20",
       "id": "featuredproductssection_featuredproductssection",
-      "community": 0
+      "community": 1
     },
     {
       "label": "FeaturedSection()",
@@ -13097,7 +13097,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
       "source_location": "L46",
       "id": "featuredproductssection_featuredsection",
-      "community": 0
+      "community": 1
     },
     {
       "label": "HomeHero.tsx",
@@ -13105,7 +13105,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/HomeHero.tsx",
       "source_location": "L1",
       "id": "homehero",
-      "community": 0
+      "community": 1
     },
     {
       "label": "HomeHeroSection.tsx",
@@ -13113,7 +13113,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/HomeHeroSection.tsx",
       "source_location": "L1",
       "id": "homeherosection",
-      "community": 0
+      "community": 1
     },
     {
       "label": "PromoAlert.tsx",
@@ -13121,7 +13121,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
       "source_location": "L1",
       "id": "promoalert",
-      "community": 0
+      "community": 11
     },
     {
       "label": "getPromoAlertCopy()",
@@ -13129,7 +13129,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
       "source_location": "L20",
       "id": "promoalert_getpromoalertcopy",
-      "community": 0
+      "community": 11
     },
     {
       "label": "PromoAlert()",
@@ -13137,7 +13137,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
       "source_location": "L59",
       "id": "promoalert_promoalert",
-      "community": 0
+      "community": 11
     },
     {
       "label": "RewardsAlert.tsx",
@@ -13145,7 +13145,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
       "source_location": "L1",
       "id": "rewardsalert",
-      "community": 0
+      "community": 11
     },
     {
       "label": "onRewardsAlertClose()",
@@ -13153,7 +13153,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
       "source_location": "L20",
       "id": "rewardsalert_onrewardsalertclose",
-      "community": 0
+      "community": 11
     },
     {
       "label": "handleShopNow()",
@@ -13161,7 +13161,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
       "source_location": "L25",
       "id": "rewardsalert_handleshopnow",
-      "community": 0
+      "community": 11
     },
     {
       "label": "useGetStoreSubcategories()",
@@ -13169,7 +13169,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
       "source_location": "L10",
       "id": "hooks_usegetstoresubcategories",
-      "community": 0
+      "community": 5
     },
     {
       "label": "useGetStoreCategories()",
@@ -13177,7 +13177,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
       "source_location": "L21",
       "id": "hooks_usegetstorecategories",
-      "community": 0
+      "community": 5
     },
     {
       "label": "useGetShopSearchParams()",
@@ -13185,7 +13185,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
       "source_location": "L55",
       "id": "hooks_usegetshopsearchparams",
-      "community": 0
+      "community": 5
     },
     {
       "label": "BagMenu.tsx",
@@ -13193,7 +13193,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/BagMenu.tsx",
       "source_location": "L1",
       "id": "bagmenu",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleOnLinkClick()",
@@ -13201,7 +13201,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/BagMenu.tsx",
       "source_location": "L47",
       "id": "bagmenu_handleonlinkclick",
-      "community": 0
+      "community": 1
     },
     {
       "label": "MobileBagMenu.tsx",
@@ -13209,7 +13209,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileBagMenu.tsx",
       "source_location": "L1",
       "id": "mobilebagmenu",
-      "community": 0
+      "community": 1
     },
     {
       "label": "MobileBagMenu()",
@@ -13217,7 +13217,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileBagMenu.tsx",
       "source_location": "L7",
       "id": "mobilebagmenu_mobilebagmenu",
-      "community": 0
+      "community": 1
     },
     {
       "label": "MobileMenu.tsx",
@@ -13225,7 +13225,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileMenu.tsx",
       "source_location": "L1",
       "id": "mobilemenu",
-      "community": 0
+      "community": 5
     },
     {
       "label": "NavigationBar.tsx",
@@ -13233,7 +13233,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/NavigationBar.tsx",
       "source_location": "L1",
       "id": "navigationbar",
-      "community": 0
+      "community": 5
     },
     {
       "label": "StoreCategoriesSubmenu()",
@@ -13241,7 +13241,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/NavigationBar.tsx",
       "source_location": "L62",
       "id": "navigationbar_storecategoriessubmenu",
-      "community": 0
+      "community": 5
     },
     {
       "label": "SiteBanner.tsx",
@@ -13249,7 +13249,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/SiteBanner.tsx",
       "source_location": "L1",
       "id": "sitebanner",
-      "community": 3
+      "community": 2
     },
     {
       "label": "SiteBanner()",
@@ -13257,7 +13257,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/SiteBanner.tsx",
       "source_location": "L17",
       "id": "sitebanner_sitebanner",
-      "community": 3
+      "community": 2
     },
     {
       "label": "navBarConstants.ts",
@@ -13265,7 +13265,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarConstants.ts",
       "source_location": "L1",
       "id": "navbarconstants",
-      "community": 20
+      "community": 5
     },
     {
       "label": "navBarStyles.ts",
@@ -13273,7 +13273,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L1",
       "id": "navbarstyles",
-      "community": 20
+      "community": 5
     },
     {
       "label": "getMainWrapperClass()",
@@ -13281,7 +13281,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L28",
       "id": "navbarstyles_getmainwrapperclass",
-      "community": 20
+      "community": 5
     },
     {
       "label": "getNavBGClass()",
@@ -13289,7 +13289,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L43",
       "id": "navbarstyles_getnavbgclass",
-      "community": 20
+      "community": 5
     },
     {
       "label": "getHoverClass()",
@@ -13297,7 +13297,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L76",
       "id": "navbarstyles_gethoverclass",
-      "community": 20
+      "community": 5
     },
     {
       "label": "getSubmenuBGClass()",
@@ -13305,7 +13305,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L93",
       "id": "navbarstyles_getsubmenubgclass",
-      "community": 20
+      "community": 5
     },
     {
       "label": "getBannerTextClass()",
@@ -13313,7 +13313,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L119",
       "id": "navbarstyles_getbannertextclass",
-      "community": 20
+      "community": 5
     },
     {
       "label": "getBannerBGClass()",
@@ -13321,7 +13321,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L136",
       "id": "navbarstyles_getbannerbgclass",
-      "community": 20
+      "community": 5
     },
     {
       "label": "getBannerAnimationDelay()",
@@ -13329,7 +13329,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L152",
       "id": "navbarstyles_getbanneranimationdelay",
-      "community": 20
+      "community": 5
     },
     {
       "label": "getNavBarWrapperClass()",
@@ -13337,7 +13337,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L163",
       "id": "navbarstyles_getnavbarwrapperclass",
-      "community": 20
+      "community": 5
     },
     {
       "label": "getNavBarAnimationDelay()",
@@ -13345,7 +13345,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L174",
       "id": "navbarstyles_getnavbaranimationdelay",
-      "community": 20
+      "community": 5
     },
     {
       "label": "getOverlayClass()",
@@ -13353,7 +13353,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L184",
       "id": "navbarstyles_getoverlayclass",
-      "community": 20
+      "community": 5
     },
     {
       "label": "NotificationPill.tsx",
@@ -13393,7 +13393,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
       "source_location": "L1",
       "id": "dimensionbar",
-      "community": 12
+      "community": 9
     },
     {
       "label": "mapValueToLabelIndex()",
@@ -13401,7 +13401,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
       "source_location": "L12",
       "id": "dimensionbar_mapvaluetolabelindex",
-      "community": 12
+      "community": 9
     },
     {
       "label": "DiscountBadge.tsx",
@@ -13409,7 +13409,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/DiscountBadge.tsx",
       "source_location": "L1",
       "id": "discountbadge",
-      "community": 0
+      "community": 9
     },
     {
       "label": "DiscountBadge()",
@@ -13417,7 +13417,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/DiscountBadge.tsx",
       "source_location": "L7",
       "id": "discountbadge_discountbadge",
-      "community": 0
+      "community": 9
     },
     {
       "label": "GalleryViewer.tsx",
@@ -13441,7 +13441,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
       "source_location": "L1",
       "id": "inventorylevelbadge",
-      "community": 12
+      "community": 9
     },
     {
       "label": "SoldOutBadge()",
@@ -13449,7 +13449,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
       "source_location": "L3",
       "id": "inventorylevelbadge_soldoutbadge",
-      "community": 12
+      "community": 9
     },
     {
       "label": "LowStockBadge()",
@@ -13457,7 +13457,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
       "source_location": "L14",
       "id": "inventorylevelbadge_lowstockbadge",
-      "community": 12
+      "community": 9
     },
     {
       "label": "SellingFastBadge()",
@@ -13465,7 +13465,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
       "source_location": "L22",
       "id": "inventorylevelbadge_sellingfastbadge",
-      "community": 12
+      "community": 9
     },
     {
       "label": "SellingFastSignal()",
@@ -13473,7 +13473,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
       "source_location": "L30",
       "id": "inventorylevelbadge_sellingfastsignal",
-      "community": 12
+      "community": 9
     },
     {
       "label": "OnSaleProduct.tsx",
@@ -13497,7 +13497,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.tsx",
       "source_location": "L1",
       "id": "productactions",
-      "community": 9
+      "community": 1
     },
     {
       "label": "ProductActions()",
@@ -13505,7 +13505,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.tsx",
       "source_location": "L17",
       "id": "productactions_productactions",
-      "community": 9
+      "community": 1
     },
     {
       "label": "ProductAttribute.tsx",
@@ -13537,7 +13537,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttributes.tsx",
       "source_location": "L3",
       "id": "productattributes_productattributes",
-      "community": 1
+      "community": 0
     },
     {
       "label": "PickupDetails()",
@@ -13545,7 +13545,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
       "source_location": "L13",
       "id": "productdetails_pickupdetails",
-      "community": 0
+      "community": 1
     },
     {
       "label": "BagProduct()",
@@ -13553,7 +13553,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
       "source_location": "L43",
       "id": "productdetails_bagproduct",
-      "community": 0
+      "community": 1
     },
     {
       "label": "ShippingPolicy()",
@@ -13561,7 +13561,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
       "source_location": "L88",
       "id": "productdetails_shippingpolicy",
-      "community": 0
+      "community": 1
     },
     {
       "label": "ProductInfo.tsx",
@@ -13569,7 +13569,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductInfo.tsx",
       "source_location": "L1",
       "id": "productinfo",
-      "community": 12
+      "community": 9
     },
     {
       "label": "showShippingPolicy()",
@@ -13585,7 +13585,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductReview.tsx",
       "source_location": "L1",
       "id": "productreview",
-      "community": 12
+      "community": 9
     },
     {
       "label": "handleHelpful()",
@@ -13593,7 +13593,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductReview.tsx",
       "source_location": "L87",
       "id": "productreview_handlehelpful",
-      "community": 12
+      "community": 9
     },
     {
       "label": "ProductReviews.tsx",
@@ -13601,7 +13601,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductReviews.tsx",
       "source_location": "L1",
       "id": "productreviews",
-      "community": 12
+      "community": 9
     },
     {
       "label": "ProductsNavigationBar.tsx",
@@ -13609,7 +13609,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductsNavigationBar.tsx",
       "source_location": "L1",
       "id": "productsnavigationbar",
-      "community": 2
+      "community": 9
     },
     {
       "label": "ReviewSummary.tsx",
@@ -13617,7 +13617,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
       "source_location": "L1",
       "id": "reviewsummary",
-      "community": 12
+      "community": 9
     },
     {
       "label": "ReviewSummary()",
@@ -13625,7 +13625,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
       "source_location": "L8",
       "id": "reviewsummary_reviewsummary",
-      "community": 12
+      "community": 9
     },
     {
       "label": "ErrorMessage.tsx",
@@ -13633,7 +13633,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ErrorMessage.tsx",
       "source_location": "L1",
       "id": "errormessage",
-      "community": 0
+      "community": 1
     },
     {
       "label": "ExistingReviewMessage.tsx",
@@ -13641,7 +13641,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ExistingReviewMessage.tsx",
       "source_location": "L1",
       "id": "existingreviewmessage",
-      "community": 0
+      "community": 1
     },
     {
       "label": "OrderItem.tsx",
@@ -13649,7 +13649,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
       "source_location": "L1",
       "id": "orderitem",
-      "community": 0
+      "community": 1
     },
     {
       "label": "OrderItem()",
@@ -13657,7 +13657,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
       "source_location": "L12",
       "id": "orderitem_orderitem",
-      "community": 0
+      "community": 1
     },
     {
       "label": "RatingSelector.tsx",
@@ -13665,7 +13665,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/RatingSelector.tsx",
       "source_location": "L1",
       "id": "ratingselector",
-      "community": 2
+      "community": 3
     },
     {
       "label": "RatingSelector()",
@@ -13673,7 +13673,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/RatingSelector.tsx",
       "source_location": "L18",
       "id": "ratingselector_ratingselector",
-      "community": 2
+      "community": 3
     },
     {
       "label": "ReviewEditor.tsx",
@@ -13681,7 +13681,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
       "source_location": "L1",
       "id": "revieweditor",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleFormDataChange()",
@@ -13689,7 +13689,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
       "source_location": "L150",
       "id": "revieweditor_handleformdatachange",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleSubmit()",
@@ -13697,7 +13697,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
       "source_location": "L157",
       "id": "revieweditor_handlesubmit",
-      "community": 0
+      "community": 1
     },
     {
       "label": "ReviewForm.tsx",
@@ -13705,7 +13705,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewForm.tsx",
       "source_location": "L1",
       "id": "reviewform",
-      "community": 5
+      "community": 1
     },
     {
       "label": "SuccessMessage.tsx",
@@ -13713,7 +13713,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/SuccessMessage.tsx",
       "source_location": "L1",
       "id": "successmessage",
-      "community": 0
+      "community": 1
     },
     {
       "label": "GuestRewardsPrompt.tsx",
@@ -13721,7 +13721,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/GuestRewardsPrompt.tsx",
       "source_location": "L1",
       "id": "guestrewardsprompt",
-      "community": 0
+      "community": 1
     },
     {
       "label": "GuestRewardsPrompt()",
@@ -13729,7 +13729,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/GuestRewardsPrompt.tsx",
       "source_location": "L10",
       "id": "guestrewardsprompt_guestrewardsprompt",
-      "community": 0
+      "community": 1
     },
     {
       "label": "OrderPointsDisplay.tsx",
@@ -13753,7 +13753,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/PastOrdersRewards.tsx",
       "source_location": "L1",
       "id": "pastordersrewards",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleClaimPoints()",
@@ -13761,7 +13761,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/PastOrdersRewards.tsx",
       "source_location": "L59",
       "id": "pastordersrewards_handleclaimpoints",
-      "community": 0
+      "community": 1
     },
     {
       "label": "RewardsPanel.tsx",
@@ -13769,7 +13769,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/RewardsPanel.tsx",
       "source_location": "L1",
       "id": "rewardspanel",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleRedeemReward()",
@@ -13777,7 +13777,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/RewardsPanel.tsx",
       "source_location": "L33",
       "id": "rewardspanel_handleredeemreward",
-      "community": 0
+      "community": 1
     },
     {
       "label": "SavedIcon.tsx",
@@ -13785,7 +13785,7 @@
       "source_file": "packages/storefront-webapp/src/components/saved-items/SavedIcon.tsx",
       "source_location": "L1",
       "id": "savedicon",
-      "community": 0
+      "community": 1
     },
     {
       "label": "BagItem()",
@@ -13801,7 +13801,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/CartIcon.tsx",
       "source_location": "L1",
       "id": "carticon",
-      "community": 0
+      "community": 5
     },
     {
       "label": "ShoppingBag.tsx",
@@ -13809,7 +13809,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L1",
       "id": "shoppingbag",
-      "community": 0
+      "community": 1
     },
     {
       "label": "PendingItem()",
@@ -13817,7 +13817,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L62",
       "id": "shoppingbag_pendingitem",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleOnCheckoutClick()",
@@ -13825,7 +13825,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L476",
       "id": "shoppingbag_handleoncheckoutclick",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleClickOnDiscountCode()",
@@ -13833,7 +13833,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L525",
       "id": "shoppingbag_handleclickondiscountcode",
-      "community": 0
+      "community": 1
     },
     {
       "label": "isSkuUnavailable()",
@@ -13841,7 +13841,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L537",
       "id": "shoppingbag_isskuunavailable",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleMoveToSaved()",
@@ -13849,7 +13849,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L552",
       "id": "shoppingbag_handlemovetosaved",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleDeleteItem()",
@@ -13857,7 +13857,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L566",
       "id": "shoppingbag_handledeleteitem",
-      "community": 0
+      "community": 1
     },
     {
       "label": "CheckoutUnavailable.tsx",
@@ -13865,7 +13865,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout unavailable/CheckoutUnavailable.tsx",
       "source_location": "L1",
       "id": "checkoutunavailable",
-      "community": 0
+      "community": 1
     },
     {
       "label": "CheckoutUnavailable()",
@@ -13873,7 +13873,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout unavailable/CheckoutUnavailable.tsx",
       "source_location": "L4",
       "id": "checkoutunavailable_checkoutunavailable",
-      "community": 0
+      "community": 1
     },
     {
       "label": "CheckoutExpired.tsx",
@@ -13881,7 +13881,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L1",
       "id": "checkoutexpired",
-      "community": 0
+      "community": 1
     },
     {
       "label": "CheckoutExpired()",
@@ -13889,7 +13889,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L9",
       "id": "checkoutexpired_checkoutexpired",
-      "community": 0
+      "community": 1
     },
     {
       "label": "NoCheckoutSession()",
@@ -13897,7 +13897,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L33",
       "id": "checkoutexpired_nocheckoutsession",
-      "community": 0
+      "community": 1
     },
     {
       "label": "CheckoutSessionNotFound()",
@@ -13905,7 +13905,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L54",
       "id": "checkoutexpired_checkoutsessionnotfound",
-      "community": 0
+      "community": 1
     },
     {
       "label": "CheckoutSessionGeneric()",
@@ -13913,7 +13913,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L73",
       "id": "checkoutexpired_checkoutsessiongeneric",
-      "community": 0
+      "community": 1
     },
     {
       "label": "handleSendEmail()",
@@ -13921,7 +13921,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L98",
       "id": "checkoutexpired_handlesendemail",
-      "community": 0
+      "community": 1
     },
     {
       "label": "ErrorBoundary.tsx",
@@ -13929,7 +13929,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/error/ErrorBoundary.tsx",
       "source_location": "L1",
       "id": "errorboundary",
-      "community": 0
+      "community": 5
     },
     {
       "label": "ErrorBoundary()",
@@ -13937,7 +13937,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/error/ErrorBoundary.tsx",
       "source_location": "L22",
       "id": "errorboundary_errorboundary",
-      "community": 0
+      "community": 5
     },
     {
       "label": "Maintenance.tsx",
@@ -13945,7 +13945,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/maintenance/Maintenance.tsx",
       "source_location": "L1",
       "id": "maintenance",
-      "community": 0
+      "community": 5
     },
     {
       "label": "AnimatedCard.tsx",
@@ -13953,7 +13953,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/AnimatedCard.tsx",
       "source_location": "L1",
       "id": "animatedcard",
-      "community": 0
+      "community": 11
     },
     {
       "label": "ScrollDownButton.tsx",
@@ -13961,7 +13961,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/ScrollDownButton.tsx",
       "source_location": "L1",
       "id": "scrolldownbutton",
-      "community": 17
+      "community": 13
     },
     {
       "label": "ScrollDownButton()",
@@ -13969,7 +13969,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/ScrollDownButton.tsx",
       "source_location": "L11",
       "id": "scrolldownbutton_scrolldownbutton",
-      "community": 17
+      "community": 13
     },
     {
       "label": "alert.tsx",
@@ -13977,7 +13977,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/alert.tsx",
       "source_location": "L1",
       "id": "alert",
-      "community": 2
+      "community": 0
     },
     {
       "label": "breadcrumb.tsx",
@@ -13985,7 +13985,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/breadcrumb.tsx",
       "source_location": "L1",
       "id": "breadcrumb",
-      "community": 2
+      "community": 9
     },
     {
       "label": "country-select.tsx",
@@ -13993,7 +13993,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/country-select.tsx",
       "source_location": "L1",
       "id": "country_select",
-      "community": 5
+      "community": 1
     },
     {
       "label": "CountrySelect()",
@@ -14001,7 +14001,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/country-select.tsx",
       "source_location": "L3",
       "id": "country_select_countryselect",
-      "community": 5
+      "community": 1
     },
     {
       "label": "ghana-region-select.tsx",
@@ -14009,7 +14009,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/ghana-region-select.tsx",
       "source_location": "L1",
       "id": "ghana_region_select",
-      "community": 5
+      "community": 1
     },
     {
       "label": "GhanaRegionSelect()",
@@ -14017,7 +14017,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/ghana-region-select.tsx",
       "source_location": "L3",
       "id": "ghana_region_select_ghanaregionselect",
-      "community": 5
+      "community": 1
     },
     {
       "label": "ghost-button.tsx",
@@ -14025,7 +14025,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/ghost-button.tsx",
       "source_location": "L1",
       "id": "ghost_button",
-      "community": 5
+      "community": 1
     },
     {
       "label": "GhostButton()",
@@ -14033,7 +14033,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/ghost-button.tsx",
       "source_location": "L9",
       "id": "ghost_button_ghostbutton",
-      "community": 5
+      "community": 1
     },
     {
       "label": "image-with-fallback.tsx",
@@ -14041,7 +14041,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/image-with-fallback.tsx",
       "source_location": "L1",
       "id": "image_with_fallback",
-      "community": 0
+      "community": 1
     },
     {
       "label": "input-with-end-button.tsx",
@@ -14049,7 +14049,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/input-with-end-button.tsx",
       "source_location": "L1",
       "id": "input_with_end_button",
-      "community": 0
+      "community": 1
     },
     {
       "label": "LeaveAReviewModal.tsx",
@@ -14057,7 +14057,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
       "source_location": "L1",
       "id": "leaveareviewmodal",
-      "community": 6
+      "community": 14
     },
     {
       "label": "handleClose()",
@@ -14065,7 +14065,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
       "source_location": "L66",
       "id": "leaveareviewmodal_handleclose",
-      "community": 6
+      "community": 14
     },
     {
       "label": "LeaveAReviewModalForm.tsx",
@@ -14073,7 +14073,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModalForm.tsx",
       "source_location": "L1",
       "id": "leaveareviewmodalform",
-      "community": 6
+      "community": 14
     },
     {
       "label": "UpsellModal.tsx",
@@ -14081,7 +14081,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
       "source_location": "L1",
       "id": "upsellmodal",
-      "community": 6
+      "community": 14
     },
     {
       "label": "handleScroll()",
@@ -14089,7 +14089,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
       "source_location": "L66",
       "id": "upsellmodal_handlescroll",
-      "community": 6
+      "community": 14
     },
     {
       "label": "handleClose()",
@@ -14097,7 +14097,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
       "source_location": "L111",
       "id": "upsellmodal_handleclose",
-      "community": 6
+      "community": 14
     },
     {
       "label": "handleSuccess()",
@@ -14105,7 +14105,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
       "source_location": "L127",
       "id": "upsellmodal_handlesuccess",
-      "community": 6
+      "community": 14
     },
     {
       "label": "UpsellModalForm.tsx",
@@ -14113,7 +14113,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
       "source_location": "L1",
       "id": "upsellmodalform",
-      "community": 6
+      "community": 14
     },
     {
       "label": "handleSubmit()",
@@ -14121,7 +14121,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
       "source_location": "L48",
       "id": "upsellmodalform_handlesubmit",
-      "community": 6
+      "community": 14
     },
     {
       "label": "handleInputChange()",
@@ -14129,7 +14129,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
       "source_location": "L63",
       "id": "upsellmodalform_handleinputchange",
-      "community": 6
+      "community": 14
     },
     {
       "label": "UpsellModalSuccess.tsx",
@@ -14137,7 +14137,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalSuccess.tsx",
       "source_location": "L1",
       "id": "upsellmodalsuccess",
-      "community": 0
+      "community": 1
     },
     {
       "label": "UpsellModalSuccess()",
@@ -14145,7 +14145,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalSuccess.tsx",
       "source_location": "L19",
       "id": "upsellmodalsuccess_upsellmodalsuccess",
-      "community": 0
+      "community": 1
     },
     {
       "label": "WelcomeBackModal.tsx",
@@ -14153,7 +14153,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
       "source_location": "L1",
       "id": "welcomebackmodal",
-      "community": 6
+      "community": 14
     },
     {
       "label": "handleClose()",
@@ -14161,7 +14161,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
       "source_location": "L63",
       "id": "welcomebackmodal_handleclose",
-      "community": 6
+      "community": 14
     },
     {
       "label": "handleSuccess()",
@@ -14169,7 +14169,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
       "source_location": "L76",
       "id": "welcomebackmodal_handlesuccess",
-      "community": 6
+      "community": 14
     },
     {
       "label": "WelcomeBackModalForm.tsx",
@@ -14177,7 +14177,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
       "source_location": "L1",
       "id": "welcomebackmodalform",
-      "community": 6
+      "community": 14
     },
     {
       "label": "handleSubmit()",
@@ -14185,7 +14185,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
       "source_location": "L36",
       "id": "welcomebackmodalform_handlesubmit",
-      "community": 6
+      "community": 14
     },
     {
       "label": "handleInputChange()",
@@ -14193,7 +14193,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
       "source_location": "L51",
       "id": "welcomebackmodalform_handleinputchange",
-      "community": 6
+      "community": 14
     },
     {
       "label": "WelcomeBackModalSuccess.tsx",
@@ -14201,7 +14201,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalSuccess.tsx",
       "source_location": "L1",
       "id": "welcomebackmodalsuccess",
-      "community": 6
+      "community": 14
     },
     {
       "label": "WelcomeBackModalSuccess()",
@@ -14209,7 +14209,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalSuccess.tsx",
       "source_location": "L13",
       "id": "welcomebackmodalsuccess_welcomebackmodalsuccess",
-      "community": 6
+      "community": 14
     },
     {
       "label": "welcomeBackModalAnimations.ts",
@@ -14217,7 +14217,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/animations/welcomeBackModalAnimations.ts",
       "source_location": "L1",
       "id": "welcomebackmodalanimations",
-      "community": 6
+      "community": 14
     },
     {
       "label": "leaveReviewModalConfig.tsx",
@@ -14225,7 +14225,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/config/leaveReviewModalConfig.tsx",
       "source_location": "L1",
       "id": "leavereviewmodalconfig",
-      "community": 6
+      "community": 14
     },
     {
       "label": "getModalConfig()",
@@ -14233,7 +14233,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/config/leaveReviewModalConfig.tsx",
       "source_location": "L46",
       "id": "leavereviewmodalconfig_getmodalconfig",
-      "community": 6
+      "community": 14
     },
     {
       "label": "welcomeBackModalConfig.tsx",
@@ -14241,7 +14241,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/config/welcomeBackModalConfig.tsx",
       "source_location": "L1",
       "id": "welcomebackmodalconfig",
-      "community": 6
+      "community": 14
     },
     {
       "label": "getModalConfig()",
@@ -14249,7 +14249,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/config/welcomeBackModalConfig.tsx",
       "source_location": "L46",
       "id": "welcomebackmodalconfig_getmodalconfig",
-      "community": 6
+      "community": 14
     },
     {
       "label": "navigation-menu.tsx",
@@ -14257,7 +14257,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/navigation-menu.tsx",
       "source_location": "L1",
       "id": "navigation_menu",
-      "community": 2
+      "community": 0
     },
     {
       "label": "webp-jpg.tsx",
@@ -14297,7 +14297,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
       "source_location": "L1",
       "id": "navigationbarprovider",
-      "community": 0
+      "community": 5
     },
     {
       "label": "NavigationBarProvider()",
@@ -14305,7 +14305,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
       "source_location": "L16",
       "id": "navigationbarprovider_navigationbarprovider",
-      "community": 0
+      "community": 5
     },
     {
       "label": "useNavigationBarContext()",
@@ -14313,7 +14313,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
       "source_location": "L39",
       "id": "navigationbarprovider_usenavigationbarcontext",
-      "community": 0
+      "community": 5
     },
     {
       "label": "StoreContext.tsx",
@@ -14321,7 +14321,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
       "source_location": "L1",
       "id": "storecontext",
-      "community": 0
+      "community": 1
     },
     {
       "label": "StoreProvider()",
@@ -14329,7 +14329,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
       "source_location": "L25",
       "id": "storecontext_storeprovider",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useStoreContext()",
@@ -14337,7 +14337,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
       "source_location": "L82",
       "id": "storecontext_usestorecontext",
-      "community": 0
+      "community": 1
     },
     {
       "label": "StorefrontObservabilityProvider.tsx",
@@ -14345,7 +14345,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
       "source_location": "L1",
       "id": "storefrontobservabilityprovider",
-      "community": 8
+      "community": 5
     },
     {
       "label": "StorefrontObservabilityProvider()",
@@ -14353,7 +14353,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
       "source_location": "L20",
       "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
-      "community": 8
+      "community": 5
     },
     {
       "label": "useStorefrontObservability()",
@@ -14361,7 +14361,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
       "source_location": "L55",
       "id": "storefrontobservabilityprovider_usestorefrontobservability",
-      "community": 8
+      "community": 5
     },
     {
       "label": "useCheckout.ts",
@@ -14369,7 +14369,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useCheckout.ts",
       "source_location": "L1",
       "id": "usecheckout",
-      "community": 5
+      "community": 1
     },
     {
       "label": "useCheckout()",
@@ -14377,7 +14377,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useCheckout.ts",
       "source_location": "L5",
       "id": "usecheckout_usecheckout",
-      "community": 5
+      "community": 1
     },
     {
       "label": "useDiscountCodeAlert.tsx",
@@ -14385,7 +14385,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useDiscountCodeAlert.tsx",
       "source_location": "L1",
       "id": "usediscountcodealert",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useDiscountCodeAlert()",
@@ -14393,7 +14393,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useDiscountCodeAlert.tsx",
       "source_location": "L14",
       "id": "usediscountcodealert_usediscountcodealert",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useEnhancedTracking.ts",
@@ -14401,7 +14401,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useEnhancedTracking.ts",
       "source_location": "L1",
       "id": "useenhancedtracking",
-      "community": 17
+      "community": 13
     },
     {
       "label": "useEnhancedTracking()",
@@ -14409,7 +14409,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useEnhancedTracking.ts",
       "source_location": "L29",
       "id": "useenhancedtracking_useenhancedtracking",
-      "community": 17
+      "community": 13
     },
     {
       "label": "useGetActiveCheckoutSession.tsx",
@@ -14417,7 +14417,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetActiveCheckoutSession.tsx",
       "source_location": "L1",
       "id": "usegetactivecheckoutsession",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useGetActiveCheckoutSession()",
@@ -14425,7 +14425,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetActiveCheckoutSession.tsx",
       "source_location": "L5",
       "id": "usegetactivecheckoutsession_usegetactivecheckoutsession",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useGetProduct.tsx",
@@ -14433,7 +14433,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetProduct.tsx",
       "source_location": "L1",
       "id": "usegetproduct",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useGetProductQuery()",
@@ -14441,7 +14441,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetProduct.tsx",
       "source_location": "L5",
       "id": "usegetproduct_usegetproductquery",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useGetProductFilters.ts",
@@ -14449,7 +14449,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetProductFilters.ts",
       "source_location": "L1",
       "id": "usegetproductfilters",
-      "community": 0
+      "community": 5
     },
     {
       "label": "useGetProductFilters()",
@@ -14457,7 +14457,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetProductFilters.ts",
       "source_location": "L3",
       "id": "usegetproductfilters_usegetproductfilters",
-      "community": 0
+      "community": 5
     },
     {
       "label": "useGetProductReviews.ts",
@@ -14465,7 +14465,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetProductReviews.ts",
       "source_location": "L1",
       "id": "usegetproductreviews",
-      "community": 12
+      "community": 9
     },
     {
       "label": "useGetProductReviewsQuery()",
@@ -14473,7 +14473,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetProductReviews.ts",
       "source_location": "L4",
       "id": "usegetproductreviews_usegetproductreviewsquery",
-      "community": 12
+      "community": 9
     },
     {
       "label": "useGetStore.ts",
@@ -14481,7 +14481,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetStore.ts",
       "source_location": "L1",
       "id": "usegetstore",
-      "community": 3
+      "community": 2
     },
     {
       "label": "useGetStore()",
@@ -14489,7 +14489,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetStore.ts",
       "source_location": "L4",
       "id": "usegetstore_usegetstore",
-      "community": 3
+      "community": 2
     },
     {
       "label": "useInventoryStatus.ts",
@@ -14497,7 +14497,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useInventoryStatus.ts",
       "source_location": "L1",
       "id": "useinventorystatus",
-      "community": 12
+      "community": 13
     },
     {
       "label": "useInventoryStatus()",
@@ -14505,7 +14505,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useInventoryStatus.ts",
       "source_location": "L9",
       "id": "useinventorystatus_useinventorystatus",
-      "community": 12
+      "community": 13
     },
     {
       "label": "useLeaveAReviewModal.tsx",
@@ -14513,7 +14513,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useLeaveAReviewModal.tsx",
       "source_location": "L1",
       "id": "useleaveareviewmodal",
-      "community": 0
+      "community": 2
     },
     {
       "label": "useLeaveAReviewModal()",
@@ -14521,7 +14521,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useLeaveAReviewModal.tsx",
       "source_location": "L17",
       "id": "useleaveareviewmodal_useleaveareviewmodal",
-      "community": 0
+      "community": 2
     },
     {
       "label": "useLogout.ts",
@@ -14529,7 +14529,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useLogout.ts",
       "source_location": "L1",
       "id": "uselogout",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useLogout()",
@@ -14537,7 +14537,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useLogout.ts",
       "source_location": "L5",
       "id": "uselogout_uselogout",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useModalState.tsx",
@@ -14545,7 +14545,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useModalState.tsx",
       "source_location": "L1",
       "id": "usemodalstate",
-      "community": 0
+      "community": 2
     },
     {
       "label": "useModalState()",
@@ -14553,7 +14553,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useModalState.tsx",
       "source_location": "L15",
       "id": "usemodalstate_usemodalstate",
-      "community": 0
+      "community": 2
     },
     {
       "label": "useProductDiscount.ts",
@@ -14561,7 +14561,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
       "source_location": "L1",
       "id": "useproductdiscount",
-      "community": 0
+      "community": 9
     },
     {
       "label": "useProductDiscounts()",
@@ -14569,7 +14569,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
       "source_location": "L25",
       "id": "useproductdiscount_useproductdiscounts",
-      "community": 0
+      "community": 9
     },
     {
       "label": "useProductDiscount()",
@@ -14577,7 +14577,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
       "source_location": "L107",
       "id": "useproductdiscount_useproductdiscount",
-      "community": 0
+      "community": 9
     },
     {
       "label": "useProductPageLogic.ts",
@@ -14585,7 +14585,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useProductPageLogic.ts",
       "source_location": "L1",
       "id": "useproductpagelogic",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useProductPageLogic()",
@@ -14593,7 +14593,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useProductPageLogic.ts",
       "source_location": "L18",
       "id": "useproductpagelogic_useproductpagelogic",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useProductReminder.tsx",
@@ -14601,7 +14601,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useProductReminder.tsx",
       "source_location": "L1",
       "id": "useproductreminder",
-      "community": 3
+      "community": 2
     },
     {
       "label": "useProductReminder()",
@@ -14609,7 +14609,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useProductReminder.tsx",
       "source_location": "L9",
       "id": "useproductreminder_useproductreminder",
-      "community": 3
+      "community": 2
     },
     {
       "label": "usePromoAlert.tsx",
@@ -14617,7 +14617,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/usePromoAlert.tsx",
       "source_location": "L1",
       "id": "usepromoalert",
-      "community": 0
+      "community": 2
     },
     {
       "label": "usePromoAlert()",
@@ -14625,7 +14625,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/usePromoAlert.tsx",
       "source_location": "L16",
       "id": "usepromoalert_usepromoalert",
-      "community": 0
+      "community": 2
     },
     {
       "label": "useQueryEnabled.ts",
@@ -14633,7 +14633,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useQueryEnabled.ts",
       "source_location": "L1",
       "id": "usequeryenabled",
-      "community": 3
+      "community": 2
     },
     {
       "label": "useQueryEnabled()",
@@ -14641,7 +14641,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useQueryEnabled.ts",
       "source_location": "L4",
       "id": "usequeryenabled_usequeryenabled",
-      "community": 3
+      "community": 2
     },
     {
       "label": "useRewardsAlert.tsx",
@@ -14649,7 +14649,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useRewardsAlert.tsx",
       "source_location": "L1",
       "id": "userewardsalert",
-      "community": 0
+      "community": 2
     },
     {
       "label": "useRewardsAlert()",
@@ -14657,7 +14657,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useRewardsAlert.tsx",
       "source_location": "L11",
       "id": "userewardsalert_userewardsalert",
-      "community": 0
+      "community": 2
     },
     {
       "label": "useScrollToTop.ts",
@@ -14665,7 +14665,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useScrollToTop.ts",
       "source_location": "L1",
       "id": "usescrolltotop",
-      "community": 7
+      "community": 4
     },
     {
       "label": "useScrollToTop()",
@@ -14673,7 +14673,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useScrollToTop.ts",
       "source_location": "L3",
       "id": "usescrolltotop_usescrolltotop",
-      "community": 7
+      "community": 4
     },
     {
       "label": "useShoppingBag.ts",
@@ -14681,7 +14681,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
       "source_location": "L1",
       "id": "useshoppingbag",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useShoppingBag()",
@@ -14689,7 +14689,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
       "source_location": "L52",
       "id": "useshoppingbag_useshoppingbag",
-      "community": 0
+      "community": 1
     },
     {
       "label": "isUnavailableProductList()",
@@ -14697,7 +14697,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
       "source_location": "L540",
       "id": "useshoppingbag_isunavailableproductlist",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useStorefrontObservability.ts",
@@ -14705,7 +14705,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useStorefrontObservability.ts",
       "source_location": "L1",
       "id": "usestorefrontobservability",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useTrackAction.ts",
@@ -14713,7 +14713,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useTrackAction.ts",
       "source_location": "L1",
       "id": "usetrackaction",
-      "community": 17
+      "community": 13
     },
     {
       "label": "useTrackAction()",
@@ -14721,7 +14721,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useTrackAction.ts",
       "source_location": "L5",
       "id": "usetrackaction_usetrackaction",
-      "community": 17
+      "community": 13
     },
     {
       "label": "useTrackEvent.ts",
@@ -14729,7 +14729,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useTrackEvent.ts",
       "source_location": "L1",
       "id": "usetrackevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useTrackEvent()",
@@ -14737,7 +14737,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useTrackEvent.ts",
       "source_location": "L5",
       "id": "usetrackevent_usetrackevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useUpsellModal.tsx",
@@ -14745,7 +14745,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useUpsellModal.tsx",
       "source_location": "L1",
       "id": "useupsellmodal",
-      "community": 6
+      "community": 2
     },
     {
       "label": "useUpsellModal()",
@@ -14753,7 +14753,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useUpsellModal.tsx",
       "source_location": "L14",
       "id": "useupsellmodal_useupsellmodal",
-      "community": 6
+      "community": 2
     },
     {
       "label": "feeUtils.test.ts",
@@ -14761,7 +14761,7 @@
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.test.ts",
       "source_location": "L1",
       "id": "feeutils_test",
-      "community": 5
+      "community": 1
     },
     {
       "label": "feeUtils.ts",
@@ -14769,7 +14769,7 @@
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L1",
       "id": "feeutils",
-      "community": 5
+      "community": 1
     },
     {
       "label": "meetsThreshold()",
@@ -14777,7 +14777,7 @@
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L17",
       "id": "feeutils_meetsthreshold",
-      "community": 5
+      "community": 1
     },
     {
       "label": "isFeeWaived()",
@@ -14785,7 +14785,7 @@
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L34",
       "id": "feeutils_isfeewaived",
-      "community": 5
+      "community": 1
     },
     {
       "label": "isAnyFeeWaived()",
@@ -14793,7 +14793,7 @@
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L74",
       "id": "feeutils_isanyfeewaived",
-      "community": 5
+      "community": 1
     },
     {
       "label": "hasWaiverConfigured()",
@@ -14801,7 +14801,7 @@
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L100",
       "id": "feeutils_haswaiverconfigured",
-      "community": 5
+      "community": 1
     },
     {
       "label": "getRemainingForFreeDelivery()",
@@ -14809,7 +14809,7 @@
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L138",
       "id": "feeutils_getremainingforfreedelivery",
-      "community": 5
+      "community": 1
     },
     {
       "label": "maintenanceUtils.test.ts",
@@ -14825,7 +14825,7 @@
       "source_file": "packages/storefront-webapp/src/lib/mutations.ts/analytics.ts",
       "source_location": "L4",
       "id": "analytics_usepostanalytics",
-      "community": 17
+      "community": 13
     },
     {
       "label": "isSoldOut()",
@@ -14833,7 +14833,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L45",
       "id": "productutils_issoldout",
-      "community": 0
+      "community": 1
     },
     {
       "label": "hasLowStock()",
@@ -14841,7 +14841,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L52",
       "id": "productutils_haslowstock",
-      "community": 0
+      "community": 1
     },
     {
       "label": "sortSkusByLength()",
@@ -14849,7 +14849,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L62",
       "id": "productutils_sortskusbylength",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useBagQueries()",
@@ -14865,7 +14865,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/bannerMessage.ts",
       "source_location": "L6",
       "id": "bannermessage_usebannermessagequeries",
-      "community": 3
+      "community": 2
     },
     {
       "label": "useCheckoutSessionQueries()",
@@ -14873,7 +14873,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/checkout.ts",
       "source_location": "L10",
       "id": "checkout_usecheckoutsessionqueries",
-      "community": 0
+      "community": 1
     },
     {
       "label": "inventory.ts",
@@ -14881,7 +14881,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/inventory.ts",
       "source_location": "L1",
       "id": "inventory",
-      "community": 3
+      "community": 2
     },
     {
       "label": "useInventoryQueries()",
@@ -14889,7 +14889,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/inventory.ts",
       "source_location": "L6",
       "id": "inventory_useinventoryqueries",
-      "community": 3
+      "community": 2
     },
     {
       "label": "useOnlineOrderQueries()",
@@ -14897,7 +14897,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/onlineOrder.ts",
       "source_location": "L5",
       "id": "onlineorder_useonlineorderqueries",
-      "community": 3
+      "community": 2
     },
     {
       "label": "useProductQueries()",
@@ -14905,7 +14905,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/product.ts",
       "source_location": "L14",
       "id": "product_useproductqueries",
-      "community": 12
+      "community": 13
     },
     {
       "label": "usePromoCodesQueries()",
@@ -14913,7 +14913,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/promoCode.ts",
       "source_location": "L9",
       "id": "promocode_usepromocodesqueries",
-      "community": 3
+      "community": 2
     },
     {
       "label": "useReviewQueries()",
@@ -14921,7 +14921,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/reviews.ts",
       "source_location": "L10",
       "id": "reviews_usereviewqueries",
-      "community": 12
+      "community": 9
     },
     {
       "label": "useRewardsQueries()",
@@ -14937,7 +14937,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/upsells.ts",
       "source_location": "L6",
       "id": "upsells_useupsellsqueries",
-      "community": 3
+      "community": 2
     },
     {
       "label": "useUserQueries()",
@@ -14945,7 +14945,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/user.ts",
       "source_location": "L5",
       "id": "user_useuserqueries",
-      "community": 3
+      "community": 2
     },
     {
       "label": "useUserOffersQueries()",
@@ -14953,7 +14953,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/userOffers.ts",
       "source_location": "L6",
       "id": "useroffers_useuseroffersqueries",
-      "community": 6
+      "community": 2
     },
     {
       "label": "states.ts",
@@ -14961,7 +14961,7 @@
       "source_file": "packages/storefront-webapp/src/lib/states.ts",
       "source_location": "L1",
       "id": "states",
-      "community": 5
+      "community": 1
     },
     {
       "label": "buildV2Config()",
@@ -15009,7 +15009,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.test.ts",
       "source_location": "L1",
       "id": "storefrontfailureobservability_test",
-      "community": 8
+      "community": 5
     },
     {
       "label": "storefrontFailureObservability.ts",
@@ -15017,7 +15017,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
       "source_location": "L1",
       "id": "storefrontfailureobservability",
-      "community": 8
+      "community": 5
     },
     {
       "label": "inferStorefrontJourneyFromRoute()",
@@ -15025,7 +15025,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
       "source_location": "L25",
       "id": "storefrontfailureobservability_inferstorefrontjourneyfromroute",
-      "community": 8
+      "community": 5
     },
     {
       "label": "normalizeStorefrontError()",
@@ -15033,7 +15033,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
       "source_location": "L47",
       "id": "storefrontfailureobservability_normalizestorefronterror",
-      "community": 8
+      "community": 5
     },
     {
       "label": "createStorefrontFailureEvent()",
@@ -15041,7 +15041,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
       "source_location": "L136",
       "id": "storefrontfailureobservability_createstorefrontfailureevent",
-      "community": 8
+      "community": 5
     },
     {
       "label": "emitStorefrontFailure()",
@@ -15049,7 +15049,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
       "source_location": "L154",
       "id": "storefrontfailureobservability_emitstorefrontfailure",
-      "community": 8
+      "community": 5
     },
     {
       "label": "storefrontJourneyEvents.test.ts",
@@ -15057,7 +15057,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.test.ts",
       "source_location": "L1",
       "id": "storefrontjourneyevents_test",
-      "community": 6
+      "community": 11
     },
     {
       "label": "storefrontJourneyEvents.ts",
@@ -15065,7 +15065,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L1",
       "id": "storefrontjourneyevents",
-      "community": 6
+      "community": 11
     },
     {
       "label": "compactContext()",
@@ -15073,7 +15073,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L7",
       "id": "storefrontjourneyevents_compactcontext",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createJourneyEvent()",
@@ -15081,7 +15081,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L19",
       "id": "storefrontjourneyevents_createjourneyevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createLandingPageViewedEvent()",
@@ -15089,7 +15089,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L33",
       "id": "storefrontjourneyevents_createlandingpageviewedevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createCategoryBrowseViewedEvent()",
@@ -15097,7 +15097,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L41",
       "id": "storefrontjourneyevents_createcategorybrowseviewedevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createProductDetailViewedEvent()",
@@ -15105,7 +15105,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L59",
       "id": "storefrontjourneyevents_createproductdetailviewedevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createBagViewedEvent()",
@@ -15113,7 +15113,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L83",
       "id": "storefrontjourneyevents_createbagviewedevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createBagAddSucceededEvent()",
@@ -15121,7 +15121,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L101",
       "id": "storefrontjourneyevents_createbagaddsucceededevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createBagRemoveSucceededEvent()",
@@ -15129,7 +15129,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L122",
       "id": "storefrontjourneyevents_createbagremovesucceededevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createCheckoutStartEvent()",
@@ -15137,7 +15137,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L143",
       "id": "storefrontjourneyevents_createcheckoutstartevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createCheckoutDetailsViewedEvent()",
@@ -15145,7 +15145,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L164",
       "id": "storefrontjourneyevents_createcheckoutdetailsviewedevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createOrderReviewViewedEvent()",
@@ -15153,7 +15153,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L179",
       "id": "storefrontjourneyevents_createorderreviewviewedevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createPaymentSubmissionStartedEvent()",
@@ -15161,7 +15161,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L194",
       "id": "storefrontjourneyevents_createpaymentsubmissionstartedevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createPaymentVerificationStartedEvent()",
@@ -15169,7 +15169,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L215",
       "id": "storefrontjourneyevents_createpaymentverificationstartedevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createCheckoutCompletionEvent()",
@@ -15177,7 +15177,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L233",
       "id": "storefrontjourneyevents_createcheckoutcompletionevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createCheckoutCompletionSucceededEvent()",
@@ -15185,7 +15185,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L256",
       "id": "storefrontjourneyevents_createcheckoutcompletionsucceededevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createCheckoutCompletionBlockedEvent()",
@@ -15193,7 +15193,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L273",
       "id": "storefrontjourneyevents_createcheckoutcompletionblockedevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createCheckoutCompletionCanceledEvent()",
@@ -15201,7 +15201,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L290",
       "id": "storefrontjourneyevents_createcheckoutcompletioncanceledevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "getAuthEntryStep()",
@@ -15209,7 +15209,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L307",
       "id": "storefrontjourneyevents_getauthentrystep",
-      "community": 6
+      "community": 11
     },
     {
       "label": "getAuthRequestStep()",
@@ -15217,7 +15217,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L311",
       "id": "storefrontjourneyevents_getauthrequeststep",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createAuthEntryViewedEvent()",
@@ -15225,7 +15225,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L315",
       "id": "storefrontjourneyevents_createauthentryviewedevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createAuthRequestStartedEvent()",
@@ -15233,7 +15233,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L335",
       "id": "storefrontjourneyevents_createauthrequeststartedevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createAuthVerificationViewedEvent()",
@@ -15241,7 +15241,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L355",
       "id": "storefrontjourneyevents_createauthverificationviewedevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createAuthVerificationSucceededEvent()",
@@ -15249,7 +15249,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L370",
       "id": "storefrontjourneyevents_createauthverificationsucceededevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createRewardsAlertViewedEvent()",
@@ -15257,7 +15257,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L387",
       "id": "storefrontjourneyevents_createrewardsalertviewedevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createRewardsAlertDismissedEvent()",
@@ -15265,7 +15265,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L395",
       "id": "storefrontjourneyevents_createrewardsalertdismissedevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createRewardsAlertShopNowEvent()",
@@ -15273,7 +15273,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L403",
       "id": "storefrontjourneyevents_createrewardsalertshopnowevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createPromoAlertViewedEvent()",
@@ -15281,7 +15281,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L411",
       "id": "storefrontjourneyevents_createpromoalertviewedevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createPromoAlertDismissedEvent()",
@@ -15289,7 +15289,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L435",
       "id": "storefrontjourneyevents_createpromoalertdismissedevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createPromoAlertShopNowEvent()",
@@ -15297,7 +15297,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L459",
       "id": "storefrontjourneyevents_createpromoalertshopnowevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createWelcomeBackModalViewedEvent()",
@@ -15305,7 +15305,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L483",
       "id": "storefrontjourneyevents_createwelcomebackmodalviewedevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createWelcomeBackModalDismissedEvent()",
@@ -15313,7 +15313,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L501",
       "id": "storefrontjourneyevents_createwelcomebackmodaldismissedevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createWelcomeBackModalSubmittedEvent()",
@@ -15321,7 +15321,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L519",
       "id": "storefrontjourneyevents_createwelcomebackmodalsubmittedevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createLeaveReviewModalViewedEvent()",
@@ -15329,7 +15329,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L537",
       "id": "storefrontjourneyevents_createleavereviewmodalviewedevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createLeaveReviewModalDismissedEvent()",
@@ -15337,7 +15337,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L555",
       "id": "storefrontjourneyevents_createleavereviewmodaldismissedevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createUpsellModalViewedEvent()",
@@ -15345,7 +15345,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L573",
       "id": "storefrontjourneyevents_createupsellmodalviewedevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createUpsellModalDismissedEvent()",
@@ -15353,7 +15353,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L600",
       "id": "storefrontjourneyevents_createupsellmodaldismissedevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createUpsellModalSubmittedEvent()",
@@ -15361,7 +15361,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L627",
       "id": "storefrontjourneyevents_createupsellmodalsubmittedevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createUpsellModalAddToBagEvent()",
@@ -15369,7 +15369,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L654",
       "id": "storefrontjourneyevents_createupsellmodaladdtobagevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createSavedBagViewedEvent()",
@@ -15377,7 +15377,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L676",
       "id": "storefrontjourneyevents_createsavedbagviewedevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createSavedBagMoveToBagEvent()",
@@ -15385,7 +15385,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L684",
       "id": "storefrontjourneyevents_createsavedbagmovetobagevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createSavedBagRemoveEvent()",
@@ -15393,7 +15393,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L705",
       "id": "storefrontjourneyevents_createsavedbagremoveevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createBagMoveToSavedEvent()",
@@ -15401,7 +15401,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L726",
       "id": "storefrontjourneyevents_createbagmovetosavedevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createDiscountCodeTriggerEvent()",
@@ -15409,7 +15409,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L747",
       "id": "storefrontjourneyevents_creatediscountcodetriggerevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createReviewEditorViewedEvent()",
@@ -15417,7 +15417,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L762",
       "id": "storefrontjourneyevents_createrevieweditorviewedevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "createReviewSubmittedEvent()",
@@ -15425,7 +15425,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L786",
       "id": "storefrontjourneyevents_createreviewsubmittedevent",
-      "community": 6
+      "community": 11
     },
     {
       "label": "storefrontObservability.test.ts",
@@ -15433,7 +15433,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.test.ts",
       "source_location": "L1",
       "id": "storefrontobservability_test",
-      "community": 8
+      "community": 5
     },
     {
       "label": "createMemoryStorage()",
@@ -15441,7 +15441,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.test.ts",
       "source_location": "L12",
       "id": "storefrontobservability_test_creatememorystorage",
-      "community": 8
+      "community": 5
     },
     {
       "label": "storefrontObservability.ts",
@@ -15449,7 +15449,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L1",
       "id": "storefrontobservability",
-      "community": 8
+      "community": 5
     },
     {
       "label": "getOrCreateStorefrontObservabilitySessionId()",
@@ -15457,7 +15457,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L109",
       "id": "storefrontobservability_getorcreatestorefrontobservabilitysessionid",
-      "community": 8
+      "community": 5
     },
     {
       "label": "createStorefrontObservabilityContext()",
@@ -15465,7 +15465,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L134",
       "id": "storefrontobservability_createstorefrontobservabilitycontext",
-      "community": 8
+      "community": 5
     },
     {
       "label": "createStorefrontObservabilityPayload()",
@@ -15473,7 +15473,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L157",
       "id": "storefrontobservability_createstorefrontobservabilitypayload",
-      "community": 8
+      "community": 5
     },
     {
       "label": "trackStorefrontEvent()",
@@ -15481,7 +15481,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L193",
       "id": "storefrontobservability_trackstorefrontevent",
-      "community": 8
+      "community": 5
     },
     {
       "label": "getStoreDetails()",
@@ -15489,7 +15489,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L53",
       "id": "utils_getstoredetails",
-      "community": 2
+      "community": 0
     },
     {
       "label": "enableQuery()",
@@ -15497,7 +15497,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L60",
       "id": "utils_enablequery",
-      "community": 2
+      "community": 0
     },
     {
       "label": "validateEmail()",
@@ -15505,7 +15505,7 @@
       "source_file": "packages/storefront-webapp/src/lib/validations/email.ts",
       "source_location": "L14",
       "id": "email_validateemail",
-      "community": 6
+      "community": 14
     },
     {
       "label": "router.tsx",
@@ -15513,7 +15513,7 @@
       "source_file": "packages/storefront-webapp/src/router.tsx",
       "source_location": "L1",
       "id": "router",
-      "community": 8
+      "community": 4
     },
     {
       "label": "createRouter()",
@@ -15521,7 +15521,7 @@
       "source_file": "packages/storefront-webapp/src/router.tsx",
       "source_location": "L5",
       "id": "router_createrouter",
-      "community": 8
+      "community": 4
     },
     {
       "label": "$orderItemId.review.tsx",
@@ -15529,7 +15529,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/$orderItemId.review.tsx",
       "source_location": "L1",
       "id": "orderitemid_review",
-      "community": 0
+      "community": 1
     },
     {
       "label": "getPaymentText()",
@@ -15537,7 +15537,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
       "source_location": "L102",
       "id": "index_getpaymenttext",
-      "community": 1
+      "community": 6
     },
     {
       "label": "getOrderMessage()",
@@ -15545,7 +15545,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
       "source_location": "L429",
       "id": "index_getordermessage",
-      "community": 1
+      "community": 6
     },
     {
       "label": "OrderNavigation()",
@@ -15553,7 +15553,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
       "source_location": "L46",
       "id": "review_ordernavigation",
-      "community": 0
+      "community": 1
     },
     {
       "label": "getOrderMessage()",
@@ -15561,7 +15561,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
       "source_location": "L250",
       "id": "review_getordermessage",
-      "community": 0
+      "community": 1
     },
     {
       "label": "_ordersLayout.tsx",
@@ -15569,7 +15569,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout.tsx",
       "source_location": "L1",
       "id": "orderslayout",
-      "community": 7
+      "community": 5
     },
     {
       "label": "LayoutComponent()",
@@ -15577,7 +15577,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout.tsx",
       "source_location": "L8",
       "id": "orderslayout_layoutcomponent",
-      "community": 7
+      "community": 5
     },
     {
       "label": "$subcategorySlug.tsx",
@@ -15585,7 +15585,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout/shop/$categorySlug/$subcategorySlug.tsx",
       "source_location": "L1",
       "id": "subcategoryslug",
-      "community": 12
+      "community": 13
     },
     {
       "label": "_shopLayout.tsx",
@@ -15593,7 +15593,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
       "source_location": "L1",
       "id": "shoplayout",
-      "community": 0
+      "community": 5
     },
     {
       "label": "onClickOnMobileFilters()",
@@ -15601,7 +15601,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
       "source_location": "L105",
       "id": "shoplayout_onclickonmobilefilters",
-      "community": 0
+      "community": 5
     },
     {
       "label": "onMobileFiltersCloseClick()",
@@ -15609,7 +15609,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
       "source_location": "L110",
       "id": "shoplayout_onmobilefilterscloseclick",
-      "community": 0
+      "community": 5
     },
     {
       "label": "clearFilters()",
@@ -15617,7 +15617,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
       "source_location": "L115",
       "id": "shoplayout_clearfilters",
-      "community": 0
+      "community": 5
     },
     {
       "label": "account.tsx",
@@ -15625,7 +15625,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
       "source_location": "L1",
       "id": "account",
-      "community": 5
+      "community": 1
     },
     {
       "label": "accountBeforeLoad()",
@@ -15633,7 +15633,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
       "source_location": "L17",
       "id": "account_accountbeforeload",
-      "community": 5
+      "community": 1
     },
     {
       "label": "handleOnSubmitForm()",
@@ -15641,7 +15641,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
       "source_location": "L63",
       "id": "account_handleonsubmitform",
-      "community": 5
+      "community": 1
     },
     {
       "label": "contact-us.tsx",
@@ -15649,7 +15649,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/contact-us.tsx",
       "source_location": "L1",
       "id": "contact_us",
-      "community": 0
+      "community": 1
     },
     {
       "label": "ContactUs()",
@@ -15657,7 +15657,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/contact-us.tsx",
       "source_location": "L14",
       "id": "contact_us_contactus",
-      "community": 0
+      "community": 1
     },
     {
       "label": "delivery-returns-exchanges.index.tsx",
@@ -15665,7 +15665,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/delivery-returns-exchanges.index.tsx",
       "source_location": "L1",
       "id": "delivery_returns_exchanges_index",
-      "community": 7
+      "community": 4
     },
     {
       "label": "OnlineOrderPolicy()",
@@ -15673,7 +15673,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/delivery-returns-exchanges.index.tsx",
       "source_location": "L13",
       "id": "delivery_returns_exchanges_index_onlineorderpolicy",
-      "community": 7
+      "community": 4
     },
     {
       "label": "privacy.index.tsx",
@@ -15681,7 +15681,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/privacy.index.tsx",
       "source_location": "L1",
       "id": "privacy_index",
-      "community": 7
+      "community": 4
     },
     {
       "label": "PrivacyPolicy()",
@@ -15689,7 +15689,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/privacy.index.tsx",
       "source_location": "L9",
       "id": "privacy_index_privacypolicy",
-      "community": 7
+      "community": 4
     },
     {
       "label": "tos.index.tsx",
@@ -15697,7 +15697,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
       "source_location": "L1",
       "id": "tos_index",
-      "community": 7
+      "community": 4
     },
     {
       "label": "TosSection()",
@@ -15705,7 +15705,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
       "source_location": "L15",
       "id": "tos_index_tossection",
-      "community": 7
+      "community": 4
     },
     {
       "label": "rewards.index.tsx",
@@ -15713,7 +15713,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/rewards.index.tsx",
       "source_location": "L1",
       "id": "rewards_index",
-      "community": 0
+      "community": 1
     },
     {
       "label": "shop.product.$productSlug.tsx",
@@ -15745,7 +15745,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout.tsx",
       "source_location": "L6",
       "id": "layout_layoutcomponent",
-      "community": 0
+      "community": 5
     },
     {
       "label": "auth.verify.tsx",
@@ -15801,7 +15801,7 @@
       "source_file": "packages/storefront-webapp/src/routes/login.tsx",
       "source_location": "L1",
       "id": "login",
-      "community": 5
+      "community": 1
     },
     {
       "label": "loginBeforeLoad()",
@@ -15809,7 +15809,7 @@
       "source_file": "packages/storefront-webapp/src/routes/login.tsx",
       "source_location": "L47",
       "id": "login_loginbeforeload",
-      "community": 5
+      "community": 1
     },
     {
       "label": "onSubmit()",
@@ -15817,7 +15817,7 @@
       "source_file": "packages/storefront-webapp/src/routes/login.tsx",
       "source_location": "L141",
       "id": "login_onsubmit",
-      "community": 5
+      "community": 1
     },
     {
       "label": "bag.index.tsx",
@@ -15825,7 +15825,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/bag.index.tsx",
       "source_location": "L1",
       "id": "bag_index",
-      "community": 0
+      "community": 1
     },
     {
       "label": "canceled.tsx",
@@ -15833,7 +15833,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/canceled.tsx",
       "source_location": "L1",
       "id": "canceled",
-      "community": 0
+      "community": 1
     },
     {
       "label": "CheckoutCanceledView()",
@@ -15841,7 +15841,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/canceled.tsx",
       "source_location": "L21",
       "id": "canceled_checkoutcanceledview",
-      "community": 0
+      "community": 1
     },
     {
       "label": "complete.tsx",
@@ -15849,7 +15849,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/complete.tsx",
       "source_location": "L1",
       "id": "complete",
-      "community": 0
+      "community": 1
     },
     {
       "label": "incomplete.tsx",
@@ -15857,7 +15857,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/incomplete.tsx",
       "source_location": "L1",
       "id": "incomplete",
-      "community": 0
+      "community": 1
     },
     {
       "label": "getErrorMessage()",
@@ -15865,7 +15865,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
       "source_location": "L26",
       "id": "index_geterrormessage",
-      "community": 1
+      "community": 6
     },
     {
       "label": "placeOrder()",
@@ -15873,7 +15873,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
       "source_location": "L71",
       "id": "index_placeorder",
-      "community": 1
+      "community": 6
     },
     {
       "label": "cancelOrder()",
@@ -15881,7 +15881,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
       "source_location": "L121",
       "id": "index_cancelorder",
-      "community": 1
+      "community": 6
     },
     {
       "label": "complete.index.tsx",
@@ -15889,7 +15889,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/complete.index.tsx",
       "source_location": "L1",
       "id": "complete_index",
-      "community": 0
+      "community": 1
     },
     {
       "label": "CheckoutComplete()",
@@ -15897,7 +15897,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/complete.index.tsx",
       "source_location": "L33",
       "id": "complete_index_checkoutcomplete",
-      "community": 0
+      "community": 1
     },
     {
       "label": "pending.tsx",
@@ -15905,7 +15905,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/pending.tsx",
       "source_location": "L1",
       "id": "pending",
-      "community": 0
+      "community": 1
     },
     {
       "label": "pod-confirmation.tsx",
@@ -15913,7 +15913,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/pod-confirmation.tsx",
       "source_location": "L1",
       "id": "pod_confirmation",
-      "community": 0
+      "community": 1
     },
     {
       "label": "completePODCheckoutSession()",
@@ -15921,7 +15921,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/pod-confirmation.tsx",
       "source_location": "L193",
       "id": "pod_confirmation_completepodcheckoutsession",
-      "community": 0
+      "community": 1
     },
     {
       "label": "verify.index.tsx",
@@ -15929,7 +15929,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
       "source_location": "L1",
       "id": "verify_index",
-      "community": 0
+      "community": 1
     },
     {
       "label": "Verify()",
@@ -15937,7 +15937,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
       "source_location": "L21",
       "id": "verify_index_verify",
-      "community": 0
+      "community": 1
     },
     {
       "label": "VerifyCheckoutSessionPayment()",
@@ -15945,7 +15945,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
       "source_location": "L107",
       "id": "verify_index_verifycheckoutsessionpayment",
-      "community": 0
+      "community": 1
     },
     {
       "label": "signup.tsx",
@@ -15953,7 +15953,7 @@
       "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
       "source_location": "L1",
       "id": "signup",
-      "community": 5
+      "community": 1
     },
     {
       "label": "signupBeforeLoad()",
@@ -15961,7 +15961,7 @@
       "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
       "source_location": "L66",
       "id": "signup_signupbeforeload",
-      "community": 5
+      "community": 1
     },
     {
       "label": "onSubmit()",
@@ -15969,7 +15969,7 @@
       "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
       "source_location": "L161",
       "id": "signup_onsubmit",
-      "community": 5
+      "community": 1
     },
     {
       "label": "ssr.tsx",
@@ -15977,7 +15977,7 @@
       "source_file": "packages/storefront-webapp/src/ssr.tsx",
       "source_location": "L1",
       "id": "ssr",
-      "community": 8
+      "community": 4
     },
     {
       "label": "bootstrap.ts",
@@ -15985,7 +15985,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
       "source_location": "L1",
       "id": "bootstrap",
-      "community": 6
+      "community": 14
     },
     {
       "label": "createMarker()",
@@ -15993,7 +15993,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
       "source_location": "L20",
       "id": "bootstrap_createmarker",
-      "community": 6
+      "community": 14
     },
     {
       "label": "createBootstrapToken()",
@@ -16001,7 +16001,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
       "source_location": "L24",
       "id": "bootstrap_createbootstraptoken",
-      "community": 6
+      "community": 14
     },
     {
       "label": "bootstrapCheckout()",
@@ -16009,7 +16009,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
       "source_location": "L46",
       "id": "bootstrap_bootstrapcheckout",
-      "community": 6
+      "community": 14
     },
     {
       "label": "requireEnv()",
@@ -16017,7 +16017,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
       "source_location": "L1",
       "id": "env_requireenv",
-      "community": 6
+      "community": 14
     },
     {
       "label": "optionalNumberEnv()",
@@ -16025,7 +16025,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
       "source_location": "L11",
       "id": "env_optionalnumberenv",
-      "community": 6
+      "community": 14
     },
     {
       "label": "test-connection.js",
@@ -16105,7 +16105,7 @@
       "source_file": "scripts/graphify-rebuild.test.ts",
       "source_location": "L1",
       "id": "graphify_rebuild_test",
-      "community": 25
+      "community": 26
     },
     {
       "label": "write()",
@@ -16113,7 +16113,7 @@
       "source_file": "scripts/graphify-rebuild.test.ts",
       "source_location": "L10",
       "id": "graphify_rebuild_test_write",
-      "community": 25
+      "community": 26
     },
     {
       "label": "createFixtureRoot()",
@@ -16121,7 +16121,7 @@
       "source_file": "scripts/graphify-rebuild.test.ts",
       "source_location": "L16",
       "id": "graphify_rebuild_test_createfixtureroot",
-      "community": 25
+      "community": 26
     },
     {
       "label": "spawn()",
@@ -16129,7 +16129,7 @@
       "source_file": "scripts/graphify-rebuild.test.ts",
       "source_location": "L38",
       "id": "graphify_rebuild_test_spawn",
-      "community": 25
+      "community": 26
     },
     {
       "label": "graphify-rebuild.ts",
@@ -16137,7 +16137,7 @@
       "source_file": "scripts/graphify-rebuild.ts",
       "source_location": "L1",
       "id": "graphify_rebuild",
-      "community": 25
+      "community": 26
     },
     {
       "label": "fileExists()",
@@ -16145,7 +16145,7 @@
       "source_file": "scripts/graphify-rebuild.ts",
       "source_location": "L67",
       "id": "graphify_rebuild_fileexists",
-      "community": 25
+      "community": 26
     },
     {
       "label": "resolveGraphifyPython()",
@@ -16153,7 +16153,7 @@
       "source_file": "scripts/graphify-rebuild.ts",
       "source_location": "L76",
       "id": "graphify_rebuild_resolvegraphifypython",
-      "community": 25
+      "community": 26
     },
     {
       "label": "runGraphifyRebuild()",
@@ -16161,7 +16161,7 @@
       "source_file": "scripts/graphify-rebuild.ts",
       "source_location": "L86",
       "id": "graphify_rebuild_rungraphifyrebuild",
-      "community": 25
+      "community": 26
     },
     {
       "label": "harness-audit.test.ts",
@@ -16169,7 +16169,7 @@
       "source_file": "scripts/harness-audit.test.ts",
       "source_location": "L1",
       "id": "harness_audit_test",
-      "community": 11
+      "community": 7
     },
     {
       "label": "write()",
@@ -16177,7 +16177,7 @@
       "source_file": "scripts/harness-audit.test.ts",
       "source_location": "L11",
       "id": "harness_audit_test_write",
-      "community": 11
+      "community": 7
     },
     {
       "label": "createFixtureRepo()",
@@ -16185,7 +16185,7 @@
       "source_file": "scripts/harness-audit.test.ts",
       "source_location": "L17",
       "id": "harness_audit_test_createfixturerepo",
-      "community": 11
+      "community": 7
     },
     {
       "label": "harness-audit.ts",
@@ -16193,103 +16193,103 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L1",
       "id": "harness_audit",
-      "community": 11
+      "community": 7
     },
     {
       "label": "normalizeRepoPath()",
       "file_type": "code",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L48",
+      "source_location": "L45",
       "id": "harness_audit_normalizerepopath",
-      "community": 11
+      "community": 7
     },
     {
       "label": "matchesPathPrefix()",
       "file_type": "code",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L52",
+      "source_location": "L49",
       "id": "harness_audit_matchespathprefix",
-      "community": 11
+      "community": 7
     },
     {
       "label": "fileExists()",
       "file_type": "code",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L66",
+      "source_location": "L63",
       "id": "harness_audit_fileexists",
-      "community": 11
+      "community": 7
     },
     {
       "label": "readJsonFile()",
       "file_type": "code",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L75",
+      "source_location": "L72",
       "id": "harness_audit_readjsonfile",
-      "community": 11
+      "community": 7
     },
     {
-      "label": "toValidationSurfaces()",
+      "label": "normalizeValidationCommand()",
       "file_type": "code",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L79",
-      "id": "harness_audit_tovalidationsurfaces",
-      "community": 11
+      "source_location": "L76",
+      "id": "harness_audit_normalizevalidationcommand",
+      "community": 7
     },
     {
       "label": "addGroupedError()",
       "file_type": "code",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L91",
+      "source_location": "L84",
       "id": "harness_audit_addgroupederror",
-      "community": 11
+      "community": 7
     },
     {
       "label": "inferGroupFromError()",
       "file_type": "code",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L105",
+      "source_location": "L98",
       "id": "harness_audit_infergroupfromerror",
-      "community": 11
+      "community": 7
     },
     {
       "label": "shouldSkipSurfaceEntry()",
       "file_type": "code",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L110",
+      "source_location": "L103",
       "id": "harness_audit_shouldskipsurfaceentry",
-      "community": 11
+      "community": 7
     },
     {
       "label": "collectLiveSurfaceEntries()",
       "file_type": "code",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L121",
+      "source_location": "L114",
       "id": "harness_audit_collectlivesurfaceentries",
-      "community": 11
+      "community": 7
     },
     {
       "label": "loadAuditTarget()",
       "file_type": "code",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L150",
+      "source_location": "L143",
       "id": "harness_audit_loadaudittarget",
-      "community": 11
+      "community": 7
     },
     {
       "label": "formatGroupedErrors()",
       "file_type": "code",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L278",
+      "source_location": "L297",
       "id": "harness_audit_formatgroupederrors",
-      "community": 11
+      "community": 7
     },
     {
       "label": "runHarnessAudit()",
       "file_type": "code",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L293",
+      "source_location": "L312",
       "id": "harness_audit_runharnessaudit",
-      "community": 11
+      "community": 7
     },
     {
       "label": "harness-check.test.ts",
@@ -16297,7 +16297,7 @@
       "source_file": "scripts/harness-check.test.ts",
       "source_location": "L1",
       "id": "harness_check_test",
-      "community": 11
+      "community": 7
     },
     {
       "label": "write()",
@@ -16305,7 +16305,7 @@
       "source_file": "scripts/harness-check.test.ts",
       "source_location": "L29",
       "id": "harness_check_test_write",
-      "community": 11
+      "community": 7
     },
     {
       "label": "createFixtureRepo()",
@@ -16313,7 +16313,7 @@
       "source_file": "scripts/harness-check.test.ts",
       "source_location": "L35",
       "id": "harness_check_test_createfixturerepo",
-      "community": 11
+      "community": 7
     },
     {
       "label": "harness-check.ts",
@@ -16321,7 +16321,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L1",
       "id": "harness_check",
-      "community": 11
+      "community": 7
     },
     {
       "label": "stripLinkDecorations()",
@@ -16329,7 +16329,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L44",
       "id": "harness_check_striplinkdecorations",
-      "community": 11
+      "community": 7
     },
     {
       "label": "isRelativeLink()",
@@ -16337,7 +16337,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L48",
       "id": "harness_check_isrelativelink",
-      "community": 11
+      "community": 7
     },
     {
       "label": "fileExists()",
@@ -16345,7 +16345,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L56",
       "id": "harness_check_fileexists",
-      "community": 11
+      "community": 7
     },
     {
       "label": "collectMarkdownLinkErrors()",
@@ -16353,7 +16353,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L65",
       "id": "harness_check_collectmarkdownlinkerrors",
-      "community": 11
+      "community": 7
     },
     {
       "label": "extractInlineCode()",
@@ -16361,7 +16361,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L94",
       "id": "harness_check_extractinlinecode",
-      "community": 11
+      "community": 7
     },
     {
       "label": "normalizePathReference()",
@@ -16369,7 +16369,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L100",
       "id": "harness_check_normalizepathreference",
-      "community": 11
+      "community": 7
     },
     {
       "label": "isLikelyPathReference()",
@@ -16377,7 +16377,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L113",
       "id": "harness_check_islikelypathreference",
-      "community": 11
+      "community": 7
     },
     {
       "label": "resolvePathReference()",
@@ -16385,7 +16385,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L138",
       "id": "harness_check_resolvepathreference",
-      "community": 11
+      "community": 7
     },
     {
       "label": "collectReferencedPathErrors()",
@@ -16393,7 +16393,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L164",
       "id": "harness_check_collectreferencedpatherrors",
-      "community": 11
+      "community": 7
     },
     {
       "label": "readPackageConfig()",
@@ -16401,7 +16401,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L199",
       "id": "harness_check_readpackageconfig",
-      "community": 11
+      "community": 7
     },
     {
       "label": "extractTestScriptFromCommand()",
@@ -16409,7 +16409,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L224",
       "id": "harness_check_extracttestscriptfromcommand",
-      "community": 11
+      "community": 7
     },
     {
       "label": "walkFiles()",
@@ -16417,7 +16417,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L256",
       "id": "harness_check_walkfiles",
-      "community": 11
+      "community": 7
     },
     {
       "label": "collectTestSurfaceRoots()",
@@ -16425,7 +16425,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L276",
       "id": "harness_check_collecttestsurfaceroots",
-      "community": 11
+      "community": 7
     },
     {
       "label": "collectTestingDocErrors()",
@@ -16433,7 +16433,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L318",
       "id": "harness_check_collecttestingdocerrors",
-      "community": 11
+      "community": 7
     },
     {
       "label": "validateHarnessDocs()",
@@ -16441,7 +16441,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L363",
       "id": "harness_check_validateharnessdocs",
-      "community": 11
+      "community": 7
     },
     {
       "label": "runHarnessCheck()",
@@ -16449,7 +16449,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L496",
       "id": "harness_check_runharnesscheck",
-      "community": 11
+      "community": 7
     },
     {
       "label": "harness-generate.test.ts",
@@ -16457,7 +16457,7 @@
       "source_file": "scripts/harness-generate.test.ts",
       "source_location": "L1",
       "id": "harness_generate_test",
-      "community": 11
+      "community": 7
     },
     {
       "label": "write()",
@@ -16465,7 +16465,7 @@
       "source_file": "scripts/harness-generate.test.ts",
       "source_location": "L10",
       "id": "harness_generate_test_write",
-      "community": 11
+      "community": 7
     },
     {
       "label": "createFixtureRepo()",
@@ -16473,7 +16473,7 @@
       "source_file": "scripts/harness-generate.test.ts",
       "source_location": "L16",
       "id": "harness_generate_test_createfixturerepo",
-      "community": 11
+      "community": 7
     },
     {
       "label": "harness-generate.ts",
@@ -16481,175 +16481,215 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L1",
       "id": "harness_generate",
-      "community": 11
+      "community": 7
     },
     {
       "label": "normalizeRepoPath()",
       "file_type": "code",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L250",
+      "source_location": "L269",
       "id": "harness_generate_normalizerepopath",
-      "community": 11
+      "community": 7
     },
     {
       "label": "shouldSkipGeneratedEntry()",
       "file_type": "code",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L254",
+      "source_location": "L273",
       "id": "harness_generate_shouldskipgeneratedentry",
-      "community": 11
+      "community": 7
     },
     {
       "label": "fileExists()",
       "file_type": "code",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L258",
+      "source_location": "L277",
       "id": "harness_generate_fileexists",
-      "community": 11
+      "community": 7
     },
     {
       "label": "walkFiles()",
       "file_type": "code",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L267",
+      "source_location": "L286",
       "id": "harness_generate_walkfiles",
-      "community": 11
+      "community": 7
     },
     {
       "label": "readPackageConfig()",
       "file_type": "code",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L289",
+      "source_location": "L308",
       "id": "harness_generate_readpackageconfig",
-      "community": 11
+      "community": 7
     },
     {
       "label": "toDocPath()",
       "file_type": "code",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L307",
+      "source_location": "L326",
       "id": "harness_generate_todocpath",
-      "community": 11
+      "community": 7
     },
     {
       "label": "formatMarkdownLink()",
       "file_type": "code",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L311",
+      "source_location": "L330",
       "id": "harness_generate_formatmarkdownlink",
-      "community": 11
+      "community": 7
     },
     {
       "label": "headingFromSegment()",
       "file_type": "code",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L315",
+      "source_location": "L334",
       "id": "harness_generate_headingfromsegment",
-      "community": 11
+      "community": 7
     },
     {
       "label": "summarizeChildren()",
       "file_type": "code",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L323",
+      "source_location": "L342",
       "id": "harness_generate_summarizechildren",
-      "community": 11
+      "community": 7
     },
     {
       "label": "collectRouteGroups()",
       "file_type": "code",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L331",
+      "source_location": "L350",
       "id": "harness_generate_collectroutegroups",
-      "community": 11
+      "community": 7
     },
     {
       "label": "collectTestFiles()",
       "file_type": "code",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L357",
+      "source_location": "L376",
       "id": "harness_generate_collecttestfiles",
-      "community": 11
+      "community": 7
     },
     {
       "label": "collectTestSurfaceRoots()",
       "file_type": "code",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L387",
+      "source_location": "L406",
       "id": "harness_generate_collecttestsurfaceroots",
-      "community": 11
+      "community": 7
     },
     {
       "label": "collectFolderFacts()",
       "file_type": "code",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L429",
+      "source_location": "L448",
       "id": "harness_generate_collectfolderfacts",
-      "community": 11
+      "community": 7
     },
     {
       "label": "formatScriptCommand()",
       "file_type": "code",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L452",
+      "source_location": "L471",
       "id": "harness_generate_formatscriptcommand",
-      "community": 11
+      "community": 7
+    },
+    {
+      "label": "toRepoValidationPath()",
+      "file_type": "code",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L481",
+      "id": "harness_generate_torepovalidationpath",
+      "community": 7
+    },
+    {
+      "label": "slugifyTitle()",
+      "file_type": "code",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L486",
+      "id": "harness_generate_slugifytitle",
+      "community": 7
+    },
+    {
+      "label": "formatValidationCommandForDoc()",
+      "file_type": "code",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L493",
+      "id": "harness_generate_formatvalidationcommandfordoc",
+      "community": 7
+    },
+    {
+      "label": "toGeneratedValidationMap()",
+      "file_type": "code",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L502",
+      "id": "harness_generate_togeneratedvalidationmap",
+      "community": 7
     },
     {
       "label": "buildGeneratedDoc()",
       "file_type": "code",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L462",
+      "source_location": "L529",
       "id": "harness_generate_buildgenerateddoc",
-      "community": 11
+      "community": 7
     },
     {
       "label": "buildRouteIndex()",
       "file_type": "code",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L472",
+      "source_location": "L539",
       "id": "harness_generate_buildrouteindex",
-      "community": 11
+      "community": 7
     },
     {
       "label": "buildTestIndex()",
       "file_type": "code",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L499",
+      "source_location": "L566",
       "id": "harness_generate_buildtestindex",
-      "community": 11
+      "community": 7
     },
     {
       "label": "buildKeyFolderIndex()",
       "file_type": "code",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L544",
+      "source_location": "L611",
       "id": "harness_generate_buildkeyfolderindex",
-      "community": 11
+      "community": 7
     },
     {
       "label": "buildValidationGuide()",
       "file_type": "code",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L577",
+      "source_location": "L644",
       "id": "harness_generate_buildvalidationguide",
-      "community": 11
+      "community": 7
+    },
+    {
+      "label": "buildValidationMap()",
+      "file_type": "code",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L677",
+      "id": "harness_generate_buildvalidationmap",
+      "community": 7
     },
     {
       "label": "generateHarnessDocs()",
       "file_type": "code",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L616",
+      "source_location": "L684",
       "id": "harness_generate_generateharnessdocs",
-      "community": 11
+      "community": 7
     },
     {
       "label": "writeGeneratedHarnessDocs()",
       "file_type": "code",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L642",
+      "source_location": "L714",
       "id": "harness_generate_writegeneratedharnessdocs",
-      "community": 11
+      "community": 7
     },
     {
       "label": "harness-review.test.ts",
@@ -16657,7 +16697,7 @@
       "source_file": "scripts/harness-review.test.ts",
       "source_location": "L1",
       "id": "harness_review_test",
-      "community": 18
+      "community": 21
     },
     {
       "label": "write()",
@@ -16665,7 +16705,7 @@
       "source_file": "scripts/harness-review.test.ts",
       "source_location": "L10",
       "id": "harness_review_test_write",
-      "community": 18
+      "community": 21
     },
     {
       "label": "createFixtureRepo()",
@@ -16673,23 +16713,23 @@
       "source_file": "scripts/harness-review.test.ts",
       "source_location": "L16",
       "id": "harness_review_test_createfixturerepo",
-      "community": 18
+      "community": 21
     },
     {
       "label": "log()",
       "file_type": "code",
       "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L146",
+      "source_location": "L152",
       "id": "harness_review_test_log",
-      "community": 18
+      "community": 21
     },
     {
       "label": "error()",
       "file_type": "code",
       "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L147",
+      "source_location": "L153",
       "id": "harness_review_test_error",
-      "community": 18
+      "community": 21
     },
     {
       "label": "harness-review.ts",
@@ -16697,95 +16737,103 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L1",
       "id": "harness_review",
-      "community": 18
+      "community": 21
     },
     {
       "label": "normalizeRepoPath()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L51",
+      "source_location": "L50",
       "id": "harness_review_normalizerepopath",
-      "community": 18
+      "community": 21
     },
     {
       "label": "matchesPathPrefix()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L55",
+      "source_location": "L54",
       "id": "harness_review_matchespathprefix",
-      "community": 18
+      "community": 21
+    },
+    {
+      "label": "normalizeValidationCommand()",
+      "file_type": "code",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L68",
+      "id": "harness_review_normalizevalidationcommand",
+      "community": 21
     },
     {
       "label": "fileExists()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L69",
+      "source_location": "L76",
       "id": "harness_review_fileexists",
-      "community": 18
+      "community": 21
     },
     {
       "label": "readJsonFile()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L78",
+      "source_location": "L85",
       "id": "harness_review_readjsonfile",
-      "community": 18
-    },
-    {
-      "label": "toValidationRules()",
-      "file_type": "code",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L82",
-      "id": "harness_review_tovalidationrules",
-      "community": 18
+      "community": 21
     },
     {
       "label": "loadReviewTarget()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L95",
+      "source_location": "L89",
       "id": "harness_review_loadreviewtarget",
-      "community": 18
+      "community": 21
     },
     {
       "label": "loadReviewTargets()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L167",
+      "source_location": "L193",
       "id": "harness_review_loadreviewtargets",
-      "community": 18
+      "community": 21
     },
     {
-      "label": "collectScriptsForChangedFiles()",
+      "label": "collectCommandsForChangedFiles()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L183",
-      "id": "harness_review_collectscriptsforchangedfiles",
-      "community": 18
+      "source_location": "L209",
+      "id": "harness_review_collectcommandsforchangedfiles",
+      "community": 21
     },
     {
       "label": "getChangedFilesFromGit()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L238",
+      "source_location": "L282",
       "id": "harness_review_getchangedfilesfromgit",
-      "community": 18
+      "community": 21
     },
     {
       "label": "runPackageScript()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L276",
+      "source_location": "L320",
       "id": "harness_review_runpackagescript",
-      "community": 18
+      "community": 21
+    },
+    {
+      "label": "runRawCommand()",
+      "file_type": "code",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L334",
+      "id": "harness_review_runrawcommand",
+      "community": 21
     },
     {
       "label": "runHarnessReview()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L290",
+      "source_location": "L347",
       "id": "harness_review_runharnessreview",
-      "community": 18
+      "community": 21
     },
     {
       "label": "pre-push-review.test.ts",
@@ -16793,7 +16841,7 @@
       "source_file": "scripts/pre-push-review.test.ts",
       "source_location": "L1",
       "id": "pre_push_review_test",
-      "community": 18
+      "community": 21
     },
     {
       "label": "log()",
@@ -16801,7 +16849,7 @@
       "source_file": "scripts/pre-push-review.test.ts",
       "source_location": "L81",
       "id": "pre_push_review_test_log",
-      "community": 18
+      "community": 21
     },
     {
       "label": "warn()",
@@ -16809,7 +16857,7 @@
       "source_file": "scripts/pre-push-review.test.ts",
       "source_location": "L82",
       "id": "pre_push_review_test_warn",
-      "community": 18
+      "community": 21
     },
     {
       "label": "error()",
@@ -16817,7 +16865,7 @@
       "source_file": "scripts/pre-push-review.test.ts",
       "source_location": "L83",
       "id": "pre_push_review_test_error",
-      "community": 18
+      "community": 21
     },
     {
       "label": "pre-push-review.ts",
@@ -16825,7 +16873,7 @@
       "source_file": "scripts/pre-push-review.ts",
       "source_location": "L1",
       "id": "pre_push_review",
-      "community": 18
+      "community": 21
     },
     {
       "label": "getChangedFilesVsOriginMain()",
@@ -16833,7 +16881,7 @@
       "source_file": "scripts/pre-push-review.ts",
       "source_location": "L24",
       "id": "pre_push_review_getchangedfilesvsoriginmain",
-      "community": 18
+      "community": 21
     },
     {
       "label": "runArchitectureCheck()",
@@ -16841,7 +16889,7 @@
       "source_file": "scripts/pre-push-review.ts",
       "source_location": "L65",
       "id": "pre_push_review_runarchitecturecheck",
-      "community": 18
+      "community": 21
     },
     {
       "label": "runPrePushReview()",
@@ -16849,7 +16897,7 @@
       "source_file": "scripts/pre-push-review.ts",
       "source_location": "L77",
       "id": "pre_push_review_runprepushreview",
-      "community": 18
+      "community": 21
     }
   ],
   "links": [
@@ -72477,7 +72525,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L48",
+      "source_location": "L45",
       "weight": 1.0,
       "_src": "harness_audit",
       "_tgt": "harness_audit_normalizerepopath",
@@ -72489,7 +72537,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L52",
+      "source_location": "L49",
       "weight": 1.0,
       "_src": "harness_audit",
       "_tgt": "harness_audit_matchespathprefix",
@@ -72501,7 +72549,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L66",
+      "source_location": "L63",
       "weight": 1.0,
       "_src": "harness_audit",
       "_tgt": "harness_audit_fileexists",
@@ -72513,7 +72561,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L75",
+      "source_location": "L72",
       "weight": 1.0,
       "_src": "harness_audit",
       "_tgt": "harness_audit_readjsonfile",
@@ -72525,19 +72573,19 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L79",
+      "source_location": "L76",
       "weight": 1.0,
       "_src": "harness_audit",
-      "_tgt": "harness_audit_tovalidationsurfaces",
+      "_tgt": "harness_audit_normalizevalidationcommand",
       "source": "harness_audit",
-      "target": "harness_audit_tovalidationsurfaces",
+      "target": "harness_audit_normalizevalidationcommand",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L91",
+      "source_location": "L84",
       "weight": 1.0,
       "_src": "harness_audit",
       "_tgt": "harness_audit_addgroupederror",
@@ -72549,7 +72597,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L105",
+      "source_location": "L98",
       "weight": 1.0,
       "_src": "harness_audit",
       "_tgt": "harness_audit_infergroupfromerror",
@@ -72561,7 +72609,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L110",
+      "source_location": "L103",
       "weight": 1.0,
       "_src": "harness_audit",
       "_tgt": "harness_audit_shouldskipsurfaceentry",
@@ -72573,7 +72621,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L121",
+      "source_location": "L114",
       "weight": 1.0,
       "_src": "harness_audit",
       "_tgt": "harness_audit_collectlivesurfaceentries",
@@ -72585,7 +72633,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L150",
+      "source_location": "L143",
       "weight": 1.0,
       "_src": "harness_audit",
       "_tgt": "harness_audit_loadaudittarget",
@@ -72597,7 +72645,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L278",
+      "source_location": "L297",
       "weight": 1.0,
       "_src": "harness_audit",
       "_tgt": "harness_audit_formatgroupederrors",
@@ -72609,7 +72657,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L293",
+      "source_location": "L312",
       "weight": 1.0,
       "_src": "harness_audit",
       "_tgt": "harness_audit_runharnessaudit",
@@ -72621,7 +72669,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L53",
+      "source_location": "L50",
       "weight": 0.8,
       "_src": "harness_audit_matchespathprefix",
       "_tgt": "harness_audit_normalizerepopath",
@@ -72633,7 +72681,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L140",
+      "source_location": "L133",
       "weight": 0.8,
       "_src": "harness_audit_collectlivesurfaceentries",
       "_tgt": "harness_audit_normalizerepopath",
@@ -72645,7 +72693,19 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L130",
+      "source_location": "L286",
+      "weight": 0.8,
+      "_src": "harness_audit_loadaudittarget",
+      "_tgt": "harness_audit_normalizerepopath",
+      "source": "harness_audit_normalizerepopath",
+      "target": "harness_audit_loadaudittarget",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L123",
       "weight": 0.8,
       "_src": "harness_audit_collectlivesurfaceentries",
       "_tgt": "harness_audit_fileexists",
@@ -72657,7 +72717,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L158",
+      "source_location": "L151",
       "weight": 0.8,
       "_src": "harness_audit_loadaudittarget",
       "_tgt": "harness_audit_fileexists",
@@ -72669,19 +72729,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L226",
-      "weight": 0.8,
-      "_src": "harness_audit_loadaudittarget",
-      "_tgt": "harness_audit_tovalidationsurfaces",
-      "source": "harness_audit_tovalidationsurfaces",
-      "target": "harness_audit_loadaudittarget",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "scripts/harness-audit.ts",
-      "source_location": "L159",
+      "source_location": "L152",
       "weight": 0.8,
       "_src": "harness_audit_loadaudittarget",
       "_tgt": "harness_audit_addgroupederror",
@@ -72693,7 +72741,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L297",
+      "source_location": "L316",
       "weight": 0.8,
       "_src": "harness_audit_runharnessaudit",
       "_tgt": "harness_audit_addgroupederror",
@@ -72705,7 +72753,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L297",
+      "source_location": "L316",
       "weight": 0.8,
       "_src": "harness_audit_runharnessaudit",
       "_tgt": "harness_audit_infergroupfromerror",
@@ -72717,7 +72765,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L136",
+      "source_location": "L129",
       "weight": 0.8,
       "_src": "harness_audit_collectlivesurfaceentries",
       "_tgt": "harness_audit_shouldskipsurfaceentry",
@@ -72729,7 +72777,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L319",
+      "source_location": "L338",
       "weight": 0.8,
       "_src": "harness_audit_runharnessaudit",
       "_tgt": "harness_audit_collectlivesurfaceentries",
@@ -72741,7 +72789,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L302",
+      "source_location": "L321",
       "weight": 0.8,
       "_src": "harness_audit_runharnessaudit",
       "_tgt": "harness_audit_loadaudittarget",
@@ -72753,7 +72801,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L346",
+      "source_location": "L365",
       "weight": 0.8,
       "_src": "harness_audit_runharnessaudit",
       "_tgt": "harness_audit_formatgroupederrors",
@@ -73377,7 +73425,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L250",
+      "source_location": "L269",
       "weight": 1.0,
       "_src": "harness_generate",
       "_tgt": "harness_generate_normalizerepopath",
@@ -73389,7 +73437,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L254",
+      "source_location": "L273",
       "weight": 1.0,
       "_src": "harness_generate",
       "_tgt": "harness_generate_shouldskipgeneratedentry",
@@ -73401,7 +73449,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L258",
+      "source_location": "L277",
       "weight": 1.0,
       "_src": "harness_generate",
       "_tgt": "harness_generate_fileexists",
@@ -73413,7 +73461,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L267",
+      "source_location": "L286",
       "weight": 1.0,
       "_src": "harness_generate",
       "_tgt": "harness_generate_walkfiles",
@@ -73425,7 +73473,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L289",
+      "source_location": "L308",
       "weight": 1.0,
       "_src": "harness_generate",
       "_tgt": "harness_generate_readpackageconfig",
@@ -73437,7 +73485,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L307",
+      "source_location": "L326",
       "weight": 1.0,
       "_src": "harness_generate",
       "_tgt": "harness_generate_todocpath",
@@ -73449,7 +73497,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L311",
+      "source_location": "L330",
       "weight": 1.0,
       "_src": "harness_generate",
       "_tgt": "harness_generate_formatmarkdownlink",
@@ -73461,7 +73509,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L315",
+      "source_location": "L334",
       "weight": 1.0,
       "_src": "harness_generate",
       "_tgt": "harness_generate_headingfromsegment",
@@ -73473,7 +73521,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L323",
+      "source_location": "L342",
       "weight": 1.0,
       "_src": "harness_generate",
       "_tgt": "harness_generate_summarizechildren",
@@ -73485,7 +73533,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L331",
+      "source_location": "L350",
       "weight": 1.0,
       "_src": "harness_generate",
       "_tgt": "harness_generate_collectroutegroups",
@@ -73497,7 +73545,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L357",
+      "source_location": "L376",
       "weight": 1.0,
       "_src": "harness_generate",
       "_tgt": "harness_generate_collecttestfiles",
@@ -73509,7 +73557,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L387",
+      "source_location": "L406",
       "weight": 1.0,
       "_src": "harness_generate",
       "_tgt": "harness_generate_collecttestsurfaceroots",
@@ -73521,7 +73569,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L429",
+      "source_location": "L448",
       "weight": 1.0,
       "_src": "harness_generate",
       "_tgt": "harness_generate_collectfolderfacts",
@@ -73533,7 +73581,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L452",
+      "source_location": "L471",
       "weight": 1.0,
       "_src": "harness_generate",
       "_tgt": "harness_generate_formatscriptcommand",
@@ -73545,7 +73593,55 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L462",
+      "source_location": "L481",
+      "weight": 1.0,
+      "_src": "harness_generate",
+      "_tgt": "harness_generate_torepovalidationpath",
+      "source": "harness_generate",
+      "target": "harness_generate_torepovalidationpath",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L486",
+      "weight": 1.0,
+      "_src": "harness_generate",
+      "_tgt": "harness_generate_slugifytitle",
+      "source": "harness_generate",
+      "target": "harness_generate_slugifytitle",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L493",
+      "weight": 1.0,
+      "_src": "harness_generate",
+      "_tgt": "harness_generate_formatvalidationcommandfordoc",
+      "source": "harness_generate",
+      "target": "harness_generate_formatvalidationcommandfordoc",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L502",
+      "weight": 1.0,
+      "_src": "harness_generate",
+      "_tgt": "harness_generate_togeneratedvalidationmap",
+      "source": "harness_generate",
+      "target": "harness_generate_togeneratedvalidationmap",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L529",
       "weight": 1.0,
       "_src": "harness_generate",
       "_tgt": "harness_generate_buildgenerateddoc",
@@ -73557,7 +73653,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L472",
+      "source_location": "L539",
       "weight": 1.0,
       "_src": "harness_generate",
       "_tgt": "harness_generate_buildrouteindex",
@@ -73569,7 +73665,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L499",
+      "source_location": "L566",
       "weight": 1.0,
       "_src": "harness_generate",
       "_tgt": "harness_generate_buildtestindex",
@@ -73581,7 +73677,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L544",
+      "source_location": "L611",
       "weight": 1.0,
       "_src": "harness_generate",
       "_tgt": "harness_generate_buildkeyfolderindex",
@@ -73593,7 +73689,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L577",
+      "source_location": "L644",
       "weight": 1.0,
       "_src": "harness_generate",
       "_tgt": "harness_generate_buildvalidationguide",
@@ -73605,7 +73701,19 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L616",
+      "source_location": "L677",
+      "weight": 1.0,
+      "_src": "harness_generate",
+      "_tgt": "harness_generate_buildvalidationmap",
+      "source": "harness_generate",
+      "target": "harness_generate_buildvalidationmap",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L684",
       "weight": 1.0,
       "_src": "harness_generate",
       "_tgt": "harness_generate_generateharnessdocs",
@@ -73617,7 +73725,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L642",
+      "source_location": "L714",
       "weight": 1.0,
       "_src": "harness_generate",
       "_tgt": "harness_generate_writegeneratedharnessdocs",
@@ -73629,7 +73737,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L308",
+      "source_location": "L327",
       "weight": 0.8,
       "_src": "harness_generate_todocpath",
       "_tgt": "harness_generate_normalizerepopath",
@@ -73641,7 +73749,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L397",
+      "source_location": "L416",
       "weight": 0.8,
       "_src": "harness_generate_collecttestsurfaceroots",
       "_tgt": "harness_generate_normalizerepopath",
@@ -73653,7 +73761,19 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L268",
+      "source_location": "L482",
+      "weight": 0.8,
+      "_src": "harness_generate_torepovalidationpath",
+      "_tgt": "harness_generate_normalizerepopath",
+      "source": "harness_generate_normalizerepopath",
+      "target": "harness_generate_torepovalidationpath",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L287",
       "weight": 0.8,
       "_src": "harness_generate_walkfiles",
       "_tgt": "harness_generate_fileexists",
@@ -73665,7 +73785,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L416",
+      "source_location": "L435",
       "weight": 0.8,
       "_src": "harness_generate_collecttestsurfaceroots",
       "_tgt": "harness_generate_fileexists",
@@ -73677,7 +73797,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L435",
+      "source_location": "L454",
       "weight": 0.8,
       "_src": "harness_generate_collectfolderfacts",
       "_tgt": "harness_generate_fileexists",
@@ -73689,7 +73809,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L336",
+      "source_location": "L355",
       "weight": 0.8,
       "_src": "harness_generate_collectroutegroups",
       "_tgt": "harness_generate_walkfiles",
@@ -73701,7 +73821,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L362",
+      "source_location": "L381",
       "weight": 0.8,
       "_src": "harness_generate_collecttestfiles",
       "_tgt": "harness_generate_walkfiles",
@@ -73713,7 +73833,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L393",
+      "source_location": "L412",
       "weight": 0.8,
       "_src": "harness_generate_collecttestsurfaceroots",
       "_tgt": "harness_generate_walkfiles",
@@ -73725,7 +73845,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L439",
+      "source_location": "L458",
       "weight": 0.8,
       "_src": "harness_generate_collectfolderfacts",
       "_tgt": "harness_generate_walkfiles",
@@ -73737,7 +73857,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L620",
+      "source_location": "L688",
       "weight": 0.8,
       "_src": "harness_generate_generateharnessdocs",
       "_tgt": "harness_generate_readpackageconfig",
@@ -73749,7 +73869,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L312",
+      "source_location": "L331",
       "weight": 0.8,
       "_src": "harness_generate_formatmarkdownlink",
       "_tgt": "harness_generate_todocpath",
@@ -73761,7 +73881,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L485",
+      "source_location": "L552",
       "weight": 0.8,
       "_src": "harness_generate_buildrouteindex",
       "_tgt": "harness_generate_formatmarkdownlink",
@@ -73773,7 +73893,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L530",
+      "source_location": "L597",
       "weight": 0.8,
       "_src": "harness_generate_buildtestindex",
       "_tgt": "harness_generate_formatmarkdownlink",
@@ -73785,7 +73905,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L561",
+      "source_location": "L628",
       "weight": 0.8,
       "_src": "harness_generate_buildkeyfolderindex",
       "_tgt": "harness_generate_formatmarkdownlink",
@@ -73797,7 +73917,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L482",
+      "source_location": "L549",
       "weight": 0.8,
       "_src": "harness_generate_buildrouteindex",
       "_tgt": "harness_generate_headingfromsegment",
@@ -73809,7 +73929,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L527",
+      "source_location": "L594",
       "weight": 0.8,
       "_src": "harness_generate_buildtestindex",
       "_tgt": "harness_generate_headingfromsegment",
@@ -73821,7 +73941,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L448",
+      "source_location": "L467",
       "weight": 0.8,
       "_src": "harness_generate_collectfolderfacts",
       "_tgt": "harness_generate_summarizechildren",
@@ -73833,7 +73953,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L476",
+      "source_location": "L543",
       "weight": 0.8,
       "_src": "harness_generate_buildrouteindex",
       "_tgt": "harness_generate_collectroutegroups",
@@ -73845,7 +73965,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L504",
+      "source_location": "L571",
       "weight": 0.8,
       "_src": "harness_generate_buildtestindex",
       "_tgt": "harness_generate_collecttestfiles",
@@ -73857,7 +73977,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L505",
+      "source_location": "L572",
       "weight": 0.8,
       "_src": "harness_generate_buildtestindex",
       "_tgt": "harness_generate_collecttestsurfaceroots",
@@ -73869,7 +73989,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L555",
+      "source_location": "L622",
       "weight": 0.8,
       "_src": "harness_generate_buildkeyfolderindex",
       "_tgt": "harness_generate_collectfolderfacts",
@@ -73881,7 +74001,19 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L513",
+      "source_location": "L499",
+      "weight": 0.8,
+      "_src": "harness_generate_formatvalidationcommandfordoc",
+      "_tgt": "harness_generate_formatscriptcommand",
+      "source": "harness_generate_formatscriptcommand",
+      "target": "harness_generate_formatvalidationcommandfordoc",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L580",
       "weight": 0.8,
       "_src": "harness_generate_buildtestindex",
       "_tgt": "harness_generate_formatscriptcommand",
@@ -73893,11 +74025,11 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L599",
+      "source_location": "L662",
       "weight": 0.8,
       "_src": "harness_generate_buildvalidationguide",
-      "_tgt": "harness_generate_formatscriptcommand",
-      "source": "harness_generate_formatscriptcommand",
+      "_tgt": "harness_generate_formatvalidationcommandfordoc",
+      "source": "harness_generate_formatvalidationcommandfordoc",
       "target": "harness_generate_buildvalidationguide",
       "confidence_score": 0.5
     },
@@ -73905,7 +74037,19 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L490",
+      "source_location": "L681",
+      "weight": 0.8,
+      "_src": "harness_generate_buildvalidationmap",
+      "_tgt": "harness_generate_togeneratedvalidationmap",
+      "source": "harness_generate_togeneratedvalidationmap",
+      "target": "harness_generate_buildvalidationmap",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L557",
       "weight": 0.8,
       "_src": "harness_generate_buildrouteindex",
       "_tgt": "harness_generate_buildgenerateddoc",
@@ -73917,7 +74061,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L535",
+      "source_location": "L602",
       "weight": 0.8,
       "_src": "harness_generate_buildtestindex",
       "_tgt": "harness_generate_buildgenerateddoc",
@@ -73929,7 +74073,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L568",
+      "source_location": "L635",
       "weight": 0.8,
       "_src": "harness_generate_buildkeyfolderindex",
       "_tgt": "harness_generate_buildgenerateddoc",
@@ -73941,7 +74085,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L609",
+      "source_location": "L670",
       "weight": 0.8,
       "_src": "harness_generate_buildvalidationguide",
       "_tgt": "harness_generate_buildgenerateddoc",
@@ -73953,7 +74097,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L623",
+      "source_location": "L691",
       "weight": 0.8,
       "_src": "harness_generate_generateharnessdocs",
       "_tgt": "harness_generate_buildrouteindex",
@@ -73965,7 +74109,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L627",
+      "source_location": "L695",
       "weight": 0.8,
       "_src": "harness_generate_generateharnessdocs",
       "_tgt": "harness_generate_buildtestindex",
@@ -73977,7 +74121,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L631",
+      "source_location": "L699",
       "weight": 0.8,
       "_src": "harness_generate_generateharnessdocs",
       "_tgt": "harness_generate_buildkeyfolderindex",
@@ -73989,7 +74133,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L635",
+      "source_location": "L703",
       "weight": 0.8,
       "_src": "harness_generate_generateharnessdocs",
       "_tgt": "harness_generate_buildvalidationguide",
@@ -74001,7 +74145,19 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L643",
+      "source_location": "L707",
+      "weight": 0.8,
+      "_src": "harness_generate_generateharnessdocs",
+      "_tgt": "harness_generate_buildvalidationmap",
+      "source": "harness_generate_buildvalidationmap",
+      "target": "harness_generate_generateharnessdocs",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-generate.ts",
+      "source_location": "L715",
       "weight": 0.8,
       "_src": "harness_generate_writegeneratedharnessdocs",
       "_tgt": "harness_generate_generateharnessdocs",
@@ -74049,7 +74205,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L299",
+      "source_location": "L386",
       "weight": 1.0,
       "_src": "harness_review_test",
       "_tgt": "harness_review_test_log",
@@ -74061,7 +74217,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L302",
+      "source_location": "L387",
       "weight": 1.0,
       "_src": "harness_review_test",
       "_tgt": "harness_review_test_error",
@@ -74085,7 +74241,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L51",
+      "source_location": "L50",
       "weight": 1.0,
       "_src": "harness_review",
       "_tgt": "harness_review_normalizerepopath",
@@ -74097,7 +74253,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L55",
+      "source_location": "L54",
       "weight": 1.0,
       "_src": "harness_review",
       "_tgt": "harness_review_matchespathprefix",
@@ -74109,7 +74265,19 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L69",
+      "source_location": "L68",
+      "weight": 1.0,
+      "_src": "harness_review",
+      "_tgt": "harness_review_normalizevalidationcommand",
+      "source": "harness_review",
+      "target": "harness_review_normalizevalidationcommand",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L76",
       "weight": 1.0,
       "_src": "harness_review",
       "_tgt": "harness_review_fileexists",
@@ -74121,7 +74289,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L78",
+      "source_location": "L85",
       "weight": 1.0,
       "_src": "harness_review",
       "_tgt": "harness_review_readjsonfile",
@@ -74133,19 +74301,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L82",
-      "weight": 1.0,
-      "_src": "harness_review",
-      "_tgt": "harness_review_tovalidationrules",
-      "source": "harness_review",
-      "target": "harness_review_tovalidationrules",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L95",
+      "source_location": "L89",
       "weight": 1.0,
       "_src": "harness_review",
       "_tgt": "harness_review_loadreviewtarget",
@@ -74157,7 +74313,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L167",
+      "source_location": "L193",
       "weight": 1.0,
       "_src": "harness_review",
       "_tgt": "harness_review_loadreviewtargets",
@@ -74169,19 +74325,19 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L183",
+      "source_location": "L209",
       "weight": 1.0,
       "_src": "harness_review",
-      "_tgt": "harness_review_collectscriptsforchangedfiles",
+      "_tgt": "harness_review_collectcommandsforchangedfiles",
       "source": "harness_review",
-      "target": "harness_review_collectscriptsforchangedfiles",
+      "target": "harness_review_collectcommandsforchangedfiles",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L238",
+      "source_location": "L282",
       "weight": 1.0,
       "_src": "harness_review",
       "_tgt": "harness_review_getchangedfilesfromgit",
@@ -74193,7 +74349,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L276",
+      "source_location": "L320",
       "weight": 1.0,
       "_src": "harness_review",
       "_tgt": "harness_review_runpackagescript",
@@ -74205,7 +74361,19 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L290",
+      "source_location": "L334",
+      "weight": 1.0,
+      "_src": "harness_review",
+      "_tgt": "harness_review_runrawcommand",
+      "source": "harness_review",
+      "target": "harness_review_runrawcommand",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L347",
       "weight": 1.0,
       "_src": "harness_review",
       "_tgt": "harness_review_runharnessreview",
@@ -74229,7 +74397,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L56",
+      "source_location": "L55",
       "weight": 0.8,
       "_src": "harness_review_matchespathprefix",
       "_tgt": "harness_review_normalizerepopath",
@@ -74241,7 +74409,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L157",
+      "source_location": "L182",
       "weight": 0.8,
       "_src": "harness_review_loadreviewtarget",
       "_tgt": "harness_review_normalizerepopath",
@@ -74253,7 +74421,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L121",
+      "source_location": "L115",
       "weight": 0.8,
       "_src": "harness_review_loadreviewtarget",
       "_tgt": "harness_review_fileexists",
@@ -74265,19 +74433,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L138",
-      "weight": 0.8,
-      "_src": "harness_review_loadreviewtarget",
-      "_tgt": "harness_review_tovalidationrules",
-      "source": "harness_review_tovalidationrules",
-      "target": "harness_review_loadreviewtarget",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "scripts/harness-review.ts",
-      "source_location": "L172",
+      "source_location": "L198",
       "weight": 0.8,
       "_src": "harness_review_loadreviewtargets",
       "_tgt": "harness_review_loadreviewtarget",
@@ -74289,7 +74445,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L301",
+      "source_location": "L358",
       "weight": 0.8,
       "_src": "harness_review_runharnessreview",
       "_tgt": "harness_review_loadreviewtargets",
@@ -74301,11 +74457,11 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L303",
+      "source_location": "L360",
       "weight": 0.8,
       "_src": "harness_review_runharnessreview",
-      "_tgt": "harness_review_collectscriptsforchangedfiles",
-      "source": "harness_review_collectscriptsforchangedfiles",
+      "_tgt": "harness_review_collectcommandsforchangedfiles",
+      "source": "harness_review_collectcommandsforchangedfiles",
       "target": "harness_review_runharnessreview",
       "confidence_score": 0.5
     },

--- a/packages/athena-webapp/docs/agent/validation-guide.md
+++ b/packages/athena-webapp/docs/agent/validation-guide.md
@@ -6,7 +6,7 @@ Use this decision guide to answer “what should I run for this change?” based
 
 ## Route or UI-only edits
 
-Touched surfaces: `src/routes`, `src/components`, `src/hooks`, `src/contexts`
+Touched surfaces: `src/assets`, `src/config.ts`, `src/routes`, `src/components`, `src/hooks`, `src/contexts`, `src/index.css`
 
 Run:
 
@@ -17,7 +17,7 @@ Use this for authenticated dashboard flows, route trees, and UI behavior changes
 
 ## Shared-lib or utility edits
 
-Touched surfaces: `src/lib`, `src/utils`, `src/stores`
+Touched surfaces: `src/lib`, `src/settings`, `src/utils`, `src/stores`
 
 Run:
 
@@ -25,6 +25,16 @@ Run:
 - `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`
 
 Reach for the package suite first, then typecheck when helpers or shared state can affect many call sites.
+
+## Frontend test harness edits
+
+Touched surfaces: `src/test`, `src/tests`
+
+Run:
+
+- `bun run --filter '@athena/webapp' test`
+
+Run the package suite when package-local frontend test helpers or focused regression tests change.
 
 ## Convex or backend-adjacent edits
 

--- a/packages/athena-webapp/docs/agent/validation-map.json
+++ b/packages/athena-webapp/docs/agent/validation-map.json
@@ -3,84 +3,106 @@
   "packageDir": "packages/athena-webapp",
   "surfaces": [
     {
-      "name": "runtime-routes",
+      "name": "route-or-ui-only-edits",
       "pathPrefixes": [
-        "packages/athena-webapp/src/assets/",
+        "packages/athena-webapp/src/assets",
         "packages/athena-webapp/src/config.ts",
-        "packages/athena-webapp/src/index.css",
+        "packages/athena-webapp/src/routes",
+        "packages/athena-webapp/src/components",
+        "packages/athena-webapp/src/hooks",
+        "packages/athena-webapp/src/contexts",
+        "packages/athena-webapp/src/index.css"
+      ],
+      "commands": [
+        {
+          "kind": "script",
+          "script": "test"
+        },
+        {
+          "kind": "script",
+          "script": "lint:architecture"
+        }
+      ]
+    },
+    {
+      "name": "shared-lib-or-utility-edits",
+      "pathPrefixes": [
+        "packages/athena-webapp/src/lib",
+        "packages/athena-webapp/src/settings",
+        "packages/athena-webapp/src/utils",
+        "packages/athena-webapp/src/stores"
+      ],
+      "commands": [
+        {
+          "kind": "script",
+          "script": "test"
+        },
+        {
+          "kind": "raw",
+          "command": "bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json"
+        }
+      ]
+    },
+    {
+      "name": "frontend-test-harness-edits",
+      "pathPrefixes": [
+        "packages/athena-webapp/src/test",
+        "packages/athena-webapp/src/tests"
+      ],
+      "commands": [
+        {
+          "kind": "script",
+          "script": "test"
+        }
+      ]
+    },
+    {
+      "name": "convex-or-backend-adjacent-edits",
+      "pathPrefixes": [
+        "packages/athena-webapp/convex",
+        "packages/athena-webapp/src/routes/_authed",
+        "packages/athena-webapp/src/main.tsx"
+      ],
+      "commands": [
+        {
+          "kind": "script",
+          "script": "test"
+        },
+        {
+          "kind": "script",
+          "script": "audit:convex"
+        },
+        {
+          "kind": "script",
+          "script": "lint:convex:changed"
+        }
+      ]
+    },
+    {
+      "name": "route-runtime-or-build-pipeline-edits",
+      "pathPrefixes": [
         "packages/athena-webapp/src/main.tsx",
         "packages/athena-webapp/src/routeTree.gen.ts",
-        "packages/athena-webapp/src/routes/"
+        "packages/athena-webapp/vite.config.ts"
       ],
-      "scripts": ["test"]
-    },
-    {
-      "name": "shared-frontend",
-      "pathPrefixes": [
-        "packages/athena-webapp/src/components/",
-        "packages/athena-webapp/src/contexts/",
-        "packages/athena-webapp/src/hooks/",
-        "packages/athena-webapp/src/lib/",
-        "packages/athena-webapp/src/settings/",
-        "packages/athena-webapp/src/stores/",
-        "packages/athena-webapp/src/utils/"
-      ],
-      "scripts": ["test"]
-    },
-    {
-      "name": "frontend-tests",
-      "pathPrefixes": [
-        "packages/athena-webapp/src/test/",
-        "packages/athena-webapp/src/tests/"
-      ],
-      "scripts": ["test"]
+      "commands": [
+        {
+          "kind": "raw",
+          "command": "bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json"
+        },
+        {
+          "kind": "script",
+          "script": "build"
+        }
+      ]
     },
     {
       "name": "harness-docs",
       "pathPrefixes": [
         "packages/athena-webapp/AGENTS.md",
-        "packages/athena-webapp/docs/agent/"
+        "packages/athena-webapp/docs/agent"
       ],
-      "scripts": []
-    },
-    {
-      "name": "convex-runtime",
-      "pathPrefixes": [
-        "packages/athena-webapp/convex/app.ts",
-        "packages/athena-webapp/convex/auth.config.js",
-        "packages/athena-webapp/convex/auth.ts",
-        "packages/athena-webapp/convex/crons.ts",
-        "packages/athena-webapp/convex/env.ts",
-        "packages/athena-webapp/convex/http.ts",
-        "packages/athena-webapp/convex/schema.ts",
-        "packages/athena-webapp/convex/tsconfig.json",
-        "packages/athena-webapp/convex/utils.ts"
-      ],
-      "scripts": ["audit:convex", "lint:convex:changed", "test"]
-    },
-    {
-      "name": "convex-domains",
-      "pathPrefixes": [
-        "packages/athena-webapp/convex/cache/",
-        "packages/athena-webapp/convex/cloudflare/",
-        "packages/athena-webapp/convex/constants/",
-        "packages/athena-webapp/convex/emails/",
-        "packages/athena-webapp/convex/http/",
-        "packages/athena-webapp/convex/inventory/",
-        "packages/athena-webapp/convex/lib/",
-        "packages/athena-webapp/convex/llm/",
-        "packages/athena-webapp/convex/mailersend/",
-        "packages/athena-webapp/convex/migrations/",
-        "packages/athena-webapp/convex/mtn/",
-        "packages/athena-webapp/convex/otp/",
-        "packages/athena-webapp/convex/paystack/",
-        "packages/athena-webapp/convex/schemas/",
-        "packages/athena-webapp/convex/sendgrid/",
-        "packages/athena-webapp/convex/services/",
-        "packages/athena-webapp/convex/storeFront/",
-        "packages/athena-webapp/convex/types/"
-      ],
-      "scripts": ["audit:convex", "lint:convex:changed", "test"]
+      "commands": []
     }
   ]
 }

--- a/packages/storefront-webapp/docs/agent/validation-guide.md
+++ b/packages/storefront-webapp/docs/agent/validation-guide.md
@@ -6,7 +6,7 @@ Use this decision guide to answer “what should I run for this change?” based
 
 ## Route or UI-only edits
 
-Touched surfaces: `src/routes`, `src/components`, `src/hooks`, `src/contexts`
+Touched surfaces: `src/assets`, `src/client.tsx`, `src/config.ts`, `src/index.css`, `src/main.tsx`, `src/router.tsx`, `src/routes`, `src/components`, `src/hooks`, `src/contexts`, `src/routeTree.gen.ts`, `src/ssr.tsx`
 
 Run:
 

--- a/packages/storefront-webapp/docs/agent/validation-map.json
+++ b/packages/storefront-webapp/docs/agent/validation-map.json
@@ -3,44 +3,89 @@
   "packageDir": "packages/storefront-webapp",
   "surfaces": [
     {
-      "name": "runtime-routes",
+      "name": "route-or-ui-only-edits",
       "pathPrefixes": [
-        "packages/storefront-webapp/src/assets/",
+        "packages/storefront-webapp/src/assets",
         "packages/storefront-webapp/src/client.tsx",
         "packages/storefront-webapp/src/config.ts",
         "packages/storefront-webapp/src/index.css",
         "packages/storefront-webapp/src/main.tsx",
-        "packages/storefront-webapp/src/routeTree.gen.ts",
         "packages/storefront-webapp/src/router.tsx",
-        "packages/storefront-webapp/src/routes/",
+        "packages/storefront-webapp/src/routes",
+        "packages/storefront-webapp/src/components",
+        "packages/storefront-webapp/src/hooks",
+        "packages/storefront-webapp/src/contexts",
+        "packages/storefront-webapp/src/routeTree.gen.ts",
         "packages/storefront-webapp/src/ssr.tsx"
       ],
-      "scripts": ["test"]
+      "commands": [
+        {
+          "kind": "script",
+          "script": "test"
+        }
+      ]
     },
     {
-      "name": "shared-app",
+      "name": "shared-lib-utility-or-api-wrapper-edits",
       "pathPrefixes": [
-        "packages/storefront-webapp/src/api/",
-        "packages/storefront-webapp/src/components/",
-        "packages/storefront-webapp/src/contexts/",
-        "packages/storefront-webapp/src/hooks/",
-        "packages/storefront-webapp/src/lib/",
-        "packages/storefront-webapp/src/utils/"
+        "packages/storefront-webapp/src/lib",
+        "packages/storefront-webapp/src/utils",
+        "packages/storefront-webapp/src/api"
       ],
-      "scripts": ["test"]
+      "commands": [
+        {
+          "kind": "script",
+          "script": "test"
+        },
+        {
+          "kind": "raw",
+          "command": "bunx tsc --noEmit -p packages/storefront-webapp/tsconfig.json"
+        }
+      ]
     },
     {
-      "name": "browser-tests",
-      "pathPrefixes": ["packages/storefront-webapp/tests/e2e/"],
-      "scripts": ["test", "test:e2e"]
+      "name": "checkout-or-auth-route-boundary-edits",
+      "pathPrefixes": [
+        "packages/storefront-webapp/src/routes/shop/checkout",
+        "packages/storefront-webapp/src/components/checkout",
+        "packages/storefront-webapp/src/routes/auth.verify.tsx"
+      ],
+      "commands": [
+        {
+          "kind": "script",
+          "script": "test"
+        },
+        {
+          "kind": "script",
+          "script": "lint:architecture"
+        }
+      ]
+    },
+    {
+      "name": "full-browser-journeys-and-payment-redirects",
+      "pathPrefixes": [
+        "packages/storefront-webapp/tests/e2e",
+        "packages/storefront-webapp/src/routes/shop/checkout",
+        "packages/storefront-webapp/src/components/checkout"
+      ],
+      "commands": [
+        {
+          "kind": "script",
+          "script": "test"
+        },
+        {
+          "kind": "script",
+          "script": "test:e2e"
+        }
+      ]
     },
     {
       "name": "harness-docs",
       "pathPrefixes": [
         "packages/storefront-webapp/AGENTS.md",
-        "packages/storefront-webapp/docs/agent/"
+        "packages/storefront-webapp/docs/agent"
       ],
-      "scripts": []
+      "commands": []
     }
   ]
 }

--- a/scripts/harness-audit.test.ts
+++ b/scripts/harness-audit.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -186,7 +186,7 @@ async function createFixtureRepo() {
               "packages/athena-webapp/src/routes/",
               "packages/athena-webapp/src/routeTree.gen.ts",
             ],
-            scripts: ["test"],
+            commands: [{ kind: "script", script: "test" }],
           },
           {
             name: "shared-ui",
@@ -199,7 +199,7 @@ async function createFixtureRepo() {
               "packages/athena-webapp/src/stores/",
               "packages/athena-webapp/src/utils/",
             ],
-            scripts: ["test"],
+            commands: [{ kind: "script", script: "test" }],
           },
           {
             name: "convex-surface",
@@ -209,7 +209,11 @@ async function createFixtureRepo() {
               "packages/athena-webapp/convex/inventory/",
               "packages/athena-webapp/convex/storeFront/",
             ],
-            scripts: ["audit:convex", "lint:convex:changed", "test"],
+            commands: [
+              { kind: "script", script: "audit:convex" },
+              { kind: "script", script: "lint:convex:changed" },
+              { kind: "script", script: "test" },
+            ],
           },
           {
             name: "tests",
@@ -217,7 +221,7 @@ async function createFixtureRepo() {
               "packages/athena-webapp/src/test/",
               "packages/athena-webapp/src/tests/",
             ],
-            scripts: ["test"],
+            commands: [{ kind: "script", script: "test" }],
           },
         ],
       },
@@ -242,7 +246,7 @@ async function createFixtureRepo() {
               "packages/storefront-webapp/src/routes/",
               "packages/storefront-webapp/src/ssr.tsx",
             ],
-            scripts: ["test"],
+            commands: [{ kind: "script", script: "test" }],
           },
           {
             name: "shared-app",
@@ -254,12 +258,15 @@ async function createFixtureRepo() {
               "packages/storefront-webapp/src/lib/",
               "packages/storefront-webapp/src/utils/",
             ],
-            scripts: ["test"],
+            commands: [{ kind: "script", script: "test" }],
           },
           {
             name: "tests",
             pathPrefixes: ["packages/storefront-webapp/tests/e2e/"],
-            scripts: ["test", "test:e2e"],
+            commands: [
+              { kind: "script", script: "test" },
+              { kind: "script", script: "test:e2e" },
+            ],
           },
         ],
       },
@@ -270,7 +277,11 @@ async function createFixtureRepo() {
   );
 
   await write("packages/athena-webapp/src/main.tsx", "export {};\n", rootDir);
+  await write("packages/athena-webapp/src/assets/placeholder.png", "", rootDir);
+  await write("packages/athena-webapp/src/config.ts", "export {};\n", rootDir);
+  await write("packages/athena-webapp/src/index.css", "body {}\n", rootDir);
   await write("packages/athena-webapp/src/routeTree.gen.ts", "export {};\n", rootDir);
+  await write("packages/athena-webapp/src/routes/_authed/index.tsx", "export {};\n", rootDir);
   await write("packages/athena-webapp/src/routes/index.tsx", "export {};\n", rootDir);
   await write("packages/athena-webapp/src/components/AppShell.tsx", "export {};\n", rootDir);
   await write("packages/athena-webapp/src/hooks/useAuth.ts", "export {};\n", rootDir);
@@ -285,11 +296,18 @@ async function createFixtureRepo() {
   await write("packages/athena-webapp/convex/http/router.ts", "export {};\n", rootDir);
   await write("packages/athena-webapp/convex/inventory/item.ts", "export {};\n", rootDir);
   await write("packages/athena-webapp/convex/storeFront/cart.ts", "export {};\n", rootDir);
+  await write("packages/athena-webapp/vite.config.ts", "export default {};\n", rootDir);
 
+  await write("packages/storefront-webapp/src/assets/placeholder.png", "", rootDir);
   await write("packages/storefront-webapp/src/client.tsx", "export {};\n", rootDir);
+  await write("packages/storefront-webapp/src/config.ts", "export {};\n", rootDir);
+  await write("packages/storefront-webapp/src/index.css", "body {}\n", rootDir);
+  await write("packages/storefront-webapp/src/main.tsx", "export {};\n", rootDir);
   await write("packages/storefront-webapp/src/router.tsx", "export {};\n", rootDir);
   await write("packages/storefront-webapp/src/routeTree.gen.ts", "export {};\n", rootDir);
+  await write("packages/storefront-webapp/src/routes/auth.verify.tsx", "export {};\n", rootDir);
   await write("packages/storefront-webapp/src/routes/__root.tsx", "export {};\n", rootDir);
+  await write("packages/storefront-webapp/src/routes/shop/checkout/index.tsx", "export {};\n", rootDir);
   await write("packages/storefront-webapp/src/ssr.tsx", "export {};\n", rootDir);
   await write("packages/storefront-webapp/src/api/storefront.ts", "export {};\n", rootDir);
   await write("packages/storefront-webapp/src/components/checkout/Bag.tsx", "export {};\n", rootDir);
@@ -351,12 +369,15 @@ describe("runHarnessAudit", () => {
                 "packages/storefront-webapp/src/routes/",
                 "packages/storefront-webapp/src/ssr.tsx",
               ],
-              scripts: ["test"],
+              commands: [{ kind: "script", script: "test" }],
             },
             {
               name: "tests",
               pathPrefixes: ["packages/storefront-webapp/tests/e2e/"],
-              scripts: ["test", "test:e2e"],
+              commands: [
+                { kind: "script", script: "test" },
+                { kind: "script", script: "test:e2e" },
+              ],
             },
           ],
         },
@@ -388,7 +409,7 @@ describe("runHarnessAudit", () => {
                 "packages/athena-webapp/src/routeTree.gen.ts",
                 "packages/athena-webapp/src/missing-runtime/",
               ],
-              scripts: ["test"],
+              commands: [{ kind: "script", script: "test" }],
             },
           ],
         },
@@ -425,5 +446,26 @@ describe("runHarnessAudit", () => {
     await expect(runHarnessAudit(rootDir)).rejects.toThrow(
       /Missing required script "@athena\/storefront-webapp:test:e2e" while generating harness docs\./
     );
+  });
+
+  it("accepts generated command-based validation surfaces that include raw repo-root commands", async () => {
+    const rootDir = await createFixtureRepo();
+    await expect(
+      readFile(
+        path.join(rootDir, "packages/athena-webapp/docs/agent/validation-map.json"),
+        "utf8"
+      )
+    ).resolves.toContain('"kind": "raw"');
+    await expect(
+      readFile(
+        path.join(
+          rootDir,
+          "packages/storefront-webapp/docs/agent/validation-map.json"
+        ),
+        "utf8"
+      )
+    ).resolves.toContain('"kind": "raw"');
+
+    await expect(runHarnessAudit(rootDir)).resolves.toBeUndefined();
   });
 });

--- a/scripts/harness-audit.ts
+++ b/scripts/harness-audit.ts
@@ -18,29 +18,26 @@ const AUDIT_TARGETS = [
   },
 ] as const;
 
-type ValidationRule = {
-  pathPrefix: string;
-  scripts: string[];
-};
+type ValidationCommand =
+  | { kind: "script"; script: string }
+  | { kind: "raw"; command: string };
 
 type ValidationSurface = {
   name: string;
   pathPrefixes: string[];
-  scripts: string[];
+  commands: ValidationCommand[];
 };
 
 type ValidationMap = {
   workspace: string;
   packageDir: string;
-  rules?: ValidationRule[];
-  surfaces?: ValidationSurface[];
+  surfaces: ValidationSurface[];
 };
 
 type LoadedAuditTarget = {
   appName: (typeof AUDIT_TARGETS)[number]["appName"];
   auditedRoots: readonly string[];
   packageDir: string;
-  packageScripts: Record<string, string>;
   surfaces: ValidationSurface[];
   testingDocContents: string;
 };
@@ -76,16 +73,12 @@ async function readJsonFile<T>(filePath: string) {
   return JSON.parse(await readFile(filePath, "utf8")) as T;
 }
 
-function toValidationSurfaces(validationMap: ValidationMap) {
-  if (validationMap.surfaces && validationMap.surfaces.length > 0) {
-    return validationMap.surfaces;
-  }
-
-  return (validationMap.rules ?? []).map((rule, index) => ({
-    name: `rule-${index + 1}`,
-    pathPrefixes: [rule.pathPrefix],
-    scripts: rule.scripts,
-  }));
+function normalizeValidationCommand(
+  command: ValidationCommand
+): ValidationCommand {
+  return command.kind === "raw"
+    ? { kind: "raw", command: command.command.trim() }
+    : { kind: "script", script: command.script };
 }
 
 function addGroupedError(
@@ -223,7 +216,10 @@ async function loadAuditTarget(
     );
   }
 
-  const surfaces = toValidationSurfaces(validationMap);
+  const surfaces = Array.isArray(validationMap.surfaces)
+    ? validationMap.surfaces
+    : [];
+
   if (surfaces.length === 0) {
     addGroupedError(
       groupedErrors,
@@ -233,12 +229,21 @@ async function loadAuditTarget(
   }
 
   for (const surface of surfaces) {
-    if (surface.pathPrefixes.length === 0) {
+    if (!Array.isArray(surface.pathPrefixes) || surface.pathPrefixes.length === 0) {
       addGroupedError(
         groupedErrors,
         target.appName,
         `Empty validation surface "${surface.name}" in ${target.validationMapPath}.`
       );
+    }
+
+    if (!Array.isArray(surface.commands)) {
+      addGroupedError(
+        groupedErrors,
+        target.appName,
+        `Missing commands for validation surface "${surface.name}" in ${target.validationMapPath}.`
+      );
+      continue;
     }
 
     for (const pathPrefix of surface.pathPrefixes) {
@@ -251,12 +256,23 @@ async function loadAuditTarget(
       }
     }
 
-    for (const script of surface.scripts) {
-      if (!packageJson.scripts?.[script]) {
+    for (const command of surface.commands.map(normalizeValidationCommand)) {
+      if (command.kind === "script") {
+        if (!packageJson.scripts?.[command.script]) {
+          addGroupedError(
+            groupedErrors,
+            target.appName,
+            `Stale validation surface: ${target.validationMapPath} references missing script "${validationMap.workspace}:${command.script}".`
+          );
+        }
+        continue;
+      }
+
+      if (!command.command) {
         addGroupedError(
           groupedErrors,
           target.appName,
-          `Stale validation surface: ${target.validationMapPath} references missing script "${validationMap.workspace}:${script}".`
+          `Stale validation surface: ${target.validationMapPath} includes an empty raw command in "${surface.name}".`
         );
       }
     }
@@ -267,9 +283,12 @@ async function loadAuditTarget(
     loadedTarget: {
       appName: target.appName,
       auditedRoots: target.auditedRoots,
-      packageDir: validationMap.packageDir,
-      packageScripts: packageJson.scripts ?? {},
-      surfaces,
+      packageDir: normalizeRepoPath(validationMap.packageDir),
+      surfaces: surfaces.map((surface) => ({
+        name: surface.name,
+        pathPrefixes: surface.pathPrefixes.map(normalizeRepoPath),
+        commands: surface.commands.map(normalizeValidationCommand),
+      })),
       testingDocContents,
     } satisfies LoadedAuditTarget,
   };

--- a/scripts/harness-check.test.ts
+++ b/scripts/harness-check.test.ts
@@ -375,4 +375,36 @@ describe("validateHarnessDocs", () => {
       "Stale generated harness doc: packages/storefront-webapp/docs/agent/route-index.md"
     );
   });
+
+  it("treats validation-map.json as a generated harness artifact", async () => {
+    const rootDir = await createFixtureRepo();
+
+    await expect(validateHarnessDocs(rootDir)).resolves.not.toContain(
+      "Missing required harness file: packages/athena-webapp/docs/agent/validation-map.json"
+    );
+    await expect(validateHarnessDocs(rootDir)).resolves.not.toContain(
+      "Missing required harness file: packages/storefront-webapp/docs/agent/validation-map.json"
+    );
+  });
+
+  it("reports stale generated validation maps when the shared config changes", async () => {
+    const rootDir = await createFixtureRepo();
+    await write(
+      "packages/athena-webapp/docs/agent/validation-map.json",
+      JSON.stringify(
+        {
+          workspace: "@athena/webapp",
+          packageDir: "packages/athena-webapp",
+          surfaces: [],
+        },
+        null,
+        2
+      ),
+      rootDir
+    );
+
+    await expect(validateHarnessDocs(rootDir)).resolves.toContain(
+      "Stale generated harness doc: packages/athena-webapp/docs/agent/validation-map.json"
+    );
+  });
 });

--- a/scripts/harness-generate.test.ts
+++ b/scripts/harness-generate.test.ts
@@ -103,6 +103,12 @@ describe("generateHarnessDocs", () => {
     expect(docs.get("packages/storefront-webapp/docs/agent/validation-guide.md")).toContain(
       "Full browser journeys"
     );
+    expect(docs.get("packages/athena-webapp/docs/agent/validation-map.json")).toContain(
+      "\"commands\""
+    );
+    expect(docs.get("packages/storefront-webapp/docs/agent/validation-map.json")).toContain(
+      "\"kind\": \"raw\""
+    );
 
     expect(await generateHarnessDocs(rootDir)).toEqual(docs);
   });
@@ -124,5 +130,11 @@ describe("generateHarnessDocs", () => {
         "utf8"
       )
     ).resolves.toContain("# Storefront Webapp Validation Guide");
+    await expect(
+      readFile(
+        path.join(rootDir, "packages/athena-webapp/docs/agent/validation-map.json"),
+        "utf8"
+      )
+    ).resolves.toContain("\"lint:architecture\"");
   });
 });

--- a/scripts/harness-generate.ts
+++ b/scripts/harness-generate.ts
@@ -11,7 +11,12 @@ export const GENERATED_HARNESS_DOCS = [
   "docs/agent/test-index.md",
   "docs/agent/key-folder-index.md",
   "docs/agent/validation-guide.md",
+  "docs/agent/validation-map.json",
 ] as const;
+
+type ValidationCommand =
+  | { kind: "script"; script: string }
+  | { kind: "raw"; command: string };
 
 type GeneratedHarnessAppConfig = {
   appName: "athena-webapp" | "storefront-webapp";
@@ -25,10 +30,7 @@ type GeneratedHarnessAppConfig = {
   validationScenarios: Array<{
     title: string;
     touchedPaths: string[];
-    commands: Array<
-      | { kind: "script"; script: string }
-      | { kind: "raw"; command: string }
-    >;
+    commands: ValidationCommand[];
     note: string;
   }>;
 };
@@ -96,10 +98,13 @@ const APP_CONFIGS: GeneratedHarnessAppConfig[] = [
       {
         title: "Route or UI-only edits",
         touchedPaths: [
+          "src/assets",
+          "src/config.ts",
           "src/routes",
           "src/components",
           "src/hooks",
           "src/contexts",
+          "src/index.css",
         ],
         commands: [
           { kind: "script", script: "test" },
@@ -109,7 +114,7 @@ const APP_CONFIGS: GeneratedHarnessAppConfig[] = [
       },
       {
         title: "Shared-lib or utility edits",
-        touchedPaths: ["src/lib", "src/utils", "src/stores"],
+        touchedPaths: ["src/lib", "src/settings", "src/utils", "src/stores"],
         commands: [
           { kind: "script", script: "test" },
           {
@@ -118,6 +123,12 @@ const APP_CONFIGS: GeneratedHarnessAppConfig[] = [
           },
         ],
         note: "Reach for the package suite first, then typecheck when helpers or shared state can affect many call sites.",
+      },
+      {
+        title: "Frontend test harness edits",
+        touchedPaths: ["src/test", "src/tests"],
+        commands: [{ kind: "script", script: "test" }],
+        note: "Run the package suite when package-local frontend test helpers or focused regression tests change.",
       },
       {
         title: "Convex or backend-adjacent edits",
@@ -196,10 +207,18 @@ const APP_CONFIGS: GeneratedHarnessAppConfig[] = [
       {
         title: "Route or UI-only edits",
         touchedPaths: [
+          "src/assets",
+          "src/client.tsx",
+          "src/config.ts",
+          "src/index.css",
+          "src/main.tsx",
+          "src/router.tsx",
           "src/routes",
           "src/components",
           "src/hooks",
           "src/contexts",
+          "src/routeTree.gen.ts",
+          "src/ssr.tsx",
         ],
         commands: [{ kind: "script", script: "test" }],
         note: "Start here for most layout, component, and route behavior changes that do not alter the checkout or browser-journey contract.",
@@ -459,6 +478,54 @@ function formatScriptCommand(packageConfig: PackageConfig, script: string) {
   return `bun run --filter '${packageConfig.packageName}' ${script}`;
 }
 
+function toRepoValidationPath(packageDir: string, touchedPath: string) {
+  const normalizedPath = normalizeRepoPath(touchedPath).replace(/\/+$/, "");
+  return normalizeRepoPath(path.posix.join(packageDir, normalizedPath));
+}
+
+function slugifyTitle(title: string) {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function formatValidationCommandForDoc(
+  packageConfig: PackageConfig,
+  command: ValidationCommand
+) {
+  return command.kind === "raw"
+    ? command.command
+    : formatScriptCommand(packageConfig, command.script);
+}
+
+function toGeneratedValidationMap(
+  config: GeneratedHarnessAppConfig,
+  packageConfig: PackageConfig
+) {
+  return {
+    workspace: packageConfig.packageName,
+    packageDir: config.packageDir,
+    surfaces: [
+      ...config.validationScenarios.map((scenario) => ({
+        name: slugifyTitle(scenario.title),
+        pathPrefixes: scenario.touchedPaths.map((touchedPath) =>
+          toRepoValidationPath(config.packageDir, touchedPath)
+        ),
+        commands: scenario.commands,
+      })),
+      {
+        name: "harness-docs",
+        pathPrefixes: [
+          `${config.packageDir}/AGENTS.md`,
+          `${config.packageDir}/docs/agent`,
+        ],
+        commands: [] as ValidationCommand[],
+      },
+    ],
+  };
+}
+
 function buildGeneratedDoc(
   title: string,
   introLines: string[],
@@ -592,13 +659,7 @@ async function buildValidationGuide(
     bodyLines.push("");
 
     for (const command of scenario.commands) {
-      bodyLines.push(
-        `- \`${
-          command.kind === "raw"
-            ? command.command
-            : formatScriptCommand(packageConfig, command.script)
-        }\``
-      );
+      bodyLines.push(`- \`${formatValidationCommandForDoc(packageConfig, command)}\``);
     }
 
     bodyLines.push("");
@@ -611,6 +672,13 @@ async function buildValidationGuide(
     [],
     bodyLines
   );
+}
+
+async function buildValidationMap(
+  config: GeneratedHarnessAppConfig,
+  packageConfig: PackageConfig
+) {
+  return `${JSON.stringify(toGeneratedValidationMap(config, packageConfig), null, 2)}\n`;
 }
 
 export async function generateHarnessDocs(rootDir: string) {
@@ -633,6 +701,10 @@ export async function generateHarnessDocs(rootDir: string) {
     docs.set(
       `${config.packageDir}/docs/agent/validation-guide.md`,
       await buildValidationGuide(config, packageConfig)
+    );
+    docs.set(
+      `${config.packageDir}/docs/agent/validation-map.json`,
+      await buildValidationMap(config, packageConfig)
     );
   }
 

--- a/scripts/harness-review.test.ts
+++ b/scripts/harness-review.test.ts
@@ -75,10 +75,15 @@ async function createFixtureRepo() {
       {
         workspace: "@athena/webapp",
         packageDir: "packages/athena-webapp",
-        rules: [
+        surfaces: [
           {
-            pathPrefix: "packages/athena-webapp/",
-            scripts: ["audit:convex", "lint:convex:changed", "test"],
+            name: "athena-package",
+            pathPrefixes: ["packages/athena-webapp"],
+            commands: [
+              { kind: "script", script: "audit:convex" },
+              { kind: "script", script: "lint:convex:changed" },
+              { kind: "script", script: "test" },
+            ],
           },
         ],
       },
@@ -93,10 +98,11 @@ async function createFixtureRepo() {
       {
         workspace: "@athena/storefront-webapp",
         packageDir: "packages/storefront-webapp",
-        rules: [
+        surfaces: [
           {
-            pathPrefix: "packages/storefront-webapp/",
-            scripts: ["test"],
+            name: "storefront-package",
+            pathPrefixes: ["packages/storefront-webapp"],
+            commands: [{ kind: "script", script: "test" }],
           },
         ],
       },
@@ -218,10 +224,11 @@ describe("runHarnessReview", () => {
         {
           workspace: "@athena/webapp",
           packageDir: "packages/athena-webapp",
-          rules: [
+          surfaces: [
             {
-              pathPrefix: "packages/athena-webapp/",
-              scripts: ["missing-script"],
+              name: "athena-package",
+              pathPrefixes: ["packages/athena-webapp"],
+              commands: [{ kind: "script", script: "missing-script" }],
             },
           ],
         },
@@ -254,10 +261,15 @@ describe("runHarnessReview", () => {
         {
           workspace: "@athena/webapp",
           packageDir: "packages/athena-webapp",
-          rules: [
+          surfaces: [
             {
-              pathPrefix: "packages/athena-webapp/convex/",
-              scripts: ["audit:convex", "lint:convex:changed", "test"],
+              name: "convex-only",
+              pathPrefixes: ["packages/athena-webapp/convex"],
+              commands: [
+                { kind: "script", script: "audit:convex" },
+                { kind: "script", script: "lint:convex:changed" },
+                { kind: "script", script: "test" },
+              ],
             },
           ],
         },
@@ -307,5 +319,79 @@ describe("runHarnessReview", () => {
     expect(logs).toContain(
       "No target-app validations selected; no touched files under packages/athena-webapp or packages/storefront-webapp."
     );
+  });
+
+  it("runs command-based validation surfaces including raw repo-root commands", async () => {
+    const rootDir = await createFixtureRepo();
+    const steps: string[] = [];
+
+    await write(
+      "packages/athena-webapp/package.json",
+      JSON.stringify(
+        {
+          name: "@athena/webapp",
+          scripts: {
+            test: "echo test",
+          },
+        },
+        null,
+        2
+      ),
+      rootDir
+    );
+    await write(
+      "packages/athena-webapp/docs/agent/validation-map.json",
+      JSON.stringify(
+        {
+          workspace: "@athena/webapp",
+          packageDir: "packages/athena-webapp",
+          surfaces: [
+            {
+              name: "shared-lib-or-utility-edits",
+              pathPrefixes: ["packages/athena-webapp/src/lib"],
+              commands: [
+                { kind: "script", script: "test" },
+                {
+                  kind: "raw",
+                  command:
+                    "bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json",
+                },
+              ],
+            },
+          ],
+        },
+        null,
+        2
+      ),
+      rootDir
+    );
+    await write(
+      "packages/athena-webapp/src/lib/session.ts",
+      "export const session = true;\n",
+      rootDir
+    );
+
+    await runHarnessReview(rootDir, {
+      getChangedFiles: async () => ["packages/athena-webapp/src/lib/session.ts"],
+      runHarnessCheck: async () => {
+        steps.push("harness:check");
+      },
+      runPackageScript: async (workspace, script) => {
+        steps.push(`${workspace}:${script}`);
+      },
+      runRawCommand: async (command) => {
+        steps.push(`raw:${command}`);
+      },
+      logger: {
+        log() {},
+        error() {},
+      },
+    });
+
+    expect(steps).toEqual([
+      "harness:check",
+      "@athena/webapp:test",
+      "raw:bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json",
+    ]);
   });
 });

--- a/scripts/harness-review.ts
+++ b/scripts/harness-review.ts
@@ -14,29 +14,27 @@ const REVIEW_TARGETS = [
   },
 ] as const;
 
-type ValidationRule = {
-  pathPrefix: string;
-  scripts: string[];
-};
+type ValidationCommand =
+  | { kind: "script"; script: string }
+  | { kind: "raw"; command: string };
 
 type ValidationSurface = {
   name: string;
   pathPrefixes: string[];
-  scripts: string[];
+  commands: ValidationCommand[];
 };
 
 type ValidationMap = {
   workspace: string;
   packageDir: string;
-  rules: ValidationRule[];
-  surfaces?: ValidationSurface[];
+  surfaces: ValidationSurface[];
 };
 
 type LoadedReviewTarget = {
   packageDir: string;
   validationMapPath: string;
   workspace: string;
-  rules: ValidationRule[];
+  surfaces: ValidationSurface[];
 };
 
 type HarnessReviewLogger = Pick<Console, "log" | "error">;
@@ -46,6 +44,7 @@ type HarnessReviewOptions = {
   logger?: HarnessReviewLogger;
   runHarnessCheck?: (rootDir: string) => Promise<void>;
   runPackageScript?: (workspace: string, script: string) => Promise<void>;
+  runRawCommand?: (command: string) => Promise<void>;
 };
 
 function normalizeRepoPath(repoPath: string) {
@@ -66,6 +65,14 @@ function matchesPathPrefix(filePath: string, pathPrefix: string) {
   );
 }
 
+function normalizeValidationCommand(
+  command: ValidationCommand
+): ValidationCommand {
+  return command.kind === "raw"
+    ? { kind: "raw", command: command.command.trim() }
+    : { kind: "script", script: command.script };
+}
+
 async function fileExists(filePath: string) {
   try {
     await access(filePath);
@@ -77,19 +84,6 @@ async function fileExists(filePath: string) {
 
 async function readJsonFile<T>(filePath: string) {
   return JSON.parse(await readFile(filePath, "utf8")) as T;
-}
-
-function toValidationRules(validationMap: ValidationMap) {
-  if (validationMap.surfaces && validationMap.surfaces.length > 0) {
-    return validationMap.surfaces.flatMap((surface) =>
-      surface.pathPrefixes.map((pathPrefix) => ({
-        pathPrefix,
-        scripts: surface.scripts,
-      }))
-    );
-  }
-
-  return validationMap.rules;
 }
 
 async function loadReviewTarget(
@@ -135,19 +129,50 @@ async function loadReviewTarget(
     );
   }
 
-  const validationRules = toValidationRules(validationMap);
+  const surfaces = Array.isArray(validationMap.surfaces)
+    ? validationMap.surfaces
+    : [];
 
-  for (const rule of validationRules) {
-    if (!(await fileExists(path.join(rootDir, rule.pathPrefix)))) {
+  if (surfaces.length === 0) {
+    throw new Error(
+      `Stale harness review config: ${validationMapPath} must define at least one validation surface.`
+    );
+  }
+
+  for (const surface of surfaces) {
+    if (!Array.isArray(surface.pathPrefixes) || surface.pathPrefixes.length === 0) {
       throw new Error(
-        `Stale harness review config: ${validationMapPath} references missing path prefix "${rule.pathPrefix}".`
+        `Stale harness review config: ${validationMapPath} includes an empty path prefix list for "${surface.name}".`
       );
     }
 
-    for (const script of rule.scripts) {
-      if (!packageJson.scripts?.[script]) {
+    if (!Array.isArray(surface.commands)) {
+      throw new Error(
+        `Stale harness review config: ${validationMapPath} is missing commands for "${surface.name}".`
+      );
+    }
+
+    for (const pathPrefix of surface.pathPrefixes) {
+      if (!(await fileExists(path.join(rootDir, pathPrefix)))) {
         throw new Error(
-          `Stale harness review config: ${validationMapPath} references missing script "${validationMap.workspace}:${script}".`
+          `Stale harness review config: ${validationMapPath} references missing path prefix "${pathPrefix}".`
+        );
+      }
+    }
+
+    for (const command of surface.commands.map(normalizeValidationCommand)) {
+      if (command.kind === "script") {
+        if (!packageJson.scripts?.[command.script]) {
+          throw new Error(
+            `Stale harness review config: ${validationMapPath} references missing script "${validationMap.workspace}:${command.script}".`
+          );
+        }
+        continue;
+      }
+
+      if (!command.command) {
+        throw new Error(
+          `Stale harness review config: ${validationMapPath} includes an empty raw command for "${surface.name}".`
         );
       }
     }
@@ -157,9 +182,10 @@ async function loadReviewTarget(
     packageDir: normalizeRepoPath(validationMap.packageDir),
     validationMapPath,
     workspace: validationMap.workspace,
-    rules: validationRules.map((rule) => ({
-      pathPrefix: normalizeRepoPath(rule.pathPrefix),
-      scripts: rule.scripts,
+    surfaces: surfaces.map((surface) => ({
+      name: surface.name,
+      pathPrefixes: surface.pathPrefixes.map(normalizeRepoPath),
+      commands: surface.commands.map(normalizeValidationCommand),
     })),
   } satisfies LoadedReviewTarget;
 }
@@ -180,12 +206,15 @@ async function loadReviewTargets(rootDir: string) {
   return targets;
 }
 
-function collectScriptsForChangedFiles(
+function collectCommandsForChangedFiles(
   changedFiles: string[],
   targets: LoadedReviewTarget[]
 ) {
   const normalizedChangedFiles = changedFiles.map(normalizeRepoPath);
-  const selectedScripts: Array<{ workspace: string; script: string }> = [];
+  const selectedCommands: Array<
+    | { kind: "script"; workspace: string; script: string }
+    | { kind: "raw"; command: string }
+  > = [];
   const uncoveredFiles: string[] = [];
   const targetFiles = normalizedChangedFiles.filter((filePath) =>
     targets.some((target) => matchesPathPrefix(filePath, `${target.packageDir}/`))
@@ -200,36 +229,51 @@ function collectScriptsForChangedFiles(
       continue;
     }
 
-    const seenScripts = new Set<string>();
+    const seenCommands = new Set<string>();
 
     for (const changedFile of targetChangedFiles) {
-      const matchingRules = target.rules.filter((rule) =>
-        matchesPathPrefix(changedFile, rule.pathPrefix)
+      const matchingSurfaces = target.surfaces.filter((surface) =>
+        surface.pathPrefixes.some((pathPrefix) =>
+          matchesPathPrefix(changedFile, pathPrefix)
+        )
       );
 
-      if (matchingRules.length === 0) {
+      if (matchingSurfaces.length === 0) {
         uncoveredFiles.push(changedFile);
         continue;
       }
 
-      for (const rule of matchingRules) {
-        for (const script of rule.scripts) {
-          if (seenScripts.has(script)) {
+      for (const surface of matchingSurfaces) {
+        for (const command of surface.commands) {
+          const commandKey =
+            command.kind === "script"
+              ? `${target.workspace}:${command.script}`
+              : `raw:${command.command}`;
+
+          if (seenCommands.has(commandKey)) {
             continue;
           }
 
-          selectedScripts.push({
-            workspace: target.workspace,
-            script,
-          });
-          seenScripts.add(script);
+          if (command.kind === "script") {
+            selectedCommands.push({
+              kind: "script",
+              workspace: target.workspace,
+              script: command.script,
+            });
+          } else {
+            selectedCommands.push({
+              kind: "raw",
+              command: command.command,
+            });
+          }
+          seenCommands.add(commandKey);
         }
       }
     }
   }
 
   return {
-    selectedScripts,
+    selectedCommands,
     uncoveredFiles,
     targetFiles,
   };
@@ -287,6 +331,19 @@ async function runPackageScript(rootDir: string, workspace: string, script: stri
   }
 }
 
+async function runRawCommand(rootDir: string, command: string) {
+  const subprocess = Bun.spawn(["/bin/zsh", "-lc", command], {
+    cwd: rootDir,
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  const exitCode = await subprocess.exited;
+
+  if (exitCode !== 0) {
+    throw new Error(`Command failed (${exitCode}): ${command}`);
+  }
+}
+
 export async function runHarnessReview(
   rootDir: string,
   options: HarnessReviewOptions = {}
@@ -299,8 +356,8 @@ export async function runHarnessReview(
   await runCheck(rootDir);
 
   const reviewTargets = await loadReviewTargets(rootDir);
-  const { selectedScripts, uncoveredFiles, targetFiles } =
-    collectScriptsForChangedFiles(changedFiles, reviewTargets);
+  const { selectedCommands, uncoveredFiles, targetFiles } =
+    collectCommandsForChangedFiles(changedFiles, reviewTargets);
 
   if (uncoveredFiles.length > 0) {
     throw new Error(
@@ -320,10 +377,20 @@ export async function runHarnessReview(
     return;
   }
 
-  for (const { workspace, script } of selectedScripts) {
-    logger.log(`Running ${workspace}:${script}`);
-    await (options.runPackageScript ?? ((nextWorkspace, nextScript) =>
-      runPackageScript(rootDir, nextWorkspace, nextScript)))(workspace, script);
+  for (const command of selectedCommands) {
+    if (command.kind === "script") {
+      logger.log(`Running ${command.workspace}:${command.script}`);
+      await (options.runPackageScript ?? ((nextWorkspace, nextScript) =>
+        runPackageScript(rootDir, nextWorkspace, nextScript)))(
+        command.workspace,
+        command.script
+      );
+      continue;
+    }
+
+    logger.log(`Running raw command: ${command.command}`);
+    await (options.runRawCommand ?? ((nextCommand) =>
+      runRawCommand(rootDir, nextCommand)))(command.command);
   }
 }
 


### PR DESCRIPTION
## Summary
- generate `validation-map.json` from the same scenario config that drives `validation-guide.md`
- make `harness:review` and `harness:audit` consume only generated `surfaces[].commands[]` validation surfaces
- refresh the generated validation docs, harness tests, and Graphify artifacts to match the new source of truth

## Why
- remove drift between the human-facing validation guide and the machine-run validation map
- ensure harness freshness checks catch stale executable validation coverage, not just stale prose
- make command-based validation the only expected contract going forward

## Validation
- `bun test scripts/harness-generate.test.ts scripts/harness-check.test.ts scripts/harness-review.test.ts scripts/harness-audit.test.ts`
- `bun run harness:generate`
- `bun run harness:check`
- `bun run harness:audit`
- `bun run harness:review`
- `bun run architecture:check`
- `bun run graphify:rebuild`
- `bun run pr:athena`

https://linear.app/v26-labs/issue/V26-195/unify-generated-validation-guides-and-executable-validation-maps-in