### PR TITLE
[V26-197]: Gate harness implementation in PR preflight and CI

### DIFF
--- a/.github/workflows/athena-pr-tests.yml
+++ b/.github/workflows/athena-pr-tests.yml
@@ -37,6 +37,25 @@ jobs:
       - name: Audit harness coverage
         run: bun run harness:audit
 
+  harness-implementation-tests:
+    name: Harness Implementation Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run harness implementation tests
+        run: bun run harness:test
+
   test-athena-webapp:
     name: Athena Webapp Validation
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -6,12 +6,15 @@ This repo uses a docs-first agent harness for `packages/athena-webapp` and `pack
 
 Key repo-level commands:
 
+- `bun run harness:test`
 - `bun run harness:check`
 - `bun run harness:audit`
 - `bun run harness:review`
 - `bun run architecture:check`
 - `bun run pre-push:review`
 - `bun run pr:athena`
+
+`bun run harness:test` is the canonical harness implementation gate for harness scripts, graphify tooling, and pre-push review wiring.
 
 ## Graphify
 

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
     "harness:check": "bun scripts/harness-check.ts",
     "harness:generate": "bun scripts/harness-generate.ts",
     "harness:review": "bun scripts/harness-review.ts",
+    "harness:test": "bun test scripts/harness-audit.test.ts scripts/harness-check.test.ts scripts/harness-generate.test.ts scripts/harness-review.test.ts scripts/graphify-rebuild.test.ts scripts/pre-push-review.test.ts",
     "pre-push:review": "bun scripts/pre-push-review.ts",
-    "pr:athena": "bun run --filter '@athena/webapp' audit:convex && bun run --filter '@athena/webapp' lint:convex:changed && bun run architecture:check && bun run --filter '@athena/webapp' test && bun run --filter '@athena/storefront-webapp' test && bun run harness:check && bun run harness:audit",
+    "pr:athena": "bun run --filter '@athena/webapp' audit:convex && bun run --filter '@athena/webapp' lint:convex:changed && bun run architecture:check && bun run --filter '@athena/webapp' test && bun run --filter '@athena/storefront-webapp' test && bun run harness:test && bun run harness:check && bun run harness:audit",
     "test": "bun run --filter '@athena/webapp' test && bun run --filter '@athena/storefront-webapp' test",
     "test:coverage": "bun run --filter '@athena/webapp' test:coverage && bun run --filter '@athena/storefront-webapp' test:coverage && bun scripts/coverage-summary.mjs"
   },

--- a/scripts/pre-push-review.test.ts
+++ b/scripts/pre-push-review.test.ts
@@ -112,17 +112,26 @@ describe("repo harness ergonomics", () => {
     expect(workflow).toContain("schedule:");
     expect(workflow).toContain("- cron:");
     expect(workflow).toContain("workflow_dispatch:");
+    expect(workflow).toContain("harness-implementation-tests:");
+    expect(workflow).toContain("run: bun run harness:test");
     expect(workflow).toContain("run: bun run harness:audit");
   });
 
-  it("includes harness audit in the local pr:athena command", async () => {
+  it("includes harness implementation tests in the local pr:athena command", async () => {
     const packageJson = JSON.parse(
       await readFile(path.join(ROOT_DIR, "package.json"), "utf8")
     ) as {
       scripts?: Record<string, string>;
     };
 
+    expect(packageJson.scripts?.["pr:athena"]).toContain("bun run harness:test");
     expect(packageJson.scripts?.["pr:athena"]).toContain("bun run harness:audit");
+  });
+
+  it("documents harness implementation tests as a repo-level command", async () => {
+    const readme = await readFile(path.join(ROOT_DIR, "README.md"), "utf8");
+
+    expect(readme).toContain("bun run harness:test");
   });
 
   it("documents graphify setup and tracked artifact policy in the README", async () => {


### PR DESCRIPTION
## Summary
- add a canonical root command `bun run harness:test` that runs harness/tooling implementation tests (`scripts/harness-*.test.ts`, `scripts/graphify-rebuild.test.ts`, `scripts/pre-push-review.test.ts`)
- include `bun run harness:test` in `bun run pr:athena` so local PR preflight fails on harness implementation regressions
- add a dedicated GitHub Actions job to run `bun run harness:test` independently of app validation jobs
- update README repo-level command guidance to document `harness:test` as the harness implementation gate
- extend repo wiring tests to assert the new preflight/CI/doc behavior

## Why
- app test suites can pass while harness script/tooling behavior regresses
- a dedicated harness implementation gate makes these regressions fail explicitly in both local preflight and CI
- keeping this gate separate preserves clear ownership between app validation and harness/tooling validation

## Validation
- `bun test scripts/pre-push-review.test.ts`
- `bun run harness:test`
- `bun run pr:athena`
- `git diff --check`
- `bun run graphify:rebuild`

https://linear.app/v26-labs/issue/V26-197/gate-the-harness-implementation-itself-in-pr-preflight-and-ci
