### PR TITLE
[V26-201]: add harness self-review command for handoff scorecards

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,12 +1,12 @@
 # Graph Report - .  (2026-04-11)
 
 ## Corpus Check
-- 1172 files · ~0 words
+- 1174 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 2117 nodes · 4816 edges · 71 communities detected
-- Extraction: 92% EXTRACTED · 8% INFERRED · 0% AMBIGUOUS · INFERRED: 407 edges (avg confidence: 0.5)
+- 2142 nodes · 4860 edges · 72 communities detected
+- Extraction: 91% EXTRACTED · 9% INFERRED · 0% AMBIGUOUS · INFERRED: 426 edges (avg confidence: 0.5)
 - Token cost: 0 input · 0 output
 
 ## God Nodes (most connected - your core abstractions)
@@ -37,43 +37,43 @@
 
 ### Community 0 - "Community 0"
 Cohesion: 0.01
-Nodes (7): AnalyticsCombinedUsers(), processAnalyticsToUsers(), modifyProduct(), onSubmit(), saveProduct(), handleFileSelect(), validateFile()
+Nodes (14): AnalyticsCombinedUsers(), processAnalyticsToUsers(), AnalyticsTopUsers(), processAnalyticsToUsers(), handleFileSelect(), validateFile(), capitalizeWords(), countGroupedAnalytics() (+6 more)
 
 ### Community 1 - "Community 1"
 Cohesion: 0.01
-Nodes (16): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold(), handleKeyDown(), handleRedeemPromoCode(), getPromoAlertCopy() (+8 more)
+Nodes (13): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold(), handleKeyDown(), handleRedeemPromoCode(), getPromoAlertCopy() (+5 more)
 
 ### Community 2 - "Community 2"
-Cohesion: 0.02
-Nodes (54): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory(), getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore(), expectIndex() (+46 more)
+Cohesion: 0.01
+Nodes (71): onSubmit(), reportAuthFailure(), resendVerificationCode(), addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), listBagItems() (+63 more)
 
 ### Community 3 - "Community 3"
 Cohesion: 0.02
-Nodes (14): AnalyticsTopUsers(), processAnalyticsToUsers(), buildUsername(), normalizeNameSegment(), onSubmit(), saveStoreChanges(), capitalizeWords(), countGroupedAnalytics() (+6 more)
-
-### Community 4 - "Community 4"
-Cohesion: 0.02
 Nodes (17): handleNewSession(), resetAutoSessionInitialized(), Logger, handleNewSession(), resetAutoSessionInitialized(), usePOSActiveSession(), usePOSSessionComplete(), usePOSSessionCreate() (+9 more)
 
-### Community 5 - "Community 5"
-Cohesion: 0.03
-Nodes (12): createReview(), deleteReview(), getBaseUrl(), getReviewByOrderItem(), getReviewsByProductId(), getReviewsByProductSkuId(), getUserReviews(), getUserReviewsForProduct() (+4 more)
-
-### Community 6 - "Community 6"
+### Community 4 - "Community 4"
 Cohesion: 0.03
 Nodes (33): checkIfItemsHaveChanged(), CheckoutSessionError, createCheckoutSession(), createOnlineOrder(), defaultCheckoutActionMessage(), findBestValuePromoCode(), getActiveCheckoutSession(), getBaseUrl() (+25 more)
 
-### Community 7 - "Community 7"
+### Community 5 - "Community 5"
 Cohesion: 0.04
 Nodes (67): addGroupedError(), collectLiveSurfaceEntries(), fileExists(), formatGroupedErrors(), inferGroupFromError(), loadAuditTarget(), matchesPathPrefix(), normalizeRepoPath() (+59 more)
 
+### Community 6 - "Community 6"
+Cohesion: 0.03
+Nodes (9): onSubmit(), saveStoreChanges(), calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock() (+1 more)
+
+### Community 7 - "Community 7"
+Cohesion: 0.03
+Nodes (5): modifyProduct(), onSubmit(), saveProduct(), onSubmit(), saveStoreChanges()
+
 ### Community 8 - "Community 8"
-Cohesion: 0.04
-Nodes (12): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource(), buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus() (+4 more)
+Cohesion: 0.03
+Nodes (2): isSkuReserved(), shouldDisable()
 
 ### Community 9 - "Community 9"
 Cohesion: 0.03
-Nodes (4): cancelOrder(), getErrorMessage(), placeOrder(), ValkeyClient
+Nodes (9): cancelOrder(), getErrorMessage(), placeOrder(), ValkeyClient, handleSave(), hasReceivingAccountDetails(), normalizePrimaryAccounts(), toPatchReceivingAccounts() (+1 more)
 
 ### Community 10 - "Community 10"
 Cohesion: 0.05
@@ -81,43 +81,43 @@ Nodes (21): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventor
 
 ### Community 11 - "Community 11"
 Cohesion: 0.04
-Nodes (7): handleSave(), hasReceivingAccountDetails(), normalizePrimaryAccounts(), toPatchReceivingAccounts(), trimToUndefined(), getRiskStyles(), RiskIndicators()
+Nodes (7): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile(), MockImage
 
 ### Community 12 - "Community 12"
 Cohesion: 0.05
-Nodes (7): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile(), MockImage
+Nodes (14): buildUsername(), normalizeNameSegment(), buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins(), getDeliveryAddress() (+6 more)
 
 ### Community 13 - "Community 13"
+Cohesion: 0.05
+Nodes (7): getNonEmptyString(), isFailureStatus(), normalizeEvent(), getRiskStyles(), RiskIndicators(), getNonEmptyString(), normalizeStorefrontObservabilityEvent()
+
+### Community 14 - "Community 14"
 Cohesion: 0.08
 Nodes (45): compactContext(), createAuthEntryViewedEvent(), createAuthRequestStartedEvent(), createAuthVerificationSucceededEvent(), createAuthVerificationViewedEvent(), createBagAddSucceededEvent(), createBagMoveToSavedEvent(), createBagRemoveSucceededEvent() (+37 more)
 
-### Community 14 - "Community 14"
-Cohesion: 0.07
-Nodes (27): onSubmit(), reportAuthFailure(), resendVerificationCode(), addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), listBagItems() (+19 more)
-
 ### Community 15 - "Community 15"
-Cohesion: 0.05
-Nodes (4): isSkuReserved(), shouldDisable(), useBulkOperations(), validateOperationValue()
+Cohesion: 0.07
+Nodes (8): getAllColors(), getBaseUrl(), buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
 
 ### Community 16 - "Community 16"
-Cohesion: 0.14
+Cohesion: 0.12
 Nodes (26): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction(), asBoolean(), asMtnMomoSetupStatus() (+18 more)
 
 ### Community 17 - "Community 17"
+Cohesion: 0.1
+Nodes (12): createReview(), deleteReview(), getBaseUrl(), getReviewByOrderItem(), getReviewsByProductId(), getReviewsByProductSkuId(), getUserReviews(), getUserReviewsForProduct() (+4 more)
+
+### Community 18 - "Community 18"
 Cohesion: 0.16
 Nodes (25): asArray(), asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), assignOrDelete(), asString() (+17 more)
 
-### Community 18 - "Community 18"
-Cohesion: 0.17
-Nodes (8): getAllColors(), getBaseUrl(), buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
-
 ### Community 19 - "Community 19"
 Cohesion: 0.14
-Nodes (0):
+Nodes (18): appendListSection(), buildMarkdownBundle(), collectCoverage(), evaluateGraphifyFreshness(), fileExists(), formatValidationCommand(), getChangedFilesFromGit(), loadSelfReviewTarget() (+10 more)
 
 ### Community 20 - "Community 20"
-Cohesion: 0.19
-Nodes (5): getNonEmptyString(), isFailureStatus(), normalizeEvent(), getNonEmptyString(), normalizeStorefrontObservabilityEvent()
+Cohesion: 0.27
+Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
 
 ### Community 21 - "Community 21"
 Cohesion: 0.18
@@ -132,24 +132,24 @@ Cohesion: 0.2
 Nodes (0):
 
 ### Community 24 - "Community 24"
-Cohesion: 0.39
-Nodes (7): calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock(), validateRefund()
-
-### Community 25 - "Community 25"
 Cohesion: 0.32
 Nodes (3): fileExists(), resolveGraphifyPython(), runGraphifyRebuild()
 
+### Community 25 - "Community 25"
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
 ### Community 26 - "Community 26"
+Cohesion: 0.7
+Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
+
+### Community 27 - "Community 27"
 Cohesion: 0.7
 Nodes (4): runTests(), testBasicOperations(), testClusterInfo(), testConnection()
 
-### Community 27 - "Community 27"
-Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
-
 ### Community 28 - "Community 28"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 29 - "Community 29"
 Cohesion: 1.0
@@ -319,92 +319,96 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 71 - "Community 71"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
-- **Thin community `Community 28`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 29`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 29`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 30`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 30`** (2 nodes): `sessionQueryIndexes.test.ts`, `readProjectFile()`
+- **Thin community `Community 31`** (2 nodes): `sessionQueryIndexes.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 31`** (2 nodes): `foundation.test.ts`, `readProjectFile()`
+- **Thin community `Community 32`** (2 nodes): `foundation.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 32`** (2 nodes): `helperOrchestration.test.ts`, `readProjectFile()`
+- **Thin community `Community 33`** (2 nodes): `helperOrchestration.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 33`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 34`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 34`** (2 nodes): `NoResultsMessage.tsx`, `NoResultsMessage()`
+- **Thin community `Community 35`** (2 nodes): `NoResultsMessage.tsx`, `NoResultsMessage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 35`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 36`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 36`** (2 nodes): `SingleLineError.tsx`, `SingleLineError()`
+- **Thin community `Community 37`** (2 nodes): `SingleLineError.tsx`, `SingleLineError()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 37`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 38`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 38`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 39`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 39`** (2 nodes): `NotificationPill.tsx`, `NotificationPill()`
+- **Thin community `Community 40`** (2 nodes): `NotificationPill.tsx`, `NotificationPill()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 40`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 41`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 41`** (2 nodes): `FormSubmissionProvider.tsx`, `useFormSubmission()`
+- **Thin community `Community 42`** (2 nodes): `FormSubmissionProvider.tsx`, `useFormSubmission()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 42`** (2 nodes): `architecture-boundaries.test.ts`, `createSnippetLinter()`
+- **Thin community `Community 43`** (2 nodes): `architecture-boundaries.test.ts`, `createSnippetLinter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 43`** (2 nodes): `architecture-boundary-check.ts`, `run()`
+- **Thin community `Community 44`** (2 nodes): `architecture-boundary-check.ts`, `run()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 44`** (1 nodes): `auth.config.js`
+- **Thin community `Community 45`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 45`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 46`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 46`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 47`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 47`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 48`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 48`** (1 nodes): `customer.ts`
+- **Thin community `Community 49`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 49`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 50`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 50`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 51`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 51`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 52`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 52`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 53`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 53`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 54`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 54`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 55`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 55`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 56`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 56`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 57`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 57`** (1 nodes): `offer.ts`
+- **Thin community `Community 58`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 58`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 59`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 59`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 60`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 60`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 61`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 61`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 62`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 62`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 63`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 63`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 64`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 64`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 65`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 65`** (1 nodes): `aws.ts`
+- **Thin community `Community 66`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 66`** (1 nodes): `setup.ts`
+- **Thin community `Community 67`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 67`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 68`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 68`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 69`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 69`** (1 nodes): `global.d.ts`
+- **Thin community `Community 70`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 70`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 71`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -57,7 +57,7 @@
       "source_file": "packages/athena-webapp/convex/auth.config.js",
       "source_location": "L1",
       "id": "auth_config",
-      "community": 44
+      "community": 45
     },
     {
       "label": "Auth.tsx",
@@ -185,7 +185,7 @@
       "source_file": "packages/storefront-webapp/src/lib/validations/email.ts",
       "source_location": "L1",
       "id": "email",
-      "community": 1
+      "community": 6
     },
     {
       "label": "ghana.ts",
@@ -289,7 +289,7 @@
       "source_file": "packages/athena-webapp/convex/emails/PosReceiptEmail.tsx",
       "source_location": "L1",
       "id": "posreceiptemail",
-      "community": 1
+      "community": 3
     },
     {
       "label": "VerificationCode.tsx",
@@ -321,7 +321,7 @@
       "source_file": "packages/storefront-webapp/src/lib/mutations.ts/analytics.ts",
       "source_location": "L1",
       "id": "analytics",
-      "community": 5
+      "community": 15
     },
     {
       "label": "bannerMessage.ts",
@@ -401,7 +401,7 @@
       "source_file": "packages/storefront-webapp/src/lib/schemas/bag.ts",
       "source_location": "L1",
       "id": "bag",
-      "community": 14
+      "community": 2
     },
     {
       "label": "checkout.ts",
@@ -481,7 +481,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/reviews.ts",
       "source_location": "L1",
       "id": "reviews",
-      "community": 5
+      "community": 17
     },
     {
       "label": "rewards.ts",
@@ -489,7 +489,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/rewards.ts",
       "source_location": "L1",
       "id": "rewards",
-      "community": 14
+      "community": 2
     },
     {
       "label": "SavedBag.tsx",
@@ -497,7 +497,7 @@
       "source_file": "packages/storefront-webapp/src/components/saved-items/SavedBag.tsx",
       "source_location": "L1",
       "id": "savedbag",
-      "community": 14
+      "community": 2
     },
     {
       "label": "security.test.ts",
@@ -593,7 +593,7 @@
       "source_file": "packages/athena-webapp/convex/http/routerComposition.test.ts",
       "source_location": "L1",
       "id": "routercomposition_test",
-      "community": 28
+      "community": 29
     },
     {
       "label": "readProjectFile()",
@@ -601,7 +601,7 @@
       "source_file": "packages/athena-webapp/convex/http/routerComposition.test.ts",
       "source_location": "L6",
       "id": "routercomposition_test_readprojectfile",
-      "community": 28
+      "community": 29
     },
     {
       "label": "utils.ts",
@@ -609,7 +609,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L1",
       "id": "utils",
-      "community": 3
+      "community": 0
     },
     {
       "label": "getStoreDataFromRequest()",
@@ -617,7 +617,7 @@
       "source_file": "packages/athena-webapp/convex/http/utils.ts",
       "source_location": "L5",
       "id": "utils_getstoredatafromrequest",
-      "community": 3
+      "community": 0
     },
     {
       "label": "getStorefrontUserFromRequest()",
@@ -625,7 +625,7 @@
       "source_file": "packages/athena-webapp/convex/http/utils.ts",
       "source_location": "L12",
       "id": "utils_getstorefrontuserfromrequest",
-      "community": 3
+      "community": 0
     },
     {
       "label": "http.ts",
@@ -673,7 +673,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/complimentaryProduct.ts",
       "source_location": "L1",
       "id": "complimentaryproduct",
-      "community": 2
+      "community": 6
     },
     {
       "label": "expenseSessionItems.ts",
@@ -1161,7 +1161,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posQueryCleanup.test.ts",
       "source_location": "L1",
       "id": "posquerycleanup_test",
-      "community": 29
+      "community": 30
     },
     {
       "label": "readProjectFile()",
@@ -1169,7 +1169,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posQueryCleanup.test.ts",
       "source_location": "L8",
       "id": "posquerycleanup_test_readprojectfile",
-      "community": 29
+      "community": 30
     },
     {
       "label": "posSessionItems.ts",
@@ -1289,7 +1289,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/sessionQueryIndexes.test.ts",
       "source_location": "L1",
       "id": "sessionqueryindexes_test",
-      "community": 30
+      "community": 31
     },
     {
       "label": "readProjectFile()",
@@ -1297,7 +1297,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/sessionQueryIndexes.test.ts",
       "source_location": "L6",
       "id": "sessionqueryindexes_test_readprojectfile",
-      "community": 30
+      "community": 31
     },
     {
       "label": "stockValidation.ts",
@@ -1313,7 +1313,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.test.ts",
       "source_location": "L1",
       "id": "storeconfigv2_test",
-      "community": 17
+      "community": 18
     },
     {
       "label": "storeConfigV2.ts",
@@ -1321,7 +1321,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L1",
       "id": "storeconfigv2",
-      "community": 17
+      "community": 18
     },
     {
       "label": "isPlainObject()",
@@ -1329,7 +1329,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L53",
       "id": "storeconfigv2_isplainobject",
-      "community": 17
+      "community": 18
     },
     {
       "label": "asRecord()",
@@ -1337,7 +1337,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L57",
       "id": "storeconfigv2_asrecord",
-      "community": 17
+      "community": 18
     },
     {
       "label": "asNumber()",
@@ -1345,7 +1345,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L61",
       "id": "storeconfigv2_asnumber",
-      "community": 17
+      "community": 18
     },
     {
       "label": "asString()",
@@ -1353,7 +1353,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L65",
       "id": "storeconfigv2_asstring",
-      "community": 17
+      "community": 18
     },
     {
       "label": "asBoolean()",
@@ -1361,7 +1361,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L69",
       "id": "storeconfigv2_asboolean",
-      "community": 17
+      "community": 18
     },
     {
       "label": "asArray()",
@@ -1369,7 +1369,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L77",
       "id": "storeconfigv2_asarray",
-      "community": 17
+      "community": 18
     },
     {
       "label": "asOptionalArray()",
@@ -1377,7 +1377,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L90",
       "id": "storeconfigv2_asoptionalarray",
-      "community": 17
+      "community": 18
     },
     {
       "label": "firstDefined()",
@@ -1385,7 +1385,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L101",
       "id": "storeconfigv2_firstdefined",
-      "community": 17
+      "community": 18
     },
     {
       "label": "mapPromotion()",
@@ -1393,7 +1393,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L111",
       "id": "storeconfigv2_mappromotion",
-      "community": 17
+      "community": 18
     },
     {
       "label": "mapStreamReel()",
@@ -1401,7 +1401,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L115",
       "id": "storeconfigv2_mapstreamreel",
-      "community": 17
+      "community": 18
     },
     {
       "label": "normalizeWaiveDeliveryFees()",
@@ -1409,7 +1409,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L135",
       "id": "storeconfigv2_normalizewaivedeliveryfees",
-      "community": 17
+      "community": 18
     },
     {
       "label": "cleanUndefined()",
@@ -1417,7 +1417,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L153",
       "id": "storeconfigv2_cleanundefined",
-      "community": 17
+      "community": 18
     },
     {
       "label": "asMtnMomoSetupStatus()",
@@ -1425,7 +1425,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L165",
       "id": "storeconfigv2_asmtnmomosetupstatus",
-      "community": 17
+      "community": 18
     },
     {
       "label": "hasMtnMomoReceivingAccountDetails()",
@@ -1433,7 +1433,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L178",
       "id": "storeconfigv2_hasmtnmomoreceivingaccountdetails",
-      "community": 17
+      "community": 18
     },
     {
       "label": "mapMtnMomoReceivingAccount()",
@@ -1441,7 +1441,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L191",
       "id": "storeconfigv2_mapmtnmomoreceivingaccount",
-      "community": 17
+      "community": 18
     },
     {
       "label": "normalizeMtnMomoReceivingAccounts()",
@@ -1449,7 +1449,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L214",
       "id": "storeconfigv2_normalizemtnmomoreceivingaccounts",
-      "community": 17
+      "community": 18
     },
     {
       "label": "toV2Config()",
@@ -1457,7 +1457,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L231",
       "id": "storeconfigv2_tov2config",
-      "community": 17
+      "community": 18
     },
     {
       "label": "normalizeStoreConfig()",
@@ -1465,7 +1465,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L474",
       "id": "storeconfigv2_normalizestoreconfig",
-      "community": 17
+      "community": 18
     },
     {
       "label": "deepMerge()",
@@ -1473,7 +1473,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L478",
       "id": "storeconfigv2_deepmerge",
-      "community": 17
+      "community": 18
     },
     {
       "label": "patchV2Config()",
@@ -1481,7 +1481,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L498",
       "id": "storeconfigv2_patchv2config",
-      "community": 17
+      "community": 18
     },
     {
       "label": "assignOrDelete()",
@@ -1489,7 +1489,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L507",
       "id": "storeconfigv2_assignordelete",
-      "community": 17
+      "community": 18
     },
     {
       "label": "mirrorLegacyKeys()",
@@ -1497,7 +1497,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L520",
       "id": "storeconfigv2_mirrorlegacykeys",
-      "community": 17
+      "community": 18
     },
     {
       "label": "getUnknownStoreConfigRootKeys()",
@@ -1505,7 +1505,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L591",
       "id": "storeconfigv2_getunknownstoreconfigrootkeys",
-      "community": 17
+      "community": 18
     },
     {
       "label": "isStoreCheckoutDisabled()",
@@ -1513,7 +1513,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L597",
       "id": "storeconfigv2_isstorecheckoutdisabled",
-      "community": 17
+      "community": 18
     },
     {
       "label": "removeLegacyRootKeysFromConfig()",
@@ -1521,7 +1521,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L606",
       "id": "storeconfigv2_removelegacyrootkeysfromconfig",
-      "community": 17
+      "community": 18
     },
     {
       "label": "isLegacyRootKey()",
@@ -1529,7 +1529,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L623",
       "id": "storeconfigv2_islegacyrootkey",
-      "community": 17
+      "community": 18
     },
     {
       "label": "isV2RootKey()",
@@ -1537,7 +1537,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L627",
       "id": "storeconfigv2_isv2rootkey",
-      "community": 17
+      "community": 18
     },
     {
       "label": "toV2OnlyConfig()",
@@ -1553,7 +1553,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L17",
       "id": "utils_getdiscountvalue",
-      "community": 3
+      "community": 0
     },
     {
       "label": "getProductDiscountValue()",
@@ -1561,7 +1561,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
       "source_location": "L75",
       "id": "utils_getproductdiscountvalue",
-      "community": 3
+      "community": 0
     },
     {
       "label": "getOrderAmount()",
@@ -1569,7 +1569,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L51",
       "id": "utils_getorderamount",
-      "community": 3
+      "community": 0
     },
     {
       "label": "formatDeliveryAddress()",
@@ -1577,7 +1577,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L74",
       "id": "utils_formatdeliveryaddress",
-      "community": 3
+      "community": 0
     },
     {
       "label": "currency.test.ts",
@@ -1585,7 +1585,7 @@
       "source_file": "packages/athena-webapp/convex/lib/currency.test.ts",
       "source_location": "L1",
       "id": "currency_test",
-      "community": 1
+      "community": 12
     },
     {
       "label": "currency.ts",
@@ -1593,7 +1593,7 @@
       "source_file": "packages/storefront-webapp/src/lib/currency.ts",
       "source_location": "L1",
       "id": "currency",
-      "community": 1
+      "community": 12
     },
     {
       "label": "toPesewas()",
@@ -1601,7 +1601,7 @@
       "source_file": "packages/storefront-webapp/src/lib/currency.ts",
       "source_location": "L1",
       "id": "currency_topesewas",
-      "community": 1
+      "community": 12
     },
     {
       "label": "toDisplayAmount()",
@@ -1609,7 +1609,7 @@
       "source_file": "packages/storefront-webapp/src/lib/currency.ts",
       "source_location": "L5",
       "id": "currency_todisplayamount",
-      "community": 1
+      "community": 12
     },
     {
       "label": "callLlmProvider.ts",
@@ -1681,7 +1681,7 @@
       "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
       "source_location": "L1",
       "id": "analyticsutils",
-      "community": 2
+      "community": 6
     },
     {
       "label": "calculateDeviceDistribution()",
@@ -1689,7 +1689,7 @@
       "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
       "source_location": "L11",
       "id": "analyticsutils_calculatedevicedistribution",
-      "community": 2
+      "community": 6
     },
     {
       "label": "calculateActivityTrend()",
@@ -1697,7 +1697,7 @@
       "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
       "source_location": "L43",
       "id": "analyticsutils_calculateactivitytrend",
-      "community": 2
+      "community": 6
     },
     {
       "label": "sendVerificationCode()",
@@ -1753,7 +1753,7 @@
       "source_file": "packages/athena-webapp/convex/migrations/migrateAmountsToPesewas.ts",
       "source_location": "L1",
       "id": "migrateamountstopesewas",
-      "community": 1
+      "community": 12
     },
     {
       "label": "client.test.ts",
@@ -1761,7 +1761,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.test.ts",
       "source_location": "L1",
       "id": "client_test",
-      "community": 8
+      "community": 20
     },
     {
       "label": "client.tsx",
@@ -1769,7 +1769,7 @@
       "source_file": "packages/storefront-webapp/src/client.tsx",
       "source_location": "L1",
       "id": "client",
-      "community": 8
+      "community": 20
     },
     {
       "label": "encodeBasicAuth()",
@@ -1777,7 +1777,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L9",
       "id": "client_encodebasicauth",
-      "community": 8
+      "community": 20
     },
     {
       "label": "toError()",
@@ -1785,7 +1785,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L13",
       "id": "client_toerror",
-      "community": 8
+      "community": 20
     },
     {
       "label": "buildHeaders()",
@@ -1793,7 +1793,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L20",
       "id": "client_buildheaders",
-      "community": 8
+      "community": 20
     },
     {
       "label": "createCollectionsAccessToken()",
@@ -1801,7 +1801,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L30",
       "id": "client_createcollectionsaccesstoken",
-      "community": 8
+      "community": 20
     },
     {
       "label": "requestToPay()",
@@ -1809,7 +1809,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L65",
       "id": "client_requesttopay",
-      "community": 8
+      "community": 20
     },
     {
       "label": "getRequestToPayStatus()",
@@ -1817,7 +1817,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L115",
       "id": "client_getrequesttopaystatus",
-      "community": 8
+      "community": 20
     },
     {
       "label": "collections.ts",
@@ -1929,7 +1929,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/foundation.test.ts",
       "source_location": "L1",
       "id": "foundation_test",
-      "community": 31
+      "community": 32
     },
     {
       "label": "readProjectFile()",
@@ -1937,7 +1937,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/foundation.test.ts",
       "source_location": "L6",
       "id": "foundation_test_readprojectfile",
-      "community": 31
+      "community": 32
     },
     {
       "label": "normalize.test.ts",
@@ -1985,7 +1985,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/types.ts",
       "source_location": "L1",
       "id": "types",
-      "community": 1
+      "community": 6
     },
     {
       "label": "ResendOTP.ts",
@@ -2041,7 +2041,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/appVerificationCode.ts",
       "source_location": "L1",
       "id": "appverificationcode",
-      "community": 45
+      "community": 46
     },
     {
       "label": "category.ts",
@@ -2057,7 +2057,7 @@
       "source_file": "packages/storefront-webapp/src/api/color.ts",
       "source_location": "L1",
       "id": "color",
-      "community": 18
+      "community": 15
     },
     {
       "label": "organization.ts",
@@ -2073,7 +2073,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/organizationMember.ts",
       "source_location": "L1",
       "id": "organizationmember",
-      "community": 46
+      "community": 47
     },
     {
       "label": "product.ts",
@@ -2081,7 +2081,7 @@
       "source_file": "packages/storefront-webapp/src/lib/schemas/product.ts",
       "source_location": "L1",
       "id": "product",
-      "community": 18
+      "community": 15
     },
     {
       "label": "redeemedPromoCode.ts",
@@ -2089,7 +2089,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/redeemedPromoCode.ts",
       "source_location": "L1",
       "id": "redeemedpromocode",
-      "community": 47
+      "community": 48
     },
     {
       "label": "store.ts",
@@ -2121,7 +2121,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customer.ts",
       "source_location": "L1",
       "id": "customer",
-      "community": 48
+      "community": 49
     },
     {
       "label": "expenseSession.ts",
@@ -2129,7 +2129,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/pos/expenseSession.ts",
       "source_location": "L1",
       "id": "expensesession",
-      "community": 49
+      "community": 50
     },
     {
       "label": "expenseSessionItem.ts",
@@ -2137,7 +2137,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/pos/expenseSessionItem.ts",
       "source_location": "L1",
       "id": "expensesessionitem",
-      "community": 50
+      "community": 51
     },
     {
       "label": "expenseTransaction.ts",
@@ -2145,7 +2145,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/pos/expenseTransaction.ts",
       "source_location": "L1",
       "id": "expensetransaction",
-      "community": 51
+      "community": 52
     },
     {
       "label": "expenseTransactionItem.ts",
@@ -2153,7 +2153,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/pos/expenseTransactionItem.ts",
       "source_location": "L1",
       "id": "expensetransactionitem",
-      "community": 52
+      "community": 53
     },
     {
       "label": "posSession.ts",
@@ -2169,7 +2169,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/pos/posSessionItem.ts",
       "source_location": "L1",
       "id": "possessionitem",
-      "community": 53
+      "community": 54
     },
     {
       "label": "posTransaction.ts",
@@ -2177,7 +2177,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/pos/posTransaction.ts",
       "source_location": "L1",
       "id": "postransaction",
-      "community": 54
+      "community": 55
     },
     {
       "label": "posTransactionItem.ts",
@@ -2185,7 +2185,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/pos/posTransactionItem.ts",
       "source_location": "L1",
       "id": "postransactionitem",
-      "community": 55
+      "community": 56
     },
     {
       "label": "bagItem.ts",
@@ -2193,7 +2193,7 @@
       "source_file": "packages/storefront-webapp/src/lib/schemas/bagItem.ts",
       "source_location": "L1",
       "id": "bagitem",
-      "community": 14
+      "community": 2
     },
     {
       "label": "checkoutSession.ts",
@@ -2201,7 +2201,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L1",
       "id": "checkoutsession",
-      "community": 6
+      "community": 4
     },
     {
       "label": "checkoutSessionItem.ts",
@@ -2209,7 +2209,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/checkoutSessionItem.ts",
       "source_location": "L1",
       "id": "checkoutsessionitem",
-      "community": 56
+      "community": 57
     },
     {
       "label": "offer.ts",
@@ -2217,7 +2217,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/offer.ts",
       "source_location": "L1",
       "id": "offer",
-      "community": 57
+      "community": 58
     },
     {
       "label": "onlineOrderItem.ts",
@@ -2249,7 +2249,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontSession.ts",
       "source_location": "L1",
       "id": "storefrontsession",
-      "community": 58
+      "community": 59
     },
     {
       "label": "storeFrontUser.ts",
@@ -2265,7 +2265,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontVerificationCode.ts",
       "source_location": "L1",
       "id": "storefrontverificationcode",
-      "community": 59
+      "community": 60
     },
     {
       "label": "supportTicket.ts",
@@ -2281,7 +2281,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L1",
       "id": "orderemailservice",
-      "community": 2
+      "community": 12
     },
     {
       "label": "shouldSendToAdmins()",
@@ -2289,7 +2289,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L42",
       "id": "orderemailservice_shouldsendtoadmins",
-      "community": 2
+      "community": 12
     },
     {
       "label": "buildOrderStatusMessage()",
@@ -2297,7 +2297,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L49",
       "id": "orderemailservice_buildorderstatusmessage",
-      "community": 2
+      "community": 12
     },
     {
       "label": "buildPickupDetails()",
@@ -2305,7 +2305,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L77",
       "id": "orderemailservice_buildpickupdetails",
-      "community": 2
+      "community": 12
     },
     {
       "label": "sendPODOrderEmails()",
@@ -2313,7 +2313,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L96",
       "id": "orderemailservice_sendpodorderemails",
-      "community": 2
+      "community": 12
     },
     {
       "label": "sendPaymentVerificationEmails()",
@@ -2321,7 +2321,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L217",
       "id": "orderemailservice_sendpaymentverificationemails",
-      "community": 2
+      "community": 12
     },
     {
       "label": "paystackService.ts",
@@ -2369,7 +2369,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L18",
       "id": "analytics_extractpromocodeid",
-      "community": 5
+      "community": 15
     },
     {
       "label": "getAnalyticsByStoreQuery()",
@@ -2377,7 +2377,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L28",
       "id": "analytics_getanalyticsbystorequery",
-      "community": 5
+      "community": 15
     },
     {
       "label": "getCompletedOrdersQuery()",
@@ -2385,7 +2385,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L59",
       "id": "analytics_getcompletedordersquery",
-      "community": 5
+      "community": 15
     },
     {
       "label": "getAnalyticsByStoreAndActionQuery()",
@@ -2393,7 +2393,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L97",
       "id": "analytics_getanalyticsbystoreandactionquery",
-      "community": 5
+      "community": 15
     },
     {
       "label": "getSkuMapForProducts()",
@@ -2401,7 +2401,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L132",
       "id": "analytics_getskumapforproducts",
-      "community": 5
+      "community": 15
     },
     {
       "label": "getStoreFrontActorById()",
@@ -2417,7 +2417,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L40",
       "id": "checkoutsession_listsessionitems",
-      "community": 6
+      "community": 4
     },
     {
       "label": "checkIfItemsHaveChanged()",
@@ -2425,7 +2425,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L50",
       "id": "checkoutsession_checkifitemshavechanged",
-      "community": 6
+      "community": 4
     },
     {
       "label": "createPatchObject()",
@@ -2433,7 +2433,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L651",
       "id": "checkoutsession_createpatchobject",
-      "community": 6
+      "community": 4
     },
     {
       "label": "handlePlaceOrder()",
@@ -2441,7 +2441,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L698",
       "id": "checkoutsession_handleplaceorder",
-      "community": 6
+      "community": 4
     },
     {
       "label": "handleOrderCreation()",
@@ -2449,7 +2449,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L734",
       "id": "checkoutsession_handleordercreation",
-      "community": 6
+      "community": 4
     },
     {
       "label": "createOnlineOrder()",
@@ -2457,7 +2457,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L765",
       "id": "checkoutsession_createonlineorder",
-      "community": 6
+      "community": 4
     },
     {
       "label": "retrieveActiveCheckoutSession()",
@@ -2465,7 +2465,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L951",
       "id": "checkoutsession_retrieveactivecheckoutsession",
-      "community": 6
+      "community": 4
     },
     {
       "label": "fetchProductSkus()",
@@ -2473,7 +2473,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L979",
       "id": "checkoutsession_fetchproductskus",
-      "community": 6
+      "community": 4
     },
     {
       "label": "checkAdjustedAvailability()",
@@ -2481,7 +2481,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L990",
       "id": "checkoutsession_checkadjustedavailability",
-      "community": 6
+      "community": 4
     },
     {
       "label": "updateExistingSession()",
@@ -2489,7 +2489,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1020",
       "id": "checkoutsession_updateexistingsession",
-      "community": 6
+      "community": 4
     },
     {
       "label": "createSessionItems()",
@@ -2497,7 +2497,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1102",
       "id": "checkoutsession_createsessionitems",
-      "community": 6
+      "community": 4
     },
     {
       "label": "updateProductAvailability()",
@@ -2505,7 +2505,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1123",
       "id": "checkoutsession_updateproductavailability",
-      "community": 6
+      "community": 4
     },
     {
       "label": "updateAvailability()",
@@ -2513,7 +2513,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1140",
       "id": "checkoutsession_updateavailability",
-      "community": 6
+      "community": 4
     },
     {
       "label": "handleExistingSession()",
@@ -2521,7 +2521,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1161",
       "id": "checkoutsession_handleexistingsession",
-      "community": 6
+      "community": 4
     },
     {
       "label": "validateExistingDiscount()",
@@ -2529,7 +2529,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1321",
       "id": "checkoutsession_validateexistingdiscount",
-      "community": 6
+      "community": 4
     },
     {
       "label": "calculatePromoCodeValue()",
@@ -2537,7 +2537,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1447",
       "id": "checkoutsession_calculatepromocodevalue",
-      "community": 6
+      "community": 4
     },
     {
       "label": "findBestValuePromoCode()",
@@ -2545,7 +2545,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1495",
       "id": "checkoutsession_findbestvaluepromocode",
-      "community": 6
+      "community": 4
     },
     {
       "label": "commerceQueryIndexes.test.ts",
@@ -2585,7 +2585,7 @@
       "source_file": "packages/athena-webapp/src/components/users/CustomerBehaviorTimeline.tsx",
       "source_location": "L1",
       "id": "customerbehaviortimeline",
-      "community": 3
+      "community": 13
     },
     {
       "label": "getTimeFilterForRange()",
@@ -2593,7 +2593,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
       "source_location": "L11",
       "id": "customerbehaviortimeline_gettimefilterforrange",
-      "community": 3
+      "community": 13
     },
     {
       "label": "getCustomerAnalyticsQuery()",
@@ -2601,7 +2601,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
       "source_location": "L26",
       "id": "customerbehaviortimeline_getcustomeranalyticsquery",
-      "community": 3
+      "community": 13
     },
     {
       "label": "getTimelineUserData()",
@@ -2609,7 +2609,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
       "source_location": "L42",
       "id": "customerbehaviortimeline_gettimelineuserdata",
-      "community": 3
+      "community": 13
     },
     {
       "label": "getProductInfoMaps()",
@@ -2617,7 +2617,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
       "source_location": "L66",
       "id": "customerbehaviortimeline_getproductinfomaps",
-      "community": 3
+      "community": 13
     },
     {
       "label": "customerObservabilityTimeline.test.ts",
@@ -2625,7 +2625,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimeline.test.ts",
       "source_location": "L1",
       "id": "customerobservabilitytimeline_test",
-      "community": 20
+      "community": 13
     },
     {
       "label": "createAnalyticsEvent()",
@@ -2633,7 +2633,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimeline.test.ts",
       "source_location": "L17",
       "id": "customerobservabilitytimeline_test_createanalyticsevent",
-      "community": 20
+      "community": 13
     },
     {
       "label": "customerObservabilityTimelineData.ts",
@@ -2641,7 +2641,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L1",
       "id": "customerobservabilitytimelinedata",
-      "community": 20
+      "community": 13
     },
     {
       "label": "getNonEmptyString()",
@@ -2649,7 +2649,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L64",
       "id": "customerobservabilitytimelinedata_getnonemptystring",
-      "community": 20
+      "community": 13
     },
     {
       "label": "isFailureStatus()",
@@ -2657,7 +2657,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L68",
       "id": "customerobservabilitytimelinedata_isfailurestatus",
-      "community": 20
+      "community": 13
     },
     {
       "label": "normalizeEvent()",
@@ -2665,7 +2665,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L72",
       "id": "customerobservabilitytimelinedata_normalizeevent",
-      "community": 20
+      "community": 13
     },
     {
       "label": "buildCustomerObservabilityTimeline()",
@@ -2673,7 +2673,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L118",
       "id": "customerobservabilitytimelinedata_buildcustomerobservabilitytimeline",
-      "community": 20
+      "community": 13
     },
     {
       "label": "helperOrchestration.test.ts",
@@ -2681,7 +2681,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helperOrchestration.test.ts",
       "source_location": "L1",
       "id": "helperorchestration_test",
-      "community": 32
+      "community": 33
     },
     {
       "label": "readProjectFile()",
@@ -2689,7 +2689,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helperOrchestration.test.ts",
       "source_location": "L6",
       "id": "helperorchestration_test_readprojectfile",
-      "community": 32
+      "community": 33
     },
     {
       "label": "listBagItems()",
@@ -2697,7 +2697,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/bag.ts",
       "source_location": "L7",
       "id": "bag_listbagitems",
-      "community": 14
+      "community": 2
     },
     {
       "label": "loadBagWithItems()",
@@ -2705,7 +2705,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/bag.ts",
       "source_location": "L14",
       "id": "bag_loadbagwithitems",
-      "community": 14
+      "community": 2
     },
     {
       "label": "generateOrderNumber()",
@@ -2753,7 +2753,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L1",
       "id": "orderupdateemails",
-      "community": 2
+      "community": 12
     },
     {
       "label": "getPickupLocation()",
@@ -2761,7 +2761,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L52",
       "id": "orderupdateemails_getpickuplocation",
-      "community": 2
+      "community": 12
     },
     {
       "label": "getDeliveryAddress()",
@@ -2769,7 +2769,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L55",
       "id": "orderupdateemails_getdeliveryaddress",
-      "community": 2
+      "community": 12
     },
     {
       "label": "getLocationDetails()",
@@ -2777,7 +2777,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L58",
       "id": "orderupdateemails_getlocationdetails",
-      "community": 2
+      "community": 12
     },
     {
       "label": "formatOrderItems()",
@@ -2785,7 +2785,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L64",
       "id": "orderupdateemails_formatorderitems",
-      "community": 2
+      "community": 12
     },
     {
       "label": "handleOrderStatusUpdate()",
@@ -2793,7 +2793,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L118",
       "id": "orderupdateemails_handleorderstatusupdate",
-      "community": 2
+      "community": 12
     },
     {
       "label": "processOrderUpdateEmail()",
@@ -2801,7 +2801,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L293",
       "id": "orderupdateemails_processorderupdateemail",
-      "community": 2
+      "community": 12
     },
     {
       "label": "paymentHelpers.ts",
@@ -2913,7 +2913,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderUtilFns.ts",
       "source_location": "L1",
       "id": "onlineorderutilfns",
-      "community": 2
+      "community": 12
     },
     {
       "label": "paystackActions.ts",
@@ -2929,7 +2929,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/reviews.ts",
       "source_location": "L17",
       "id": "reviews_getstorefrontactorbyid",
-      "community": 5
+      "community": 17
     },
     {
       "label": "listSavedBagItems()",
@@ -2937,7 +2937,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/savedBag.ts",
       "source_location": "L14",
       "id": "savedbag_listsavedbagitems",
-      "community": 14
+      "community": 2
     },
     {
       "label": "storefrontObservabilityReport.test.ts",
@@ -2945,7 +2945,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.test.ts",
       "source_location": "L1",
       "id": "storefrontobservabilityreport_test",
-      "community": 20
+      "community": 13
     },
     {
       "label": "createAnalyticsEvent()",
@@ -2953,7 +2953,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.test.ts",
       "source_location": "L7",
       "id": "storefrontobservabilityreport_test_createanalyticsevent",
-      "community": 20
+      "community": 13
     },
     {
       "label": "storefrontObservabilityReport.ts",
@@ -2961,7 +2961,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
       "source_location": "L1",
       "id": "storefrontobservabilityreport",
-      "community": 20
+      "community": 13
     },
     {
       "label": "getNonEmptyString()",
@@ -2969,7 +2969,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
       "source_location": "L59",
       "id": "storefrontobservabilityreport_getnonemptystring",
-      "community": 20
+      "community": 13
     },
     {
       "label": "normalizeStorefrontObservabilityEvent()",
@@ -2977,7 +2977,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
       "source_location": "L63",
       "id": "storefrontobservabilityreport_normalizestorefrontobservabilityevent",
-      "community": 20
+      "community": 13
     },
     {
       "label": "buildStorefrontObservabilityReport()",
@@ -2985,7 +2985,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
       "source_location": "L95",
       "id": "storefrontobservabilityreport_buildstorefrontobservabilityreport",
-      "community": 20
+      "community": 13
     },
     {
       "label": "timeQueryRefactors.test.ts",
@@ -2993,7 +2993,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/timeQueryRefactors.test.ts",
       "source_location": "L1",
       "id": "timequeryrefactors_test",
-      "community": 33
+      "community": 34
     },
     {
       "label": "readSource()",
@@ -3001,7 +3001,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/timeQueryRefactors.test.ts",
       "source_location": "L5",
       "id": "timequeryrefactors_test_readsource",
-      "community": 33
+      "community": 34
     },
     {
       "label": "getStoreFrontActorById()",
@@ -3033,7 +3033,7 @@
       "source_file": "packages/athena-webapp/src/lib/utils.ts",
       "source_location": "L37",
       "id": "utils_toslug",
-      "community": 3
+      "community": 0
     },
     {
       "label": "getAddressString()",
@@ -3041,7 +3041,7 @@
       "source_file": "packages/athena-webapp/convex/utils.ts",
       "source_location": "L14",
       "id": "utils_getaddressstring",
-      "community": 3
+      "community": 0
     },
     {
       "label": "capitalizeWords()",
@@ -3049,7 +3049,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L23",
       "id": "utils_capitalizewords",
-      "community": 3
+      "community": 0
     },
     {
       "label": "currencyFormatter()",
@@ -3057,7 +3057,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L35",
       "id": "utils_currencyformatter",
-      "community": 3
+      "community": 0
     },
     {
       "label": "formatDate()",
@@ -3065,7 +3065,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L44",
       "id": "utils_formatdate",
-      "community": 3
+      "community": 0
     },
     {
       "label": "getProductName()",
@@ -3073,7 +3073,7 @@
       "source_file": "packages/athena-webapp/convex/utils.ts",
       "source_location": "L64",
       "id": "utils_getproductname",
-      "community": 3
+      "community": 0
     },
     {
       "label": "generateTransactionNumber()",
@@ -3081,7 +3081,7 @@
       "source_file": "packages/athena-webapp/convex/utils.ts",
       "source_location": "L77",
       "id": "utils_generatetransactionnumber",
-      "community": 3
+      "community": 0
     },
     {
       "label": "eslint.config.js",
@@ -3089,7 +3089,7 @@
       "source_file": "packages/storefront-webapp/eslint.config.js",
       "source_location": "L1",
       "id": "eslint_config",
-      "community": 60
+      "community": 61
     },
     {
       "label": "postcss.config.js",
@@ -3097,7 +3097,7 @@
       "source_file": "packages/athena-webapp/postcss.config.js",
       "source_location": "L1",
       "id": "postcss_config",
-      "community": 61
+      "community": 62
     },
     {
       "label": "GenericComboBox.tsx",
@@ -3105,7 +3105,7 @@
       "source_file": "packages/athena-webapp/src/components/GenericComboBox.tsx",
       "source_location": "L1",
       "id": "genericcombobox",
-      "community": 0
+      "community": 1
     },
     {
       "label": "Navbar.tsx",
@@ -3185,7 +3185,7 @@
       "source_file": "packages/athena-webapp/src/components/PermissionGate.tsx",
       "source_location": "L1",
       "id": "permissiongate",
-      "community": 0
+      "community": 6
     },
     {
       "label": "PermissionGate()",
@@ -3193,7 +3193,7 @@
       "source_file": "packages/athena-webapp/src/components/PermissionGate.tsx",
       "source_location": "L11",
       "id": "permissiongate_permissiongate",
-      "community": 0
+      "community": 6
     },
     {
       "label": "ProtectedRoute.tsx",
@@ -3201,7 +3201,7 @@
       "source_file": "packages/athena-webapp/src/components/ProtectedRoute.tsx",
       "source_location": "L1",
       "id": "protectedroute",
-      "community": 8
+      "community": 7
     },
     {
       "label": "ProtectedRoute()",
@@ -3209,7 +3209,7 @@
       "source_file": "packages/athena-webapp/src/components/ProtectedRoute.tsx",
       "source_location": "L11",
       "id": "protectedroute_protectedroute",
-      "community": 8
+      "community": 7
     },
     {
       "label": "SettingsView.tsx",
@@ -3233,7 +3233,7 @@
       "source_file": "packages/athena-webapp/src/components/StoreAccordion.tsx",
       "source_location": "L1",
       "id": "storeaccordion",
-      "community": 0
+      "community": 1
     },
     {
       "label": "StoreActions.tsx",
@@ -3241,7 +3241,7 @@
       "source_file": "packages/athena-webapp/src/components/StoreActions.tsx",
       "source_location": "L1",
       "id": "storeactions",
-      "community": 0
+      "community": 1
     },
     {
       "label": "StoreActions()",
@@ -3249,7 +3249,7 @@
       "source_file": "packages/athena-webapp/src/components/StoreActions.tsx",
       "source_location": "L12",
       "id": "storeactions_storeactions",
-      "community": 0
+      "community": 1
     },
     {
       "label": "StoreDropdown.tsx",
@@ -3257,7 +3257,7 @@
       "source_file": "packages/athena-webapp/src/components/StoreDropdown.tsx",
       "source_location": "L1",
       "id": "storedropdown",
-      "community": 0
+      "community": 1
     },
     {
       "label": "StoreDropdown()",
@@ -3265,7 +3265,7 @@
       "source_file": "packages/athena-webapp/src/components/StoreDropdown.tsx",
       "source_location": "L42",
       "id": "storedropdown_storedropdown",
-      "community": 0
+      "community": 1
     },
     {
       "label": "StoreView.tsx",
@@ -3289,7 +3289,7 @@
       "source_file": "packages/athena-webapp/src/components/StoresAccordion.tsx",
       "source_location": "L1",
       "id": "storesaccordion",
-      "community": 0
+      "community": 1
     },
     {
       "label": "StoresDropdown.tsx",
@@ -3313,7 +3313,7 @@
       "source_file": "packages/athena-webapp/src/components/ThemeToggle.tsx",
       "source_location": "L1",
       "id": "themetoggle",
-      "community": 62
+      "community": 63
     },
     {
       "label": "View.tsx",
@@ -3337,7 +3337,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
       "source_location": "L1",
       "id": "attributesmanager",
-      "community": 3
+      "community": 0
     },
     {
       "label": "Sidebar()",
@@ -3345,7 +3345,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
       "source_location": "L26",
       "id": "attributesmanager_sidebar",
-      "community": 3
+      "community": 0
     },
     {
       "label": "ColorManager()",
@@ -3353,7 +3353,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
       "source_location": "L45",
       "id": "attributesmanager_colormanager",
-      "community": 3
+      "community": 0
     },
     {
       "label": "AttributesManager()",
@@ -3361,7 +3361,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
       "source_location": "L228",
       "id": "attributesmanager_attributesmanager",
-      "community": 3
+      "community": 0
     },
     {
       "label": "AttributesTable.tsx",
@@ -3369,7 +3369,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
       "source_location": "L1",
       "id": "attributestable",
-      "community": 15
+      "community": 8
     },
     {
       "label": "handleChange()",
@@ -3377,7 +3377,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
       "source_location": "L32",
       "id": "attributestable_handlechange",
-      "community": 15
+      "community": 8
     },
     {
       "label": "getProductAttribute()",
@@ -3385,7 +3385,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
       "source_location": "L55",
       "id": "attributestable_getproductattribute",
-      "community": 15
+      "community": 8
     },
     {
       "label": "onSubmit()",
@@ -3393,7 +3393,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
       "source_location": "L210",
       "id": "attributestable_onsubmit",
-      "community": 15
+      "community": 8
     },
     {
       "label": "BarcodeQRViewer.tsx",
@@ -3401,7 +3401,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/BarcodeQRViewer.tsx",
       "source_location": "L1",
       "id": "barcodeqrviewer",
-      "community": 5
+      "community": 8
     },
     {
       "label": "handlePrint()",
@@ -3409,7 +3409,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/BarcodeQRViewer.tsx",
       "source_location": "L31",
       "id": "barcodeqrviewer_handleprint",
-      "community": 5
+      "community": 8
     },
     {
       "label": "CategorySubcategoryManager.tsx",
@@ -3417,7 +3417,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
       "source_location": "L1",
       "id": "categorysubcategorymanager",
-      "community": 3
+      "community": 0
     },
     {
       "label": "Sidebar()",
@@ -3425,7 +3425,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
       "source_location": "L26",
       "id": "categorysubcategorymanager_sidebar",
-      "community": 3
+      "community": 0
     },
     {
       "label": "CategoryManager()",
@@ -3433,7 +3433,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
       "source_location": "L51",
       "id": "categorysubcategorymanager_categorymanager",
-      "community": 3
+      "community": 0
     },
     {
       "label": "SubcategoryManager()",
@@ -3441,7 +3441,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
       "source_location": "L290",
       "id": "categorysubcategorymanager_subcategorymanager",
-      "community": 3
+      "community": 0
     },
     {
       "label": "DefaultAttributesToggleGroup.tsx",
@@ -3449,7 +3449,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/DefaultAttributesToggleGroup.tsx",
       "source_location": "L1",
       "id": "defaultattributestogglegroup",
-      "community": 3
+      "community": 0
     },
     {
       "label": "ProcessingFees.tsx",
@@ -3497,7 +3497,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
       "source_location": "L1",
       "id": "productavailability",
-      "community": 3
+      "community": 0
     },
     {
       "label": "ProductAvailabilityView()",
@@ -3505,7 +3505,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
       "source_location": "L5",
       "id": "productavailability_productavailabilityview",
-      "community": 3
+      "community": 0
     },
     {
       "label": "ProductAvailability()",
@@ -3513,7 +3513,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
       "source_location": "L18",
       "id": "productavailability_productavailability",
-      "community": 3
+      "community": 0
     },
     {
       "label": "ProductAvailabilityToggleGroup.tsx",
@@ -3521,7 +3521,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailabilityToggleGroup.tsx",
       "source_location": "L1",
       "id": "productavailabilitytogglegroup",
-      "community": 3
+      "community": 0
     },
     {
       "label": "ProductAvailabilityToggleGroup()",
@@ -3529,7 +3529,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailabilityToggleGroup.tsx",
       "source_location": "L5",
       "id": "productavailabilitytogglegroup_productavailabilitytogglegroup",
-      "community": 3
+      "community": 0
     },
     {
       "label": "ProductCategorization.tsx",
@@ -3537,7 +3537,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
       "source_location": "L1",
       "id": "productcategorization",
-      "community": 3
+      "community": 0
     },
     {
       "label": "handleClose()",
@@ -3545,7 +3545,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
       "source_location": "L203",
       "id": "productcategorization_handleclose",
-      "community": 3
+      "community": 0
     },
     {
       "label": "setInitialSelectedOption()",
@@ -3553,7 +3553,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
       "source_location": "L230",
       "id": "productcategorization_setinitialselectedoption",
-      "community": 3
+      "community": 0
     },
     {
       "label": "handleProductVisibility()",
@@ -3561,7 +3561,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
       "source_location": "L243",
       "id": "productcategorization_handleproductvisibility",
-      "community": 3
+      "community": 0
     },
     {
       "label": "getProductName()",
@@ -3569,7 +3569,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
       "source_location": "L286",
       "id": "productcategorization_getproductname",
-      "community": 3
+      "community": 0
     },
     {
       "label": "ProductDetails.tsx",
@@ -3577,7 +3577,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
       "source_location": "L1",
       "id": "productdetails",
-      "community": 5
+      "community": 1
     },
     {
       "label": "handleNameChange()",
@@ -3585,7 +3585,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductDetails.tsx",
       "source_location": "L10",
       "id": "productdetails_handlenamechange",
-      "community": 5
+      "community": 1
     },
     {
       "label": "ProductImages.tsx",
@@ -3609,7 +3609,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductPage.tsx",
       "source_location": "L1",
       "id": "productpage",
-      "community": 5
+      "community": 8
     },
     {
       "label": "ProductPage()",
@@ -3617,7 +3617,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductPage.tsx",
       "source_location": "L13",
       "id": "productpage_productpage",
-      "community": 5
+      "community": 8
     },
     {
       "label": "ProductStock.tsx",
@@ -3625,7 +3625,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
       "source_location": "L1",
       "id": "productstock",
-      "community": 15
+      "community": 8
     },
     {
       "label": "restock()",
@@ -3633,7 +3633,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L107",
       "id": "productstock_restock",
-      "community": 15
+      "community": 8
     },
     {
       "label": "isSkuReserved()",
@@ -3641,7 +3641,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L174",
       "id": "productstock_isskureserved",
-      "community": 15
+      "community": 8
     },
     {
       "label": "getReservationType()",
@@ -3649,7 +3649,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L178",
       "id": "productstock_getreservationtype",
-      "community": 15
+      "community": 8
     },
     {
       "label": "handleGenerateBarcode()",
@@ -3657,7 +3657,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L239",
       "id": "productstock_handlegeneratebarcode",
-      "community": 15
+      "community": 8
     },
     {
       "label": "handleSaveBarcode()",
@@ -3665,7 +3665,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L285",
       "id": "productstock_handlesavebarcode",
-      "community": 15
+      "community": 8
     },
     {
       "label": "handleViewBarcode()",
@@ -3673,7 +3673,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L300",
       "id": "productstock_handleviewbarcode",
-      "community": 15
+      "community": 8
     },
     {
       "label": "handleClearBarcodeClick()",
@@ -3681,7 +3681,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L308",
       "id": "productstock_handleclearbarcodeclick",
-      "community": 15
+      "community": 8
     },
     {
       "label": "handleClearBarcodeConfirm()",
@@ -3689,7 +3689,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L313",
       "id": "productstock_handleclearbarcodeconfirm",
-      "community": 15
+      "community": 8
     },
     {
       "label": "handleClearBarcodeCancel()",
@@ -3697,7 +3697,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L379",
       "id": "productstock_handleclearbarcodecancel",
-      "community": 15
+      "community": 8
     },
     {
       "label": "handleChange()",
@@ -3705,7 +3705,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L384",
       "id": "productstock_handlechange",
-      "community": 15
+      "community": 8
     },
     {
       "label": "addRow()",
@@ -3713,7 +3713,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L430",
       "id": "productstock_addrow",
-      "community": 15
+      "community": 8
     },
     {
       "label": "handleDeleteAction()",
@@ -3721,7 +3721,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L445",
       "id": "productstock_handledeleteaction",
-      "community": 15
+      "community": 8
     },
     {
       "label": "setOutOfStock()",
@@ -3729,7 +3729,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L462",
       "id": "productstock_setoutofstock",
-      "community": 15
+      "community": 8
     },
     {
       "label": "setVisibility()",
@@ -3737,7 +3737,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L472",
       "id": "productstock_setvisibility",
-      "community": 15
+      "community": 8
     },
     {
       "label": "isLastActiveVariant()",
@@ -3745,7 +3745,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L486",
       "id": "productstock_islastactivevariant",
-      "community": 15
+      "community": 8
     },
     {
       "label": "isLastVisibleVariant()",
@@ -3753,7 +3753,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L492",
       "id": "productstock_islastvisiblevariant",
-      "community": 15
+      "community": 8
     },
     {
       "label": "shouldDisable()",
@@ -3761,7 +3761,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L498",
       "id": "productstock_shoulddisable",
-      "community": 15
+      "community": 8
     },
     {
       "label": "hasQuantityError()",
@@ -3769,7 +3769,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L506",
       "id": "productstock_hasquantityerror",
-      "community": 15
+      "community": 8
     },
     {
       "label": "hasPriceError()",
@@ -3777,7 +3777,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductStock.tsx",
       "source_location": "L514",
       "id": "productstock_haspriceerror",
-      "community": 15
+      "community": 8
     },
     {
       "label": "ProductView.tsx",
@@ -3785,7 +3785,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L1",
       "id": "productview",
-      "community": 0
+      "community": 7
     },
     {
       "label": "deleteActiveProduct()",
@@ -3793,7 +3793,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L82",
       "id": "productview_deleteactiveproduct",
-      "community": 0
+      "community": 7
     },
     {
       "label": "saveProduct()",
@@ -3801,7 +3801,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L115",
       "id": "productview_saveproduct",
-      "community": 0
+      "community": 7
     },
     {
       "label": "modifyProduct()",
@@ -3809,7 +3809,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L170",
       "id": "productview_modifyproduct",
-      "community": 0
+      "community": 7
     },
     {
       "label": "createVariantSku()",
@@ -3817,7 +3817,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L245",
       "id": "productview_createvariantsku",
-      "community": 0
+      "community": 7
     },
     {
       "label": "updateVariantSku()",
@@ -3825,7 +3825,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L300",
       "id": "productview_updatevariantsku",
-      "community": 0
+      "community": 7
     },
     {
       "label": "onSubmit()",
@@ -3833,7 +3833,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L369",
       "id": "productview_onsubmit",
-      "community": 0
+      "community": 7
     },
     {
       "label": "handleKeyDown()",
@@ -3841,7 +3841,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L380",
       "id": "productview_handlekeydown",
-      "community": 0
+      "community": 7
     },
     {
       "label": "updateProductVisibility()",
@@ -3849,7 +3849,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L431",
       "id": "productview_updateproductvisibility",
-      "community": 0
+      "community": 7
     },
     {
       "label": "SheetProvider.tsx",
@@ -3857,7 +3857,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
       "source_location": "L1",
       "id": "sheetprovider",
-      "community": 5
+      "community": 8
     },
     {
       "label": "useSheet()",
@@ -3865,7 +3865,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
       "source_location": "L11",
       "id": "sheetprovider_usesheet",
-      "community": 5
+      "community": 8
     },
     {
       "label": "SheetProvider()",
@@ -3873,7 +3873,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
       "source_location": "L19",
       "id": "sheetprovider_sheetprovider",
-      "community": 5
+      "community": 8
     },
     {
       "label": "WigType.tsx",
@@ -3905,7 +3905,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
       "source_location": "L1",
       "id": "copyimagesprovider",
-      "community": 15
+      "community": 8
     },
     {
       "label": "useCopyImages()",
@@ -3913,7 +3913,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
       "source_location": "L13",
       "id": "copyimagesprovider_usecopyimages",
-      "community": 15
+      "community": 8
     },
     {
       "label": "CopyImagesProvider()",
@@ -3921,7 +3921,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
       "source_location": "L21",
       "id": "copyimagesprovider_copyimagesprovider",
-      "community": 15
+      "community": 8
     },
     {
       "label": "CopyImagesView.tsx",
@@ -3969,7 +3969,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-faceted-filter.tsx",
       "source_location": "L1",
       "id": "data_table_faceted_filter",
-      "community": 0
+      "community": 1
     },
     {
       "label": "data-table-pagination.tsx",
@@ -3985,7 +3985,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
       "source_location": "L1",
       "id": "data_table_toolbar_provider",
-      "community": 0
+      "community": 7
     },
     {
       "label": "OrdersTableToolbarProvider()",
@@ -3993,7 +3993,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
       "source_location": "L16",
       "id": "data_table_toolbar_provider_orderstabletoolbarprovider",
-      "community": 0
+      "community": 7
     },
     {
       "label": "useOrdersTableToolbar()",
@@ -4001,7 +4001,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
       "source_location": "L46",
       "id": "data_table_toolbar_provider_useorderstabletoolbar",
-      "community": 0
+      "community": 7
     },
     {
       "label": "data-table-toolbar.tsx",
@@ -4009,7 +4009,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-toolbar.tsx",
       "source_location": "L1",
       "id": "data_table_toolbar",
-      "community": 0
+      "community": 7
     },
     {
       "label": "DataTableToolbar()",
@@ -4017,7 +4017,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
       "source_location": "L23",
       "id": "data_table_toolbar_datatabletoolbar",
-      "community": 0
+      "community": 7
     },
     {
       "label": "data-table-view-options.tsx",
@@ -4049,7 +4049,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
       "source_location": "L1",
       "id": "product_variant_columns",
-      "community": 15
+      "community": 8
     },
     {
       "label": "setSourceVariant()",
@@ -4057,7 +4057,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
       "source_location": "L47",
       "id": "product_variant_columns_setsourcevariant",
-      "community": 15
+      "community": 8
     },
     {
       "label": "ActivityTimeline.tsx",
@@ -4065,7 +4065,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/ActivityTimeline.tsx",
       "source_location": "L1",
       "id": "activitytimeline",
-      "community": 11
+      "community": 0
     },
     {
       "label": "capitalizeFirstLetter()",
@@ -4073,7 +4073,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/ActivityTimeline.tsx",
       "source_location": "L151",
       "id": "activitytimeline_capitalizefirstletter",
-      "community": 11
+      "community": 0
     },
     {
       "label": "AnalyticsCombinedUsers.tsx",
@@ -4137,7 +4137,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsTopUsers.tsx",
       "source_location": "L1",
       "id": "analyticstopusers",
-      "community": 3
+      "community": 0
     },
     {
       "label": "processAnalyticsToUsers()",
@@ -4145,7 +4145,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsTopUsers.tsx",
       "source_location": "L10",
       "id": "analyticstopusers_processanalyticstousers",
-      "community": 3
+      "community": 0
     },
     {
       "label": "AnalyticsTopUsers()",
@@ -4153,7 +4153,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsTopUsers.tsx",
       "source_location": "L100",
       "id": "analyticstopusers_analyticstopusers",
-      "community": 3
+      "community": 0
     },
     {
       "label": "AnalyticsUsers.tsx",
@@ -4209,7 +4209,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/ConversionFunnelChart.tsx",
       "source_location": "L1",
       "id": "conversionfunnelchart",
-      "community": 11
+      "community": 0
     },
     {
       "label": "EnhancedAnalyticsView.tsx",
@@ -4217,7 +4217,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/EnhancedAnalyticsView.tsx",
       "source_location": "L1",
       "id": "enhancedanalyticsview",
-      "community": 11
+      "community": 0
     },
     {
       "label": "getDateRangeMilliseconds()",
@@ -4225,7 +4225,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/EnhancedAnalyticsView.tsx",
       "source_location": "L42",
       "id": "enhancedanalyticsview_getdaterangemilliseconds",
-      "community": 11
+      "community": 0
     },
     {
       "label": "RevenueChart.tsx",
@@ -4233,7 +4233,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/RevenueChart.tsx",
       "source_location": "L1",
       "id": "revenuechart",
-      "community": 11
+      "community": 0
     },
     {
       "label": "getTrendIcon()",
@@ -4273,7 +4273,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/VisitorChart.tsx",
       "source_location": "L1",
       "id": "visitorchart",
-      "community": 11
+      "community": 0
     },
     {
       "label": "formatHour()",
@@ -4281,7 +4281,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/VisitorChart.tsx",
       "source_location": "L18",
       "id": "visitorchart_formathour",
-      "community": 11
+      "community": 0
     },
     {
       "label": "analytics-columns.tsx",
@@ -4297,7 +4297,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-row-actions.tsx",
       "source_location": "L1",
       "id": "data_table_row_actions",
-      "community": 0
+      "community": 8
     },
     {
       "label": "DataTableRowActions()",
@@ -4305,7 +4305,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-row-actions.tsx",
       "source_location": "L25",
       "id": "data_table_row_actions_datatablerowactions",
-      "community": 0
+      "community": 8
     },
     {
       "label": "selectable-data-provider.tsx",
@@ -4345,7 +4345,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/chart.tsx",
       "source_location": "L1",
       "id": "chart",
-      "community": 11
+      "community": 6
     },
     {
       "label": "data.ts",
@@ -4353,7 +4353,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data.ts",
       "source_location": "L1",
       "id": "data",
-      "community": 0
+      "community": 7
     },
     {
       "label": "groupAnalytics()",
@@ -4361,7 +4361,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
       "source_location": "L3",
       "id": "utils_groupanalytics",
-      "community": 3
+      "community": 0
     },
     {
       "label": "countGroupedAnalytics()",
@@ -4369,7 +4369,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
       "source_location": "L52",
       "id": "utils_countgroupedanalytics",
-      "community": 3
+      "community": 0
     },
     {
       "label": "groupProductViewsByDay()",
@@ -4377,7 +4377,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
       "source_location": "L90",
       "id": "utils_groupproductviewsbyday",
-      "community": 3
+      "community": 0
     },
     {
       "label": "LogItems.tsx",
@@ -4385,7 +4385,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/LogItems.tsx",
       "source_location": "L1",
       "id": "logitems",
-      "community": 0
+      "community": 6
     },
     {
       "label": "LogItems()",
@@ -4393,7 +4393,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/LogItems.tsx",
       "source_location": "L6",
       "id": "logitems_logitems",
-      "community": 0
+      "community": 6
     },
     {
       "label": "LogView.tsx",
@@ -4401,7 +4401,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/LogView.tsx",
       "source_location": "L1",
       "id": "logview",
-      "community": 0
+      "community": 7
     },
     {
       "label": "Header()",
@@ -4409,7 +4409,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/LogView.tsx",
       "source_location": "L10",
       "id": "logview_header",
-      "community": 0
+      "community": 7
     },
     {
       "label": "LogsView.tsx",
@@ -4417,7 +4417,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
       "source_location": "L1",
       "id": "logsview",
-      "community": 0
+      "community": 6
     },
     {
       "label": "Navigation()",
@@ -4425,7 +4425,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
       "source_location": "L27",
       "id": "logsview_navigation",
-      "community": 0
+      "community": 6
     },
     {
       "label": "log-items-provider.tsx",
@@ -4433,7 +4433,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
       "source_location": "L1",
       "id": "log_items_provider",
-      "community": 0
+      "community": 6
     },
     {
       "label": "LogItemsProvider()",
@@ -4441,7 +4441,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
       "source_location": "L15",
       "id": "log_items_provider_logitemsprovider",
-      "community": 0
+      "community": 6
     },
     {
       "label": "useLogItems()",
@@ -4449,7 +4449,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
       "source_location": "L39",
       "id": "log_items_provider_uselogitems",
-      "community": 0
+      "community": 6
     },
     {
       "label": "useLoadLogItems.ts",
@@ -4513,7 +4513,7 @@
       "source_file": "packages/storefront-webapp/src/components/DefaultCatchBoundary.tsx",
       "source_location": "L1",
       "id": "defaultcatchboundary",
-      "community": 6
+      "community": 4
     },
     {
       "label": "InputOTP.tsx",
@@ -4521,7 +4521,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
       "source_location": "L1",
       "id": "inputotp",
-      "community": 9
+      "community": 12
     },
     {
       "label": "handlePinChange()",
@@ -4529,7 +4529,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
       "source_location": "L48",
       "id": "inputotp_handlepinchange",
-      "community": 9
+      "community": 12
     },
     {
       "label": "onSubmit()",
@@ -4537,7 +4537,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
       "source_location": "L56",
       "id": "inputotp_onsubmit",
-      "community": 9
+      "community": 12
     },
     {
       "label": "LoginForm.tsx",
@@ -4561,7 +4561,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsFilters.tsx",
       "source_location": "L1",
       "id": "bulkoperationsfilters",
-      "community": 3
+      "community": 1
     },
     {
       "label": "handleLoadProducts()",
@@ -4569,7 +4569,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsFilters.tsx",
       "source_location": "L49",
       "id": "bulkoperationsfilters_handleloadproducts",
-      "community": 3
+      "community": 1
     },
     {
       "label": "BulkOperationsPage.tsx",
@@ -4585,7 +4585,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.test.tsx",
       "source_location": "L1",
       "id": "bulkoperationspreview_test",
-      "community": 15
+      "community": 12
     },
     {
       "label": "makeRow()",
@@ -4593,7 +4593,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.test.tsx",
       "source_location": "L23",
       "id": "bulkoperationspreview_test_makerow",
-      "community": 15
+      "community": 12
     },
     {
       "label": "BulkOperationsPreview.tsx",
@@ -4601,7 +4601,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.tsx",
       "source_location": "L1",
       "id": "bulkoperationspreview",
-      "community": 15
+      "community": 12
     },
     {
       "label": "formatPrice()",
@@ -4609,7 +4609,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.tsx",
       "source_location": "L50",
       "id": "bulkoperationspreview_formatprice",
-      "community": 15
+      "community": 12
     },
     {
       "label": "CashierManagement.tsx",
@@ -4617,7 +4617,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L1",
       "id": "cashiermanagement",
-      "community": 3
+      "community": 12
     },
     {
       "label": "normalizeNameSegment()",
@@ -4625,7 +4625,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L42",
       "id": "cashiermanagement_normalizenamesegment",
-      "community": 3
+      "community": 12
     },
     {
       "label": "buildUsername()",
@@ -4633,7 +4633,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L50",
       "id": "cashiermanagement_buildusername",
-      "community": 3
+      "community": 12
     },
     {
       "label": "handleSubmit()",
@@ -4641,7 +4641,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L109",
       "id": "cashiermanagement_handlesubmit",
-      "community": 3
+      "community": 12
     },
     {
       "label": "handlePinKeyDown()",
@@ -4649,7 +4649,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L169",
       "id": "cashiermanagement_handlepinkeydown",
-      "community": 3
+      "community": 12
     },
     {
       "label": "handleDelete()",
@@ -4657,7 +4657,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L320",
       "id": "cashiermanagement_handledelete",
-      "community": 3
+      "community": 12
     },
     {
       "label": "CheckoutSessionsTable.tsx",
@@ -4729,7 +4729,7 @@
       "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
       "source_location": "L1",
       "id": "dashboard",
-      "community": 11
+      "community": 7
     },
     {
       "label": "getPeriodRange()",
@@ -4737,7 +4737,7 @@
       "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
       "source_location": "L20",
       "id": "dashboard_getperiodrange",
-      "community": 11
+      "community": 7
     },
     {
       "label": "LoadingSection()",
@@ -4745,7 +4745,7 @@
       "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
       "source_location": "L50",
       "id": "dashboard_loadingsection",
-      "community": 11
+      "community": 7
     },
     {
       "label": "renderSalesSection()",
@@ -4753,7 +4753,7 @@
       "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
       "source_location": "L322",
       "id": "dashboard_rendersalessection",
-      "community": 11
+      "community": 7
     },
     {
       "label": "renderProductsSection()",
@@ -4761,7 +4761,7 @@
       "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
       "source_location": "L342",
       "id": "dashboard_renderproductssection",
-      "community": 11
+      "community": 7
     },
     {
       "label": "MetricCard.tsx",
@@ -4769,7 +4769,7 @@
       "source_file": "packages/athena-webapp/src/components/dashboard/MetricCard.tsx",
       "source_location": "L1",
       "id": "metriccard",
-      "community": 11
+      "community": 7
     },
     {
       "label": "ExpenseCompletion.tsx",
@@ -4777,7 +4777,7 @@
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseCompletion.tsx",
       "source_location": "L1",
       "id": "expensecompletion",
-      "community": 4
+      "community": 3
     },
     {
       "label": "ExpenseView.tsx",
@@ -4785,7 +4785,7 @@
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
       "source_location": "L1",
       "id": "expenseview",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleSessionLoaded()",
@@ -4793,7 +4793,7 @@
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
       "source_location": "L60",
       "id": "expenseview_handlesessionloaded",
-      "community": 4
+      "community": 3
     },
     {
       "label": "resetAutoSessionInitialized()",
@@ -4801,7 +4801,7 @@
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
       "source_location": "L64",
       "id": "expenseview_resetautosessioninitialized",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleNewSession()",
@@ -4809,7 +4809,7 @@
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
       "source_location": "L68",
       "id": "expenseview_handlenewsession",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleCashierAuthenticated()",
@@ -4817,7 +4817,7 @@
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
       "source_location": "L86",
       "id": "expenseview_handlecashierauthenticated",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleBarcodeSubmit()",
@@ -4825,7 +4825,7 @@
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
       "source_location": "L295",
       "id": "expenseview_handlebarcodesubmit",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleClearCart()",
@@ -4833,7 +4833,7 @@
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
       "source_location": "L322",
       "id": "expenseview_handleclearcart",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleCompleteExpense()",
@@ -4841,7 +4841,7 @@
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
       "source_location": "L335",
       "id": "expenseview_handlecompleteexpense",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleNavigateBack()",
@@ -4849,7 +4849,7 @@
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
       "source_location": "L383",
       "id": "expenseview_handlenavigateback",
-      "community": 4
+      "community": 3
     },
     {
       "label": "BannerMessageEditor.tsx",
@@ -4857,7 +4857,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L1",
       "id": "bannermessageeditor",
-      "community": 3
+      "community": 0
     },
     {
       "label": "handleSave()",
@@ -4865,7 +4865,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L46",
       "id": "bannermessageeditor_handlesave",
-      "community": 3
+      "community": 0
     },
     {
       "label": "handleClear()",
@@ -4873,7 +4873,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L66",
       "id": "bannermessageeditor_handleclear",
-      "community": 3
+      "community": 0
     },
     {
       "label": "handleActiveToggle()",
@@ -4881,7 +4881,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L91",
       "id": "bannermessageeditor_handleactivetoggle",
-      "community": 3
+      "community": 0
     },
     {
       "label": "handleCountdownChange()",
@@ -4889,7 +4889,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L113",
       "id": "bannermessageeditor_handlecountdownchange",
-      "community": 3
+      "community": 0
     },
     {
       "label": "getCountdownStatus()",
@@ -4897,7 +4897,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L123",
       "id": "bannermessageeditor_getcountdownstatus",
-      "community": 3
+      "community": 0
     },
     {
       "label": "BestSellers.tsx",
@@ -4985,7 +4985,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L1",
       "id": "heroheaderimageuploader",
-      "community": 12
+      "community": 11
     },
     {
       "label": "validateFile()",
@@ -4993,7 +4993,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L50",
       "id": "heroheaderimageuploader_validatefile",
-      "community": 12
+      "community": 11
     },
     {
       "label": "uploadImage()",
@@ -5001,7 +5001,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L67",
       "id": "heroheaderimageuploader_uploadimage",
-      "community": 12
+      "community": 11
     },
     {
       "label": "resetEditState()",
@@ -5009,7 +5009,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L95",
       "id": "heroheaderimageuploader_reseteditstate",
-      "community": 12
+      "community": 11
     },
     {
       "label": "handleEditClick()",
@@ -5017,7 +5017,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L108",
       "id": "heroheaderimageuploader_handleeditclick",
-      "community": 12
+      "community": 11
     },
     {
       "label": "handleFileSelect()",
@@ -5025,7 +5025,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L113",
       "id": "heroheaderimageuploader_handlefileselect",
-      "community": 12
+      "community": 11
     },
     {
       "label": "handleUpload()",
@@ -5033,7 +5033,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L127",
       "id": "heroheaderimageuploader_handleupload",
-      "community": 12
+      "community": 11
     },
     {
       "label": "handleRevert()",
@@ -5041,7 +5041,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L163",
       "id": "heroheaderimageuploader_handlerevert",
-      "community": 12
+      "community": 11
     },
     {
       "label": "EditModeButtons()",
@@ -5049,7 +5049,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L179",
       "id": "heroheaderimageuploader_editmodebuttons",
-      "community": 12
+      "community": 11
     },
     {
       "label": "ViewModeButton()",
@@ -5057,7 +5057,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L205",
       "id": "heroheaderimageuploader_viewmodebutton",
-      "community": 12
+      "community": 11
     },
     {
       "label": "HeroSectionTabs.tsx",
@@ -5297,7 +5297,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
       "source_location": "L1",
       "id": "activityview",
-      "community": 5
+      "community": 0
     },
     {
       "label": "isRefundAction()",
@@ -5305,7 +5305,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
       "source_location": "L50",
       "id": "activityview_isrefundaction",
-      "community": 5
+      "community": 0
     },
     {
       "label": "isTransitionAction()",
@@ -5313,7 +5313,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
       "source_location": "L53",
       "id": "activityview_istransitionaction",
-      "community": 5
+      "community": 0
     },
     {
       "label": "isCreatedAction()",
@@ -5321,7 +5321,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
       "source_location": "L58",
       "id": "activityview_iscreatedaction",
-      "community": 5
+      "community": 0
     },
     {
       "label": "isFeedbackRequestAction()",
@@ -5329,7 +5329,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
       "source_location": "L63",
       "id": "activityview_isfeedbackrequestaction",
-      "community": 5
+      "community": 0
     },
     {
       "label": "CustomerDetailsView.tsx",
@@ -5473,7 +5473,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/OrderSummary.tsx",
       "source_location": "L1",
       "id": "ordersummary",
-      "community": 1
+      "community": 3
     },
     {
       "label": "OrderView.tsx",
@@ -5513,7 +5513,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
       "source_location": "L1",
       "id": "ordersview",
-      "community": 8
+      "community": 7
     },
     {
       "label": "getTimeFilter()",
@@ -5521,7 +5521,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
       "source_location": "L35",
       "id": "ordersview_gettimefilter",
-      "community": 8
+      "community": 7
     },
     {
       "label": "PickupDetailsView.tsx",
@@ -5529,7 +5529,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/PickupDetailsView.tsx",
       "source_location": "L1",
       "id": "pickupdetailsview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "PickupDetailsView()",
@@ -5537,7 +5537,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/PickupDetailsView.tsx",
       "source_location": "L9",
       "id": "pickupdetailsview_pickupdetailsview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "DeliveryDetails()",
@@ -5545,7 +5545,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/PickupDetailsView.tsx",
       "source_location": "L67",
       "id": "pickupdetailsview_deliverydetails",
-      "community": 1
+      "community": 0
     },
     {
       "label": "RefundsView.tsx",
@@ -5585,7 +5585,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar.tsx",
       "source_location": "L34",
       "id": "data_table_toolbar_handleclearfilters",
-      "community": 0
+      "community": 7
     },
     {
       "label": "orderColumns.tsx",
@@ -5609,7 +5609,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L1",
       "id": "refundutils",
-      "community": 24
+      "community": 6
     },
     {
       "label": "refundReducer()",
@@ -5617,7 +5617,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L31",
       "id": "refundutils_refundreducer",
-      "community": 24
+      "community": 6
     },
     {
       "label": "getAmountRefunded()",
@@ -5625,7 +5625,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L98",
       "id": "refundutils_getamountrefunded",
-      "community": 24
+      "community": 6
     },
     {
       "label": "getNetAmount()",
@@ -5633,7 +5633,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L106",
       "id": "refundutils_getnetamount",
-      "community": 24
+      "community": 6
     },
     {
       "label": "getAvailableItems()",
@@ -5641,7 +5641,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L115",
       "id": "refundutils_getavailableitems",
-      "community": 24
+      "community": 6
     },
     {
       "label": "calculateRefundAmount()",
@@ -5649,7 +5649,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L124",
       "id": "refundutils_calculaterefundamount",
-      "community": 24
+      "community": 6
     },
     {
       "label": "getItemsToRefund()",
@@ -5657,7 +5657,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L174",
       "id": "refundutils_getitemstorefund",
-      "community": 24
+      "community": 6
     },
     {
       "label": "validateRefund()",
@@ -5665,7 +5665,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L199",
       "id": "refundutils_validaterefund",
-      "community": 24
+      "community": 6
     },
     {
       "label": "shouldShowReturnToStock()",
@@ -5673,7 +5673,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L255",
       "id": "refundutils_shouldshowreturntostock",
-      "community": 24
+      "community": 6
     },
     {
       "label": "getOrderState()",
@@ -5681,7 +5681,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
       "source_location": "L1",
       "id": "utils_getorderstate",
-      "community": 3
+      "community": 0
     },
     {
       "label": "getAmountPaidForOrder()",
@@ -5689,7 +5689,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
       "source_location": "L108",
       "id": "utils_getamountpaidfororder",
-      "community": 3
+      "community": 0
     },
     {
       "label": "onSubmit()",
@@ -5753,7 +5753,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx",
       "source_location": "L1",
       "id": "cashierauthdialog",
-      "community": 3
+      "community": 12
     },
     {
       "label": "CashierView.tsx",
@@ -5761,7 +5761,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CashierView.tsx",
       "source_location": "L1",
       "id": "cashierview",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleSignOut()",
@@ -5769,7 +5769,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CashierView.tsx",
       "source_location": "L63",
       "id": "cashierview_handlesignout",
-      "community": 4
+      "community": 3
     },
     {
       "label": "CustomerInfoPanel.tsx",
@@ -5777,7 +5777,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
       "source_location": "L1",
       "id": "customerinfopanel",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleSelectCustomer()",
@@ -5785,7 +5785,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
       "source_location": "L59",
       "id": "customerinfopanel_handleselectcustomer",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleCreateCustomer()",
@@ -5793,7 +5793,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
       "source_location": "L77",
       "id": "customerinfopanel_handlecreatecustomer",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleStartEdit()",
@@ -5801,7 +5801,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
       "source_location": "L105",
       "id": "customerinfopanel_handlestartedit",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleSaveEdit()",
@@ -5809,7 +5809,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
       "source_location": "L115",
       "id": "customerinfopanel_handlesaveedit",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleCancelEdit()",
@@ -5817,7 +5817,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
       "source_location": "L146",
       "id": "customerinfopanel_handlecanceledit",
-      "community": 4
+      "community": 3
     },
     {
       "label": "clearCustomer()",
@@ -5825,7 +5825,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
       "source_location": "L155",
       "id": "customerinfopanel_clearcustomer",
-      "community": 4
+      "community": 3
     },
     {
       "label": "DebugProducts.tsx",
@@ -5881,7 +5881,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/NoResultsMessage.tsx",
       "source_location": "L1",
       "id": "noresultsmessage",
-      "community": 34
+      "community": 35
     },
     {
       "label": "NoResultsMessage()",
@@ -5889,7 +5889,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/NoResultsMessage.tsx",
       "source_location": "L7",
       "id": "noresultsmessage_noresultsmessage",
-      "community": 34
+      "community": 35
     },
     {
       "label": "handleCompleteTransaction()",
@@ -5897,7 +5897,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
       "source_location": "L128",
       "id": "ordersummary_handlecompletetransaction",
-      "community": 1
+      "community": 3
     },
     {
       "label": "handleSelectedPaymentMethod()",
@@ -5905,7 +5905,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
       "source_location": "L150",
       "id": "ordersummary_handleselectedpaymentmethod",
-      "community": 1
+      "community": 3
     },
     {
       "label": "handleNewTransaction()",
@@ -5913,7 +5913,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
       "source_location": "L162",
       "id": "ordersummary_handlenewtransaction",
-      "community": 1
+      "community": 3
     },
     {
       "label": "POSRegisterView.tsx",
@@ -5921,7 +5921,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/POSRegisterView.tsx",
       "source_location": "L1",
       "id": "posregisterview",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleSessionLoaded()",
@@ -5929,7 +5929,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/POSRegisterView.tsx",
       "source_location": "L83",
       "id": "posregisterview_handlesessionloaded",
-      "community": 4
+      "community": 3
     },
     {
       "label": "resetAutoSessionInitialized()",
@@ -5937,7 +5937,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/POSRegisterView.tsx",
       "source_location": "L87",
       "id": "posregisterview_resetautosessioninitialized",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleNewSession()",
@@ -5945,7 +5945,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/POSRegisterView.tsx",
       "source_location": "L92",
       "id": "posregisterview_handlenewsession",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleCashierAuthenticated()",
@@ -5953,7 +5953,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/POSRegisterView.tsx",
       "source_location": "L133",
       "id": "posregisterview_handlecashierauthenticated",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleBarcodeSubmit()",
@@ -5961,7 +5961,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/POSRegisterView.tsx",
       "source_location": "L606",
       "id": "posregisterview_handlebarcodesubmit",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleClearCart()",
@@ -5969,7 +5969,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/POSRegisterView.tsx",
       "source_location": "L678",
       "id": "posregisterview_handleclearcart",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleNavigateBack()",
@@ -5977,7 +5977,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/POSRegisterView.tsx",
       "source_location": "L709",
       "id": "posregisterview_handlenavigateback",
-      "community": 4
+      "community": 3
     },
     {
       "label": "PaymentView.tsx",
@@ -5985,7 +5985,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
       "source_location": "L1",
       "id": "paymentview",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleAddPayment()",
@@ -5993,7 +5993,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
       "source_location": "L178",
       "id": "paymentview_handleaddpayment",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleClearAll()",
@@ -6001,7 +6001,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
       "source_location": "L219",
       "id": "paymentview_handleclearall",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleAmountChange()",
@@ -6009,7 +6009,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
       "source_location": "L224",
       "id": "paymentview_handleamountchange",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleAmountBlur()",
@@ -6017,7 +6017,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
       "source_location": "L253",
       "id": "paymentview_handleamountblur",
-      "community": 4
+      "community": 3
     },
     {
       "label": "PaymentsAddedList.tsx",
@@ -6025,7 +6025,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L1",
       "id": "paymentsaddedlist",
-      "community": 4
+      "community": 3
     },
     {
       "label": "getPaymentMethodLabel()",
@@ -6033,7 +6033,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L18",
       "id": "paymentsaddedlist_getpaymentmethodlabel",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleStartEdit()",
@@ -6041,7 +6041,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L57",
       "id": "paymentsaddedlist_handlestartedit",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleSaveEdit()",
@@ -6049,7 +6049,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L62",
       "id": "paymentsaddedlist_handlesaveedit",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleCancelEdit()",
@@ -6057,7 +6057,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L93",
       "id": "paymentsaddedlist_handlecanceledit",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handleRemovePayment()",
@@ -6065,7 +6065,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L98",
       "id": "paymentsaddedlist_handleremovepayment",
-      "community": 4
+      "community": 3
     },
     {
       "label": "PinInput.tsx",
@@ -6073,7 +6073,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
       "source_location": "L1",
       "id": "pininput",
-      "community": 3
+      "community": 12
     },
     {
       "label": "PinInput()",
@@ -6081,7 +6081,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
       "source_location": "L13",
       "id": "pininput_pininput",
-      "community": 3
+      "community": 12
     },
     {
       "label": "PointOfSaleView.tsx",
@@ -6105,7 +6105,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
       "source_location": "L1",
       "id": "printinstructions",
-      "community": 35
+      "community": 36
     },
     {
       "label": "PrintInstructions()",
@@ -6113,7 +6113,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
       "source_location": "L3",
       "id": "printinstructions_printinstructions",
-      "community": 35
+      "community": 36
     },
     {
       "label": "ProductCard.tsx",
@@ -6121,7 +6121,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductCard.tsx",
       "source_location": "L1",
       "id": "productcard",
-      "community": 1
+      "community": 6
     },
     {
       "label": "ProductCard()",
@@ -6129,7 +6129,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/ProductCard.tsx",
       "source_location": "L14",
       "id": "productcard_productcard",
-      "community": 1
+      "community": 6
     },
     {
       "label": "ProductEntry.tsx",
@@ -6137,7 +6137,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
       "source_location": "L1",
       "id": "productentry",
-      "community": 1
+      "community": 6
     },
     {
       "label": "handleClearSearch()",
@@ -6145,7 +6145,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
       "source_location": "L86",
       "id": "productentry_handleclearsearch",
-      "community": 1
+      "community": 6
     },
     {
       "label": "ProductLookup.tsx",
@@ -6153,7 +6153,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/ProductLookup.tsx",
       "source_location": "L1",
       "id": "productlookup",
-      "community": 1
+      "community": 6
     },
     {
       "label": "QuickActionsBar.tsx",
@@ -6161,7 +6161,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/QuickActionsBar.tsx",
       "source_location": "L1",
       "id": "quickactionsbar",
-      "community": 4
+      "community": 3
     },
     {
       "label": "QuickActionsBar()",
@@ -6169,7 +6169,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/QuickActionsBar.tsx",
       "source_location": "L11",
       "id": "quickactionsbar_quickactionsbar",
-      "community": 4
+      "community": 3
     },
     {
       "label": "RegisterActions.tsx",
@@ -6177,7 +6177,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/RegisterActions.tsx",
       "source_location": "L1",
       "id": "registeractions",
-      "community": 4
+      "community": 3
     },
     {
       "label": "SearchResultsSection.tsx",
@@ -6185,7 +6185,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SearchResultsSection.tsx",
       "source_location": "L1",
       "id": "searchresultssection",
-      "community": 1
+      "community": 6
     },
     {
       "label": "SessionDemo.tsx",
@@ -6193,7 +6193,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionDemo.tsx",
       "source_location": "L1",
       "id": "sessiondemo",
-      "community": 11
+      "community": 0
     },
     {
       "label": "SessionDemo()",
@@ -6201,7 +6201,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionDemo.tsx",
       "source_location": "L15",
       "id": "sessiondemo_sessiondemo",
-      "community": 11
+      "community": 0
     },
     {
       "label": "SessionManager.tsx",
@@ -6209,7 +6209,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
       "source_location": "L1",
       "id": "sessionmanager",
-      "community": 4
+      "community": 3
     },
     {
       "label": "onHoldConfirm()",
@@ -6217,7 +6217,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
       "source_location": "L72",
       "id": "sessionmanager_onholdconfirm",
-      "community": 4
+      "community": 3
     },
     {
       "label": "onResumeSession()",
@@ -6225,7 +6225,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
       "source_location": "L77",
       "id": "sessionmanager_onresumesession",
-      "community": 4
+      "community": 3
     },
     {
       "label": "onVoidConfirm()",
@@ -6233,7 +6233,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
       "source_location": "L90",
       "id": "sessionmanager_onvoidconfirm",
-      "community": 4
+      "community": 3
     },
     {
       "label": "onNewSessionClick()",
@@ -6241,7 +6241,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
       "source_location": "L96",
       "id": "sessionmanager_onnewsessionclick",
-      "community": 4
+      "community": 3
     },
     {
       "label": "TotalsDisplay.tsx",
@@ -6249,7 +6249,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.tsx",
       "source_location": "L1",
       "id": "totalsdisplay",
-      "community": 1
+      "community": 3
     },
     {
       "label": "TotalsDisplay()",
@@ -6257,7 +6257,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.tsx",
       "source_location": "L12",
       "id": "totalsdisplay_totalsdisplay",
-      "community": 1
+      "community": 3
     },
     {
       "label": "ExpenseReportView.tsx",
@@ -6297,7 +6297,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
       "source_location": "L1",
       "id": "hooks",
-      "community": 6
+      "community": 4
     },
     {
       "label": "usePOSCashier()",
@@ -6305,7 +6305,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/hooks.ts",
       "source_location": "L5",
       "id": "hooks_useposcashier",
-      "community": 6
+      "community": 4
     },
     {
       "label": "HeldSessionsList.tsx",
@@ -6313,7 +6313,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx",
       "source_location": "L1",
       "id": "heldsessionslist",
-      "community": 4
+      "community": 3
     },
     {
       "label": "hasExpired()",
@@ -6321,7 +6321,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx",
       "source_location": "L54",
       "id": "heldsessionslist_hasexpired",
-      "community": 4
+      "community": 3
     },
     {
       "label": "getSessionCartItemsCount()",
@@ -6329,7 +6329,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx",
       "source_location": "L58",
       "id": "heldsessionslist_getsessioncartitemscount",
-      "community": 4
+      "community": 3
     },
     {
       "label": "HoldSessionDialog.tsx",
@@ -6337,7 +6337,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/HoldSessionDialog.tsx",
       "source_location": "L1",
       "id": "holdsessiondialog",
-      "community": 3
+      "community": 1
     },
     {
       "label": "HoldSessionDialog()",
@@ -6345,7 +6345,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/HoldSessionDialog.tsx",
       "source_location": "L19",
       "id": "holdsessiondialog_holdsessiondialog",
-      "community": 3
+      "community": 1
     },
     {
       "label": "VoidSessionDialog.tsx",
@@ -6353,7 +6353,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/VoidSessionDialog.tsx",
       "source_location": "L1",
       "id": "voidsessiondialog",
-      "community": 3
+      "community": 1
     },
     {
       "label": "VoidSessionDialog()",
@@ -6361,7 +6361,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/VoidSessionDialog.tsx",
       "source_location": "L19",
       "id": "voidsessiondialog_voidsessiondialog",
-      "community": 3
+      "community": 1
     },
     {
       "label": "POSSettingsView.tsx",
@@ -6369,7 +6369,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
       "source_location": "L1",
       "id": "possettingsview",
-      "community": 8
+      "community": 0
     },
     {
       "label": "loadFingerprint()",
@@ -6377,7 +6377,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
       "source_location": "L166",
       "id": "possettingsview_loadfingerprint",
-      "community": 8
+      "community": 0
     },
     {
       "label": "handleRegisterTerminal()",
@@ -6385,7 +6385,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
       "source_location": "L247",
       "id": "possettingsview_handleregisterterminal",
-      "community": 8
+      "community": 0
     },
     {
       "label": "handleUpdateExistingTerminal()",
@@ -6393,7 +6393,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
       "source_location": "L284",
       "id": "possettingsview_handleupdateexistingterminal",
-      "community": 8
+      "community": 0
     },
     {
       "label": "TransactionView.tsx",
@@ -6537,7 +6537,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
       "source_location": "L4",
       "id": "productstock_productstockstatus",
-      "community": 15
+      "community": 8
     },
     {
       "label": "OutOfStockStatus()",
@@ -6545,7 +6545,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
       "source_location": "L38",
       "id": "productstock_outofstockstatus",
-      "community": 15
+      "community": 8
     },
     {
       "label": "LowStockStatus()",
@@ -6553,7 +6553,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
       "source_location": "L47",
       "id": "productstock_lowstockstatus",
-      "community": 15
+      "community": 8
     },
     {
       "label": "SKUSelector.tsx",
@@ -6785,7 +6785,7 @@
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/add-product-command.tsx",
       "source_location": "L1",
       "id": "add_product_command",
-      "community": 0
+      "community": 1
     },
     {
       "label": "AddProductCommand()",
@@ -6793,7 +6793,7 @@
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/add-product-command.tsx",
       "source_location": "L17",
       "id": "add_product_command_addproductcommand",
-      "community": 0
+      "community": 1
     },
     {
       "label": "productColumns.tsx",
@@ -6817,7 +6817,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeForm.tsx",
       "source_location": "L1",
       "id": "promocodeform",
-      "community": 3
+      "community": 1
     },
     {
       "label": "toggleDiscountType()",
@@ -6825,7 +6825,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeForm.tsx",
       "source_location": "L84",
       "id": "promocodeform_togglediscounttype",
-      "community": 3
+      "community": 1
     },
     {
       "label": "PromoCodeHeader.tsx",
@@ -6897,7 +6897,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L1",
       "id": "promocodes",
-      "community": 1
+      "community": 25
     },
     {
       "label": "PromoCodesView.tsx",
@@ -6921,7 +6921,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/SelectableCategories.tsx",
       "source_location": "L1",
       "id": "selectablecategories",
-      "community": 3
+      "community": 12
     },
     {
       "label": "toggle()",
@@ -6929,7 +6929,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/SelectableCategories.tsx",
       "source_location": "L23",
       "id": "selectablecategories_toggle",
-      "community": 3
+      "community": 12
     },
     {
       "label": "DiscountTypeToggleGroup.tsx",
@@ -6937,7 +6937,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/DiscountTypeToggleGroup.tsx",
       "source_location": "L1",
       "id": "discounttypetogglegroup",
-      "community": 3
+      "community": 6
     },
     {
       "label": "DiscountTypeToggleGroup()",
@@ -6945,7 +6945,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/DiscountTypeToggleGroup.tsx",
       "source_location": "L5",
       "id": "discounttypetogglegroup_discounttypetogglegroup",
-      "community": 3
+      "community": 6
     },
     {
       "label": "PromoCodeSpanToggleGroup.tsx",
@@ -6953,7 +6953,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/PromoCodeSpanToggleGroup.tsx",
       "source_location": "L1",
       "id": "promocodespantogglegroup",
-      "community": 3
+      "community": 6
     },
     {
       "label": "PromoCodeSpanToggleGroup()",
@@ -6961,7 +6961,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/PromoCodeSpanToggleGroup.tsx",
       "source_location": "L4",
       "id": "promocodespantogglegroup_promocodespantogglegroup",
-      "community": 3
+      "community": 6
     },
     {
       "label": "PromoCodeAnalytics.tsx",
@@ -7001,7 +7001,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
       "source_location": "L1",
       "id": "color_picker",
-      "community": 3
+      "community": 11
     },
     {
       "label": "handleInputChange()",
@@ -7009,7 +7009,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
       "source_location": "L20",
       "id": "color_picker_handleinputchange",
-      "community": 3
+      "community": 11
     },
     {
       "label": "handleBlur()",
@@ -7017,7 +7017,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
       "source_location": "L24",
       "id": "color_picker_handleblur",
-      "community": 3
+      "community": 11
     },
     {
       "label": "promo-code-modal.tsx",
@@ -7025,7 +7025,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/promo-code-modal.tsx",
       "source_location": "L1",
       "id": "promo_code_modal",
-      "community": 12
+      "community": 11
     },
     {
       "label": "PromoCodeModal()",
@@ -7033,7 +7033,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/promo-code-modal.tsx",
       "source_location": "L29",
       "id": "promo_code_modal_promocodemodal",
-      "community": 12
+      "community": 11
     },
     {
       "label": "welcome-offer-modal.tsx",
@@ -7041,7 +7041,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L1",
       "id": "welcome_offer_modal",
-      "community": 12
+      "community": 11
     },
     {
       "label": "handleChange()",
@@ -7049,7 +7049,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L76",
       "id": "welcome_offer_modal_handlechange",
-      "community": 12
+      "community": 11
     },
     {
       "label": "handleNumberChange()",
@@ -7057,7 +7057,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L83",
       "id": "welcome_offer_modal_handlenumberchange",
-      "community": 12
+      "community": 11
     },
     {
       "label": "handleSwitchChange()",
@@ -7065,7 +7065,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L88",
       "id": "welcome_offer_modal_handleswitchchange",
-      "community": 12
+      "community": 11
     },
     {
       "label": "handleColorChange()",
@@ -7073,7 +7073,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L92",
       "id": "welcome_offer_modal_handlecolorchange",
-      "community": 12
+      "community": 11
     },
     {
       "label": "handleSelectChange()",
@@ -7081,7 +7081,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L96",
       "id": "welcome_offer_modal_handleselectchange",
-      "community": 12
+      "community": 11
     },
     {
       "label": "updateImages()",
@@ -7089,7 +7089,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L100",
       "id": "welcome_offer_modal_updateimages",
-      "community": 12
+      "community": 11
     },
     {
       "label": "handleSubmit()",
@@ -7097,7 +7097,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L104",
       "id": "welcome_offer_modal_handlesubmit",
-      "community": 12
+      "community": 11
     },
     {
       "label": "welcome-offer-card.tsx",
@@ -7113,7 +7113,7 @@
       "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
       "source_location": "L1",
       "id": "currency_provider",
-      "community": 3
+      "community": 1
     },
     {
       "label": "useStoreCurrency()",
@@ -7121,7 +7121,7 @@
       "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
       "source_location": "L17",
       "id": "currency_provider_usestorecurrency",
-      "community": 3
+      "community": 1
     },
     {
       "label": "CurrencyProvider()",
@@ -7129,7 +7129,7 @@
       "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
       "source_location": "L25",
       "id": "currency_provider_currencyprovider",
-      "community": 3
+      "community": 1
     },
     {
       "label": "RatingStars.tsx",
@@ -7137,7 +7137,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/RatingStars.tsx",
       "source_location": "L1",
       "id": "ratingstars",
-      "community": 9
+      "community": 6
     },
     {
       "label": "ReviewActions.tsx",
@@ -7145,7 +7145,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewActions.tsx",
       "source_location": "L1",
       "id": "reviewactions",
-      "community": 9
+      "community": 6
     },
     {
       "label": "ReviewActions()",
@@ -7153,7 +7153,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewActions.tsx",
       "source_location": "L20",
       "id": "reviewactions_reviewactions",
-      "community": 9
+      "community": 6
     },
     {
       "label": "ReviewCard.tsx",
@@ -7161,7 +7161,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewCard.tsx",
       "source_location": "L1",
       "id": "reviewcard",
-      "community": 9
+      "community": 6
     },
     {
       "label": "ReviewMetadata.tsx",
@@ -7169,7 +7169,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewMetadata.tsx",
       "source_location": "L1",
       "id": "reviewmetadata",
-      "community": 9
+      "community": 6
     },
     {
       "label": "ReviewsView.tsx",
@@ -7177,7 +7177,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L1",
       "id": "reviewsview",
-      "community": 9
+      "community": 6
     },
     {
       "label": "Header()",
@@ -7185,7 +7185,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L13",
       "id": "reviewsview_header",
-      "community": 9
+      "community": 6
     },
     {
       "label": "handleApprove()",
@@ -7193,7 +7193,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L42",
       "id": "reviewsview_handleapprove",
-      "community": 9
+      "community": 6
     },
     {
       "label": "handleReject()",
@@ -7201,7 +7201,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L58",
       "id": "reviewsview_handlereject",
-      "community": 9
+      "community": 6
     },
     {
       "label": "handlePublish()",
@@ -7209,7 +7209,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L74",
       "id": "reviewsview_handlepublish",
-      "community": 9
+      "community": 6
     },
     {
       "label": "handleUnpublish()",
@@ -7217,7 +7217,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L90",
       "id": "reviewsview_handleunpublish",
-      "community": 9
+      "community": 6
     },
     {
       "label": "empty-state.tsx",
@@ -7241,7 +7241,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/error/SingleLineError.tsx",
       "source_location": "L1",
       "id": "singlelineerror",
-      "community": 36
+      "community": 37
     },
     {
       "label": "SingleLineError()",
@@ -7249,7 +7249,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/error/SingleLineError.tsx",
       "source_location": "L3",
       "id": "singlelineerror_singlelineerror",
-      "community": 36
+      "community": 37
     },
     {
       "label": "ErrorPage()",
@@ -7329,7 +7329,7 @@
       "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermission.tsx",
       "source_location": "L1",
       "id": "nopermission",
-      "community": 8
+      "community": 7
     },
     {
       "label": "NoPermission()",
@@ -7337,7 +7337,7 @@
       "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermission.tsx",
       "source_location": "L3",
       "id": "nopermission_nopermission",
-      "community": 8
+      "community": 7
     },
     {
       "label": "NoPermissionView.tsx",
@@ -7345,7 +7345,7 @@
       "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermissionView.tsx",
       "source_location": "L1",
       "id": "nopermissionview",
-      "community": 8
+      "community": 7
     },
     {
       "label": "NoPermissionView()",
@@ -7353,7 +7353,7 @@
       "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermissionView.tsx",
       "source_location": "L4",
       "id": "nopermissionview_nopermissionview",
-      "community": 8
+      "community": 7
     },
     {
       "label": "NotFound.tsx",
@@ -7361,7 +7361,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/not-found/NotFound.tsx",
       "source_location": "L1",
       "id": "notfound",
-      "community": 5
+      "community": 1
     },
     {
       "label": "NotFound()",
@@ -7369,7 +7369,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/not-found/NotFound.tsx",
       "source_location": "L4",
       "id": "notfound_notfound",
-      "community": 5
+      "community": 1
     },
     {
       "label": "NotFoundView.tsx",
@@ -7377,7 +7377,7 @@
       "source_file": "packages/athena-webapp/src/components/states/not-found/NotFoundView.tsx",
       "source_location": "L1",
       "id": "notfoundview",
-      "community": 8
+      "community": 7
     },
     {
       "label": "NotFoundView()",
@@ -7385,7 +7385,7 @@
       "source_file": "packages/athena-webapp/src/components/states/not-found/NotFoundView.tsx",
       "source_location": "L4",
       "id": "notfoundview_notfoundview",
-      "community": 8
+      "community": 7
     },
     {
       "label": "ContactView.tsx",
@@ -7537,7 +7537,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.test.tsx",
       "source_location": "L1",
       "id": "mtnmomoview_test",
-      "community": 11
+      "community": 9
     },
     {
       "label": "MtnMomoView.tsx",
@@ -7545,7 +7545,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L1",
       "id": "mtnmomoview",
-      "community": 11
+      "community": 9
     },
     {
       "label": "cloneReceivingAccount()",
@@ -7553,7 +7553,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L27",
       "id": "mtnmomoview_clonereceivingaccount",
-      "community": 11
+      "community": 9
     },
     {
       "label": "createEmptyReceivingAccount()",
@@ -7561,7 +7561,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L35",
       "id": "mtnmomoview_createemptyreceivingaccount",
-      "community": 11
+      "community": 9
     },
     {
       "label": "trimToUndefined()",
@@ -7569,7 +7569,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L47",
       "id": "mtnmomoview_trimtoundefined",
-      "community": 11
+      "community": 9
     },
     {
       "label": "cleanUndefinedFields()",
@@ -7577,7 +7577,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L52",
       "id": "mtnmomoview_cleanundefinedfields",
-      "community": 11
+      "community": 9
     },
     {
       "label": "hasReceivingAccountDetails()",
@@ -7585,7 +7585,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L64",
       "id": "mtnmomoview_hasreceivingaccountdetails",
-      "community": 11
+      "community": 9
     },
     {
       "label": "normalizePrimaryAccounts()",
@@ -7593,7 +7593,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L77",
       "id": "mtnmomoview_normalizeprimaryaccounts",
-      "community": 11
+      "community": 9
     },
     {
       "label": "toPatchReceivingAccounts()",
@@ -7601,7 +7601,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L93",
       "id": "mtnmomoview_topatchreceivingaccounts",
-      "community": 11
+      "community": 9
     },
     {
       "label": "getStatusBadgeVariant()",
@@ -7609,7 +7609,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L114",
       "id": "mtnmomoview_getstatusbadgevariant",
-      "community": 11
+      "community": 9
     },
     {
       "label": "updateAccount()",
@@ -7617,7 +7617,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L141",
       "id": "mtnmomoview_updateaccount",
-      "community": 11
+      "community": 9
     },
     {
       "label": "handleAddAccount()",
@@ -7625,7 +7625,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L152",
       "id": "mtnmomoview_handleaddaccount",
-      "community": 11
+      "community": 9
     },
     {
       "label": "handleMakePrimary()",
@@ -7633,7 +7633,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L159",
       "id": "mtnmomoview_handlemakeprimary",
-      "community": 11
+      "community": 9
     },
     {
       "label": "handleRemoveAccount()",
@@ -7641,7 +7641,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L168",
       "id": "mtnmomoview_handleremoveaccount",
-      "community": 11
+      "community": 9
     },
     {
       "label": "handleSave()",
@@ -7649,7 +7649,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L188",
       "id": "mtnmomoview_handlesave",
-      "community": 11
+      "community": 9
     },
     {
       "label": "TaxView.tsx",
@@ -7689,7 +7689,7 @@
       "source_file": "packages/athena-webapp/src/components/store-switcher.tsx",
       "source_location": "L1",
       "id": "store_switcher",
-      "community": 3
+      "community": 1
     },
     {
       "label": "onStoreSelect()",
@@ -7697,7 +7697,7 @@
       "source_file": "packages/athena-webapp/src/components/store-switcher.tsx",
       "source_location": "L63",
       "id": "store_switcher_onstoreselect",
-      "community": 3
+      "community": 1
     },
     {
       "label": "accordion.tsx",
@@ -7705,7 +7705,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/accordion.tsx",
       "source_location": "L1",
       "id": "accordion",
-      "community": 0
+      "community": 1
     },
     {
       "label": "app-context-menu.tsx",
@@ -7713,7 +7713,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/app-context-menu.tsx",
       "source_location": "L1",
       "id": "app_context_menu",
-      "community": 12
+      "community": 11
     },
     {
       "label": "AppContextMenu()",
@@ -7721,7 +7721,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/app-context-menu.tsx",
       "source_location": "L20",
       "id": "app_context_menu_appcontextmenu",
-      "community": 12
+      "community": 11
     },
     {
       "label": "badge.tsx",
@@ -7745,7 +7745,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/button.test.tsx",
       "source_location": "L1",
       "id": "button_test",
-      "community": 0
+      "community": 1
     },
     {
       "label": "button.tsx",
@@ -7753,7 +7753,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/button.tsx",
       "source_location": "L1",
       "id": "button",
-      "community": 0
+      "community": 1
     },
     {
       "label": "calendar.test.tsx",
@@ -7761,7 +7761,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/calendar.test.tsx",
       "source_location": "L1",
       "id": "calendar_test",
-      "community": 3
+      "community": 1
     },
     {
       "label": "calendar.tsx",
@@ -7769,7 +7769,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/calendar.tsx",
       "source_location": "L1",
       "id": "calendar",
-      "community": 3
+      "community": 1
     },
     {
       "label": "card.tsx",
@@ -7777,7 +7777,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/card.tsx",
       "source_location": "L1",
       "id": "card",
-      "community": 11
+      "community": 0
     },
     {
       "label": "useChart()",
@@ -7785,7 +7785,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/chart.tsx",
       "source_location": "L25",
       "id": "chart_usechart",
-      "community": 11
+      "community": 6
     },
     {
       "label": "checkbox.tsx",
@@ -7793,7 +7793,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/checkbox.tsx",
       "source_location": "L1",
       "id": "checkbox",
-      "community": 3
+      "community": 12
     },
     {
       "label": "collapsible.tsx",
@@ -7801,7 +7801,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/collapsible.tsx",
       "source_location": "L1",
       "id": "collapsible",
-      "community": 63
+      "community": 64
     },
     {
       "label": "command.tsx",
@@ -7809,7 +7809,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/command.tsx",
       "source_location": "L1",
       "id": "command",
-      "community": 0
+      "community": 1
     },
     {
       "label": "context-menu.tsx",
@@ -7817,7 +7817,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/context-menu.tsx",
       "source_location": "L1",
       "id": "context_menu",
-      "community": 12
+      "community": 11
     },
     {
       "label": "copy-button.tsx",
@@ -7857,7 +7857,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/date-time-picker.tsx",
       "source_location": "L1",
       "id": "date_time_picker",
-      "community": 3
+      "community": 1
     },
     {
       "label": "DateTimePicker()",
@@ -7865,7 +7865,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/date-time-picker.tsx",
       "source_location": "L21",
       "id": "date_time_picker_datetimepicker",
-      "community": 3
+      "community": 1
     },
     {
       "label": "dialog.tsx",
@@ -7873,7 +7873,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/dialog.tsx",
       "source_location": "L1",
       "id": "dialog",
-      "community": 3
+      "community": 1
     },
     {
       "label": "dropdown-menu.tsx",
@@ -7905,7 +7905,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1",
       "id": "image_uploader",
-      "community": 12
+      "community": 11
     },
     {
       "label": "onDrop()",
@@ -7913,7 +7913,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L20",
       "id": "image_uploader_ondrop",
-      "community": 12
+      "community": 11
     },
     {
       "label": "removeImage()",
@@ -7921,7 +7921,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L31",
       "id": "image_uploader_removeimage",
-      "community": 12
+      "community": 11
     },
     {
       "label": "unmarkForDeletion()",
@@ -7929,7 +7929,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L46",
       "id": "image_uploader_unmarkfordeletion",
-      "community": 12
+      "community": 11
     },
     {
       "label": "onDragEnd()",
@@ -7937,7 +7937,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L100",
       "id": "image_uploader_ondragend",
-      "community": 12
+      "community": 11
     },
     {
       "label": "input-otp.tsx",
@@ -7945,7 +7945,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/input-otp.tsx",
       "source_location": "L1",
       "id": "input_otp",
-      "community": 3
+      "community": 12
     },
     {
       "label": "input.tsx",
@@ -7961,7 +7961,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/label.tsx",
       "source_location": "L1",
       "id": "label",
-      "community": 3
+      "community": 0
     },
     {
       "label": "Label()",
@@ -7969,7 +7969,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/label.tsx",
       "source_location": "L6",
       "id": "label_label",
-      "community": 3
+      "community": 0
     },
     {
       "label": "loading-button.tsx",
@@ -8017,7 +8017,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/alert-modal.tsx",
       "source_location": "L1",
       "id": "alert_modal",
-      "community": 0
+      "community": 8
     },
     {
       "label": "AlertModal()",
@@ -8025,7 +8025,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/alert-modal.tsx",
       "source_location": "L20",
       "id": "alert_modal_alertmodal",
-      "community": 0
+      "community": 8
     },
     {
       "label": "custom-modal-example.tsx",
@@ -8033,7 +8033,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
       "source_location": "L1",
       "id": "custom_modal_example",
-      "community": 12
+      "community": 11
     },
     {
       "label": "BasicModalExample()",
@@ -8041,7 +8041,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
       "source_location": "L7",
       "id": "custom_modal_example_basicmodalexample",
-      "community": 12
+      "community": 11
     },
     {
       "label": "CustomPositionModalExample()",
@@ -8049,7 +8049,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
       "source_location": "L44",
       "id": "custom_modal_example_custompositionmodalexample",
-      "community": 12
+      "community": 11
     },
     {
       "label": "CustomCloseButtonExample()",
@@ -8057,7 +8057,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
       "source_location": "L69",
       "id": "custom_modal_example_customclosebuttonexample",
-      "community": 12
+      "community": 11
     },
     {
       "label": "FullScreenModalExample()",
@@ -8065,7 +8065,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
       "source_location": "L103",
       "id": "custom_modal_example_fullscreenmodalexample",
-      "community": 12
+      "community": 11
     },
     {
       "label": "custom-modal.tsx",
@@ -8073,7 +8073,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
       "source_location": "L1",
       "id": "custom_modal",
-      "community": 12
+      "community": 11
     },
     {
       "label": "CustomModal()",
@@ -8081,7 +8081,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
       "source_location": "L25",
       "id": "custom_modal_custommodal",
-      "community": 12
+      "community": 11
     },
     {
       "label": "organization-modal.tsx",
@@ -8121,7 +8121,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/store-modal.tsx",
       "source_location": "L1",
       "id": "store_modal",
-      "community": 0
+      "community": 1
     },
     {
       "label": "onSubmit()",
@@ -8129,7 +8129,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/store-modal.tsx",
       "source_location": "L63",
       "id": "store_modal_onsubmit",
-      "community": 0
+      "community": 1
     },
     {
       "label": "welcome-back-modal-example.tsx",
@@ -8137,7 +8137,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal-example.tsx",
       "source_location": "L1",
       "id": "welcome_back_modal_example",
-      "community": 12
+      "community": 11
     },
     {
       "label": "WelcomeBackModalExample()",
@@ -8145,7 +8145,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal-example.tsx",
       "source_location": "L5",
       "id": "welcome_back_modal_example_welcomebackmodalexample",
-      "community": 12
+      "community": 11
     },
     {
       "label": "welcome-back-modal.tsx",
@@ -8153,7 +8153,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal.tsx",
       "source_location": "L1",
       "id": "welcome_back_modal",
-      "community": 12
+      "community": 11
     },
     {
       "label": "WelcomeBackModal()",
@@ -8161,7 +8161,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal.tsx",
       "source_location": "L12",
       "id": "welcome_back_modal_welcomebackmodal",
-      "community": 12
+      "community": 11
     },
     {
       "label": "popover.tsx",
@@ -8169,7 +8169,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/popover.tsx",
       "source_location": "L1",
       "id": "popover",
-      "community": 3
+      "community": 1
     },
     {
       "label": "radio-group.tsx",
@@ -8177,7 +8177,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/radio-group.tsx",
       "source_location": "L1",
       "id": "radio_group",
-      "community": 3
+      "community": 0
     },
     {
       "label": "scroll-area.tsx",
@@ -8185,7 +8185,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/scroll-area.tsx",
       "source_location": "L1",
       "id": "scroll_area",
-      "community": 5
+      "community": 8
     },
     {
       "label": "select-native.tsx",
@@ -8193,7 +8193,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/select-native.tsx",
       "source_location": "L1",
       "id": "select_native",
-      "community": 3
+      "community": 0
     },
     {
       "label": "cn()",
@@ -8201,7 +8201,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/select-native.tsx",
       "source_location": "L15",
       "id": "select_native_cn",
-      "community": 3
+      "community": 0
     },
     {
       "label": "select.tsx",
@@ -8209,7 +8209,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/select.tsx",
       "source_location": "L1",
       "id": "select",
-      "community": 3
+      "community": 1
     },
     {
       "label": "separator.tsx",
@@ -8217,7 +8217,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/separator.tsx",
       "source_location": "L1",
       "id": "separator",
-      "community": 3
+      "community": 1
     },
     {
       "label": "sheet.tsx",
@@ -8225,7 +8225,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/sheet.tsx",
       "source_location": "L1",
       "id": "sheet",
-      "community": 5
+      "community": 8
     },
     {
       "label": "sidebar.tsx",
@@ -8233,7 +8233,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L1",
       "id": "sidebar",
-      "community": 19
+      "community": 8
     },
     {
       "label": "useSidebar()",
@@ -8241,7 +8241,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L45",
       "id": "sidebar_usesidebar",
-      "community": 19
+      "community": 8
     },
     {
       "label": "handleKeyDown()",
@@ -8249,7 +8249,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L105",
       "id": "sidebar_handlekeydown",
-      "community": 19
+      "community": 8
     },
     {
       "label": "cn()",
@@ -8257,7 +8257,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L147",
       "id": "sidebar_cn",
-      "community": 19
+      "community": 8
     },
     {
       "label": "handleOnHover()",
@@ -8265,7 +8265,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L224",
       "id": "sidebar_handleonhover",
-      "community": 19
+      "community": 8
     },
     {
       "label": "handleOnMouseLeave()",
@@ -8273,7 +8273,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L228",
       "id": "sidebar_handleonmouseleave",
-      "community": 19
+      "community": 8
     },
     {
       "label": "skeleton.tsx",
@@ -8337,7 +8337,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/table.tsx",
       "source_location": "L1",
       "id": "table",
-      "community": 15
+      "community": 12
     },
     {
       "label": "tabs.tsx",
@@ -8361,7 +8361,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/timeline-item.tsx",
       "source_location": "L1",
       "id": "timeline_item",
-      "community": 37
+      "community": 38
     },
     {
       "label": "TimelineItem()",
@@ -8369,7 +8369,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/timeline-item.tsx",
       "source_location": "L3",
       "id": "timeline_item_timelineitem",
-      "community": 37
+      "community": 38
     },
     {
       "label": "toggle-group.tsx",
@@ -8377,7 +8377,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/toggle-group.tsx",
       "source_location": "L1",
       "id": "toggle_group",
-      "community": 3
+      "community": 0
     },
     {
       "label": "toggle.tsx",
@@ -8385,7 +8385,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/toggle.tsx",
       "source_location": "L1",
       "id": "toggle",
-      "community": 3
+      "community": 0
     },
     {
       "label": "tooltip.tsx",
@@ -8401,7 +8401,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/webp-image.tsx",
       "source_location": "L1",
       "id": "webp_image",
-      "community": 38
+      "community": 39
     },
     {
       "label": "WebpImage()",
@@ -8409,7 +8409,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/webp-image.tsx",
       "source_location": "L1",
       "id": "webp_image_webpimage",
-      "community": 38
+      "community": 39
     },
     {
       "label": "upload-button.tsx",
@@ -8497,7 +8497,7 @@
       "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
       "source_location": "L1",
       "id": "activitysummarycards",
-      "community": 11
+      "community": 6
     },
     {
       "label": "SummaryCard()",
@@ -8505,7 +8505,7 @@
       "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
       "source_location": "L19",
       "id": "activitysummarycards_summarycard",
-      "community": 11
+      "community": 6
     },
     {
       "label": "ActivitySummaryCards()",
@@ -8513,7 +8513,7 @@
       "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
       "source_location": "L44",
       "id": "activitysummarycards_activitysummarycards",
-      "community": 11
+      "community": 6
     },
     {
       "label": "String()",
@@ -8521,7 +8521,7 @@
       "source_file": "packages/athena-webapp/src/components/users/CustomerBehaviorTimeline.tsx",
       "source_location": "L110",
       "id": "customerbehaviortimeline_string",
-      "community": 3
+      "community": 13
     },
     {
       "label": "LinkedAccounts.tsx",
@@ -8537,7 +8537,7 @@
       "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.test.tsx",
       "source_location": "L1",
       "id": "timelineeventcard_test",
-      "community": 3
+      "community": 13
     },
     {
       "label": "TimelineEventCard.tsx",
@@ -8545,7 +8545,7 @@
       "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
       "source_location": "L1",
       "id": "timelineeventcard",
-      "community": 3
+      "community": 13
     },
     {
       "label": "formatObservabilityLabel()",
@@ -8553,7 +8553,7 @@
       "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
       "source_location": "L139",
       "id": "timelineeventcard_formatobservabilitylabel",
-      "community": 3
+      "community": 13
     },
     {
       "label": "loadMore()",
@@ -8561,7 +8561,7 @@
       "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
       "source_location": "L175",
       "id": "timelineeventcard_loadmore",
-      "community": 3
+      "community": 13
     },
     {
       "label": "UserActivity.tsx",
@@ -8689,7 +8689,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/CustomerJourneyStage.tsx",
       "source_location": "L1",
       "id": "customerjourneystage",
-      "community": 11
+      "community": 13
     },
     {
       "label": "CustomerJourneyStageCard()",
@@ -8697,7 +8697,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/CustomerJourneyStage.tsx",
       "source_location": "L13",
       "id": "customerjourneystage_customerjourneystagecard",
-      "community": 11
+      "community": 13
     },
     {
       "label": "EngagementMetrics.tsx",
@@ -8705,7 +8705,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
       "source_location": "L1",
       "id": "engagementmetrics",
-      "community": 11
+      "community": 13
     },
     {
       "label": "formatLastActivity()",
@@ -8713,7 +8713,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
       "source_location": "L75",
       "id": "engagementmetrics_formatlastactivity",
-      "community": 11
+      "community": 13
     },
     {
       "label": "getDeviceIcon()",
@@ -8721,7 +8721,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
       "source_location": "L82",
       "id": "engagementmetrics_getdeviceicon",
-      "community": 11
+      "community": 13
     },
     {
       "label": "getDeviceLabel()",
@@ -8729,7 +8729,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
       "source_location": "L93",
       "id": "engagementmetrics_getdevicelabel",
-      "community": 11
+      "community": 13
     },
     {
       "label": "RiskIndicators.tsx",
@@ -8737,7 +8737,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
       "source_location": "L1",
       "id": "riskindicators",
-      "community": 11
+      "community": 13
     },
     {
       "label": "getRiskIcon()",
@@ -8745,7 +8745,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
       "source_location": "L15",
       "id": "riskindicators_getriskicon",
-      "community": 11
+      "community": 13
     },
     {
       "label": "getRiskStyles()",
@@ -8753,7 +8753,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
       "source_location": "L28",
       "id": "riskindicators_getriskstyles",
-      "community": 11
+      "community": 13
     },
     {
       "label": "RiskIndicators()",
@@ -8761,7 +8761,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
       "source_location": "L54",
       "id": "riskindicators_riskindicators",
-      "community": 11
+      "community": 13
     },
     {
       "label": "UserBehaviorInsights.tsx",
@@ -8769,7 +8769,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/UserBehaviorInsights.tsx",
       "source_location": "L1",
       "id": "userbehaviorinsights",
-      "community": 11
+      "community": 13
     },
     {
       "label": "OnlineOrderContext.tsx",
@@ -8801,7 +8801,7 @@
       "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
       "source_location": "L1",
       "id": "permissionscontext",
-      "community": 19
+      "community": 6
     },
     {
       "label": "PermissionsProvider()",
@@ -8809,7 +8809,7 @@
       "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
       "source_location": "L23",
       "id": "permissionscontext_permissionsprovider",
-      "community": 19
+      "community": 6
     },
     {
       "label": "usePermissionsContext()",
@@ -8817,7 +8817,7 @@
       "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
       "source_location": "L51",
       "id": "permissionscontext_usepermissionscontext",
-      "community": 19
+      "community": 6
     },
     {
       "label": "ProductContext.tsx",
@@ -8849,7 +8849,7 @@
       "source_file": "packages/athena-webapp/src/contexts/ThemeContext.tsx",
       "source_location": "L1",
       "id": "themecontext",
-      "community": 64
+      "community": 65
     },
     {
       "label": "UserContext.tsx",
@@ -8857,7 +8857,7 @@
       "source_file": "packages/athena-webapp/src/contexts/UserContext.tsx",
       "source_location": "L1",
       "id": "usercontext",
-      "community": 3
+      "community": 1
     },
     {
       "label": "UserProvider()",
@@ -8865,7 +8865,7 @@
       "source_file": "packages/athena-webapp/src/contexts/UserContext.tsx",
       "source_location": "L12",
       "id": "usercontext_userprovider",
-      "community": 3
+      "community": 1
     },
     {
       "label": "useUserContext()",
@@ -8873,7 +8873,7 @@
       "source_file": "packages/athena-webapp/src/contexts/UserContext.tsx",
       "source_location": "L37",
       "id": "usercontext_useusercontext",
-      "community": 3
+      "community": 1
     },
     {
       "label": "use-image-upload.ts",
@@ -8897,7 +8897,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
       "source_location": "L1",
       "id": "use_mobile",
-      "community": 19
+      "community": 8
     },
     {
       "label": "useIsMobile()",
@@ -8905,7 +8905,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
       "source_location": "L5",
       "id": "use_mobile_useismobile",
-      "community": 19
+      "community": 8
     },
     {
       "label": "use-navigate-back.ts",
@@ -8929,7 +8929,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-navigation-keyboard-shortcuts.ts",
       "source_location": "L1",
       "id": "use_navigation_keyboard_shortcuts",
-      "community": 6
+      "community": 4
     },
     {
       "label": "useNavigationKeyboardShortcuts()",
@@ -8937,7 +8937,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-navigation-keyboard-shortcuts.ts",
       "source_location": "L7",
       "id": "use_navigation_keyboard_shortcuts_usenavigationkeyboardshortcuts",
-      "community": 6
+      "community": 4
     },
     {
       "label": "use-pagination-persistence.ts",
@@ -8961,7 +8961,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/use-store-modal.tsx",
       "source_location": "L1",
       "id": "use_store_modal",
-      "community": 0
+      "community": 1
     },
     {
       "label": "use-table-keyboard-pagination.ts",
@@ -9001,7 +9001,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.test.ts",
       "source_location": "L1",
       "id": "usebulkoperations_test",
-      "community": 15
+      "community": 12
     },
     {
       "label": "makeSku()",
@@ -9009,7 +9009,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.test.ts",
       "source_location": "L168",
       "id": "usebulkoperations_test_makesku",
-      "community": 15
+      "community": 12
     },
     {
       "label": "useBulkOperations.ts",
@@ -9017,7 +9017,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L1",
       "id": "usebulkoperations",
-      "community": 15
+      "community": 12
     },
     {
       "label": "applyOperation()",
@@ -9025,7 +9025,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L56",
       "id": "usebulkoperations_applyoperation",
-      "community": 15
+      "community": 12
     },
     {
       "label": "calculatePriceWithFee()",
@@ -9033,7 +9033,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L87",
       "id": "usebulkoperations_calculatepricewithfee",
-      "community": 15
+      "community": 12
     },
     {
       "label": "computePreview()",
@@ -9041,7 +9041,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L101",
       "id": "usebulkoperations_computepreview",
-      "community": 15
+      "community": 12
     },
     {
       "label": "validateOperationValue()",
@@ -9049,7 +9049,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L139",
       "id": "usebulkoperations_validateoperationvalue",
-      "community": 15
+      "community": 12
     },
     {
       "label": "useBulkOperations()",
@@ -9057,7 +9057,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L158",
       "id": "usebulkoperations_usebulkoperations",
-      "community": 15
+      "community": 12
     },
     {
       "label": "useCartOperations.ts",
@@ -9065,7 +9065,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useCartOperations.ts",
       "source_location": "L1",
       "id": "usecartoperations",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useCartOperations()",
@@ -9073,7 +9073,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useCartOperations.ts",
       "source_location": "L23",
       "id": "usecartoperations_usecartoperations",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useCopyText.ts",
@@ -9113,7 +9113,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useCustomerOperations.ts",
       "source_location": "L1",
       "id": "usecustomeroperations",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useCustomerOperations()",
@@ -9121,7 +9121,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useCustomerOperations.ts",
       "source_location": "L21",
       "id": "usecustomeroperations_usecustomeroperations",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useDebounce.ts",
@@ -9129,7 +9129,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useDebounce.ts",
       "source_location": "L1",
       "id": "usedebounce",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useDebounce()",
@@ -9137,7 +9137,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useDebounce.ts",
       "source_location": "L12",
       "id": "usedebounce_usedebounce",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useExpenseOperations.ts",
@@ -9145,7 +9145,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
       "source_location": "L1",
       "id": "useexpenseoperations",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useExpenseOperations()",
@@ -9153,7 +9153,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
       "source_location": "L23",
       "id": "useexpenseoperations_useexpenseoperations",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useExpenseSessions.ts",
@@ -9161,7 +9161,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L1",
       "id": "useexpensesessions",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useExpenseStoreSessions()",
@@ -9169,7 +9169,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L7",
       "id": "useexpensesessions_useexpensestoresessions",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useExpenseSession()",
@@ -9177,7 +9177,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L23",
       "id": "useexpensesessions_useexpensesession",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useExpenseActiveSession()",
@@ -9185,7 +9185,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L33",
       "id": "useexpensesessions_useexpenseactivesession",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useExpenseSessionCreate()",
@@ -9193,7 +9193,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L48",
       "id": "useexpensesessions_useexpensesessioncreate",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useExpenseSessionUpdate()",
@@ -9201,7 +9201,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L85",
       "id": "useexpensesessions_useexpensesessionupdate",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useGetActiveProduct.ts",
@@ -9417,7 +9417,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L1",
       "id": "useposcustomers",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSCustomerSearch()",
@@ -9425,7 +9425,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L7",
       "id": "useposcustomers_useposcustomersearch",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSCustomer()",
@@ -9433,7 +9433,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L18",
       "id": "useposcustomers_useposcustomer",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSCustomerCreate()",
@@ -9441,7 +9441,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L26",
       "id": "useposcustomers_useposcustomercreate",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSCustomerUpdate()",
@@ -9449,7 +9449,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L57",
       "id": "useposcustomers_useposcustomerupdate",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSCustomerTransactions()",
@@ -9457,7 +9457,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L90",
       "id": "useposcustomers_useposcustomertransactions",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSOperations.ts",
@@ -9465,7 +9465,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSOperations.ts",
       "source_location": "L1",
       "id": "useposoperations",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSOperations()",
@@ -9473,7 +9473,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSOperations.ts",
       "source_location": "L30",
       "id": "useposoperations_useposoperations",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSState()",
@@ -9481,7 +9481,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSOperations.ts",
       "source_location": "L580",
       "id": "useposoperations_useposstate",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSProducts.ts",
@@ -9489,7 +9489,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L1",
       "id": "useposproducts",
-      "community": 4
+      "community": 6
     },
     {
       "label": "usePOSProductSearch()",
@@ -9497,7 +9497,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L10",
       "id": "useposproducts_useposproductsearch",
-      "community": 4
+      "community": 6
     },
     {
       "label": "usePOSBarcodeSearch()",
@@ -9505,7 +9505,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L30",
       "id": "useposproducts_useposbarcodesearch",
-      "community": 4
+      "community": 6
     },
     {
       "label": "usePOSProductIdSearch()",
@@ -9513,7 +9513,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L41",
       "id": "useposproducts_useposproductidsearch",
-      "community": 4
+      "community": 6
     },
     {
       "label": "usePOSTransactionComplete()",
@@ -9521,7 +9521,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L100",
       "id": "useposproducts_usepostransactioncomplete",
-      "community": 4
+      "community": 6
     },
     {
       "label": "usePOSSessions.ts",
@@ -9529,7 +9529,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L1",
       "id": "usepossessions",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSStoreSessions()",
@@ -9537,7 +9537,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L8",
       "id": "usepossessions_useposstoresessions",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSSession()",
@@ -9545,7 +9545,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L24",
       "id": "usepossessions_usepossession",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSActiveSession()",
@@ -9553,7 +9553,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L32",
       "id": "usepossessions_useposactivesession",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSSessionCreate()",
@@ -9561,7 +9561,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L47",
       "id": "usepossessions_usepossessioncreate",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSSessionUpdate()",
@@ -9569,7 +9569,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L82",
       "id": "usepossessions_usepossessionupdate",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSSessionHold()",
@@ -9577,7 +9577,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L117",
       "id": "usepossessions_usepossessionhold",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSSessionResume()",
@@ -9585,7 +9585,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L137",
       "id": "usepossessions_usepossessionresume",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSSessionComplete()",
@@ -9593,7 +9593,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L157",
       "id": "usepossessions_usepossessioncomplete",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSSessionVoid()",
@@ -9601,7 +9601,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L191",
       "id": "usepossessions_usepossessionvoid",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSSessionManager()",
@@ -9609,7 +9609,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L207",
       "id": "usepossessions_usepossessionmanager",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePermissions.ts",
@@ -9617,7 +9617,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePermissions.ts",
       "source_location": "L1",
       "id": "usepermissions",
-      "community": 0
+      "community": 6
     },
     {
       "label": "usePermissions()",
@@ -9625,7 +9625,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePermissions.ts",
       "source_location": "L12",
       "id": "usepermissions_usepermissions",
-      "community": 0
+      "community": 6
     },
     {
       "label": "usePrint.ts",
@@ -9633,7 +9633,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
       "source_location": "L1",
       "id": "useprint",
-      "community": 1
+      "community": 3
     },
     {
       "label": "usePrint()",
@@ -9641,7 +9641,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
       "source_location": "L3",
       "id": "useprint_useprint",
-      "community": 1
+      "community": 3
     },
     {
       "label": "useProductSearchResults.ts",
@@ -9649,7 +9649,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
       "source_location": "L1",
       "id": "useproductsearchresults",
-      "community": 1
+      "community": 6
     },
     {
       "label": "useProductSearchResults()",
@@ -9657,7 +9657,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
       "source_location": "L26",
       "id": "useproductsearchresults_useproductsearchresults",
-      "community": 1
+      "community": 6
     },
     {
       "label": "useProductWithNoImagesNotification.tsx",
@@ -9681,7 +9681,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSessionManagement.ts",
       "source_location": "L1",
       "id": "usesessionmanagement",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useSessionManagement()",
@@ -9689,7 +9689,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSessionManagement.ts",
       "source_location": "L17",
       "id": "usesessionmanagement_usesessionmanagement",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useSessionManagementExpense.ts",
@@ -9697,7 +9697,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSessionManagementExpense.ts",
       "source_location": "L1",
       "id": "usesessionmanagementexpense",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useSessionManagementExpense()",
@@ -9705,7 +9705,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSessionManagementExpense.ts",
       "source_location": "L17",
       "id": "usesessionmanagementexpense_usesessionmanagementexpense",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useSessionManagerOperations.ts",
@@ -9713,7 +9713,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSessionManagerOperations.ts",
       "source_location": "L1",
       "id": "usesessionmanageroperations",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useSessionManagerOperations()",
@@ -9721,7 +9721,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSessionManagerOperations.ts",
       "source_location": "L16",
       "id": "usesessionmanageroperations_usesessionmanageroperations",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useSkusReservedInCheckout.ts",
@@ -9777,7 +9777,7 @@
       "source_file": "packages/athena-webapp/src/lib/aws.ts",
       "source_location": "L1",
       "id": "aws",
-      "community": 65
+      "community": 66
     },
     {
       "label": "behaviorUtils.ts",
@@ -9785,7 +9785,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L1",
       "id": "behaviorutils",
-      "community": 11
+      "community": 13
     },
     {
       "label": "getCustomerJourneyStage()",
@@ -9793,7 +9793,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L36",
       "id": "behaviorutils_getcustomerjourneystage",
-      "community": 11
+      "community": 13
     },
     {
       "label": "calculateRiskIndicators()",
@@ -9801,7 +9801,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L71",
       "id": "behaviorutils_calculateriskindicators",
-      "community": 11
+      "community": 13
     },
     {
       "label": "calculateEngagementMetrics()",
@@ -9809,7 +9809,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L173",
       "id": "behaviorutils_calculateengagementmetrics",
-      "community": 11
+      "community": 13
     },
     {
       "label": "getActivityPriority()",
@@ -9817,7 +9817,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L251",
       "id": "behaviorutils_getactivitypriority",
-      "community": 11
+      "community": 13
     },
     {
       "label": "getJourneyStageInfo()",
@@ -9825,7 +9825,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L277",
       "id": "behaviorutils_getjourneystageinfo",
-      "community": 11
+      "community": 13
     },
     {
       "label": "browserFingerprint.ts",
@@ -9833,7 +9833,7 @@
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
       "source_location": "L1",
       "id": "browserfingerprint",
-      "community": 8
+      "community": 26
     },
     {
       "label": "bufferToHex()",
@@ -9841,7 +9841,7 @@
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
       "source_location": "L18",
       "id": "browserfingerprint_buffertohex",
-      "community": 8
+      "community": 26
     },
     {
       "label": "collectBrowserInfo()",
@@ -9849,7 +9849,7 @@
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
       "source_location": "L23",
       "id": "browserfingerprint_collectbrowserinfo",
-      "community": 8
+      "community": 26
     },
     {
       "label": "hashFingerprintSource()",
@@ -9857,7 +9857,7 @@
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
       "source_location": "L45",
       "id": "browserfingerprint_hashfingerprintsource",
-      "community": 8
+      "community": 26
     },
     {
       "label": "generateBrowserFingerprint()",
@@ -9865,7 +9865,7 @@
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
       "source_location": "L65",
       "id": "browserfingerprint_generatebrowserfingerprint",
-      "community": 8
+      "community": 26
     },
     {
       "label": "customerObservabilityTimeline.ts",
@@ -9873,7 +9873,7 @@
       "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
       "source_location": "L1",
       "id": "customerobservabilitytimeline",
-      "community": 3
+      "community": 13
     },
     {
       "label": "formatObservabilityLabel()",
@@ -9881,7 +9881,7 @@
       "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
       "source_location": "L59",
       "id": "customerobservabilitytimeline_formatobservabilitylabel",
-      "community": 3
+      "community": 13
     },
     {
       "label": "getObservabilityStatusStyles()",
@@ -9889,7 +9889,7 @@
       "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
       "source_location": "L67",
       "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
-      "community": 3
+      "community": 13
     },
     {
       "label": "getDeviceIcon()",
@@ -9897,7 +9897,7 @@
       "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
       "source_location": "L114",
       "id": "customerobservabilitytimeline_getdeviceicon",
-      "community": 3
+      "community": 13
     },
     {
       "label": "ghanaRegions.ts",
@@ -9913,7 +9913,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
       "source_location": "L1",
       "id": "imageutils_test",
-      "community": 12
+      "community": 11
     },
     {
       "label": "constructor()",
@@ -9921,7 +9921,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
       "source_location": "L74",
       "id": "imageutils_test_constructor",
-      "community": 12
+      "community": 11
     },
     {
       "label": "arrayBuffer()",
@@ -9929,7 +9929,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
       "source_location": "L78",
       "id": "imageutils_test_arraybuffer",
-      "community": 12
+      "community": 11
     },
     {
       "label": "MockImage",
@@ -9937,7 +9937,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
       "source_location": "L103",
       "id": "imageutils_test_mockimage",
-      "community": 12
+      "community": 11
     },
     {
       "label": ".src()",
@@ -9945,7 +9945,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
       "source_location": "L109",
       "id": "imageutils_test_mockimage_src",
-      "community": 12
+      "community": 11
     },
     {
       "label": "imageUtils.ts",
@@ -9953,7 +9953,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
       "source_location": "L1",
       "id": "imageutils",
-      "community": 12
+      "community": 11
     },
     {
       "label": "getUploadImagesData()",
@@ -9961,7 +9961,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
       "source_location": "L4",
       "id": "imageutils_getuploadimagesdata",
-      "community": 12
+      "community": 11
     },
     {
       "label": "convertImagesToWebp()",
@@ -9969,7 +9969,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
       "source_location": "L26",
       "id": "imageutils_convertimagestowebp",
-      "community": 12
+      "community": 11
     },
     {
       "label": "convertToJpg()",
@@ -9977,7 +9977,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
       "source_location": "L38",
       "id": "imageutils_converttojpg",
-      "community": 12
+      "community": 11
     },
     {
       "label": "convertImagesToJpg()",
@@ -9985,7 +9985,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
       "source_location": "L75",
       "id": "imageutils_convertimagestojpg",
-      "community": 12
+      "community": 11
     },
     {
       "label": "logger.ts",
@@ -9993,7 +9993,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L1",
       "id": "logger",
-      "community": 4
+      "community": 3
     },
     {
       "label": "Logger",
@@ -10001,7 +10001,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L12",
       "id": "logger_logger",
-      "community": 4
+      "community": 3
     },
     {
       "label": ".constructor()",
@@ -10009,7 +10009,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L15",
       "id": "logger_logger_constructor",
-      "community": 4
+      "community": 3
     },
     {
       "label": ".shouldLog()",
@@ -10017,7 +10017,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L20",
       "id": "logger_logger_shouldlog",
-      "community": 4
+      "community": 3
     },
     {
       "label": ".formatMessage()",
@@ -10025,7 +10025,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L30",
       "id": "logger_logger_formatmessage",
-      "community": 4
+      "community": 3
     },
     {
       "label": ".debug()",
@@ -10033,7 +10033,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L45",
       "id": "logger_logger_debug",
-      "community": 4
+      "community": 3
     },
     {
       "label": ".info()",
@@ -10041,7 +10041,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L51",
       "id": "logger_logger_info",
-      "community": 4
+      "community": 3
     },
     {
       "label": ".warn()",
@@ -10049,7 +10049,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L57",
       "id": "logger_logger_warn",
-      "community": 4
+      "community": 3
     },
     {
       "label": ".error()",
@@ -10057,7 +10057,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L63",
       "id": "logger_logger_error",
-      "community": 4
+      "community": 3
     },
     {
       "label": "maintenanceUtils.ts",
@@ -10065,7 +10065,7 @@
       "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.ts",
       "source_location": "L1",
       "id": "maintenanceutils",
-      "community": 6
+      "community": 16
     },
     {
       "label": "isInMaintenanceMode()",
@@ -10073,7 +10073,7 @@
       "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.ts",
       "source_location": "L7",
       "id": "maintenanceutils_isinmaintenancemode",
-      "community": 6
+      "community": 16
     },
     {
       "label": "navigationUtils.ts",
@@ -10097,7 +10097,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
       "source_location": "L1",
       "id": "barcodeutils",
-      "community": 4
+      "community": 6
     },
     {
       "label": "isValidConvexId()",
@@ -10105,7 +10105,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
       "source_location": "L16",
       "id": "barcodeutils_isvalidconvexid",
-      "community": 4
+      "community": 6
     },
     {
       "label": "extractBarcodeFromInput()",
@@ -10113,7 +10113,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
       "source_location": "L51",
       "id": "barcodeutils_extractbarcodefrominput",
-      "community": 4
+      "community": 6
     },
     {
       "label": "isUrlOrBarcode()",
@@ -10121,7 +10121,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
       "source_location": "L92",
       "id": "barcodeutils_isurlorbarcode",
-      "community": 4
+      "community": 6
     },
     {
       "label": "calculations.ts",
@@ -10129,7 +10129,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/calculations.ts",
       "source_location": "L1",
       "id": "calculations",
-      "community": 1
+      "community": 6
     },
     {
       "label": "calculateCartTotals()",
@@ -10137,7 +10137,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/calculations.ts",
       "source_location": "L10",
       "id": "calculations_calculatecarttotals",
-      "community": 1
+      "community": 6
     },
     {
       "label": "calculationService.ts",
@@ -10145,7 +10145,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
       "source_location": "L1",
       "id": "calculationservice",
-      "community": 4
+      "community": 3
     },
     {
       "label": "calculateCartTotals()",
@@ -10153,7 +10153,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
       "source_location": "L30",
       "id": "calculationservice_calculatecarttotals",
-      "community": 4
+      "community": 3
     },
     {
       "label": "calculateItemTotal()",
@@ -10161,7 +10161,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
       "source_location": "L61",
       "id": "calculationservice_calculateitemtotal",
-      "community": 4
+      "community": 3
     },
     {
       "label": "calculateChange()",
@@ -10169,7 +10169,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
       "source_location": "L68",
       "id": "calculationservice_calculatechange",
-      "community": 4
+      "community": 3
     },
     {
       "label": "formatCurrency()",
@@ -10177,7 +10177,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
       "source_location": "L75",
       "id": "calculationservice_formatcurrency",
-      "community": 4
+      "community": 3
     },
     {
       "label": "isPaymentSufficient()",
@@ -10185,7 +10185,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
       "source_location": "L85",
       "id": "calculationservice_ispaymentsufficient",
-      "community": 4
+      "community": 3
     },
     {
       "label": "getEffectivePrice()",
@@ -10193,7 +10193,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
       "source_location": "L96",
       "id": "calculationservice_geteffectiveprice",
-      "community": 4
+      "community": 3
     },
     {
       "label": "toastService.ts",
@@ -10201,7 +10201,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L1",
       "id": "toastservice",
-      "community": 4
+      "community": 3
     },
     {
       "label": "handlePOSOperation()",
@@ -10209,7 +10209,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L171",
       "id": "toastservice_handleposoperation",
-      "community": 4
+      "community": 3
     },
     {
       "label": "showValidationError()",
@@ -10217,7 +10217,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L293",
       "id": "toastservice_showvalidationerror",
-      "community": 4
+      "community": 3
     },
     {
       "label": "showInventoryError()",
@@ -10225,7 +10225,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L302",
       "id": "toastservice_showinventoryerror",
-      "community": 4
+      "community": 3
     },
     {
       "label": "showSessionExpiredError()",
@@ -10233,7 +10233,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L312",
       "id": "toastservice_showsessionexpirederror",
-      "community": 4
+      "community": 3
     },
     {
       "label": "showNoActiveSessionError()",
@@ -10241,7 +10241,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L319",
       "id": "toastservice_shownoactivesessionerror",
-      "community": 4
+      "community": 3
     },
     {
       "label": "transactionUtils.ts",
@@ -10249,7 +10249,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
       "source_location": "L1",
       "id": "transactionutils",
-      "community": 4
+      "community": 3
     },
     {
       "label": "generateTransactionNumber()",
@@ -10257,7 +10257,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
       "source_location": "L14",
       "id": "transactionutils_generatetransactionnumber",
-      "community": 4
+      "community": 3
     },
     {
       "label": "formatCurrency()",
@@ -10265,7 +10265,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
       "source_location": "L29",
       "id": "transactionutils_formatcurrency",
-      "community": 4
+      "community": 3
     },
     {
       "label": "calculateChange()",
@@ -10273,7 +10273,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
       "source_location": "L42",
       "id": "transactionutils_calculatechange",
-      "community": 4
+      "community": 3
     },
     {
       "label": "formatTimestamp()",
@@ -10281,7 +10281,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
       "source_location": "L49",
       "id": "transactionutils_formattimestamp",
-      "community": 4
+      "community": 3
     },
     {
       "label": "validation.ts",
@@ -10289,7 +10289,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L1",
       "id": "validation",
-      "community": 4
+      "community": 3
     },
     {
       "label": "validateCart()",
@@ -10297,7 +10297,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L21",
       "id": "validation_validatecart",
-      "community": 4
+      "community": 3
     },
     {
       "label": "validateProduct()",
@@ -10305,7 +10305,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L68",
       "id": "validation_validateproduct",
-      "community": 4
+      "community": 3
     },
     {
       "label": "validateCustomer()",
@@ -10313,7 +10313,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L108",
       "id": "validation_validatecustomer",
-      "community": 4
+      "community": 3
     },
     {
       "label": "validatePayment()",
@@ -10321,7 +10321,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L146",
       "id": "validation_validatepayment",
-      "community": 4
+      "community": 3
     },
     {
       "label": "validateBarcode()",
@@ -10329,7 +10329,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L185",
       "id": "validation_validatebarcode",
-      "community": 4
+      "community": 3
     },
     {
       "label": "validateQuantity()",
@@ -10337,7 +10337,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L213",
       "id": "validation_validatequantity",
-      "community": 4
+      "community": 3
     },
     {
       "label": "isValidEmail()",
@@ -10345,7 +10345,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L244",
       "id": "validation_isvalidemail",
-      "community": 4
+      "community": 3
     },
     {
       "label": "validateSession()",
@@ -10353,7 +10353,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L252",
       "id": "validation_validatesession",
-      "community": 4
+      "community": 3
     },
     {
       "label": "isValidPhone()",
@@ -10361,7 +10361,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L304",
       "id": "validation_isvalidphone",
-      "community": 4
+      "community": 3
     },
     {
       "label": "validatePaymentAmount()",
@@ -10369,7 +10369,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L317",
       "id": "validation_validatepaymentamount",
-      "community": 4
+      "community": 3
     },
     {
       "label": "validatePayments()",
@@ -10377,7 +10377,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L359",
       "id": "validation_validatepayments",
-      "community": 4
+      "community": 3
     },
     {
       "label": "canCompleteTransaction()",
@@ -10385,7 +10385,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L404",
       "id": "validation_cancompletetransaction",
-      "community": 4
+      "community": 3
     },
     {
       "label": "productUtils.test.ts",
@@ -10393,7 +10393,7 @@
       "source_file": "packages/athena-webapp/src/lib/productUtils.test.ts",
       "source_location": "L1",
       "id": "productutils_test",
-      "community": 5
+      "community": 1
     },
     {
       "label": "productUtils.ts",
@@ -10401,7 +10401,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L1",
       "id": "productutils",
-      "community": 5
+      "community": 1
     },
     {
       "label": "getProductName()",
@@ -10409,7 +10409,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L18",
       "id": "productutils_getproductname",
-      "community": 5
+      "community": 1
     },
     {
       "label": "sortProduct()",
@@ -10417,7 +10417,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L66",
       "id": "productutils_sortproduct",
-      "community": 5
+      "community": 1
     },
     {
       "label": "pinHash.ts",
@@ -10425,7 +10425,7 @@
       "source_file": "packages/athena-webapp/src/lib/security/pinHash.ts",
       "source_location": "L1",
       "id": "pinhash",
-      "community": 3
+      "community": 12
     },
     {
       "label": "hashPin()",
@@ -10433,7 +10433,7 @@
       "source_file": "packages/athena-webapp/src/lib/security/pinHash.ts",
       "source_location": "L12",
       "id": "pinhash_hashpin",
-      "community": 3
+      "community": 12
     },
     {
       "label": "storeConfig.test.ts",
@@ -10585,7 +10585,7 @@
       "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
       "source_location": "L1",
       "id": "timelineutils",
-      "community": 3
+      "community": 13
     },
     {
       "label": "enrichTimelineEvent()",
@@ -10593,7 +10593,7 @@
       "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
       "source_location": "L184",
       "id": "timelineutils_enrichtimelineevent",
-      "community": 3
+      "community": 13
     },
     {
       "label": "enrichTimelineEvents()",
@@ -10601,7 +10601,7 @@
       "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
       "source_location": "L200",
       "id": "timelineutils_enrichtimelineevents",
-      "community": 3
+      "community": 13
     },
     {
       "label": "groupEventsByTimeframe()",
@@ -10609,7 +10609,7 @@
       "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
       "source_location": "L206",
       "id": "timelineutils_groupeventsbytimeframe",
-      "community": 3
+      "community": 13
     },
     {
       "label": "getTimeRangeLabel()",
@@ -10617,7 +10617,7 @@
       "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
       "source_location": "L244",
       "id": "timelineutils_gettimerangelabel",
-      "community": 3
+      "community": 13
     },
     {
       "label": "utils.test.ts",
@@ -10625,7 +10625,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.test.ts",
       "source_location": "L1",
       "id": "utils_test",
-      "community": 3
+      "community": 6
     },
     {
       "label": "cn()",
@@ -10633,7 +10633,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L9",
       "id": "utils_cn",
-      "community": 3
+      "community": 0
     },
     {
       "label": "getErrorForField()",
@@ -10641,7 +10641,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L14",
       "id": "utils_geterrorforfield",
-      "community": 3
+      "community": 0
     },
     {
       "label": "capitalizeFirstLetter()",
@@ -10649,7 +10649,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L18",
       "id": "utils_capitalizefirstletter",
-      "community": 3
+      "community": 0
     },
     {
       "label": "slugToWords()",
@@ -10657,7 +10657,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L31",
       "id": "utils_slugtowords",
-      "community": 3
+      "community": 0
     },
     {
       "label": "snakeCaseToWords()",
@@ -10665,7 +10665,7 @@
       "source_file": "packages/athena-webapp/src/lib/utils.ts",
       "source_location": "L50",
       "id": "utils_snakecasetowords",
-      "community": 3
+      "community": 0
     },
     {
       "label": "getRelativeTime()",
@@ -10673,7 +10673,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L67",
       "id": "utils_getrelativetime",
-      "community": 3
+      "community": 0
     },
     {
       "label": "getTimeRemaining()",
@@ -10681,7 +10681,7 @@
       "source_file": "packages/athena-webapp/src/lib/utils.ts",
       "source_location": "L71",
       "id": "utils_gettimeremaining",
-      "community": 3
+      "community": 0
     },
     {
       "label": "formatUserId()",
@@ -10689,7 +10689,7 @@
       "source_file": "packages/athena-webapp/src/lib/utils.ts",
       "source_location": "L91",
       "id": "utils_formatuserid",
-      "community": 3
+      "community": 0
     },
     {
       "label": "main.tsx",
@@ -10697,7 +10697,7 @@
       "source_file": "packages/storefront-webapp/src/main.tsx",
       "source_location": "L1",
       "id": "main",
-      "community": 8
+      "community": 20
     },
     {
       "label": "App()",
@@ -10705,7 +10705,7 @@
       "source_file": "packages/storefront-webapp/src/main.tsx",
       "source_location": "L38",
       "id": "main_app",
-      "community": 8
+      "community": 20
     },
     {
       "label": "routeTree.gen.ts",
@@ -10713,7 +10713,7 @@
       "source_file": "packages/storefront-webapp/src/routeTree.gen.ts",
       "source_location": "L1",
       "id": "routetree_gen",
-      "community": 8
+      "community": 7
     },
     {
       "label": "__root.tsx",
@@ -10721,7 +10721,7 @@
       "source_file": "packages/storefront-webapp/src/routes/__root.tsx",
       "source_location": "L1",
       "id": "root",
-      "community": 6
+      "community": 4
     },
     {
       "label": "$storeUrlSlug.tsx",
@@ -10729,7 +10729,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/stores/$storeUrlSlug.tsx",
       "source_location": "L1",
       "id": "storeurlslug",
-      "community": 8
+      "community": 7
     },
     {
       "label": "assets.index.tsx",
@@ -10737,7 +10737,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/assets.index.tsx",
       "source_location": "L1",
       "id": "assets_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "bags.$bagId.tsx",
@@ -10745,7 +10745,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.$bagId.tsx",
       "source_location": "L1",
       "id": "bags_bagid",
-      "community": 8
+      "community": 7
     },
     {
       "label": "bags.index.tsx",
@@ -10753,7 +10753,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.index.tsx",
       "source_location": "L1",
       "id": "bags_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "checkout-sessions.index.tsx",
@@ -10761,7 +10761,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/checkout-sessions.index.tsx",
       "source_location": "L1",
       "id": "checkout_sessions_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "configuration.index.tsx",
@@ -10769,7 +10769,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/configuration.index.tsx",
       "source_location": "L1",
       "id": "configuration_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "dashboard.index.tsx",
@@ -10777,7 +10777,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/dashboard.index.tsx",
       "source_location": "L1",
       "id": "dashboard_index",
-      "community": 11
+      "community": 7
     },
     {
       "label": "StoreRootRedirect()",
@@ -10793,7 +10793,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.$logId.tsx",
       "source_location": "L1",
       "id": "logs_logid",
-      "community": 8
+      "community": 7
     },
     {
       "label": "logs.index.tsx",
@@ -10801,7 +10801,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.index.tsx",
       "source_location": "L1",
       "id": "logs_index",
-      "community": 8
+      "community": 6
     },
     {
       "label": "members.index.tsx",
@@ -10809,7 +10809,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/members.index.tsx",
       "source_location": "L1",
       "id": "members_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "all.index.tsx",
@@ -10817,7 +10817,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/all.index.tsx",
       "source_location": "L1",
       "id": "all_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "cancelled.index.tsx",
@@ -10825,7 +10825,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/cancelled.index.tsx",
       "source_location": "L1",
       "id": "cancelled_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "completed.index.tsx",
@@ -10833,7 +10833,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/completed.index.tsx",
       "source_location": "L1",
       "id": "completed_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "open.index.tsx",
@@ -10841,7 +10841,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/open.index.tsx",
       "source_location": "L1",
       "id": "open_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "out-for-delivery.index.tsx",
@@ -10849,7 +10849,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/out-for-delivery.index.tsx",
       "source_location": "L1",
       "id": "out_for_delivery_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "ready.index.tsx",
@@ -10857,7 +10857,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/ready.index.tsx",
       "source_location": "L1",
       "id": "ready_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "refunded.index.tsx",
@@ -10865,7 +10865,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/refunded.index.tsx",
       "source_location": "L1",
       "id": "refunded_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "$reportId.tsx",
@@ -10873,7 +10873,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports/$reportId.tsx",
       "source_location": "L1",
       "id": "reportid",
-      "community": 8
+      "community": 7
     },
     {
       "label": "expense-reports.index.tsx",
@@ -10881,7 +10881,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports.index.tsx",
       "source_location": "L1",
       "id": "expense_reports_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "expense.index.tsx",
@@ -10889,7 +10889,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense.index.tsx",
       "source_location": "L1",
       "id": "expense_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "register.index.tsx",
@@ -10897,7 +10897,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/register.index.tsx",
       "source_location": "L1",
       "id": "register_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "settings.index.tsx",
@@ -10905,7 +10905,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/settings.index.tsx",
       "source_location": "L1",
       "id": "settings_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "$transactionId.tsx",
@@ -10913,7 +10913,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId.tsx",
       "source_location": "L1",
       "id": "transactionid",
-      "community": 8
+      "community": 7
     },
     {
       "label": "transactions.index.tsx",
@@ -10921,7 +10921,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions.index.tsx",
       "source_location": "L1",
       "id": "transactions_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "edit.tsx",
@@ -10929,7 +10929,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/edit.tsx",
       "source_location": "L1",
       "id": "edit",
-      "community": 0
+      "community": 7
     },
     {
       "label": "new.tsx",
@@ -10945,7 +10945,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/unresolved.tsx",
       "source_location": "L1",
       "id": "unresolved",
-      "community": 8
+      "community": 7
     },
     {
       "label": "$promoCodeSlug.tsx",
@@ -10961,7 +10961,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/new.index.tsx",
       "source_location": "L1",
       "id": "new_index",
-      "community": 9
+      "community": 6
     },
     {
       "label": "published.index.tsx",
@@ -10969,7 +10969,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/published.index.tsx",
       "source_location": "L1",
       "id": "published_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "RouteComponent()",
@@ -10977,7 +10977,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/published.index.tsx",
       "source_location": "L9",
       "id": "published_index_routecomponent",
-      "community": 8
+      "community": 7
     },
     {
       "label": "users.$userId.tsx",
@@ -10985,7 +10985,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/users.$userId.tsx",
       "source_location": "L1",
       "id": "users_userid",
-      "community": 8
+      "community": 7
     },
     {
       "label": "_authed.tsx",
@@ -10993,7 +10993,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed.tsx",
       "source_location": "L1",
       "id": "authed",
-      "community": 19
+      "community": 8
     },
     {
       "label": "AuthedComponent()",
@@ -11001,7 +11001,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed.tsx",
       "source_location": "L18",
       "id": "authed_authedcomponent",
-      "community": 19
+      "community": 8
     },
     {
       "label": "Layout()",
@@ -11009,7 +11009,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed.tsx",
       "source_location": "L38",
       "id": "authed_layout",
-      "community": 19
+      "community": 8
     },
     {
       "label": "Index()",
@@ -11025,7 +11025,7 @@
       "source_file": "packages/athena-webapp/src/routes/join-team.index.tsx",
       "source_location": "L1",
       "id": "join_team_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "_layout.index.tsx",
@@ -11041,7 +11041,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout.tsx",
       "source_location": "L1",
       "id": "layout",
-      "community": 6
+      "community": 4
     },
     {
       "label": "LoginLayout()",
@@ -11049,7 +11049,7 @@
       "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
       "source_location": "L36",
       "id": "layout_loginlayout",
-      "community": 6
+      "community": 4
     },
     {
       "label": "OrganizationSettingsView.tsx",
@@ -11057,7 +11057,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L1",
       "id": "organizationsettingsview",
-      "community": 3
+      "community": 6
     },
     {
       "label": "OrganizationSettings()",
@@ -11065,7 +11065,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L24",
       "id": "organizationsettingsview_organizationsettings",
-      "community": 3
+      "community": 6
     },
     {
       "label": "saveStoreChanges()",
@@ -11073,7 +11073,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L71",
       "id": "organizationsettingsview_savestorechanges",
-      "community": 3
+      "community": 6
     },
     {
       "label": "onSubmit()",
@@ -11081,7 +11081,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L105",
       "id": "organizationsettingsview_onsubmit",
-      "community": 3
+      "community": 6
     },
     {
       "label": "handleDeleteStore()",
@@ -11089,7 +11089,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L156",
       "id": "organizationsettingsview_handledeletestore",
-      "community": 3
+      "community": 6
     },
     {
       "label": "Navigation()",
@@ -11097,7 +11097,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L198",
       "id": "organizationsettingsview_navigation",
-      "community": 3
+      "community": 6
     },
     {
       "label": "OrganizationsSettingsAccordion.tsx",
@@ -11105,7 +11105,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationsSettingsAccordion.tsx",
       "source_location": "L1",
       "id": "organizationssettingsaccordion",
-      "community": 0
+      "community": 1
     },
     {
       "label": "OrganizationSettingsAccordion()",
@@ -11113,7 +11113,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationsSettingsAccordion.tsx",
       "source_location": "L13",
       "id": "organizationssettingsaccordion_organizationsettingsaccordion",
-      "community": 0
+      "community": 1
     },
     {
       "label": "StoreSettingsView.tsx",
@@ -11121,7 +11121,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L1",
       "id": "storesettingsview",
-      "community": 8
+      "community": 7
     },
     {
       "label": "StoreSettings()",
@@ -11129,7 +11129,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L28",
       "id": "storesettingsview_storesettings",
-      "community": 8
+      "community": 7
     },
     {
       "label": "saveStoreChanges()",
@@ -11137,7 +11137,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L82",
       "id": "storesettingsview_savestorechanges",
-      "community": 8
+      "community": 7
     },
     {
       "label": "onSubmit()",
@@ -11145,7 +11145,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L116",
       "id": "storesettingsview_onsubmit",
-      "community": 8
+      "community": 7
     },
     {
       "label": "handleDeleteStore()",
@@ -11153,7 +11153,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L167",
       "id": "storesettingsview_handledeletestore",
-      "community": 8
+      "community": 7
     },
     {
       "label": "handleDeleteAllProductsInStore()",
@@ -11161,7 +11161,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L232",
       "id": "storesettingsview_handledeleteallproductsinstore",
-      "community": 8
+      "community": 7
     },
     {
       "label": "StoresSettingsAccordion.tsx",
@@ -11169,7 +11169,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoresSettingsAccordion.tsx",
       "source_location": "L1",
       "id": "storessettingsaccordion",
-      "community": 0
+      "community": 1
     },
     {
       "label": "expenseStore.ts",
@@ -11177,7 +11177,7 @@
       "source_file": "packages/athena-webapp/src/stores/expenseStore.ts",
       "source_location": "L1",
       "id": "expensestore",
-      "community": 4
+      "community": 3
     },
     {
       "label": "posStore.ts",
@@ -11185,7 +11185,7 @@
       "source_file": "packages/athena-webapp/src/stores/posStore.ts",
       "source_location": "L1",
       "id": "posstore",
-      "community": 4
+      "community": 3
     },
     {
       "label": "setup.ts",
@@ -11193,7 +11193,7 @@
       "source_file": "packages/athena-webapp/src/test/setup.ts",
       "source_location": "L1",
       "id": "setup",
-      "community": 66
+      "community": 67
     },
     {
       "label": "backend.test.ts",
@@ -11289,7 +11289,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/inventoryValidationLogic.test.ts",
       "source_location": "L1",
       "id": "inventoryvalidationlogic_test",
-      "community": 27
+      "community": 28
     },
     {
       "label": "validateInventoryForTransaction()",
@@ -11297,7 +11297,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/inventoryValidationLogic.test.ts",
       "source_location": "L20",
       "id": "inventoryvalidationlogic_test_validateinventoryfortransaction",
-      "community": 27
+      "community": 28
     },
     {
       "label": "mockGetSku()",
@@ -11305,7 +11305,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/inventoryValidationLogic.test.ts",
       "source_location": "L66",
       "id": "inventoryvalidationlogic_test_mockgetsku",
-      "community": 27
+      "community": 28
     },
     {
       "label": "simple.test.ts",
@@ -11393,7 +11393,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/usePrint.test.ts",
       "source_location": "L1",
       "id": "useprint_test",
-      "community": 1
+      "community": 3
     },
     {
       "label": "formatNumber.ts",
@@ -11401,7 +11401,7 @@
       "source_file": "packages/athena-webapp/src/utils/formatNumber.ts",
       "source_location": "L1",
       "id": "formatnumber",
-      "community": 11
+      "community": 0
     },
     {
       "label": "formatNumber()",
@@ -11409,7 +11409,7 @@
       "source_file": "packages/athena-webapp/src/utils/formatNumber.ts",
       "source_location": "L1",
       "id": "formatnumber_formatnumber",
-      "community": 11
+      "community": 0
     },
     {
       "label": "hashPassword()",
@@ -11441,7 +11441,7 @@
       "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
       "source_location": "L1",
       "id": "versionchecker",
-      "community": 8
+      "community": 20
     },
     {
       "label": "createVersionChecker()",
@@ -11449,7 +11449,7 @@
       "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
       "source_location": "L16",
       "id": "versionchecker_createversionchecker",
-      "community": 8
+      "community": 20
     },
     {
       "label": "tailwind.config.js",
@@ -11457,7 +11457,7 @@
       "source_file": "packages/storefront-webapp/tailwind.config.js",
       "source_location": "L1",
       "id": "tailwind_config",
-      "community": 67
+      "community": 68
     },
     {
       "label": "vite.config.ts",
@@ -11489,7 +11489,7 @@
       "source_file": "packages/storefront-webapp/vitest.setup.ts",
       "source_location": "L1",
       "id": "vitest_setup",
-      "community": 68
+      "community": 69
     },
     {
       "label": "global.d.ts",
@@ -11497,7 +11497,7 @@
       "source_file": "packages/storefront-webapp/global.d.ts",
       "source_location": "L1",
       "id": "global_d",
-      "community": 69
+      "community": 70
     },
     {
       "label": "playwright.config.ts",
@@ -11505,7 +11505,7 @@
       "source_file": "packages/storefront-webapp/playwright.config.ts",
       "source_location": "L1",
       "id": "playwright_config",
-      "community": 70
+      "community": 71
     },
     {
       "label": "postAnalytics()",
@@ -11513,7 +11513,7 @@
       "source_file": "packages/storefront-webapp/src/api/analytics.ts",
       "source_location": "L3",
       "id": "analytics_postanalytics",
-      "community": 5
+      "community": 15
     },
     {
       "label": "updateAnalyticsOwner()",
@@ -11521,7 +11521,7 @@
       "source_file": "packages/storefront-webapp/src/api/analytics.ts",
       "source_location": "L32",
       "id": "analytics_updateanalyticsowner",
-      "community": 5
+      "community": 15
     },
     {
       "label": "logout()",
@@ -11529,7 +11529,7 @@
       "source_file": "packages/storefront-webapp/src/api/analytics.ts",
       "source_location": "L60",
       "id": "analytics_logout",
-      "community": 5
+      "community": 15
     },
     {
       "label": "getProductViewCount()",
@@ -11537,7 +11537,7 @@
       "source_file": "packages/storefront-webapp/src/api/analytics.ts",
       "source_location": "L78",
       "id": "analytics_getproductviewcount",
-      "community": 5
+      "community": 15
     },
     {
       "label": "verifyUserAccount()",
@@ -11561,7 +11561,7 @@
       "source_file": "packages/storefront-webapp/src/api/bag.ts",
       "source_location": "L10",
       "id": "bag_getbaseurl",
-      "community": 14
+      "community": 2
     },
     {
       "label": "getActiveBag()",
@@ -11569,7 +11569,7 @@
       "source_file": "packages/storefront-webapp/src/api/bag.ts",
       "source_location": "L12",
       "id": "bag_getactivebag",
-      "community": 14
+      "community": 2
     },
     {
       "label": "addItemToBag()",
@@ -11577,7 +11577,7 @@
       "source_file": "packages/storefront-webapp/src/api/bag.ts",
       "source_location": "L27",
       "id": "bag_additemtobag",
-      "community": 14
+      "community": 2
     },
     {
       "label": "updateBagItem()",
@@ -11585,7 +11585,7 @@
       "source_file": "packages/storefront-webapp/src/api/bag.ts",
       "source_location": "L63",
       "id": "bag_updatebagitem",
-      "community": 14
+      "community": 2
     },
     {
       "label": "removeItemFromBag()",
@@ -11593,7 +11593,7 @@
       "source_file": "packages/storefront-webapp/src/api/bag.ts",
       "source_location": "L90",
       "id": "bag_removeitemfrombag",
-      "community": 14
+      "community": 2
     },
     {
       "label": "clearBag()",
@@ -11601,7 +11601,7 @@
       "source_file": "packages/storefront-webapp/src/api/bag.ts",
       "source_location": "L106",
       "id": "bag_clearbag",
-      "community": 14
+      "community": 2
     },
     {
       "label": "updateBagOwner()",
@@ -11609,7 +11609,7 @@
       "source_file": "packages/storefront-webapp/src/api/bag.ts",
       "source_location": "L118",
       "id": "bag_updatebagowner",
-      "community": 14
+      "community": 2
     },
     {
       "label": "getBannerMessage()",
@@ -11657,7 +11657,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.test.ts",
       "source_location": "L1",
       "id": "checkoutsession_test",
-      "community": 6
+      "community": 4
     },
     {
       "label": "jsonResponse()",
@@ -11665,7 +11665,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.test.ts",
       "source_location": "L27",
       "id": "checkoutsession_test_jsonresponse",
-      "community": 6
+      "community": 4
     },
     {
       "label": "getBaseUrl()",
@@ -11673,7 +11673,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L5",
       "id": "checkoutsession_getbaseurl",
-      "community": 6
+      "community": 4
     },
     {
       "label": "CheckoutSessionError",
@@ -11681,7 +11681,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L64",
       "id": "checkoutsession_checkoutsessionerror",
-      "community": 6
+      "community": 4
     },
     {
       "label": ".constructor()",
@@ -11689,7 +11689,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L69",
       "id": "checkoutsession_checkoutsessionerror_constructor",
-      "community": 6
+      "community": 4
     },
     {
       "label": "isRecord()",
@@ -11697,7 +11697,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L78",
       "id": "checkoutsession_isrecord",
-      "community": 6
+      "community": 4
     },
     {
       "label": "parseJson()",
@@ -11705,7 +11705,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L81",
       "id": "checkoutsession_parsejson",
-      "community": 6
+      "community": 4
     },
     {
       "label": "getCheckoutErrorMessageFromPayload()",
@@ -11713,7 +11713,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L98",
       "id": "checkoutsession_getcheckouterrormessagefrompayload",
-      "community": 6
+      "community": 4
     },
     {
       "label": "parseCheckoutResponse()",
@@ -11721,7 +11721,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L115",
       "id": "checkoutsession_parsecheckoutresponse",
-      "community": 6
+      "community": 4
     },
     {
       "label": "defaultCheckoutActionMessage()",
@@ -11729,7 +11729,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L135",
       "id": "checkoutsession_defaultcheckoutactionmessage",
-      "community": 6
+      "community": 4
     },
     {
       "label": "getCheckoutActionErrorMessage()",
@@ -11737,7 +11737,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L147",
       "id": "checkoutsession_getcheckoutactionerrormessage",
-      "community": 6
+      "community": 4
     },
     {
       "label": "createCheckoutSession()",
@@ -11745,7 +11745,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L184",
       "id": "checkoutsession_createcheckoutsession",
-      "community": 6
+      "community": 4
     },
     {
       "label": "getActiveCheckoutSession()",
@@ -11753,7 +11753,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L204",
       "id": "checkoutsession_getactivecheckoutsession",
-      "community": 6
+      "community": 4
     },
     {
       "label": "getPendingCheckoutSessions()",
@@ -11761,7 +11761,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L215",
       "id": "checkoutsession_getpendingcheckoutsessions",
-      "community": 6
+      "community": 4
     },
     {
       "label": "getCheckoutSession()",
@@ -11769,7 +11769,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L226",
       "id": "checkoutsession_getcheckoutsession",
-      "community": 6
+      "community": 4
     },
     {
       "label": "updateCheckoutSession()",
@@ -11777,7 +11777,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L239",
       "id": "checkoutsession_updatecheckoutsession",
-      "community": 6
+      "community": 4
     },
     {
       "label": "verifyCheckoutSessionPayment()",
@@ -11785,7 +11785,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L274",
       "id": "checkoutsession_verifycheckoutsessionpayment",
-      "community": 6
+      "community": 4
     },
     {
       "label": "getBaseUrl()",
@@ -11793,7 +11793,7 @@
       "source_file": "packages/storefront-webapp/src/api/color.ts",
       "source_location": "L5",
       "id": "color_getbaseurl",
-      "community": 18
+      "community": 15
     },
     {
       "label": "getAllColors()",
@@ -11801,7 +11801,7 @@
       "source_file": "packages/storefront-webapp/src/api/color.ts",
       "source_location": "L7",
       "id": "color_getallcolors",
-      "community": 18
+      "community": 15
     },
     {
       "label": "updateGuest()",
@@ -11889,7 +11889,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L5",
       "id": "product_buildquerystring",
-      "community": 18
+      "community": 15
     },
     {
       "label": "getBaseUrl()",
@@ -11897,7 +11897,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L18",
       "id": "product_getbaseurl",
-      "community": 18
+      "community": 15
     },
     {
       "label": "getAllProducts()",
@@ -11905,7 +11905,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L20",
       "id": "product_getallproducts",
-      "community": 18
+      "community": 15
     },
     {
       "label": "getProduct()",
@@ -11913,7 +11913,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L40",
       "id": "product_getproduct",
-      "community": 18
+      "community": 15
     },
     {
       "label": "getBestSellers()",
@@ -11921,7 +11921,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L59",
       "id": "product_getbestsellers",
-      "community": 18
+      "community": 15
     },
     {
       "label": "getFeatured()",
@@ -11929,7 +11929,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L73",
       "id": "product_getfeatured",
-      "community": 18
+      "community": 15
     },
     {
       "label": "getInventoryBySkuIds()",
@@ -11937,7 +11937,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L93",
       "id": "product_getinventorybyskuids",
-      "community": 18
+      "community": 15
     },
     {
       "label": "getBaseUrl()",
@@ -11945,7 +11945,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L4",
       "id": "promocodes_getbaseurl",
-      "community": 1
+      "community": 25
     },
     {
       "label": "redeemPromoCode()",
@@ -11953,7 +11953,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L6",
       "id": "promocodes_redeempromocode",
-      "community": 1
+      "community": 25
     },
     {
       "label": "getPromoCodes()",
@@ -11961,7 +11961,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L34",
       "id": "promocodes_getpromocodes",
-      "community": 1
+      "community": 25
     },
     {
       "label": "getPromoCodeItems()",
@@ -11969,7 +11969,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L49",
       "id": "promocodes_getpromocodeitems",
-      "community": 1
+      "community": 25
     },
     {
       "label": "getRedeemedPromoCodes()",
@@ -11977,7 +11977,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L74",
       "id": "promocodes_getredeemedpromocodes",
-      "community": 1
+      "community": 25
     },
     {
       "label": "getBaseUrl()",
@@ -11985,7 +11985,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L4",
       "id": "reviews_getbaseurl",
-      "community": 5
+      "community": 17
     },
     {
       "label": "createReview()",
@@ -11993,7 +11993,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L13",
       "id": "reviews_createreview",
-      "community": 5
+      "community": 17
     },
     {
       "label": "getReviewByOrderItem()",
@@ -12001,7 +12001,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L32",
       "id": "reviews_getreviewbyorderitem",
-      "community": 5
+      "community": 17
     },
     {
       "label": "updateReview()",
@@ -12009,7 +12009,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L48",
       "id": "reviews_updatereview",
-      "community": 5
+      "community": 17
     },
     {
       "label": "deleteReview()",
@@ -12017,7 +12017,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L69",
       "id": "reviews_deletereview",
-      "community": 5
+      "community": 17
     },
     {
       "label": "getReviewsByProductSkuId()",
@@ -12025,7 +12025,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L83",
       "id": "reviews_getreviewsbyproductskuid",
-      "community": 5
+      "community": 17
     },
     {
       "label": "getUserReviews()",
@@ -12033,7 +12033,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L99",
       "id": "reviews_getuserreviews",
-      "community": 5
+      "community": 17
     },
     {
       "label": "getUserReviewsForProduct()",
@@ -12041,7 +12041,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L113",
       "id": "reviews_getuserreviewsforproduct",
-      "community": 5
+      "community": 17
     },
     {
       "label": "getReviewsByProductId()",
@@ -12049,7 +12049,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L132",
       "id": "reviews_getreviewsbyproductid",
-      "community": 5
+      "community": 17
     },
     {
       "label": "markReviewHelpful()",
@@ -12057,7 +12057,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L148",
       "id": "reviews_markreviewhelpful",
-      "community": 5
+      "community": 17
     },
     {
       "label": "hasReviewForOrderItem()",
@@ -12065,7 +12065,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L164",
       "id": "reviews_hasreviewfororderitem",
-      "community": 5
+      "community": 17
     },
     {
       "label": "hasUserReviewForOrderItem()",
@@ -12073,7 +12073,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L183",
       "id": "reviews_hasuserreviewfororderitem",
-      "community": 5
+      "community": 17
     },
     {
       "label": "getBaseUrl()",
@@ -12081,7 +12081,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L3",
       "id": "rewards_getbaseurl",
-      "community": 14
+      "community": 2
     },
     {
       "label": "getUserPoints()",
@@ -12089,7 +12089,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L54",
       "id": "rewards_getuserpoints",
-      "community": 14
+      "community": 2
     },
     {
       "label": "getPointHistory()",
@@ -12097,7 +12097,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L71",
       "id": "rewards_getpointhistory",
-      "community": 14
+      "community": 2
     },
     {
       "label": "getRewardTiers()",
@@ -12105,7 +12105,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L90",
       "id": "rewards_getrewardtiers",
-      "community": 14
+      "community": 2
     },
     {
       "label": "redeemRewardPoints()",
@@ -12113,7 +12113,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L107",
       "id": "rewards_redeemrewardpoints",
-      "community": 14
+      "community": 2
     },
     {
       "label": "getEligiblePastOrders()",
@@ -12121,7 +12121,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L129",
       "id": "rewards_geteligiblepastorders",
-      "community": 14
+      "community": 2
     },
     {
       "label": "awardPointsForPastOrder()",
@@ -12129,7 +12129,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L151",
       "id": "rewards_awardpointsforpastorder",
-      "community": 14
+      "community": 2
     },
     {
       "label": "getOrderRewardPoints()",
@@ -12137,7 +12137,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L175",
       "id": "rewards_getorderrewardpoints",
-      "community": 14
+      "community": 2
     },
     {
       "label": "awardPointsForGuestOrders()",
@@ -12145,7 +12145,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L198",
       "id": "rewards_awardpointsforguestorders",
-      "community": 14
+      "community": 2
     },
     {
       "label": "getBaseUrl()",
@@ -12153,7 +12153,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L8",
       "id": "savedbag_getbaseurl",
-      "community": 14
+      "community": 2
     },
     {
       "label": "getActiveSavedBag()",
@@ -12161,7 +12161,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L10",
       "id": "savedbag_getactivesavedbag",
-      "community": 14
+      "community": 2
     },
     {
       "label": "addItemToSavedBag()",
@@ -12169,7 +12169,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L25",
       "id": "savedbag_additemtosavedbag",
-      "community": 14
+      "community": 2
     },
     {
       "label": "updateSavedBagItem()",
@@ -12177,7 +12177,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L61",
       "id": "savedbag_updatesavedbagitem",
-      "community": 14
+      "community": 2
     },
     {
       "label": "removeItemFromSavedBag()",
@@ -12185,7 +12185,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L91",
       "id": "savedbag_removeitemfromsavedbag",
-      "community": 14
+      "community": 2
     },
     {
       "label": "updateSavedBagOwner()",
@@ -12193,7 +12193,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L109",
       "id": "savedbag_updatesavedbagowner",
-      "community": 14
+      "community": 2
     },
     {
       "label": "getBaseUrl()",
@@ -12329,7 +12329,7 @@
       "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
       "source_location": "L1",
       "id": "entitypage",
-      "community": 18
+      "community": 15
     },
     {
       "label": "EntityPage()",
@@ -12337,7 +12337,7 @@
       "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
       "source_location": "L10",
       "id": "entitypage_entitypage",
-      "community": 18
+      "community": 15
     },
     {
       "label": "HomePage.tsx",
@@ -12377,7 +12377,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
       "source_location": "L1",
       "id": "productactionbar",
-      "community": 5
+      "community": 1
     },
     {
       "label": "checkScroll()",
@@ -12385,7 +12385,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
       "source_location": "L50",
       "id": "productactionbar_checkscroll",
-      "community": 5
+      "community": 1
     },
     {
       "label": "handleDismiss()",
@@ -12393,7 +12393,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
       "source_location": "L74",
       "id": "productactionbar_handledismiss",
-      "community": 5
+      "community": 1
     },
     {
       "label": "handleAction()",
@@ -12401,7 +12401,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
       "source_location": "L92",
       "id": "productactionbar_handleaction",
-      "community": 5
+      "community": 1
     },
     {
       "label": "ProductReminderBar.tsx",
@@ -12409,7 +12409,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
       "source_location": "L1",
       "id": "productreminderbar",
-      "community": 5
+      "community": 1
     },
     {
       "label": "checkScroll()",
@@ -12417,7 +12417,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
       "source_location": "L62",
       "id": "productreminderbar_checkscroll",
-      "community": 5
+      "community": 1
     },
     {
       "label": "handleAddToBag()",
@@ -12425,7 +12425,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
       "source_location": "L109",
       "id": "productreminderbar_handleaddtobag",
-      "community": 5
+      "community": 1
     },
     {
       "label": "handleDismiss()",
@@ -12433,7 +12433,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
       "source_location": "L177",
       "id": "productreminderbar_handledismiss",
-      "community": 5
+      "community": 1
     },
     {
       "label": "ProductsPage.tsx",
@@ -12441,7 +12441,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductsPage.tsx",
       "source_location": "L1",
       "id": "productspage",
-      "community": 1
+      "community": 15
     },
     {
       "label": "ProductCardLoadingSkeleton()",
@@ -12449,7 +12449,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductsPage.tsx",
       "source_location": "L10",
       "id": "productspage_productcardloadingskeleton",
-      "community": 1
+      "community": 15
     },
     {
       "label": "Upsell.tsx",
@@ -12457,7 +12457,7 @@
       "source_file": "packages/storefront-webapp/src/components/Upsell.tsx",
       "source_location": "L1",
       "id": "upsell",
-      "community": 3
+      "community": 1
     },
     {
       "label": "AuthComponent()",
@@ -12745,7 +12745,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/OrderSummary.tsx",
       "source_location": "L18",
       "id": "ordersummary_ordersummary",
-      "community": 1
+      "community": 3
     },
     {
       "label": "PickupDetails()",
@@ -12825,7 +12825,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.test.ts",
       "source_location": "L1",
       "id": "deliveryfees_test",
-      "community": 1
+      "community": 6
     },
     {
       "label": "deliveryFees.ts",
@@ -12833,7 +12833,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.ts",
       "source_location": "L1",
       "id": "deliveryfees",
-      "community": 1
+      "community": 6
     },
     {
       "label": "calculateDeliveryFee()",
@@ -12841,7 +12841,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.ts",
       "source_location": "L40",
       "id": "deliveryfees_calculatedeliveryfee",
-      "community": 1
+      "community": 6
     },
     {
       "label": "deriveCheckoutState.test.ts",
@@ -12849,7 +12849,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.test.ts",
       "source_location": "L1",
       "id": "derivecheckoutstate_test",
-      "community": 1
+      "community": 6
     },
     {
       "label": "deriveCheckoutState.ts",
@@ -12857,7 +12857,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
       "source_location": "L1",
       "id": "derivecheckoutstate",
-      "community": 1
+      "community": 6
     },
     {
       "label": "deriveCheckoutState()",
@@ -12865,7 +12865,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
       "source_location": "L3",
       "id": "derivecheckoutstate_derivecheckoutstate",
-      "community": 1
+      "community": 6
     },
     {
       "label": "billingDetailsSchema.ts",
@@ -12945,7 +12945,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L107",
       "id": "utils_getpotentialpoints",
-      "community": 3
+      "community": 0
     },
     {
       "label": "CustomerDetailsForm.tsx",
@@ -12985,7 +12985,7 @@
       "source_file": "packages/storefront-webapp/src/components/common/hooks.ts",
       "source_location": "L3",
       "id": "hooks_usecountdown",
-      "community": 6
+      "community": 4
     },
     {
       "label": "TrustSignals.tsx",
@@ -12993,7 +12993,7 @@
       "source_file": "packages/storefront-webapp/src/components/communication/TrustSignals.tsx",
       "source_location": "L1",
       "id": "trustsignals",
-      "community": 5
+      "community": 8
     },
     {
       "label": "TrustSignals()",
@@ -13001,7 +13001,7 @@
       "source_file": "packages/storefront-webapp/src/components/communication/TrustSignals.tsx",
       "source_location": "L4",
       "id": "trustsignals_trustsignals",
-      "community": 5
+      "community": 8
     },
     {
       "label": "ProductFilter.tsx",
@@ -13009,7 +13009,7 @@
       "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
       "source_location": "L1",
       "id": "productfilter",
-      "community": 3
+      "community": 4
     },
     {
       "label": "ProductFilter()",
@@ -13017,7 +13017,7 @@
       "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
       "source_location": "L14",
       "id": "productfilter_productfilter",
-      "community": 3
+      "community": 4
     },
     {
       "label": "ProductFilterBar.tsx",
@@ -13025,7 +13025,7 @@
       "source_file": "packages/storefront-webapp/src/components/filter/ProductFilterBar.tsx",
       "source_location": "L1",
       "id": "productfilterbar",
-      "community": 6
+      "community": 4
     },
     {
       "label": "Filter.tsx",
@@ -13033,7 +13033,7 @@
       "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
       "source_location": "L1",
       "id": "filter",
-      "community": 3
+      "community": 12
     },
     {
       "label": "handleCheckboxChange()",
@@ -13041,7 +13041,7 @@
       "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
       "source_location": "L27",
       "id": "filter_handlecheckboxchange",
-      "community": 3
+      "community": 12
     },
     {
       "label": "Footer.tsx",
@@ -13169,7 +13169,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
       "source_location": "L10",
       "id": "hooks_usegetstoresubcategories",
-      "community": 6
+      "community": 4
     },
     {
       "label": "useGetStoreCategories()",
@@ -13177,7 +13177,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
       "source_location": "L21",
       "id": "hooks_usegetstorecategories",
-      "community": 6
+      "community": 4
     },
     {
       "label": "useGetShopSearchParams()",
@@ -13185,7 +13185,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
       "source_location": "L55",
       "id": "hooks_usegetshopsearchparams",
-      "community": 6
+      "community": 4
     },
     {
       "label": "BagMenu.tsx",
@@ -13209,7 +13209,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileBagMenu.tsx",
       "source_location": "L1",
       "id": "mobilebagmenu",
-      "community": 6
+      "community": 1
     },
     {
       "label": "MobileBagMenu()",
@@ -13217,7 +13217,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileBagMenu.tsx",
       "source_location": "L7",
       "id": "mobilebagmenu_mobilebagmenu",
-      "community": 6
+      "community": 1
     },
     {
       "label": "MobileMenu.tsx",
@@ -13225,7 +13225,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileMenu.tsx",
       "source_location": "L1",
       "id": "mobilemenu",
-      "community": 6
+      "community": 4
     },
     {
       "label": "NavigationBar.tsx",
@@ -13233,7 +13233,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/NavigationBar.tsx",
       "source_location": "L1",
       "id": "navigationbar",
-      "community": 6
+      "community": 4
     },
     {
       "label": "StoreCategoriesSubmenu()",
@@ -13241,7 +13241,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/NavigationBar.tsx",
       "source_location": "L62",
       "id": "navigationbar_storecategoriessubmenu",
-      "community": 6
+      "community": 4
     },
     {
       "label": "SiteBanner.tsx",
@@ -13249,7 +13249,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/SiteBanner.tsx",
       "source_location": "L1",
       "id": "sitebanner",
-      "community": 2
+      "community": 4
     },
     {
       "label": "SiteBanner()",
@@ -13257,7 +13257,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/SiteBanner.tsx",
       "source_location": "L17",
       "id": "sitebanner_sitebanner",
-      "community": 2
+      "community": 4
     },
     {
       "label": "navBarConstants.ts",
@@ -13265,7 +13265,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarConstants.ts",
       "source_location": "L1",
       "id": "navbarconstants",
-      "community": 6
+      "community": 4
     },
     {
       "label": "navBarStyles.ts",
@@ -13273,7 +13273,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L1",
       "id": "navbarstyles",
-      "community": 6
+      "community": 4
     },
     {
       "label": "getMainWrapperClass()",
@@ -13281,7 +13281,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L28",
       "id": "navbarstyles_getmainwrapperclass",
-      "community": 6
+      "community": 4
     },
     {
       "label": "getNavBGClass()",
@@ -13289,7 +13289,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L43",
       "id": "navbarstyles_getnavbgclass",
-      "community": 6
+      "community": 4
     },
     {
       "label": "getHoverClass()",
@@ -13297,7 +13297,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L76",
       "id": "navbarstyles_gethoverclass",
-      "community": 6
+      "community": 4
     },
     {
       "label": "getSubmenuBGClass()",
@@ -13305,7 +13305,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L93",
       "id": "navbarstyles_getsubmenubgclass",
-      "community": 6
+      "community": 4
     },
     {
       "label": "getBannerTextClass()",
@@ -13313,7 +13313,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L119",
       "id": "navbarstyles_getbannertextclass",
-      "community": 6
+      "community": 4
     },
     {
       "label": "getBannerBGClass()",
@@ -13321,7 +13321,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L136",
       "id": "navbarstyles_getbannerbgclass",
-      "community": 6
+      "community": 4
     },
     {
       "label": "getBannerAnimationDelay()",
@@ -13329,7 +13329,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L152",
       "id": "navbarstyles_getbanneranimationdelay",
-      "community": 6
+      "community": 4
     },
     {
       "label": "getNavBarWrapperClass()",
@@ -13337,7 +13337,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L163",
       "id": "navbarstyles_getnavbarwrapperclass",
-      "community": 6
+      "community": 4
     },
     {
       "label": "getNavBarAnimationDelay()",
@@ -13345,7 +13345,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L174",
       "id": "navbarstyles_getnavbaranimationdelay",
-      "community": 6
+      "community": 4
     },
     {
       "label": "getOverlayClass()",
@@ -13353,7 +13353,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L184",
       "id": "navbarstyles_getoverlayclass",
-      "community": 6
+      "community": 4
     },
     {
       "label": "NotificationPill.tsx",
@@ -13361,7 +13361,7 @@
       "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
       "source_location": "L1",
       "id": "notificationpill",
-      "community": 39
+      "community": 40
     },
     {
       "label": "NotificationPill()",
@@ -13369,7 +13369,7 @@
       "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
       "source_location": "L1",
       "id": "notificationpill_notificationpill",
-      "community": 39
+      "community": 40
     },
     {
       "label": "About.tsx",
@@ -13377,7 +13377,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/About.tsx",
       "source_location": "L1",
       "id": "about",
-      "community": 5
+      "community": 8
     },
     {
       "label": "AboutProduct.tsx",
@@ -13385,7 +13385,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/AboutProduct.tsx",
       "source_location": "L1",
       "id": "aboutproduct",
-      "community": 5
+      "community": 8
     },
     {
       "label": "DimensionBar.tsx",
@@ -13393,7 +13393,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
       "source_location": "L1",
       "id": "dimensionbar",
-      "community": 5
+      "community": 17
     },
     {
       "label": "mapValueToLabelIndex()",
@@ -13401,7 +13401,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
       "source_location": "L12",
       "id": "dimensionbar_mapvaluetolabelindex",
-      "community": 5
+      "community": 17
     },
     {
       "label": "DiscountBadge.tsx",
@@ -13425,7 +13425,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/GalleryViewer.tsx",
       "source_location": "L1",
       "id": "galleryviewer",
-      "community": 5
+      "community": 8
     },
     {
       "label": "handleClickOnPreview()",
@@ -13433,7 +13433,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/GalleryViewer.tsx",
       "source_location": "L45",
       "id": "galleryviewer_handleclickonpreview",
-      "community": 5
+      "community": 8
     },
     {
       "label": "InventoryLevelBadge.tsx",
@@ -13441,7 +13441,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
       "source_location": "L1",
       "id": "inventorylevelbadge",
-      "community": 5
+      "community": 17
     },
     {
       "label": "SoldOutBadge()",
@@ -13449,7 +13449,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
       "source_location": "L3",
       "id": "inventorylevelbadge_soldoutbadge",
-      "community": 5
+      "community": 17
     },
     {
       "label": "LowStockBadge()",
@@ -13457,7 +13457,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
       "source_location": "L14",
       "id": "inventorylevelbadge_lowstockbadge",
-      "community": 5
+      "community": 17
     },
     {
       "label": "SellingFastBadge()",
@@ -13465,7 +13465,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
       "source_location": "L22",
       "id": "inventorylevelbadge_sellingfastbadge",
-      "community": 5
+      "community": 17
     },
     {
       "label": "SellingFastSignal()",
@@ -13473,7 +13473,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
       "source_location": "L30",
       "id": "inventorylevelbadge_sellingfastsignal",
-      "community": 5
+      "community": 17
     },
     {
       "label": "OnSaleProduct.tsx",
@@ -13481,7 +13481,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/OnSaleProduct.tsx",
       "source_location": "L1",
       "id": "onsaleproduct",
-      "community": 5
+      "community": 8
     },
     {
       "label": "OnsaleProduct()",
@@ -13489,7 +13489,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/OnSaleProduct.tsx",
       "source_location": "L5",
       "id": "onsaleproduct_onsaleproduct",
-      "community": 5
+      "community": 8
     },
     {
       "label": "ProductActions.tsx",
@@ -13497,7 +13497,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.tsx",
       "source_location": "L1",
       "id": "productactions",
-      "community": 5
+      "community": 8
     },
     {
       "label": "ProductActions()",
@@ -13505,7 +13505,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.tsx",
       "source_location": "L17",
       "id": "productactions_productactions",
-      "community": 5
+      "community": 8
     },
     {
       "label": "ProductAttribute.tsx",
@@ -13513,7 +13513,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
       "source_location": "L1",
       "id": "productattribute",
-      "community": 5
+      "community": 8
     },
     {
       "label": "findSize()",
@@ -13521,7 +13521,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
       "source_location": "L61",
       "id": "productattribute_findsize",
-      "community": 5
+      "community": 8
     },
     {
       "label": "handleClick()",
@@ -13529,7 +13529,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
       "source_location": "L65",
       "id": "productattribute_handleclick",
-      "community": 5
+      "community": 8
     },
     {
       "label": "ProductAttributes()",
@@ -13545,7 +13545,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
       "source_location": "L13",
       "id": "productdetails_pickupdetails",
-      "community": 5
+      "community": 1
     },
     {
       "label": "BagProduct()",
@@ -13553,7 +13553,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
       "source_location": "L43",
       "id": "productdetails_bagproduct",
-      "community": 5
+      "community": 1
     },
     {
       "label": "ShippingPolicy()",
@@ -13561,7 +13561,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
       "source_location": "L88",
       "id": "productdetails_shippingpolicy",
-      "community": 5
+      "community": 1
     },
     {
       "label": "ProductInfo.tsx",
@@ -13569,7 +13569,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductInfo.tsx",
       "source_location": "L1",
       "id": "productinfo",
-      "community": 5
+      "community": 17
     },
     {
       "label": "showShippingPolicy()",
@@ -13577,7 +13577,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductPage.tsx",
       "source_location": "L78",
       "id": "productpage_showshippingpolicy",
-      "community": 5
+      "community": 8
     },
     {
       "label": "ProductReview.tsx",
@@ -13585,7 +13585,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductReview.tsx",
       "source_location": "L1",
       "id": "productreview",
-      "community": 5
+      "community": 17
     },
     {
       "label": "handleHelpful()",
@@ -13593,7 +13593,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductReview.tsx",
       "source_location": "L87",
       "id": "productreview_handlehelpful",
-      "community": 5
+      "community": 17
     },
     {
       "label": "ProductReviews.tsx",
@@ -13601,7 +13601,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductReviews.tsx",
       "source_location": "L1",
       "id": "productreviews",
-      "community": 5
+      "community": 17
     },
     {
       "label": "ProductsNavigationBar.tsx",
@@ -13609,7 +13609,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductsNavigationBar.tsx",
       "source_location": "L1",
       "id": "productsnavigationbar",
-      "community": 3
+      "community": 9
     },
     {
       "label": "ReviewSummary.tsx",
@@ -13617,7 +13617,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
       "source_location": "L1",
       "id": "reviewsummary",
-      "community": 5
+      "community": 17
     },
     {
       "label": "ReviewSummary()",
@@ -13625,7 +13625,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
       "source_location": "L8",
       "id": "reviewsummary_reviewsummary",
-      "community": 5
+      "community": 17
     },
     {
       "label": "ErrorMessage.tsx",
@@ -13665,7 +13665,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/RatingSelector.tsx",
       "source_location": "L1",
       "id": "ratingselector",
-      "community": 1
+      "community": 6
     },
     {
       "label": "RatingSelector()",
@@ -13673,7 +13673,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/RatingSelector.tsx",
       "source_location": "L18",
       "id": "ratingselector_ratingselector",
-      "community": 1
+      "community": 6
     },
     {
       "label": "ReviewEditor.tsx",
@@ -13737,7 +13737,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
       "source_location": "L1",
       "id": "orderpointsdisplay",
-      "community": 14
+      "community": 2
     },
     {
       "label": "OrderPointsDisplay()",
@@ -13745,7 +13745,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
       "source_location": "L11",
       "id": "orderpointsdisplay_orderpointsdisplay",
-      "community": 14
+      "community": 2
     },
     {
       "label": "PastOrdersRewards.tsx",
@@ -13753,7 +13753,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/PastOrdersRewards.tsx",
       "source_location": "L1",
       "id": "pastordersrewards",
-      "community": 14
+      "community": 1
     },
     {
       "label": "handleClaimPoints()",
@@ -13761,7 +13761,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/PastOrdersRewards.tsx",
       "source_location": "L59",
       "id": "pastordersrewards_handleclaimpoints",
-      "community": 14
+      "community": 1
     },
     {
       "label": "RewardsPanel.tsx",
@@ -13769,7 +13769,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/RewardsPanel.tsx",
       "source_location": "L1",
       "id": "rewardspanel",
-      "community": 14
+      "community": 1
     },
     {
       "label": "handleRedeemReward()",
@@ -13777,7 +13777,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/RewardsPanel.tsx",
       "source_location": "L33",
       "id": "rewardspanel_handleredeemreward",
-      "community": 14
+      "community": 1
     },
     {
       "label": "SavedIcon.tsx",
@@ -13793,7 +13793,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/BagItem.tsx",
       "source_location": "L19",
       "id": "bagitem_bagitem",
-      "community": 14
+      "community": 2
     },
     {
       "label": "CartIcon.tsx",
@@ -13801,7 +13801,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/CartIcon.tsx",
       "source_location": "L1",
       "id": "carticon",
-      "community": 6
+      "community": 4
     },
     {
       "label": "ShoppingBag.tsx",
@@ -13929,7 +13929,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/error/ErrorBoundary.tsx",
       "source_location": "L1",
       "id": "errorboundary",
-      "community": 6
+      "community": 4
     },
     {
       "label": "ErrorBoundary()",
@@ -13937,7 +13937,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/error/ErrorBoundary.tsx",
       "source_location": "L22",
       "id": "errorboundary_errorboundary",
-      "community": 6
+      "community": 4
     },
     {
       "label": "Maintenance.tsx",
@@ -13945,7 +13945,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/maintenance/Maintenance.tsx",
       "source_location": "L1",
       "id": "maintenance",
-      "community": 6
+      "community": 4
     },
     {
       "label": "AnimatedCard.tsx",
@@ -13961,7 +13961,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/ScrollDownButton.tsx",
       "source_location": "L1",
       "id": "scrolldownbutton",
-      "community": 5
+      "community": 15
     },
     {
       "label": "ScrollDownButton()",
@@ -13969,7 +13969,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/ScrollDownButton.tsx",
       "source_location": "L11",
       "id": "scrolldownbutton_scrolldownbutton",
-      "community": 5
+      "community": 15
     },
     {
       "label": "alert.tsx",
@@ -13977,7 +13977,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/alert.tsx",
       "source_location": "L1",
       "id": "alert",
-      "community": 3
+      "community": 0
     },
     {
       "label": "breadcrumb.tsx",
@@ -13985,7 +13985,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/breadcrumb.tsx",
       "source_location": "L1",
       "id": "breadcrumb",
-      "community": 3
+      "community": 9
     },
     {
       "label": "country-select.tsx",
@@ -14057,7 +14057,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
       "source_location": "L1",
       "id": "leaveareviewmodal",
-      "community": 1
+      "community": 6
     },
     {
       "label": "handleClose()",
@@ -14065,7 +14065,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
       "source_location": "L66",
       "id": "leaveareviewmodal_handleclose",
-      "community": 1
+      "community": 6
     },
     {
       "label": "LeaveAReviewModalForm.tsx",
@@ -14073,7 +14073,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModalForm.tsx",
       "source_location": "L1",
       "id": "leaveareviewmodalform",
-      "community": 1
+      "community": 6
     },
     {
       "label": "UpsellModal.tsx",
@@ -14177,7 +14177,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
       "source_location": "L1",
       "id": "welcomebackmodalform",
-      "community": 1
+      "community": 6
     },
     {
       "label": "handleSubmit()",
@@ -14185,7 +14185,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
       "source_location": "L36",
       "id": "welcomebackmodalform_handlesubmit",
-      "community": 1
+      "community": 6
     },
     {
       "label": "handleInputChange()",
@@ -14193,7 +14193,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
       "source_location": "L51",
       "id": "welcomebackmodalform_handleinputchange",
-      "community": 1
+      "community": 6
     },
     {
       "label": "WelcomeBackModalSuccess.tsx",
@@ -14225,7 +14225,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/config/leaveReviewModalConfig.tsx",
       "source_location": "L1",
       "id": "leavereviewmodalconfig",
-      "community": 1
+      "community": 6
     },
     {
       "label": "getModalConfig()",
@@ -14233,7 +14233,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/config/leaveReviewModalConfig.tsx",
       "source_location": "L46",
       "id": "leavereviewmodalconfig_getmodalconfig",
-      "community": 1
+      "community": 6
     },
     {
       "label": "welcomeBackModalConfig.tsx",
@@ -14241,7 +14241,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/config/welcomeBackModalConfig.tsx",
       "source_location": "L1",
       "id": "welcomebackmodalconfig",
-      "community": 1
+      "community": 6
     },
     {
       "label": "getModalConfig()",
@@ -14249,7 +14249,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/config/welcomeBackModalConfig.tsx",
       "source_location": "L46",
       "id": "welcomebackmodalconfig_getmodalconfig",
-      "community": 1
+      "community": 6
     },
     {
       "label": "navigation-menu.tsx",
@@ -14257,7 +14257,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/navigation-menu.tsx",
       "source_location": "L1",
       "id": "navigation_menu",
-      "community": 3
+      "community": 0
     },
     {
       "label": "webp-jpg.tsx",
@@ -14265,7 +14265,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/webp-jpg.tsx",
       "source_location": "L1",
       "id": "webp_jpg",
-      "community": 40
+      "community": 41
     },
     {
       "label": "WebpImage()",
@@ -14273,7 +14273,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/webp-jpg.tsx",
       "source_location": "L1",
       "id": "webp_jpg_webpimage",
-      "community": 40
+      "community": 41
     },
     {
       "label": "FormSubmissionProvider.tsx",
@@ -14281,7 +14281,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/FormSubmissionProvider.tsx",
       "source_location": "L1",
       "id": "formsubmissionprovider",
-      "community": 41
+      "community": 42
     },
     {
       "label": "useFormSubmission()",
@@ -14289,7 +14289,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/FormSubmissionProvider.tsx",
       "source_location": "L15",
       "id": "formsubmissionprovider_useformsubmission",
-      "community": 41
+      "community": 42
     },
     {
       "label": "NavigationBarProvider.tsx",
@@ -14297,7 +14297,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
       "source_location": "L1",
       "id": "navigationbarprovider",
-      "community": 6
+      "community": 4
     },
     {
       "label": "NavigationBarProvider()",
@@ -14305,7 +14305,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
       "source_location": "L16",
       "id": "navigationbarprovider_navigationbarprovider",
-      "community": 6
+      "community": 4
     },
     {
       "label": "useNavigationBarContext()",
@@ -14313,7 +14313,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
       "source_location": "L39",
       "id": "navigationbarprovider_usenavigationbarcontext",
-      "community": 6
+      "community": 4
     },
     {
       "label": "StoreContext.tsx",
@@ -14345,7 +14345,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
       "source_location": "L1",
       "id": "storefrontobservabilityprovider",
-      "community": 6
+      "community": 4
     },
     {
       "label": "StorefrontObservabilityProvider()",
@@ -14353,7 +14353,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
       "source_location": "L20",
       "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
-      "community": 6
+      "community": 4
     },
     {
       "label": "useStorefrontObservability()",
@@ -14361,7 +14361,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
       "source_location": "L55",
       "id": "storefrontobservabilityprovider_usestorefrontobservability",
-      "community": 6
+      "community": 4
     },
     {
       "label": "useCheckout.ts",
@@ -14401,7 +14401,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useEnhancedTracking.ts",
       "source_location": "L1",
       "id": "useenhancedtracking",
-      "community": 5
+      "community": 15
     },
     {
       "label": "useEnhancedTracking()",
@@ -14409,7 +14409,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useEnhancedTracking.ts",
       "source_location": "L29",
       "id": "useenhancedtracking_useenhancedtracking",
-      "community": 5
+      "community": 15
     },
     {
       "label": "useGetActiveCheckoutSession.tsx",
@@ -14449,7 +14449,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetProductFilters.ts",
       "source_location": "L1",
       "id": "usegetproductfilters",
-      "community": 6
+      "community": 4
     },
     {
       "label": "useGetProductFilters()",
@@ -14457,7 +14457,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetProductFilters.ts",
       "source_location": "L3",
       "id": "usegetproductfilters_usegetproductfilters",
-      "community": 6
+      "community": 4
     },
     {
       "label": "useGetProductReviews.ts",
@@ -14465,7 +14465,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetProductReviews.ts",
       "source_location": "L1",
       "id": "usegetproductreviews",
-      "community": 5
+      "community": 17
     },
     {
       "label": "useGetProductReviewsQuery()",
@@ -14473,7 +14473,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetProductReviews.ts",
       "source_location": "L4",
       "id": "usegetproductreviews_usegetproductreviewsquery",
-      "community": 5
+      "community": 17
     },
     {
       "label": "useGetStore.ts",
@@ -14497,7 +14497,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useInventoryStatus.ts",
       "source_location": "L1",
       "id": "useinventorystatus",
-      "community": 18
+      "community": 15
     },
     {
       "label": "useInventoryStatus()",
@@ -14505,7 +14505,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useInventoryStatus.ts",
       "source_location": "L9",
       "id": "useinventorystatus_useinventorystatus",
-      "community": 18
+      "community": 15
     },
     {
       "label": "useLeaveAReviewModal.tsx",
@@ -14665,7 +14665,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useScrollToTop.ts",
       "source_location": "L1",
       "id": "usescrolltotop",
-      "community": 8
+      "community": 7
     },
     {
       "label": "useScrollToTop()",
@@ -14673,7 +14673,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useScrollToTop.ts",
       "source_location": "L3",
       "id": "usescrolltotop_usescrolltotop",
-      "community": 8
+      "community": 7
     },
     {
       "label": "useShoppingBag.ts",
@@ -14713,7 +14713,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useTrackAction.ts",
       "source_location": "L1",
       "id": "usetrackaction",
-      "community": 5
+      "community": 15
     },
     {
       "label": "useTrackAction()",
@@ -14721,7 +14721,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useTrackAction.ts",
       "source_location": "L5",
       "id": "usetrackaction_usetrackaction",
-      "community": 5
+      "community": 15
     },
     {
       "label": "useTrackEvent.ts",
@@ -14729,7 +14729,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useTrackEvent.ts",
       "source_location": "L1",
       "id": "usetrackevent",
-      "community": 5
+      "community": 1
     },
     {
       "label": "useTrackEvent()",
@@ -14737,7 +14737,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useTrackEvent.ts",
       "source_location": "L5",
       "id": "usetrackevent_usetrackevent",
-      "community": 5
+      "community": 1
     },
     {
       "label": "useUpsellModal.tsx",
@@ -14817,7 +14817,7 @@
       "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.test.ts",
       "source_location": "L1",
       "id": "maintenanceutils_test",
-      "community": 6
+      "community": 16
     },
     {
       "label": "usePostAnalytics()",
@@ -14825,7 +14825,7 @@
       "source_file": "packages/storefront-webapp/src/lib/mutations.ts/analytics.ts",
       "source_location": "L4",
       "id": "analytics_usepostanalytics",
-      "community": 5
+      "community": 15
     },
     {
       "label": "isSoldOut()",
@@ -14833,7 +14833,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L45",
       "id": "productutils_issoldout",
-      "community": 5
+      "community": 1
     },
     {
       "label": "hasLowStock()",
@@ -14841,7 +14841,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L52",
       "id": "productutils_haslowstock",
-      "community": 5
+      "community": 1
     },
     {
       "label": "sortSkusByLength()",
@@ -14849,7 +14849,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L62",
       "id": "productutils_sortskusbylength",
-      "community": 5
+      "community": 1
     },
     {
       "label": "useBagQueries()",
@@ -14857,7 +14857,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/bag.ts",
       "source_location": "L7",
       "id": "bag_usebagqueries",
-      "community": 14
+      "community": 2
     },
     {
       "label": "useBannerMessageQueries()",
@@ -14905,7 +14905,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/product.ts",
       "source_location": "L14",
       "id": "product_useproductqueries",
-      "community": 18
+      "community": 15
     },
     {
       "label": "usePromoCodesQueries()",
@@ -14921,7 +14921,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/reviews.ts",
       "source_location": "L10",
       "id": "reviews_usereviewqueries",
-      "community": 5
+      "community": 17
     },
     {
       "label": "useRewardsQueries()",
@@ -14929,7 +14929,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/rewards.ts",
       "source_location": "L11",
       "id": "rewards_userewardsqueries",
-      "community": 14
+      "community": 2
     },
     {
       "label": "useUpsellsQueries()",
@@ -15009,7 +15009,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.test.ts",
       "source_location": "L1",
       "id": "storefrontfailureobservability_test",
-      "community": 6
+      "community": 4
     },
     {
       "label": "storefrontFailureObservability.ts",
@@ -15017,7 +15017,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
       "source_location": "L1",
       "id": "storefrontfailureobservability",
-      "community": 6
+      "community": 4
     },
     {
       "label": "inferStorefrontJourneyFromRoute()",
@@ -15025,7 +15025,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
       "source_location": "L25",
       "id": "storefrontfailureobservability_inferstorefrontjourneyfromroute",
-      "community": 6
+      "community": 4
     },
     {
       "label": "normalizeStorefrontError()",
@@ -15033,7 +15033,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
       "source_location": "L47",
       "id": "storefrontfailureobservability_normalizestorefronterror",
-      "community": 6
+      "community": 4
     },
     {
       "label": "createStorefrontFailureEvent()",
@@ -15041,7 +15041,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
       "source_location": "L136",
       "id": "storefrontfailureobservability_createstorefrontfailureevent",
-      "community": 6
+      "community": 4
     },
     {
       "label": "emitStorefrontFailure()",
@@ -15049,7 +15049,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
       "source_location": "L154",
       "id": "storefrontfailureobservability_emitstorefrontfailure",
-      "community": 6
+      "community": 4
     },
     {
       "label": "storefrontJourneyEvents.test.ts",
@@ -15057,7 +15057,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.test.ts",
       "source_location": "L1",
       "id": "storefrontjourneyevents_test",
-      "community": 13
+      "community": 14
     },
     {
       "label": "storefrontJourneyEvents.ts",
@@ -15065,7 +15065,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L1",
       "id": "storefrontjourneyevents",
-      "community": 13
+      "community": 14
     },
     {
       "label": "compactContext()",
@@ -15073,7 +15073,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L7",
       "id": "storefrontjourneyevents_compactcontext",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createJourneyEvent()",
@@ -15081,7 +15081,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L19",
       "id": "storefrontjourneyevents_createjourneyevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createLandingPageViewedEvent()",
@@ -15089,7 +15089,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L33",
       "id": "storefrontjourneyevents_createlandingpageviewedevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createCategoryBrowseViewedEvent()",
@@ -15097,7 +15097,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L41",
       "id": "storefrontjourneyevents_createcategorybrowseviewedevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createProductDetailViewedEvent()",
@@ -15105,7 +15105,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L59",
       "id": "storefrontjourneyevents_createproductdetailviewedevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createBagViewedEvent()",
@@ -15113,7 +15113,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L83",
       "id": "storefrontjourneyevents_createbagviewedevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createBagAddSucceededEvent()",
@@ -15121,7 +15121,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L101",
       "id": "storefrontjourneyevents_createbagaddsucceededevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createBagRemoveSucceededEvent()",
@@ -15129,7 +15129,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L122",
       "id": "storefrontjourneyevents_createbagremovesucceededevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createCheckoutStartEvent()",
@@ -15137,7 +15137,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L143",
       "id": "storefrontjourneyevents_createcheckoutstartevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createCheckoutDetailsViewedEvent()",
@@ -15145,7 +15145,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L164",
       "id": "storefrontjourneyevents_createcheckoutdetailsviewedevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createOrderReviewViewedEvent()",
@@ -15153,7 +15153,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L179",
       "id": "storefrontjourneyevents_createorderreviewviewedevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createPaymentSubmissionStartedEvent()",
@@ -15161,7 +15161,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L194",
       "id": "storefrontjourneyevents_createpaymentsubmissionstartedevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createPaymentVerificationStartedEvent()",
@@ -15169,7 +15169,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L215",
       "id": "storefrontjourneyevents_createpaymentverificationstartedevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createCheckoutCompletionEvent()",
@@ -15177,7 +15177,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L233",
       "id": "storefrontjourneyevents_createcheckoutcompletionevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createCheckoutCompletionSucceededEvent()",
@@ -15185,7 +15185,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L256",
       "id": "storefrontjourneyevents_createcheckoutcompletionsucceededevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createCheckoutCompletionBlockedEvent()",
@@ -15193,7 +15193,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L273",
       "id": "storefrontjourneyevents_createcheckoutcompletionblockedevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createCheckoutCompletionCanceledEvent()",
@@ -15201,7 +15201,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L290",
       "id": "storefrontjourneyevents_createcheckoutcompletioncanceledevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "getAuthEntryStep()",
@@ -15209,7 +15209,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L307",
       "id": "storefrontjourneyevents_getauthentrystep",
-      "community": 13
+      "community": 14
     },
     {
       "label": "getAuthRequestStep()",
@@ -15217,7 +15217,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L311",
       "id": "storefrontjourneyevents_getauthrequeststep",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createAuthEntryViewedEvent()",
@@ -15225,7 +15225,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L315",
       "id": "storefrontjourneyevents_createauthentryviewedevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createAuthRequestStartedEvent()",
@@ -15233,7 +15233,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L335",
       "id": "storefrontjourneyevents_createauthrequeststartedevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createAuthVerificationViewedEvent()",
@@ -15241,7 +15241,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L355",
       "id": "storefrontjourneyevents_createauthverificationviewedevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createAuthVerificationSucceededEvent()",
@@ -15249,7 +15249,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L370",
       "id": "storefrontjourneyevents_createauthverificationsucceededevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createRewardsAlertViewedEvent()",
@@ -15257,7 +15257,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L387",
       "id": "storefrontjourneyevents_createrewardsalertviewedevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createRewardsAlertDismissedEvent()",
@@ -15265,7 +15265,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L395",
       "id": "storefrontjourneyevents_createrewardsalertdismissedevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createRewardsAlertShopNowEvent()",
@@ -15273,7 +15273,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L403",
       "id": "storefrontjourneyevents_createrewardsalertshopnowevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createPromoAlertViewedEvent()",
@@ -15281,7 +15281,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L411",
       "id": "storefrontjourneyevents_createpromoalertviewedevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createPromoAlertDismissedEvent()",
@@ -15289,7 +15289,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L435",
       "id": "storefrontjourneyevents_createpromoalertdismissedevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createPromoAlertShopNowEvent()",
@@ -15297,7 +15297,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L459",
       "id": "storefrontjourneyevents_createpromoalertshopnowevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createWelcomeBackModalViewedEvent()",
@@ -15305,7 +15305,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L483",
       "id": "storefrontjourneyevents_createwelcomebackmodalviewedevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createWelcomeBackModalDismissedEvent()",
@@ -15313,7 +15313,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L501",
       "id": "storefrontjourneyevents_createwelcomebackmodaldismissedevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createWelcomeBackModalSubmittedEvent()",
@@ -15321,7 +15321,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L519",
       "id": "storefrontjourneyevents_createwelcomebackmodalsubmittedevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createLeaveReviewModalViewedEvent()",
@@ -15329,7 +15329,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L537",
       "id": "storefrontjourneyevents_createleavereviewmodalviewedevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createLeaveReviewModalDismissedEvent()",
@@ -15337,7 +15337,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L555",
       "id": "storefrontjourneyevents_createleavereviewmodaldismissedevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createUpsellModalViewedEvent()",
@@ -15345,7 +15345,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L573",
       "id": "storefrontjourneyevents_createupsellmodalviewedevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createUpsellModalDismissedEvent()",
@@ -15353,7 +15353,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L600",
       "id": "storefrontjourneyevents_createupsellmodaldismissedevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createUpsellModalSubmittedEvent()",
@@ -15361,7 +15361,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L627",
       "id": "storefrontjourneyevents_createupsellmodalsubmittedevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createUpsellModalAddToBagEvent()",
@@ -15369,7 +15369,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L654",
       "id": "storefrontjourneyevents_createupsellmodaladdtobagevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createSavedBagViewedEvent()",
@@ -15377,7 +15377,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L676",
       "id": "storefrontjourneyevents_createsavedbagviewedevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createSavedBagMoveToBagEvent()",
@@ -15385,7 +15385,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L684",
       "id": "storefrontjourneyevents_createsavedbagmovetobagevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createSavedBagRemoveEvent()",
@@ -15393,7 +15393,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L705",
       "id": "storefrontjourneyevents_createsavedbagremoveevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createBagMoveToSavedEvent()",
@@ -15401,7 +15401,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L726",
       "id": "storefrontjourneyevents_createbagmovetosavedevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createDiscountCodeTriggerEvent()",
@@ -15409,7 +15409,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L747",
       "id": "storefrontjourneyevents_creatediscountcodetriggerevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createReviewEditorViewedEvent()",
@@ -15417,7 +15417,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L762",
       "id": "storefrontjourneyevents_createrevieweditorviewedevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createReviewSubmittedEvent()",
@@ -15425,7 +15425,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L786",
       "id": "storefrontjourneyevents_createreviewsubmittedevent",
-      "community": 13
+      "community": 14
     },
     {
       "label": "storefrontObservability.test.ts",
@@ -15433,7 +15433,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.test.ts",
       "source_location": "L1",
       "id": "storefrontobservability_test",
-      "community": 6
+      "community": 4
     },
     {
       "label": "createMemoryStorage()",
@@ -15441,7 +15441,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.test.ts",
       "source_location": "L12",
       "id": "storefrontobservability_test_creatememorystorage",
-      "community": 6
+      "community": 4
     },
     {
       "label": "storefrontObservability.ts",
@@ -15449,7 +15449,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L1",
       "id": "storefrontobservability",
-      "community": 6
+      "community": 4
     },
     {
       "label": "getOrCreateStorefrontObservabilitySessionId()",
@@ -15457,7 +15457,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L109",
       "id": "storefrontobservability_getorcreatestorefrontobservabilitysessionid",
-      "community": 6
+      "community": 4
     },
     {
       "label": "createStorefrontObservabilityContext()",
@@ -15465,7 +15465,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L134",
       "id": "storefrontobservability_createstorefrontobservabilitycontext",
-      "community": 6
+      "community": 4
     },
     {
       "label": "createStorefrontObservabilityPayload()",
@@ -15473,7 +15473,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L157",
       "id": "storefrontobservability_createstorefrontobservabilitypayload",
-      "community": 6
+      "community": 4
     },
     {
       "label": "trackStorefrontEvent()",
@@ -15481,7 +15481,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L193",
       "id": "storefrontobservability_trackstorefrontevent",
-      "community": 6
+      "community": 4
     },
     {
       "label": "getStoreDetails()",
@@ -15489,7 +15489,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L53",
       "id": "utils_getstoredetails",
-      "community": 3
+      "community": 0
     },
     {
       "label": "enableQuery()",
@@ -15497,7 +15497,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L60",
       "id": "utils_enablequery",
-      "community": 3
+      "community": 0
     },
     {
       "label": "validateEmail()",
@@ -15505,7 +15505,7 @@
       "source_file": "packages/storefront-webapp/src/lib/validations/email.ts",
       "source_location": "L14",
       "id": "email_validateemail",
-      "community": 1
+      "community": 6
     },
     {
       "label": "router.tsx",
@@ -15513,7 +15513,7 @@
       "source_file": "packages/storefront-webapp/src/router.tsx",
       "source_location": "L1",
       "id": "router",
-      "community": 6
+      "community": 4
     },
     {
       "label": "createRouter()",
@@ -15521,7 +15521,7 @@
       "source_file": "packages/storefront-webapp/src/router.tsx",
       "source_location": "L5",
       "id": "router_createrouter",
-      "community": 6
+      "community": 4
     },
     {
       "label": "$orderItemId.review.tsx",
@@ -15569,7 +15569,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout.tsx",
       "source_location": "L1",
       "id": "orderslayout",
-      "community": 8
+      "community": 7
     },
     {
       "label": "LayoutComponent()",
@@ -15577,7 +15577,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout.tsx",
       "source_location": "L8",
       "id": "orderslayout_layoutcomponent",
-      "community": 8
+      "community": 7
     },
     {
       "label": "$subcategorySlug.tsx",
@@ -15585,7 +15585,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout/shop/$categorySlug/$subcategorySlug.tsx",
       "source_location": "L1",
       "id": "subcategoryslug",
-      "community": 18
+      "community": 15
     },
     {
       "label": "_shopLayout.tsx",
@@ -15593,7 +15593,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
       "source_location": "L1",
       "id": "shoplayout",
-      "community": 6
+      "community": 4
     },
     {
       "label": "onClickOnMobileFilters()",
@@ -15601,7 +15601,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
       "source_location": "L105",
       "id": "shoplayout_onclickonmobilefilters",
-      "community": 6
+      "community": 4
     },
     {
       "label": "onMobileFiltersCloseClick()",
@@ -15609,7 +15609,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
       "source_location": "L110",
       "id": "shoplayout_onmobilefilterscloseclick",
-      "community": 6
+      "community": 4
     },
     {
       "label": "clearFilters()",
@@ -15617,7 +15617,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
       "source_location": "L115",
       "id": "shoplayout_clearfilters",
-      "community": 6
+      "community": 4
     },
     {
       "label": "account.tsx",
@@ -15665,7 +15665,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/delivery-returns-exchanges.index.tsx",
       "source_location": "L1",
       "id": "delivery_returns_exchanges_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "OnlineOrderPolicy()",
@@ -15673,7 +15673,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/delivery-returns-exchanges.index.tsx",
       "source_location": "L13",
       "id": "delivery_returns_exchanges_index_onlineorderpolicy",
-      "community": 8
+      "community": 7
     },
     {
       "label": "privacy.index.tsx",
@@ -15681,7 +15681,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/privacy.index.tsx",
       "source_location": "L1",
       "id": "privacy_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "PrivacyPolicy()",
@@ -15689,7 +15689,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/privacy.index.tsx",
       "source_location": "L9",
       "id": "privacy_index_privacypolicy",
-      "community": 8
+      "community": 7
     },
     {
       "label": "tos.index.tsx",
@@ -15697,7 +15697,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
       "source_location": "L1",
       "id": "tos_index",
-      "community": 8
+      "community": 7
     },
     {
       "label": "TosSection()",
@@ -15705,7 +15705,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
       "source_location": "L15",
       "id": "tos_index_tossection",
-      "community": 8
+      "community": 7
     },
     {
       "label": "rewards.index.tsx",
@@ -15713,7 +15713,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/rewards.index.tsx",
       "source_location": "L1",
       "id": "rewards_index",
-      "community": 14
+      "community": 1
     },
     {
       "label": "shop.product.$productSlug.tsx",
@@ -15721,7 +15721,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/shop.product.$productSlug.tsx",
       "source_location": "L1",
       "id": "shop_product_productslug",
-      "community": 5
+      "community": 9
     },
     {
       "label": "Component()",
@@ -15729,7 +15729,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/shop.product.$productSlug.tsx",
       "source_location": "L16",
       "id": "shop_product_productslug_component",
-      "community": 5
+      "community": 9
     },
     {
       "label": "shop.saved.index.tsx",
@@ -15737,7 +15737,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/shop.saved.index.tsx",
       "source_location": "L1",
       "id": "shop_saved_index",
-      "community": 14
+      "community": 2
     },
     {
       "label": "LayoutComponent()",
@@ -15745,7 +15745,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout.tsx",
       "source_location": "L6",
       "id": "layout_layoutcomponent",
-      "community": 6
+      "community": 4
     },
     {
       "label": "auth.verify.tsx",
@@ -15753,7 +15753,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L1",
       "id": "auth_verify",
-      "community": 14
+      "community": 2
     },
     {
       "label": "reportAuthFailure()",
@@ -15761,7 +15761,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L93",
       "id": "auth_verify_reportauthfailure",
-      "community": 14
+      "community": 2
     },
     {
       "label": "formatTime()",
@@ -15769,7 +15769,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L149",
       "id": "auth_verify_formattime",
-      "community": 14
+      "community": 2
     },
     {
       "label": "handleCodeChange()",
@@ -15777,7 +15777,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L156",
       "id": "auth_verify_handlecodechange",
-      "community": 14
+      "community": 2
     },
     {
       "label": "onSubmit()",
@@ -15785,7 +15785,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L201",
       "id": "auth_verify_onsubmit",
-      "community": 14
+      "community": 2
     },
     {
       "label": "resendVerificationCode()",
@@ -15793,7 +15793,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L282",
       "id": "auth_verify_resendverificationcode",
-      "community": 14
+      "community": 2
     },
     {
       "label": "login.tsx",
@@ -15977,7 +15977,7 @@
       "source_file": "packages/storefront-webapp/src/ssr.tsx",
       "source_location": "L1",
       "id": "ssr",
-      "community": 6
+      "community": 4
     },
     {
       "label": "bootstrap.ts",
@@ -16033,7 +16033,7 @@
       "source_file": "packages/valkey-proxy-server/test-connection.js",
       "source_location": "L1",
       "id": "test_connection",
-      "community": 26
+      "community": 27
     },
     {
       "label": "testConnection()",
@@ -16041,7 +16041,7 @@
       "source_file": "packages/valkey-proxy-server/test-connection.js",
       "source_location": "L40",
       "id": "test_connection_testconnection",
-      "community": 26
+      "community": 27
     },
     {
       "label": "testClusterInfo()",
@@ -16049,7 +16049,7 @@
       "source_file": "packages/valkey-proxy-server/test-connection.js",
       "source_location": "L52",
       "id": "test_connection_testclusterinfo",
-      "community": 26
+      "community": 27
     },
     {
       "label": "testBasicOperations()",
@@ -16057,7 +16057,7 @@
       "source_file": "packages/valkey-proxy-server/test-connection.js",
       "source_location": "L64",
       "id": "test_connection_testbasicoperations",
-      "community": 26
+      "community": 27
     },
     {
       "label": "runTests()",
@@ -16065,7 +16065,7 @@
       "source_file": "packages/valkey-proxy-server/test-connection.js",
       "source_location": "L89",
       "id": "test_connection_runtests",
-      "community": 26
+      "community": 27
     },
     {
       "label": "architecture-boundaries.test.ts",
@@ -16073,7 +16073,7 @@
       "source_file": "scripts/architecture-boundaries.test.ts",
       "source_location": "L1",
       "id": "architecture_boundaries_test",
-      "community": 42
+      "community": 43
     },
     {
       "label": "createSnippetLinter()",
@@ -16081,7 +16081,7 @@
       "source_file": "scripts/architecture-boundaries.test.ts",
       "source_location": "L10",
       "id": "architecture_boundaries_test_createsnippetlinter",
-      "community": 42
+      "community": 43
     },
     {
       "label": "architecture-boundary-check.ts",
@@ -16089,7 +16089,7 @@
       "source_file": "scripts/architecture-boundary-check.ts",
       "source_location": "L1",
       "id": "architecture_boundary_check",
-      "community": 43
+      "community": 44
     },
     {
       "label": "run()",
@@ -16097,7 +16097,7 @@
       "source_file": "scripts/architecture-boundary-check.ts",
       "source_location": "L29",
       "id": "architecture_boundary_check_run",
-      "community": 43
+      "community": 44
     },
     {
       "label": "graphify-rebuild.test.ts",
@@ -16105,7 +16105,7 @@
       "source_file": "scripts/graphify-rebuild.test.ts",
       "source_location": "L1",
       "id": "graphify_rebuild_test",
-      "community": 25
+      "community": 24
     },
     {
       "label": "write()",
@@ -16113,7 +16113,7 @@
       "source_file": "scripts/graphify-rebuild.test.ts",
       "source_location": "L10",
       "id": "graphify_rebuild_test_write",
-      "community": 25
+      "community": 24
     },
     {
       "label": "createFixtureRoot()",
@@ -16121,7 +16121,7 @@
       "source_file": "scripts/graphify-rebuild.test.ts",
       "source_location": "L16",
       "id": "graphify_rebuild_test_createfixtureroot",
-      "community": 25
+      "community": 24
     },
     {
       "label": "spawn()",
@@ -16129,7 +16129,7 @@
       "source_file": "scripts/graphify-rebuild.test.ts",
       "source_location": "L38",
       "id": "graphify_rebuild_test_spawn",
-      "community": 25
+      "community": 24
     },
     {
       "label": "graphify-rebuild.ts",
@@ -16137,7 +16137,7 @@
       "source_file": "scripts/graphify-rebuild.ts",
       "source_location": "L1",
       "id": "graphify_rebuild",
-      "community": 25
+      "community": 24
     },
     {
       "label": "fileExists()",
@@ -16145,7 +16145,7 @@
       "source_file": "scripts/graphify-rebuild.ts",
       "source_location": "L67",
       "id": "graphify_rebuild_fileexists",
-      "community": 25
+      "community": 24
     },
     {
       "label": "resolveGraphifyPython()",
@@ -16153,7 +16153,7 @@
       "source_file": "scripts/graphify-rebuild.ts",
       "source_location": "L76",
       "id": "graphify_rebuild_resolvegraphifypython",
-      "community": 25
+      "community": 24
     },
     {
       "label": "runGraphifyRebuild()",
@@ -16161,7 +16161,7 @@
       "source_file": "scripts/graphify-rebuild.ts",
       "source_location": "L86",
       "id": "graphify_rebuild_rungraphifyrebuild",
-      "community": 25
+      "community": 24
     },
     {
       "label": "harness-app-registry.ts",
@@ -16169,7 +16169,7 @@
       "source_file": "scripts/harness-app-registry.ts",
       "source_location": "L1",
       "id": "harness_app_registry",
-      "community": 7
+      "community": 5
     },
     {
       "label": "buildHarnessDocPaths()",
@@ -16177,7 +16177,7 @@
       "source_file": "scripts/harness-app-registry.ts",
       "source_location": "L103",
       "id": "harness_app_registry_buildharnessdocpaths",
-      "community": 7
+      "community": 5
     },
     {
       "label": "getHarnessPackageRegistration()",
@@ -16185,7 +16185,7 @@
       "source_file": "scripts/harness-app-registry.ts",
       "source_location": "L375",
       "id": "harness_app_registry_getharnesspackageregistration",
-      "community": 7
+      "community": 5
     },
     {
       "label": "harness-audit.test.ts",
@@ -16193,7 +16193,7 @@
       "source_file": "scripts/harness-audit.test.ts",
       "source_location": "L1",
       "id": "harness_audit_test",
-      "community": 7
+      "community": 5
     },
     {
       "label": "write()",
@@ -16201,7 +16201,7 @@
       "source_file": "scripts/harness-audit.test.ts",
       "source_location": "L11",
       "id": "harness_audit_test_write",
-      "community": 7
+      "community": 5
     },
     {
       "label": "createFixtureRepo()",
@@ -16209,7 +16209,7 @@
       "source_file": "scripts/harness-audit.test.ts",
       "source_location": "L17",
       "id": "harness_audit_test_createfixturerepo",
-      "community": 7
+      "community": 5
     },
     {
       "label": "harness-audit.ts",
@@ -16217,7 +16217,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L1",
       "id": "harness_audit",
-      "community": 7
+      "community": 5
     },
     {
       "label": "normalizeRepoPath()",
@@ -16225,7 +16225,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L38",
       "id": "harness_audit_normalizerepopath",
-      "community": 7
+      "community": 5
     },
     {
       "label": "matchesPathPrefix()",
@@ -16233,7 +16233,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L42",
       "id": "harness_audit_matchespathprefix",
-      "community": 7
+      "community": 5
     },
     {
       "label": "fileExists()",
@@ -16241,7 +16241,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L56",
       "id": "harness_audit_fileexists",
-      "community": 7
+      "community": 5
     },
     {
       "label": "readJsonFile()",
@@ -16249,7 +16249,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L65",
       "id": "harness_audit_readjsonfile",
-      "community": 7
+      "community": 5
     },
     {
       "label": "normalizeValidationCommand()",
@@ -16257,7 +16257,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L69",
       "id": "harness_audit_normalizevalidationcommand",
-      "community": 7
+      "community": 5
     },
     {
       "label": "addGroupedError()",
@@ -16265,7 +16265,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L77",
       "id": "harness_audit_addgroupederror",
-      "community": 7
+      "community": 5
     },
     {
       "label": "inferGroupFromError()",
@@ -16273,7 +16273,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L91",
       "id": "harness_audit_infergroupfromerror",
-      "community": 7
+      "community": 5
     },
     {
       "label": "shouldSkipSurfaceEntry()",
@@ -16281,7 +16281,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L96",
       "id": "harness_audit_shouldskipsurfaceentry",
-      "community": 7
+      "community": 5
     },
     {
       "label": "collectLiveSurfaceEntries()",
@@ -16289,7 +16289,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L107",
       "id": "harness_audit_collectlivesurfaceentries",
-      "community": 7
+      "community": 5
     },
     {
       "label": "loadAuditTarget()",
@@ -16297,7 +16297,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L136",
       "id": "harness_audit_loadaudittarget",
-      "community": 7
+      "community": 5
     },
     {
       "label": "formatGroupedErrors()",
@@ -16305,7 +16305,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L290",
       "id": "harness_audit_formatgroupederrors",
-      "community": 7
+      "community": 5
     },
     {
       "label": "runHarnessAudit()",
@@ -16313,7 +16313,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L305",
       "id": "harness_audit_runharnessaudit",
-      "community": 7
+      "community": 5
     },
     {
       "label": "harness-check.test.ts",
@@ -16321,7 +16321,7 @@
       "source_file": "scripts/harness-check.test.ts",
       "source_location": "L1",
       "id": "harness_check_test",
-      "community": 7
+      "community": 5
     },
     {
       "label": "write()",
@@ -16329,7 +16329,7 @@
       "source_file": "scripts/harness-check.test.ts",
       "source_location": "L29",
       "id": "harness_check_test_write",
-      "community": 7
+      "community": 5
     },
     {
       "label": "createFixtureRepo()",
@@ -16337,7 +16337,7 @@
       "source_file": "scripts/harness-check.test.ts",
       "source_location": "L35",
       "id": "harness_check_test_createfixturerepo",
-      "community": 7
+      "community": 5
     },
     {
       "label": "harness-check.ts",
@@ -16345,7 +16345,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L1",
       "id": "harness_check",
-      "community": 7
+      "community": 5
     },
     {
       "label": "stripLinkDecorations()",
@@ -16353,7 +16353,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L28",
       "id": "harness_check_striplinkdecorations",
-      "community": 7
+      "community": 5
     },
     {
       "label": "isRelativeLink()",
@@ -16361,7 +16361,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L32",
       "id": "harness_check_isrelativelink",
-      "community": 7
+      "community": 5
     },
     {
       "label": "fileExists()",
@@ -16369,7 +16369,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L40",
       "id": "harness_check_fileexists",
-      "community": 7
+      "community": 5
     },
     {
       "label": "collectMarkdownLinkErrors()",
@@ -16377,7 +16377,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L49",
       "id": "harness_check_collectmarkdownlinkerrors",
-      "community": 7
+      "community": 5
     },
     {
       "label": "extractInlineCode()",
@@ -16385,7 +16385,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L78",
       "id": "harness_check_extractinlinecode",
-      "community": 7
+      "community": 5
     },
     {
       "label": "normalizePathReference()",
@@ -16393,7 +16393,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L84",
       "id": "harness_check_normalizepathreference",
-      "community": 7
+      "community": 5
     },
     {
       "label": "isLikelyPathReference()",
@@ -16401,7 +16401,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L97",
       "id": "harness_check_islikelypathreference",
-      "community": 7
+      "community": 5
     },
     {
       "label": "resolvePathReference()",
@@ -16409,7 +16409,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L122",
       "id": "harness_check_resolvepathreference",
-      "community": 7
+      "community": 5
     },
     {
       "label": "collectReferencedPathErrors()",
@@ -16417,7 +16417,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L148",
       "id": "harness_check_collectreferencedpatherrors",
-      "community": 7
+      "community": 5
     },
     {
       "label": "readPackageConfig()",
@@ -16425,7 +16425,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L183",
       "id": "harness_check_readpackageconfig",
-      "community": 7
+      "community": 5
     },
     {
       "label": "listWorkspacePackageDirs()",
@@ -16433,7 +16433,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L211",
       "id": "harness_check_listworkspacepackagedirs",
-      "community": 7
+      "community": 5
     },
     {
       "label": "collectHarnessOnboardingErrors()",
@@ -16441,7 +16441,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L234",
       "id": "harness_check_collectharnessonboardingerrors",
-      "community": 7
+      "community": 5
     },
     {
       "label": "extractTestScriptFromCommand()",
@@ -16449,7 +16449,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L265",
       "id": "harness_check_extracttestscriptfromcommand",
-      "community": 7
+      "community": 5
     },
     {
       "label": "walkFiles()",
@@ -16457,7 +16457,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L297",
       "id": "harness_check_walkfiles",
-      "community": 7
+      "community": 5
     },
     {
       "label": "collectTestSurfaceRoots()",
@@ -16465,7 +16465,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L317",
       "id": "harness_check_collecttestsurfaceroots",
-      "community": 7
+      "community": 5
     },
     {
       "label": "collectTestingDocErrors()",
@@ -16473,7 +16473,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L359",
       "id": "harness_check_collecttestingdocerrors",
-      "community": 7
+      "community": 5
     },
     {
       "label": "validateHarnessDocs()",
@@ -16481,7 +16481,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L404",
       "id": "harness_check_validateharnessdocs",
-      "community": 7
+      "community": 5
     },
     {
       "label": "runHarnessCheck()",
@@ -16489,7 +16489,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L538",
       "id": "harness_check_runharnesscheck",
-      "community": 7
+      "community": 5
     },
     {
       "label": "harness-generate.test.ts",
@@ -16497,7 +16497,7 @@
       "source_file": "scripts/harness-generate.test.ts",
       "source_location": "L1",
       "id": "harness_generate_test",
-      "community": 7
+      "community": 5
     },
     {
       "label": "write()",
@@ -16505,7 +16505,7 @@
       "source_file": "scripts/harness-generate.test.ts",
       "source_location": "L10",
       "id": "harness_generate_test_write",
-      "community": 7
+      "community": 5
     },
     {
       "label": "createFixtureRepo()",
@@ -16513,7 +16513,7 @@
       "source_file": "scripts/harness-generate.test.ts",
       "source_location": "L16",
       "id": "harness_generate_test_createfixturerepo",
-      "community": 7
+      "community": 5
     },
     {
       "label": "harness-generate.ts",
@@ -16521,7 +16521,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L1",
       "id": "harness_generate",
-      "community": 7
+      "community": 5
     },
     {
       "label": "normalizeRepoPath()",
@@ -16529,7 +16529,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L23",
       "id": "harness_generate_normalizerepopath",
-      "community": 7
+      "community": 5
     },
     {
       "label": "shouldSkipGeneratedEntry()",
@@ -16537,7 +16537,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L27",
       "id": "harness_generate_shouldskipgeneratedentry",
-      "community": 7
+      "community": 5
     },
     {
       "label": "fileExists()",
@@ -16545,7 +16545,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L31",
       "id": "harness_generate_fileexists",
-      "community": 7
+      "community": 5
     },
     {
       "label": "walkFiles()",
@@ -16553,7 +16553,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L40",
       "id": "harness_generate_walkfiles",
-      "community": 7
+      "community": 5
     },
     {
       "label": "readPackageConfig()",
@@ -16561,7 +16561,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L62",
       "id": "harness_generate_readpackageconfig",
-      "community": 7
+      "community": 5
     },
     {
       "label": "toDocPath()",
@@ -16569,7 +16569,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L80",
       "id": "harness_generate_todocpath",
-      "community": 7
+      "community": 5
     },
     {
       "label": "formatMarkdownLink()",
@@ -16577,7 +16577,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L84",
       "id": "harness_generate_formatmarkdownlink",
-      "community": 7
+      "community": 5
     },
     {
       "label": "headingFromSegment()",
@@ -16585,7 +16585,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L88",
       "id": "harness_generate_headingfromsegment",
-      "community": 7
+      "community": 5
     },
     {
       "label": "summarizeChildren()",
@@ -16593,7 +16593,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L96",
       "id": "harness_generate_summarizechildren",
-      "community": 7
+      "community": 5
     },
     {
       "label": "collectRouteGroups()",
@@ -16601,7 +16601,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L104",
       "id": "harness_generate_collectroutegroups",
-      "community": 7
+      "community": 5
     },
     {
       "label": "collectTestFiles()",
@@ -16609,7 +16609,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L130",
       "id": "harness_generate_collecttestfiles",
-      "community": 7
+      "community": 5
     },
     {
       "label": "collectTestSurfaceRoots()",
@@ -16617,7 +16617,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L160",
       "id": "harness_generate_collecttestsurfaceroots",
-      "community": 7
+      "community": 5
     },
     {
       "label": "collectFolderFacts()",
@@ -16625,7 +16625,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L202",
       "id": "harness_generate_collectfolderfacts",
-      "community": 7
+      "community": 5
     },
     {
       "label": "formatScriptCommand()",
@@ -16633,7 +16633,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L225",
       "id": "harness_generate_formatscriptcommand",
-      "community": 7
+      "community": 5
     },
     {
       "label": "toRepoValidationPath()",
@@ -16641,7 +16641,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L235",
       "id": "harness_generate_torepovalidationpath",
-      "community": 7
+      "community": 5
     },
     {
       "label": "slugifyTitle()",
@@ -16649,7 +16649,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L240",
       "id": "harness_generate_slugifytitle",
-      "community": 7
+      "community": 5
     },
     {
       "label": "formatValidationCommandForDoc()",
@@ -16657,7 +16657,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L247",
       "id": "harness_generate_formatvalidationcommandfordoc",
-      "community": 7
+      "community": 5
     },
     {
       "label": "toGeneratedValidationMap()",
@@ -16665,7 +16665,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L256",
       "id": "harness_generate_togeneratedvalidationmap",
-      "community": 7
+      "community": 5
     },
     {
       "label": "buildGeneratedDoc()",
@@ -16673,7 +16673,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L283",
       "id": "harness_generate_buildgenerateddoc",
-      "community": 7
+      "community": 5
     },
     {
       "label": "buildRouteIndex()",
@@ -16681,7 +16681,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L293",
       "id": "harness_generate_buildrouteindex",
-      "community": 7
+      "community": 5
     },
     {
       "label": "buildTestIndex()",
@@ -16689,7 +16689,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L320",
       "id": "harness_generate_buildtestindex",
-      "community": 7
+      "community": 5
     },
     {
       "label": "buildKeyFolderIndex()",
@@ -16697,7 +16697,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L365",
       "id": "harness_generate_buildkeyfolderindex",
-      "community": 7
+      "community": 5
     },
     {
       "label": "buildValidationGuide()",
@@ -16705,7 +16705,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L398",
       "id": "harness_generate_buildvalidationguide",
-      "community": 7
+      "community": 5
     },
     {
       "label": "buildValidationMap()",
@@ -16713,7 +16713,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L431",
       "id": "harness_generate_buildvalidationmap",
-      "community": 7
+      "community": 5
     },
     {
       "label": "generateHarnessDocs()",
@@ -16721,7 +16721,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L438",
       "id": "harness_generate_generateharnessdocs",
-      "community": 7
+      "community": 5
     },
     {
       "label": "writeGeneratedHarnessDocs()",
@@ -16729,7 +16729,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L468",
       "id": "harness_generate_writegeneratedharnessdocs",
-      "community": 7
+      "community": 5
     },
     {
       "label": "harness-review.test.ts",
@@ -16737,7 +16737,7 @@
       "source_file": "scripts/harness-review.test.ts",
       "source_location": "L1",
       "id": "harness_review_test",
-      "community": 7
+      "community": 5
     },
     {
       "label": "write()",
@@ -16745,7 +16745,7 @@
       "source_file": "scripts/harness-review.test.ts",
       "source_location": "L10",
       "id": "harness_review_test_write",
-      "community": 7
+      "community": 5
     },
     {
       "label": "createFixtureRepo()",
@@ -16753,7 +16753,7 @@
       "source_file": "scripts/harness-review.test.ts",
       "source_location": "L16",
       "id": "harness_review_test_createfixturerepo",
-      "community": 7
+      "community": 5
     },
     {
       "label": "log()",
@@ -16761,7 +16761,7 @@
       "source_file": "scripts/harness-review.test.ts",
       "source_location": "L152",
       "id": "harness_review_test_log",
-      "community": 7
+      "community": 5
     },
     {
       "label": "error()",
@@ -16769,7 +16769,7 @@
       "source_file": "scripts/harness-review.test.ts",
       "source_location": "L153",
       "id": "harness_review_test_error",
-      "community": 7
+      "community": 5
     },
     {
       "label": "harness-review.ts",
@@ -16777,7 +16777,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L1",
       "id": "harness_review",
-      "community": 7
+      "community": 5
     },
     {
       "label": "normalizeRepoPath()",
@@ -16785,7 +16785,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L42",
       "id": "harness_review_normalizerepopath",
-      "community": 7
+      "community": 5
     },
     {
       "label": "matchesPathPrefix()",
@@ -16793,7 +16793,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L46",
       "id": "harness_review_matchespathprefix",
-      "community": 7
+      "community": 5
     },
     {
       "label": "normalizeValidationCommand()",
@@ -16801,7 +16801,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L60",
       "id": "harness_review_normalizevalidationcommand",
-      "community": 7
+      "community": 5
     },
     {
       "label": "fileExists()",
@@ -16809,7 +16809,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L68",
       "id": "harness_review_fileexists",
-      "community": 7
+      "community": 5
     },
     {
       "label": "readJsonFile()",
@@ -16817,7 +16817,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L77",
       "id": "harness_review_readjsonfile",
-      "community": 7
+      "community": 5
     },
     {
       "label": "loadReviewTarget()",
@@ -16825,7 +16825,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L81",
       "id": "harness_review_loadreviewtarget",
-      "community": 7
+      "community": 5
     },
     {
       "label": "loadReviewTargets()",
@@ -16833,7 +16833,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L185",
       "id": "harness_review_loadreviewtargets",
-      "community": 7
+      "community": 5
     },
     {
       "label": "collectCommandsForChangedFiles()",
@@ -16841,7 +16841,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L201",
       "id": "harness_review_collectcommandsforchangedfiles",
-      "community": 7
+      "community": 5
     },
     {
       "label": "getChangedFilesFromGit()",
@@ -16849,7 +16849,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L274",
       "id": "harness_review_getchangedfilesfromgit",
-      "community": 7
+      "community": 5
     },
     {
       "label": "runPackageScript()",
@@ -16857,7 +16857,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L312",
       "id": "harness_review_runpackagescript",
-      "community": 7
+      "community": 5
     },
     {
       "label": "runRawCommand()",
@@ -16865,7 +16865,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L326",
       "id": "harness_review_runrawcommand",
-      "community": 7
+      "community": 5
     },
     {
       "label": "runHarnessReview()",
@@ -16873,7 +16873,207 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L339",
       "id": "harness_review_runharnessreview",
-      "community": 7
+      "community": 5
+    },
+    {
+      "label": "harness-self-review.test.ts",
+      "file_type": "code",
+      "source_file": "scripts/harness-self-review.test.ts",
+      "source_location": "L1",
+      "id": "harness_self_review_test",
+      "community": 19
+    },
+    {
+      "label": "write()",
+      "file_type": "code",
+      "source_file": "scripts/harness-self-review.test.ts",
+      "source_location": "L10",
+      "id": "harness_self_review_test_write",
+      "community": 19
+    },
+    {
+      "label": "createFixtureRepo()",
+      "file_type": "code",
+      "source_file": "scripts/harness-self-review.test.ts",
+      "source_location": "L16",
+      "id": "harness_self_review_test_createfixturerepo",
+      "community": 19
+    },
+    {
+      "label": "harness-self-review.ts",
+      "file_type": "code",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L1",
+      "id": "harness_self_review",
+      "community": 19
+    },
+    {
+      "label": "normalizeRepoPath()",
+      "file_type": "code",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L91",
+      "id": "harness_self_review_normalizerepopath",
+      "community": 19
+    },
+    {
+      "label": "sortUniquePaths()",
+      "file_type": "code",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L95",
+      "id": "harness_self_review_sortuniquepaths",
+      "community": 19
+    },
+    {
+      "label": "matchesPathPrefix()",
+      "file_type": "code",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L101",
+      "id": "harness_self_review_matchespathprefix",
+      "community": 19
+    },
+    {
+      "label": "normalizeValidationCommand()",
+      "file_type": "code",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L115",
+      "id": "harness_self_review_normalizevalidationcommand",
+      "community": 19
+    },
+    {
+      "label": "formatValidationCommand()",
+      "file_type": "code",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L123",
+      "id": "harness_self_review_formatvalidationcommand",
+      "community": 19
+    },
+    {
+      "label": "quoteCode()",
+      "file_type": "code",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L131",
+      "id": "harness_self_review_quotecode",
+      "community": 19
+    },
+    {
+      "label": "fileExists()",
+      "file_type": "code",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L135",
+      "id": "harness_self_review_fileexists",
+      "community": 19
+    },
+    {
+      "label": "readJsonFile()",
+      "file_type": "code",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L144",
+      "id": "harness_self_review_readjsonfile",
+      "community": 19
+    },
+    {
+      "label": "runCommand()",
+      "file_type": "code",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L148",
+      "id": "harness_self_review_runcommand",
+      "community": 19
+    },
+    {
+      "label": "getChangedFilesFromGit()",
+      "file_type": "code",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L168",
+      "id": "harness_self_review_getchangedfilesfromgit",
+      "community": 19
+    },
+    {
+      "label": "parseRuntimeScenarios()",
+      "file_type": "code",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L232",
+      "id": "harness_self_review_parseruntimescenarios",
+      "community": 19
+    },
+    {
+      "label": "loadSelfReviewTarget()",
+      "file_type": "code",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L238",
+      "id": "harness_self_review_loadselfreviewtarget",
+      "community": 19
+    },
+    {
+      "label": "loadSelfReviewTargets()",
+      "file_type": "code",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L350",
+      "id": "harness_self_review_loadselfreviewtargets",
+      "community": 19
+    },
+    {
+      "label": "collectCoverage()",
+      "file_type": "code",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L369",
+      "id": "harness_self_review_collectcoverage",
+      "community": 19
+    },
+    {
+      "label": "isLikelyCodeOrConfig()",
+      "file_type": "code",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L447",
+      "id": "harness_self_review_islikelycodeorconfig",
+      "community": 19
+    },
+    {
+      "label": "evaluateGraphifyFreshness()",
+      "file_type": "code",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L468",
+      "id": "harness_self_review_evaluategraphifyfreshness",
+      "community": 19
+    },
+    {
+      "label": "runQuietHarnessCheck()",
+      "file_type": "code",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L532",
+      "id": "harness_self_review_runquietharnesscheck",
+      "community": 19
+    },
+    {
+      "label": "appendListSection()",
+      "file_type": "code",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L541",
+      "id": "harness_self_review_appendlistsection",
+      "community": 19
+    },
+    {
+      "label": "buildMarkdownBundle()",
+      "file_type": "code",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L560",
+      "id": "harness_self_review_buildmarkdownbundle",
+      "community": 19
+    },
+    {
+      "label": "parseCliArguments()",
+      "file_type": "code",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L717",
+      "id": "harness_self_review_parsecliarguments",
+      "community": 19
+    },
+    {
+      "label": "runHarnessSelfReview()",
+      "file_type": "code",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L766",
+      "id": "harness_self_review_runharnessselfreview",
+      "community": 19
     },
     {
       "label": "pre-push-review.test.ts",
@@ -16881,7 +17081,7 @@
       "source_file": "scripts/pre-push-review.test.ts",
       "source_location": "L1",
       "id": "pre_push_review_test",
-      "community": 7
+      "community": 5
     },
     {
       "label": "log()",
@@ -16889,7 +17089,7 @@
       "source_file": "scripts/pre-push-review.test.ts",
       "source_location": "L81",
       "id": "pre_push_review_test_log",
-      "community": 7
+      "community": 5
     },
     {
       "label": "warn()",
@@ -16897,7 +17097,7 @@
       "source_file": "scripts/pre-push-review.test.ts",
       "source_location": "L82",
       "id": "pre_push_review_test_warn",
-      "community": 7
+      "community": 5
     },
     {
       "label": "error()",
@@ -16905,7 +17105,7 @@
       "source_file": "scripts/pre-push-review.test.ts",
       "source_location": "L83",
       "id": "pre_push_review_test_error",
-      "community": 7
+      "community": 5
     },
     {
       "label": "pre-push-review.ts",
@@ -16913,7 +17113,7 @@
       "source_file": "scripts/pre-push-review.ts",
       "source_location": "L1",
       "id": "pre_push_review",
-      "community": 7
+      "community": 5
     },
     {
       "label": "getChangedFilesVsOriginMain()",
@@ -16921,7 +17121,7 @@
       "source_file": "scripts/pre-push-review.ts",
       "source_location": "L24",
       "id": "pre_push_review_getchangedfilesvsoriginmain",
-      "community": 7
+      "community": 5
     },
     {
       "label": "runArchitectureCheck()",
@@ -16929,7 +17129,7 @@
       "source_file": "scripts/pre-push-review.ts",
       "source_location": "L65",
       "id": "pre_push_review_runarchitecturecheck",
-      "community": 7
+      "community": 5
     },
     {
       "label": "runPrePushReview()",
@@ -16937,7 +17137,7 @@
       "source_file": "scripts/pre-push-review.ts",
       "source_location": "L77",
       "id": "pre_push_review_runprepushreview",
-      "community": 7
+      "community": 5
     }
   ],
   "links": [
@@ -73222,6 +73422,18 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L4",
+      "weight": 1.0,
+      "_src": "harness_self_review",
+      "_tgt": "harness_check",
+      "source": "harness_check",
+      "target": "harness_self_review",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/harness-check.ts",
@@ -74647,6 +74859,522 @@
       "_tgt": "harness_review_collectcommandsforchangedfiles",
       "source": "harness_review_collectcommandsforchangedfiles",
       "target": "harness_review_runharnessreview",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-self-review.test.ts",
+      "source_location": "L6",
+      "weight": 1.0,
+      "_src": "harness_self_review_test",
+      "_tgt": "harness_self_review",
+      "source": "harness_self_review_test",
+      "target": "harness_self_review",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-self-review.test.ts",
+      "source_location": "L10",
+      "weight": 1.0,
+      "_src": "harness_self_review_test",
+      "_tgt": "harness_self_review_test_write",
+      "source": "harness_self_review_test",
+      "target": "harness_self_review_test_write",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-self-review.test.ts",
+      "source_location": "L16",
+      "weight": 1.0,
+      "_src": "harness_self_review_test",
+      "_tgt": "harness_self_review_test_createfixturerepo",
+      "source": "harness_self_review_test",
+      "target": "harness_self_review_test_createfixturerepo",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-self-review.test.ts",
+      "source_location": "L20",
+      "weight": 0.8,
+      "_src": "harness_self_review_test_createfixturerepo",
+      "_tgt": "harness_self_review_test_write",
+      "source": "harness_self_review_test_write",
+      "target": "harness_self_review_test_createfixturerepo",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L91",
+      "weight": 1.0,
+      "_src": "harness_self_review",
+      "_tgt": "harness_self_review_normalizerepopath",
+      "source": "harness_self_review",
+      "target": "harness_self_review_normalizerepopath",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L95",
+      "weight": 1.0,
+      "_src": "harness_self_review",
+      "_tgt": "harness_self_review_sortuniquepaths",
+      "source": "harness_self_review",
+      "target": "harness_self_review_sortuniquepaths",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L101",
+      "weight": 1.0,
+      "_src": "harness_self_review",
+      "_tgt": "harness_self_review_matchespathprefix",
+      "source": "harness_self_review",
+      "target": "harness_self_review_matchespathprefix",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L115",
+      "weight": 1.0,
+      "_src": "harness_self_review",
+      "_tgt": "harness_self_review_normalizevalidationcommand",
+      "source": "harness_self_review",
+      "target": "harness_self_review_normalizevalidationcommand",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L123",
+      "weight": 1.0,
+      "_src": "harness_self_review",
+      "_tgt": "harness_self_review_formatvalidationcommand",
+      "source": "harness_self_review",
+      "target": "harness_self_review_formatvalidationcommand",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L131",
+      "weight": 1.0,
+      "_src": "harness_self_review",
+      "_tgt": "harness_self_review_quotecode",
+      "source": "harness_self_review",
+      "target": "harness_self_review_quotecode",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L135",
+      "weight": 1.0,
+      "_src": "harness_self_review",
+      "_tgt": "harness_self_review_fileexists",
+      "source": "harness_self_review",
+      "target": "harness_self_review_fileexists",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L144",
+      "weight": 1.0,
+      "_src": "harness_self_review",
+      "_tgt": "harness_self_review_readjsonfile",
+      "source": "harness_self_review",
+      "target": "harness_self_review_readjsonfile",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L148",
+      "weight": 1.0,
+      "_src": "harness_self_review",
+      "_tgt": "harness_self_review_runcommand",
+      "source": "harness_self_review",
+      "target": "harness_self_review_runcommand",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L168",
+      "weight": 1.0,
+      "_src": "harness_self_review",
+      "_tgt": "harness_self_review_getchangedfilesfromgit",
+      "source": "harness_self_review",
+      "target": "harness_self_review_getchangedfilesfromgit",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L232",
+      "weight": 1.0,
+      "_src": "harness_self_review",
+      "_tgt": "harness_self_review_parseruntimescenarios",
+      "source": "harness_self_review",
+      "target": "harness_self_review_parseruntimescenarios",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L238",
+      "weight": 1.0,
+      "_src": "harness_self_review",
+      "_tgt": "harness_self_review_loadselfreviewtarget",
+      "source": "harness_self_review",
+      "target": "harness_self_review_loadselfreviewtarget",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L350",
+      "weight": 1.0,
+      "_src": "harness_self_review",
+      "_tgt": "harness_self_review_loadselfreviewtargets",
+      "source": "harness_self_review",
+      "target": "harness_self_review_loadselfreviewtargets",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L369",
+      "weight": 1.0,
+      "_src": "harness_self_review",
+      "_tgt": "harness_self_review_collectcoverage",
+      "source": "harness_self_review",
+      "target": "harness_self_review_collectcoverage",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L447",
+      "weight": 1.0,
+      "_src": "harness_self_review",
+      "_tgt": "harness_self_review_islikelycodeorconfig",
+      "source": "harness_self_review",
+      "target": "harness_self_review_islikelycodeorconfig",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L468",
+      "weight": 1.0,
+      "_src": "harness_self_review",
+      "_tgt": "harness_self_review_evaluategraphifyfreshness",
+      "source": "harness_self_review",
+      "target": "harness_self_review_evaluategraphifyfreshness",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L532",
+      "weight": 1.0,
+      "_src": "harness_self_review",
+      "_tgt": "harness_self_review_runquietharnesscheck",
+      "source": "harness_self_review",
+      "target": "harness_self_review_runquietharnesscheck",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L541",
+      "weight": 1.0,
+      "_src": "harness_self_review",
+      "_tgt": "harness_self_review_appendlistsection",
+      "source": "harness_self_review",
+      "target": "harness_self_review_appendlistsection",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L560",
+      "weight": 1.0,
+      "_src": "harness_self_review",
+      "_tgt": "harness_self_review_buildmarkdownbundle",
+      "source": "harness_self_review",
+      "target": "harness_self_review_buildmarkdownbundle",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L717",
+      "weight": 1.0,
+      "_src": "harness_self_review",
+      "_tgt": "harness_self_review_parsecliarguments",
+      "source": "harness_self_review",
+      "target": "harness_self_review_parsecliarguments",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L766",
+      "weight": 1.0,
+      "_src": "harness_self_review",
+      "_tgt": "harness_self_review_runharnessselfreview",
+      "source": "harness_self_review",
+      "target": "harness_self_review_runharnessselfreview",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L102",
+      "weight": 0.8,
+      "_src": "harness_self_review_matchespathprefix",
+      "_tgt": "harness_self_review_normalizerepopath",
+      "source": "harness_self_review_normalizerepopath",
+      "target": "harness_self_review_matchespathprefix",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L338",
+      "weight": 0.8,
+      "_src": "harness_self_review_loadselfreviewtarget",
+      "_tgt": "harness_self_review_normalizerepopath",
+      "source": "harness_self_review_normalizerepopath",
+      "target": "harness_self_review_loadselfreviewtarget",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L226",
+      "weight": 0.8,
+      "_src": "harness_self_review_getchangedfilesfromgit",
+      "_tgt": "harness_self_review_sortuniquepaths",
+      "source": "harness_self_review_sortuniquepaths",
+      "target": "harness_self_review_getchangedfilesfromgit",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L365",
+      "weight": 0.8,
+      "_src": "harness_self_review_loadselfreviewtargets",
+      "_tgt": "harness_self_review_sortuniquepaths",
+      "source": "harness_self_review_sortuniquepaths",
+      "target": "harness_self_review_loadselfreviewtargets",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L401",
+      "weight": 0.8,
+      "_src": "harness_self_review_collectcoverage",
+      "_tgt": "harness_self_review_sortuniquepaths",
+      "source": "harness_self_review_sortuniquepaths",
+      "target": "harness_self_review_collectcoverage",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L493",
+      "weight": 0.8,
+      "_src": "harness_self_review_evaluategraphifyfreshness",
+      "_tgt": "harness_self_review_sortuniquepaths",
+      "source": "harness_self_review_sortuniquepaths",
+      "target": "harness_self_review_evaluategraphifyfreshness",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L802",
+      "weight": 0.8,
+      "_src": "harness_self_review_runharnessselfreview",
+      "_tgt": "harness_self_review_sortuniquepaths",
+      "source": "harness_self_review_sortuniquepaths",
+      "target": "harness_self_review_runharnessselfreview",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L412",
+      "weight": 0.8,
+      "_src": "harness_self_review_collectcoverage",
+      "_tgt": "harness_self_review_formatvalidationcommand",
+      "source": "harness_self_review_formatvalidationcommand",
+      "target": "harness_self_review_collectcoverage",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L578",
+      "weight": 0.8,
+      "_src": "harness_self_review_buildmarkdownbundle",
+      "_tgt": "harness_self_review_quotecode",
+      "source": "harness_self_review_quotecode",
+      "target": "harness_self_review_buildmarkdownbundle",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L263",
+      "weight": 0.8,
+      "_src": "harness_self_review_loadselfreviewtarget",
+      "_tgt": "harness_self_review_fileexists",
+      "source": "harness_self_review_fileexists",
+      "target": "harness_self_review_loadselfreviewtarget",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L172",
+      "weight": 0.8,
+      "_src": "harness_self_review_getchangedfilesfromgit",
+      "_tgt": "harness_self_review_runcommand",
+      "source": "harness_self_review_runcommand",
+      "target": "harness_self_review_getchangedfilesfromgit",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L331",
+      "weight": 0.8,
+      "_src": "harness_self_review_loadselfreviewtarget",
+      "_tgt": "harness_self_review_parseruntimescenarios",
+      "source": "harness_self_review_parseruntimescenarios",
+      "target": "harness_self_review_loadselfreviewtarget",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L356",
+      "weight": 0.8,
+      "_src": "harness_self_review_loadselfreviewtargets",
+      "_tgt": "harness_self_review_loadselfreviewtarget",
+      "source": "harness_self_review_loadselfreviewtarget",
+      "target": "harness_self_review_loadselfreviewtargets",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L799",
+      "weight": 0.8,
+      "_src": "harness_self_review_runharnessselfreview",
+      "_tgt": "harness_self_review_loadselfreviewtargets",
+      "source": "harness_self_review_loadselfreviewtargets",
+      "target": "harness_self_review_runharnessselfreview",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L809",
+      "weight": 0.8,
+      "_src": "harness_self_review_runharnessselfreview",
+      "_tgt": "harness_self_review_collectcoverage",
+      "source": "harness_self_review_collectcoverage",
+      "target": "harness_self_review_runharnessselfreview",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L823",
+      "weight": 0.8,
+      "_src": "harness_self_review_runharnessselfreview",
+      "_tgt": "harness_self_review_evaluategraphifyfreshness",
+      "source": "harness_self_review_evaluategraphifyfreshness",
+      "target": "harness_self_review_runharnessselfreview",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L585",
+      "weight": 0.8,
+      "_src": "harness_self_review_buildmarkdownbundle",
+      "_tgt": "harness_self_review_appendlistsection",
+      "source": "harness_self_review_appendlistsection",
+      "target": "harness_self_review_buildmarkdownbundle",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L842",
+      "weight": 0.8,
+      "_src": "harness_self_review_runharnessselfreview",
+      "_tgt": "harness_self_review_buildmarkdownbundle",
+      "source": "harness_self_review_buildmarkdownbundle",
+      "target": "harness_self_review_runharnessselfreview",
       "confidence_score": 0.5
     },
     {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "harness:audit": "bun scripts/harness-audit.ts",
     "harness:check": "bun scripts/harness-check.ts",
     "harness:generate": "bun scripts/harness-generate.ts",
+    "harness:self-review": "bun scripts/harness-self-review.ts",
     "harness:review": "bun scripts/harness-review.ts",
     "harness:test": "bun test scripts/harness-audit.test.ts scripts/harness-check.test.ts scripts/harness-generate.test.ts scripts/harness-review.test.ts scripts/graphify-rebuild.test.ts scripts/pre-push-review.test.ts",
     "pre-push:review": "bun scripts/pre-push-review.ts",

--- a/scripts/harness-self-review.test.ts
+++ b/scripts/harness-self-review.test.ts
@@ -1,0 +1,270 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { runHarnessSelfReview } from "./harness-self-review";
+
+const tempRoots: string[] = [];
+
+async function write(relativePath: string, contents: string, rootDir: string) {
+  const filePath = path.join(rootDir, relativePath);
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, contents);
+}
+
+async function createFixtureRepo() {
+  const rootDir = await mkdtemp(path.join(tmpdir(), "athena-harness-self-review-"));
+  tempRoots.push(rootDir);
+
+  await write(
+    "packages/athena-webapp/package.json",
+    JSON.stringify(
+      {
+        name: "@athena/webapp",
+        scripts: {
+          test: "echo test",
+          "lint:architecture": "echo lint",
+        },
+      },
+      null,
+      2
+    ),
+    rootDir
+  );
+
+  await write(
+    "packages/storefront-webapp/package.json",
+    JSON.stringify(
+      {
+        name: "@athena/storefront-webapp",
+        scripts: {
+          test: "echo test",
+        },
+      },
+      null,
+      2
+    ),
+    rootDir
+  );
+
+  await write(
+    "packages/athena-webapp/docs/agent/testing.md",
+    [
+      "# Athena Webapp Testing",
+      "",
+      "Run `bun run harness:review` from the repo root for touched-file validation coverage.",
+      "Machine-readable review coverage lives in [validation-map.json](./validation-map.json).",
+    ].join("\n"),
+    rootDir
+  );
+
+  await write(
+    "packages/storefront-webapp/docs/agent/testing.md",
+    [
+      "# Storefront Webapp Testing",
+      "",
+      "Run `bun run harness:review` from the repo root for touched-file validation coverage.",
+      "Machine-readable review coverage lives in [validation-map.json](./validation-map.json).",
+    ].join("\n"),
+    rootDir
+  );
+
+  await write(
+    "packages/athena-webapp/docs/agent/validation-map.json",
+    JSON.stringify(
+      {
+        workspace: "@athena/webapp",
+        packageDir: "packages/athena-webapp",
+        surfaces: [
+          {
+            name: "route-or-ui-only-edits",
+            pathPrefixes: ["packages/athena-webapp/src/routes"],
+            commands: [
+              { kind: "script", script: "test" },
+              { kind: "script", script: "lint:architecture" },
+            ],
+          },
+          {
+            name: "shared-lib-or-utility-edits",
+            pathPrefixes: ["packages/athena-webapp/src/lib"],
+            commands: [
+              { kind: "script", script: "test" },
+              {
+                kind: "raw",
+                command: "bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json",
+              },
+            ],
+          },
+          {
+            name: "harness-docs",
+            pathPrefixes: ["packages/athena-webapp/docs/agent"],
+            commands: [],
+          },
+        ],
+      },
+      null,
+      2
+    ),
+    rootDir
+  );
+
+  await write(
+    "packages/storefront-webapp/docs/agent/validation-map.json",
+    JSON.stringify(
+      {
+        workspace: "@athena/storefront-webapp",
+        packageDir: "packages/storefront-webapp",
+        surfaces: [
+          {
+            name: "route-or-ui-only-edits",
+            pathPrefixes: ["packages/storefront-webapp/src/routes"],
+            commands: [{ kind: "script", script: "test" }],
+          },
+          {
+            name: "harness-docs",
+            pathPrefixes: ["packages/storefront-webapp/docs/agent"],
+            commands: [],
+          },
+        ],
+      },
+      null,
+      2
+    ),
+    rootDir
+  );
+
+  await write(
+    "packages/athena-webapp/docs/agent/validation-guide.md",
+    [
+      "# Athena Webapp Validation Guide",
+      "",
+      "## Route or UI-only edits",
+      "",
+      "Run:",
+      "",
+      "- `bun run --filter '@athena/webapp' test`",
+      "",
+      "## Shared-lib or utility edits",
+      "",
+      "Run:",
+      "",
+      "- `bun run --filter '@athena/webapp' test`",
+      "- `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`",
+    ].join("\n"),
+    rootDir
+  );
+
+  await write(
+    "packages/storefront-webapp/docs/agent/validation-guide.md",
+    [
+      "# Storefront Webapp Validation Guide",
+      "",
+      "## Full browser journeys and payment redirects",
+      "",
+      "Run:",
+      "",
+      "- `bun run --filter '@athena/storefront-webapp' test`",
+    ].join("\n"),
+    rootDir
+  );
+
+  await write("packages/athena-webapp/src/routes/index.tsx", "export {};\n", rootDir);
+  await write("packages/athena-webapp/src/lib/session.ts", "export {};\n", rootDir);
+  await write("packages/athena-webapp/src/unmapped.ts", "export {};\n", rootDir);
+  await write("packages/storefront-webapp/src/routes/index.tsx", "export {};\n", rootDir);
+
+  await write("graphify-out/GRAPH_REPORT.md", "# Graph\n", rootDir);
+  await write("graphify-out/graph.json", "{}\n", rootDir);
+
+  return rootDir;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((rootDir) =>
+      rm(rootDir, { recursive: true, force: true })
+    )
+  );
+});
+
+describe("runHarnessSelfReview", () => {
+  it("produces deterministic markdown with mapped surfaces and selected validations", async () => {
+    const rootDir = await createFixtureRepo();
+
+    const changedFiles = {
+      baseFiles: [
+        "graphify-out/graph.json",
+        "packages/athena-webapp/src/lib/session.ts",
+        "graphify-out/GRAPH_REPORT.md",
+      ],
+      trackedFiles: [],
+      untrackedFiles: [],
+    };
+
+    const first = await runHarnessSelfReview(rootDir, {
+      baseRef: "origin/main",
+      getChangedFiles: async () => changedFiles,
+      runHarnessCheck: async () => {},
+    });
+    const second = await runHarnessSelfReview(rootDir, {
+      baseRef: "origin/main",
+      getChangedFiles: async () => changedFiles,
+      runHarnessCheck: async () => {},
+    });
+
+    expect(first.blockers).toEqual([]);
+    expect(first.markdown).toBe(second.markdown);
+    expect(first.markdown).toContain("# Harness Self Review");
+    expect(first.markdown).toContain("## Changed surfaces");
+    expect(first.markdown).toContain("shared-lib-or-utility-edits");
+    expect(first.markdown).toContain("## Selected validations");
+    expect(first.markdown).toContain("bun run --filter '@athena/webapp' test");
+    expect(first.markdown).toContain("bun run harness:check");
+    expect(first.markdown).toContain("## Graphify freshness");
+    expect(first.markdown).toContain("status: fresh");
+    expect(first.markdown).toContain("## Runtime behavior scenarios");
+    expect(first.markdown).toContain("Route or UI-only edits");
+    expect(first.markdown).toContain("## Verdict");
+    expect(first.markdown).toContain("READY");
+  });
+
+  it("fails with a hard blocker when changed files are not covered by validation surfaces", async () => {
+    const rootDir = await createFixtureRepo();
+
+    const result = await runHarnessSelfReview(rootDir, {
+      baseRef: "origin/main",
+      getChangedFiles: async () => ({
+        baseFiles: ["packages/athena-webapp/src/unmapped.ts"],
+        trackedFiles: [],
+        untrackedFiles: [],
+      }),
+      runHarnessCheck: async () => {},
+    });
+
+    expect(result.blockers).toContain(
+      "Harness review coverage gap: packages/athena-webapp/src/unmapped.ts is not covered by any validation mapping."
+    );
+    expect(result.markdown).toContain("## Harness coverage");
+    expect(result.markdown).toContain("### Blockers");
+    expect(result.markdown).toContain("BLOCKED");
+  });
+
+  it("lists available runtime behavior scenarios for touched packages", async () => {
+    const rootDir = await createFixtureRepo();
+
+    const result = await runHarnessSelfReview(rootDir, {
+      baseRef: "origin/main",
+      getChangedFiles: async () => ({
+        baseFiles: ["packages/storefront-webapp/src/routes/index.tsx"],
+        trackedFiles: [],
+        untrackedFiles: [],
+      }),
+      runHarnessCheck: async () => {},
+    });
+
+    expect(result.blockers).toEqual([]);
+    expect(result.markdown).toContain("Storefront Webapp");
+    expect(result.markdown).toContain("Full browser journeys and payment redirects");
+  });
+});

--- a/scripts/harness-self-review.ts
+++ b/scripts/harness-self-review.ts
@@ -1,0 +1,895 @@
+import { access, readFile } from "node:fs/promises";
+import path from "node:path";
+
+import { validateHarnessDocs } from "./harness-check";
+
+const SELF_REVIEW_TARGETS = [
+  {
+    appLabel: "Athena Webapp",
+    packageDir: "packages/athena-webapp",
+    testingDocPath: "packages/athena-webapp/docs/agent/testing.md",
+    validationMapPath: "packages/athena-webapp/docs/agent/validation-map.json",
+    validationGuidePath: "packages/athena-webapp/docs/agent/validation-guide.md",
+  },
+  {
+    appLabel: "Storefront Webapp",
+    packageDir: "packages/storefront-webapp",
+    testingDocPath: "packages/storefront-webapp/docs/agent/testing.md",
+    validationMapPath: "packages/storefront-webapp/docs/agent/validation-map.json",
+    validationGuidePath: "packages/storefront-webapp/docs/agent/validation-guide.md",
+  },
+] as const;
+
+const GRAPHIFY_ARTIFACTS = [
+  "graphify-out/GRAPH_REPORT.md",
+  "graphify-out/graph.json",
+] as const;
+
+type ValidationCommand =
+  | { kind: "script"; script: string }
+  | { kind: "raw"; command: string };
+
+type ValidationSurface = {
+  name: string;
+  pathPrefixes: string[];
+  commands: ValidationCommand[];
+};
+
+type ValidationMap = {
+  workspace: string;
+  packageDir: string;
+  surfaces: ValidationSurface[];
+};
+
+type LoadedSelfReviewTarget = {
+  appLabel: string;
+  packageDir: string;
+  workspace: string;
+  validationMapPath: string;
+  surfaces: ValidationSurface[];
+  runtimeScenarios: string[];
+};
+
+type ChangedFiles = {
+  baseFiles: string[];
+  trackedFiles: string[];
+  untrackedFiles: string[];
+};
+
+type GraphifyFreshness = {
+  status: "fresh" | "stale" | "missing-artifacts" | "partial" | "n/a";
+  detail: string;
+};
+
+type HarnessSelfReviewResult = {
+  markdown: string;
+  blockers: string[];
+  warnings: string[];
+  info: string[];
+  selectedValidations: string[];
+  recommendedValidations: string[];
+};
+
+type HarnessSelfReviewOptions = {
+  baseRef: string;
+  getChangedFiles?: (rootDir: string, baseRef: string) => Promise<ChangedFiles>;
+  runHarnessCheck?: (rootDir: string) => Promise<void>;
+};
+
+type SurfaceCoverage = {
+  surfaceName: string;
+  files: string[];
+};
+
+type TargetCoverage = {
+  target: LoadedSelfReviewTarget;
+  touchedFiles: string[];
+  uncoveredFiles: string[];
+  matchedSurfaces: SurfaceCoverage[];
+};
+
+function normalizeRepoPath(repoPath: string) {
+  return repoPath.replaceAll("\\", "/");
+}
+
+function sortUniquePaths(paths: string[]) {
+  return [...new Set(paths.map((entry) => normalizeRepoPath(entry).trim()).filter(Boolean))].sort(
+    (left, right) => left.localeCompare(right)
+  );
+}
+
+function matchesPathPrefix(filePath: string, pathPrefix: string) {
+  const normalizedFilePath = normalizeRepoPath(filePath);
+  const normalizedPathPrefix = normalizeRepoPath(pathPrefix);
+
+  if (normalizedPathPrefix.endsWith("/")) {
+    return normalizedFilePath.startsWith(normalizedPathPrefix);
+  }
+
+  return (
+    normalizedFilePath === normalizedPathPrefix ||
+    normalizedFilePath.startsWith(`${normalizedPathPrefix}/`)
+  );
+}
+
+function normalizeValidationCommand(
+  command: ValidationCommand
+): ValidationCommand {
+  return command.kind === "raw"
+    ? { kind: "raw", command: command.command.trim() }
+    : { kind: "script", script: command.script };
+}
+
+function formatValidationCommand(workspace: string, command: ValidationCommand) {
+  if (command.kind === "script") {
+    return `bun run --filter '${workspace}' ${command.script}`;
+  }
+
+  return command.command;
+}
+
+function quoteCode(entry: string) {
+  return `\`${entry}\``;
+}
+
+async function fileExists(filePath: string) {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readJsonFile<T>(filePath: string) {
+  return JSON.parse(await readFile(filePath, "utf8")) as T;
+}
+
+async function runCommand(rootDir: string, command: string[]) {
+  const process = Bun.spawn(command, {
+    cwd: rootDir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(process.stdout).text(),
+    new Response(process.stderr).text(),
+    process.exited,
+  ]);
+
+  return {
+    stdout,
+    stderr,
+    exitCode,
+  };
+}
+
+async function getChangedFilesFromGit(
+  rootDir: string,
+  baseRef: string
+): Promise<ChangedFiles> {
+  const baseRefCheck = await runCommand(rootDir, [
+    "git",
+    "rev-parse",
+    "--verify",
+    baseRef,
+  ]);
+
+  if (baseRefCheck.exitCode !== 0) {
+    const message = baseRefCheck.stderr.trim() || `${baseRef} is not reachable.`;
+    throw new Error(`Base ref check failed for ${baseRef}: ${message}`);
+  }
+
+  const [baseDiff, trackedDiff, untrackedDiff] = await Promise.all([
+    runCommand(rootDir, [
+      "git",
+      "diff",
+      "--name-only",
+      "--diff-filter=ACDMRTUXB",
+      `${baseRef}...HEAD`,
+      "--",
+    ]),
+    runCommand(rootDir, [
+      "git",
+      "diff",
+      "--name-only",
+      "--diff-filter=ACDMRTUXB",
+      "HEAD",
+      "--",
+    ]),
+    runCommand(rootDir, ["git", "ls-files", "--others", "--exclude-standard"]),
+  ]);
+
+  if (baseDiff.exitCode !== 0) {
+    throw new Error(
+      baseDiff.stderr.trim() ||
+        `Failed to read changed files against ${baseRef}.`
+    );
+  }
+
+  if (trackedDiff.exitCode !== 0) {
+    throw new Error(
+      trackedDiff.stderr.trim() ||
+        "Failed to read tracked working-tree changes."
+    );
+  }
+
+  if (untrackedDiff.exitCode !== 0) {
+    throw new Error(
+      untrackedDiff.stderr.trim() ||
+        "Failed to read untracked working-tree changes."
+    );
+  }
+
+  return {
+    baseFiles: sortUniquePaths(baseDiff.stdout.split("\n")),
+    trackedFiles: sortUniquePaths(trackedDiff.stdout.split("\n")),
+    untrackedFiles: sortUniquePaths(untrackedDiff.stdout.split("\n")),
+  };
+}
+
+function parseRuntimeScenarios(contents: string) {
+  return [...contents.matchAll(/^##\s+(.+)$/gm)]
+    .map((match) => match[1]?.trim() ?? "")
+    .filter(Boolean);
+}
+
+async function loadSelfReviewTarget(
+  rootDir: string,
+  target: (typeof SELF_REVIEW_TARGETS)[number]
+): Promise<LoadedSelfReviewTarget> {
+  const testingDocContents = await readFile(
+    path.join(rootDir, target.testingDocPath),
+    "utf8"
+  );
+
+  if (!testingDocContents.includes("`bun run harness:review`")) {
+    throw new Error(
+      `Stale harness self-review config: ${target.testingDocPath} must mention \`bun run harness:review\`.`
+    );
+  }
+
+  if (!testingDocContents.includes("(./validation-map.json)")) {
+    throw new Error(
+      `Stale harness self-review config: ${target.testingDocPath} must link ./validation-map.json.`
+    );
+  }
+
+  const absoluteValidationMapPath = path.join(rootDir, target.validationMapPath);
+  const validationMap = await readJsonFile<ValidationMap>(absoluteValidationMapPath);
+  const packageJsonPath = path.join(rootDir, validationMap.packageDir, "package.json");
+
+  if (!(await fileExists(packageJsonPath))) {
+    throw new Error(
+      `Stale harness self-review config: ${target.validationMapPath} references missing package surface "${validationMap.packageDir}".`
+    );
+  }
+
+  const packageJson = await readJsonFile<{
+    name?: string;
+    scripts?: Record<string, string>;
+  }>(packageJsonPath);
+
+  if (packageJson.name !== validationMap.workspace) {
+    throw new Error(
+      `Stale harness self-review config: ${target.validationMapPath} expected workspace "${validationMap.workspace}" at ${validationMap.packageDir}.`
+    );
+  }
+
+  const surfaces = Array.isArray(validationMap.surfaces)
+    ? validationMap.surfaces
+    : [];
+
+  if (surfaces.length === 0) {
+    throw new Error(
+      `Stale harness self-review config: ${target.validationMapPath} must define at least one validation surface.`
+    );
+  }
+
+  for (const surface of surfaces) {
+    if (!Array.isArray(surface.pathPrefixes) || surface.pathPrefixes.length === 0) {
+      throw new Error(
+        `Stale harness self-review config: ${target.validationMapPath} includes an empty path prefix list for "${surface.name}".`
+      );
+    }
+
+    if (!Array.isArray(surface.commands)) {
+      throw new Error(
+        `Stale harness self-review config: ${target.validationMapPath} is missing commands for "${surface.name}".`
+      );
+    }
+
+    for (const pathPrefix of surface.pathPrefixes) {
+      if (!(await fileExists(path.join(rootDir, pathPrefix)))) {
+        throw new Error(
+          `Stale harness self-review config: ${target.validationMapPath} references missing path prefix "${pathPrefix}".`
+        );
+      }
+    }
+
+    for (const command of surface.commands.map(normalizeValidationCommand)) {
+      if (command.kind === "script") {
+        if (!packageJson.scripts?.[command.script]) {
+          throw new Error(
+            `Stale harness self-review config: ${target.validationMapPath} references missing script "${validationMap.workspace}:${command.script}".`
+          );
+        }
+        continue;
+      }
+
+      if (!command.command) {
+        throw new Error(
+          `Stale harness self-review config: ${target.validationMapPath} includes an empty raw command for "${surface.name}".`
+        );
+      }
+    }
+  }
+
+  const absoluteValidationGuidePath = path.join(rootDir, target.validationGuidePath);
+  const runtimeScenarios = (await fileExists(absoluteValidationGuidePath))
+    ? parseRuntimeScenarios(
+        await readFile(absoluteValidationGuidePath, "utf8")
+      )
+    : [];
+
+  return {
+    appLabel: target.appLabel,
+    packageDir: normalizeRepoPath(validationMap.packageDir),
+    validationMapPath: target.validationMapPath,
+    workspace: validationMap.workspace,
+    surfaces: surfaces.map((surface) => ({
+      name: surface.name,
+      pathPrefixes: surface.pathPrefixes.map(normalizeRepoPath),
+      commands: surface.commands.map(normalizeValidationCommand),
+    })),
+    runtimeScenarios,
+  } satisfies LoadedSelfReviewTarget;
+}
+
+async function loadSelfReviewTargets(rootDir: string) {
+  const loadedTargets: LoadedSelfReviewTarget[] = [];
+  const blockers: string[] = [];
+
+  for (const target of SELF_REVIEW_TARGETS) {
+    try {
+      loadedTargets.push(await loadSelfReviewTarget(rootDir, target));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      blockers.push(message);
+    }
+  }
+
+  return {
+    loadedTargets,
+    blockers: sortUniquePaths(blockers),
+  };
+}
+
+function collectCoverage(
+  changedFiles: string[],
+  targets: LoadedSelfReviewTarget[]
+) {
+  const coverageByTarget: TargetCoverage[] = [];
+  const blockers: string[] = [];
+  const selectedValidationCommands = ["bun run harness:check"];
+  const selectedCommandKeys = new Set(selectedValidationCommands);
+
+  for (const target of targets) {
+    const touchedFiles = changedFiles.filter((filePath) =>
+      matchesPathPrefix(filePath, `${target.packageDir}/`)
+    );
+
+    if (touchedFiles.length === 0) {
+      continue;
+    }
+
+    const matchedSurfaces: SurfaceCoverage[] = [];
+    const coveredFiles = new Set<string>();
+
+    for (const surface of target.surfaces) {
+      const matchedFiles = touchedFiles.filter((filePath) =>
+        surface.pathPrefixes.some((pathPrefix) =>
+          matchesPathPrefix(filePath, pathPrefix)
+        )
+      );
+
+      if (matchedFiles.length === 0) {
+        continue;
+      }
+
+      const sortedMatchedFiles = sortUniquePaths(matchedFiles);
+      matchedSurfaces.push({
+        surfaceName: surface.name,
+        files: sortedMatchedFiles,
+      });
+
+      for (const matchedFile of sortedMatchedFiles) {
+        coveredFiles.add(matchedFile);
+      }
+
+      for (const command of surface.commands) {
+        const formattedCommand = formatValidationCommand(target.workspace, command);
+        if (selectedCommandKeys.has(formattedCommand)) {
+          continue;
+        }
+
+        selectedCommandKeys.add(formattedCommand);
+        selectedValidationCommands.push(formattedCommand);
+      }
+    }
+
+    const uncoveredFiles = sortUniquePaths(
+      touchedFiles.filter((filePath) => !coveredFiles.has(filePath))
+    );
+
+    for (const filePath of uncoveredFiles) {
+      blockers.push(
+        `Harness review coverage gap: ${filePath} is not covered by any validation mapping.`
+      );
+    }
+
+    coverageByTarget.push({
+      target,
+      touchedFiles: sortUniquePaths(touchedFiles),
+      uncoveredFiles,
+      matchedSurfaces,
+    });
+  }
+
+  return {
+    coverageByTarget,
+    blockers: sortUniquePaths(blockers),
+    selectedValidationCommands,
+  };
+}
+
+function isLikelyCodeOrConfig(filePath: string) {
+  const ext = path.posix.extname(filePath).toLowerCase();
+  if (!ext) {
+    return true;
+  }
+
+  return ![
+    ".md",
+    ".txt",
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".gif",
+    ".webp",
+    ".svg",
+    ".ico",
+    ".lock",
+    ".log",
+  ].includes(ext);
+}
+
+async function evaluateGraphifyFreshness(
+  rootDir: string,
+  changedFiles: string[]
+): Promise<GraphifyFreshness> {
+  const [reportExists, graphExists] = await Promise.all(
+    GRAPHIFY_ARTIFACTS.map((artifactPath) =>
+      fileExists(path.join(rootDir, artifactPath))
+    )
+  );
+
+  const missingArtifacts: string[] = [];
+  if (!reportExists) {
+    missingArtifacts.push("graphify-out/GRAPH_REPORT.md");
+  }
+  if (!graphExists) {
+    missingArtifacts.push("graphify-out/graph.json");
+  }
+
+  if (missingArtifacts.length > 0) {
+    return {
+      status: "missing-artifacts",
+      detail: `Missing Graphify artifacts: ${missingArtifacts.map(quoteCode).join(", ")}.`,
+    };
+  }
+
+  const normalizedChanged = sortUniquePaths(changedFiles);
+  const changedArtifacts = GRAPHIFY_ARTIFACTS.filter((artifactPath) =>
+    normalizedChanged.includes(artifactPath)
+  );
+  const nonGraphifyCodeChanges = normalizedChanged.filter(
+    (filePath) =>
+      !filePath.startsWith("graphify-out/") && isLikelyCodeOrConfig(filePath)
+  );
+
+  if (nonGraphifyCodeChanges.length === 0) {
+    return {
+      status: "n/a",
+      detail: "No code-or-config changes detected outside Graphify artifacts.",
+    };
+  }
+
+  if (changedArtifacts.length === GRAPHIFY_ARTIFACTS.length) {
+    return {
+      status: "fresh",
+      detail:
+        "Both Graphify artifacts are present in the changed file set alongside code/config updates.",
+    };
+  }
+
+  if (changedArtifacts.length > 0) {
+    return {
+      status: "partial",
+      detail:
+        "Only part of the Graphify artifact set is included in changed files while code/config changed.",
+    };
+  }
+
+  return {
+    status: "stale",
+    detail:
+      "Code/config changes were detected without Graphify artifact updates in the changed file set.",
+  };
+}
+
+async function runQuietHarnessCheck(rootDir: string) {
+  const errors = await validateHarnessDocs(rootDir);
+  if (errors.length === 0) {
+    return;
+  }
+
+  throw new Error(errors.join("\n"));
+}
+
+function appendListSection(
+  lines: string[],
+  title: string,
+  entries: string[],
+  emptyMessage = "- None"
+) {
+  lines.push(title);
+  if (entries.length === 0) {
+    lines.push(emptyMessage);
+    lines.push("");
+    return;
+  }
+
+  for (const entry of entries) {
+    lines.push(`- ${entry}`);
+  }
+  lines.push("");
+}
+
+function buildMarkdownBundle(params: {
+  baseRef: string;
+  changedFiles: ChangedFiles;
+  allChangedFiles: string[];
+  outsideTargetFiles: string[];
+  coverageByTarget: TargetCoverage[];
+  selectedValidations: string[];
+  recommendedValidations: string[];
+  blockers: string[];
+  warnings: string[];
+  info: string[];
+  graphifyFreshness: GraphifyFreshness;
+}) {
+  const lines: string[] = [];
+  lines.push("# Harness Self Review");
+  lines.push("");
+
+  lines.push("## Inputs");
+  lines.push(`- base ref: ${quoteCode(params.baseRef)}`);
+  lines.push(`- base diff files: ${params.changedFiles.baseFiles.length}`);
+  lines.push(`- tracked working-tree files: ${params.changedFiles.trackedFiles.length}`);
+  lines.push(`- untracked files: ${params.changedFiles.untrackedFiles.length}`);
+  lines.push(`- total unique changed files: ${params.allChangedFiles.length}`);
+  lines.push("");
+
+  appendListSection(
+    lines,
+    `## Base diff files (${quoteCode(`${params.baseRef}...HEAD`)})`,
+    params.changedFiles.baseFiles.map(quoteCode)
+  );
+
+  appendListSection(
+    lines,
+    "## Local tracked files",
+    params.changedFiles.trackedFiles.map(quoteCode)
+  );
+
+  appendListSection(
+    lines,
+    "## Local untracked files",
+    params.changedFiles.untrackedFiles.map(quoteCode)
+  );
+
+  lines.push("## Changed surfaces");
+  if (params.coverageByTarget.length === 0) {
+    lines.push("- No touched files under target app packages.");
+    lines.push("");
+  } else {
+    for (const coverage of params.coverageByTarget) {
+      lines.push(
+        `### ${coverage.target.appLabel} (${quoteCode(coverage.target.packageDir)})`
+      );
+
+      if (coverage.matchedSurfaces.length === 0) {
+        lines.push("- No matched validation surfaces.");
+      } else {
+        for (const surface of coverage.matchedSurfaces) {
+          lines.push(
+            `- ${quoteCode(surface.surfaceName)}: ${surface.files
+              .map(quoteCode)
+              .join(", ")}`
+          );
+        }
+      }
+
+      if (coverage.uncoveredFiles.length > 0) {
+        lines.push(
+          `- uncovered: ${coverage.uncoveredFiles.map(quoteCode).join(", ")}`
+        );
+      }
+
+      lines.push("");
+    }
+  }
+
+  appendListSection(
+    lines,
+    "## Outside target-app surfaces",
+    params.outsideTargetFiles.map(quoteCode)
+  );
+
+  appendListSection(
+    lines,
+    "## Selected validations",
+    params.selectedValidations.map(quoteCode)
+  );
+
+  appendListSection(
+    lines,
+    "## Recommended validations",
+    params.recommendedValidations.map(quoteCode)
+  );
+
+  lines.push("## Graphify freshness");
+  lines.push(`- status: ${params.graphifyFreshness.status}`);
+  lines.push(`- detail: ${params.graphifyFreshness.detail}`);
+  lines.push("");
+
+  lines.push("## Runtime behavior scenarios");
+  const touchedTargetScenarios = params.coverageByTarget
+    .map((coverage) => ({
+      appLabel: coverage.target.appLabel,
+      scenarios: coverage.target.runtimeScenarios,
+    }))
+    .filter((entry) => entry.scenarios.length > 0);
+
+  if (touchedTargetScenarios.length === 0) {
+    lines.push("- No runtime behavior scenarios discovered for touched packages.");
+    lines.push("");
+  } else {
+    for (const entry of touchedTargetScenarios) {
+      lines.push(`### ${entry.appLabel}`);
+      for (const scenario of entry.scenarios) {
+        lines.push(`- ${scenario}`);
+      }
+      lines.push("");
+    }
+  }
+
+  lines.push("## Harness coverage");
+  lines.push("### Blockers");
+  if (params.blockers.length === 0) {
+    lines.push("- None");
+  } else {
+    for (const blocker of params.blockers) {
+      lines.push(`- ${blocker}`);
+    }
+  }
+  lines.push("");
+
+  lines.push("### Warnings");
+  if (params.warnings.length === 0) {
+    lines.push("- None");
+  } else {
+    for (const warning of params.warnings) {
+      lines.push(`- ${warning}`);
+    }
+  }
+  lines.push("");
+
+  lines.push("### Info");
+  if (params.info.length === 0) {
+    lines.push("- None");
+  } else {
+    for (const note of params.info) {
+      lines.push(`- ${note}`);
+    }
+  }
+  lines.push("");
+
+  lines.push("## Verdict");
+  lines.push(params.blockers.length > 0 ? "- BLOCKED" : "- READY");
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+function parseCliArguments(argv: string[]) {
+  let baseRef: string | null = null;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const currentArg = argv[index];
+
+    if (!currentArg) {
+      continue;
+    }
+
+    if (currentArg === "--base") {
+      const nextValue = argv[index + 1];
+      if (!nextValue || nextValue.startsWith("--")) {
+        throw new Error("Missing value for --base. Example: bun run harness:self-review --base origin/main");
+      }
+      baseRef = nextValue;
+      index += 1;
+      continue;
+    }
+
+    if (currentArg.startsWith("--base=")) {
+      baseRef = currentArg.slice("--base=".length);
+      continue;
+    }
+
+    if (currentArg === "--help" || currentArg === "-h") {
+      return {
+        baseRef: "",
+        help: true,
+      };
+    }
+
+    throw new Error(
+      `Unknown argument: ${currentArg}. Usage: bun run harness:self-review --base <ref>`
+    );
+  }
+
+  if (!baseRef) {
+    throw new Error(
+      "Missing required --base <ref>. Usage: bun run harness:self-review --base origin/main"
+    );
+  }
+
+  return {
+    baseRef,
+    help: false,
+  };
+}
+
+export async function runHarnessSelfReview(
+  rootDir: string,
+  options: HarnessSelfReviewOptions
+): Promise<HarnessSelfReviewResult> {
+  const blockers: string[] = [];
+  const warnings: string[] = [];
+  const info: string[] = [];
+
+  const getChangedFiles = options.getChangedFiles ?? getChangedFilesFromGit;
+  const runCheck = options.runHarnessCheck ?? runQuietHarnessCheck;
+
+  let changedFiles: ChangedFiles = {
+    baseFiles: [],
+    trackedFiles: [],
+    untrackedFiles: [],
+  };
+
+  try {
+    changedFiles = await getChangedFiles(rootDir, options.baseRef);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    blockers.push(`Unable to compute changed files: ${message}`);
+  }
+
+  try {
+    await runCheck(rootDir);
+    info.push("harness:check passed.");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    blockers.push(`harness:check failed: ${message}`);
+  }
+
+  const { loadedTargets, blockers: targetLoadBlockers } =
+    await loadSelfReviewTargets(rootDir);
+  blockers.push(...targetLoadBlockers);
+
+  const allChangedFiles = sortUniquePaths([
+    ...changedFiles.baseFiles,
+    ...changedFiles.trackedFiles,
+    ...changedFiles.untrackedFiles,
+  ]);
+
+  const { coverageByTarget, blockers: coverageBlockers, selectedValidationCommands } =
+    collectCoverage(allChangedFiles, loadedTargets);
+  blockers.push(...coverageBlockers);
+
+  const outsideTargetFiles = allChangedFiles.filter(
+    (filePath) =>
+      !loadedTargets.some((target) =>
+        matchesPathPrefix(filePath, `${target.packageDir}/`)
+      )
+  );
+
+  const recommendedValidations = coverageByTarget.length
+    ? ["bun run harness:audit", "bun run pr:athena"]
+    : [];
+
+  const graphifyFreshness = await evaluateGraphifyFreshness(
+    rootDir,
+    allChangedFiles
+  );
+
+  if (graphifyFreshness.status === "stale") {
+    warnings.push(
+      "Graphify appears stale relative to current changed files. Run `bun run graphify:rebuild` before handoff."
+    );
+  } else if (graphifyFreshness.status === "partial") {
+    warnings.push(
+      "Graphify artifact updates are partial. Ensure both `graphify-out/GRAPH_REPORT.md` and `graphify-out/graph.json` are refreshed together."
+    );
+  } else if (graphifyFreshness.status === "missing-artifacts") {
+    warnings.push(
+      "Required Graphify artifacts are missing in the working tree."
+    );
+  }
+
+  const markdown = buildMarkdownBundle({
+    baseRef: options.baseRef,
+    changedFiles: {
+      baseFiles: sortUniquePaths(changedFiles.baseFiles),
+      trackedFiles: sortUniquePaths(changedFiles.trackedFiles),
+      untrackedFiles: sortUniquePaths(changedFiles.untrackedFiles),
+    },
+    allChangedFiles,
+    outsideTargetFiles,
+    coverageByTarget,
+    selectedValidations: selectedValidationCommands,
+    recommendedValidations,
+    blockers: sortUniquePaths(blockers),
+    warnings: sortUniquePaths(warnings),
+    info: sortUniquePaths(info),
+    graphifyFreshness,
+  });
+
+  return {
+    markdown,
+    blockers: sortUniquePaths(blockers),
+    warnings: sortUniquePaths(warnings),
+    info: sortUniquePaths(info),
+    selectedValidations: selectedValidationCommands,
+    recommendedValidations,
+  };
+}
+
+if (import.meta.main) {
+  try {
+    const parsedArgs = parseCliArguments(Bun.argv.slice(2));
+
+    if (parsedArgs.help) {
+      console.log("Usage: bun run harness:self-review --base <ref>");
+      process.exit(0);
+    }
+
+    const result = await runHarnessSelfReview(process.cwd(), {
+      baseRef: parsedArgs.baseRef,
+    });
+
+    console.log(result.markdown);
+
+    if (result.blockers.length > 0) {
+      throw new Error(
+        `harness:self-review blocked with ${result.blockers.length} blocker(s).`
+      );
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`\n[harness:self-review] BLOCKED: ${message}`);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary
- add `bun run harness:self-review --base <ref>` and implement `scripts/harness-self-review.ts`
- generate deterministic markdown with changed surfaces, selected/recommended validations, graphify freshness, harness blockers/warnings/info, and runtime scenario sections
- fail the CLI with a clear non-zero exit when hard blockers exist while still emitting the review bundle
- add focused tests in `scripts/harness-self-review.test.ts` and wire the new script in root `package.json`

## Why
- agents need a read-only, repo-local handoff artifact that summarizes what changed, what validations are appropriate, and what blockers remain
- this reduces handoff ambiguity for PR descriptions, Linear updates, and scorecard-style status communication

## Validation
- `bun test scripts/harness-self-review.test.ts`
- `bun test scripts/harness-self-review.test.ts scripts/harness-review.test.ts scripts/harness-audit.test.ts`
- `bun run harness:self-review --base origin/main`
- `bun run graphify:rebuild`
- `bun run pr:athena` (after rebasing onto latest `origin/main`)
- `git diff --check`

https://linear.app/v26-labs/issue/V26-201/add-a-harness-self-review-command-for-agent-handoff-and-scorecard