### PR TITLE
[V26-200]: add shared runtime behavior harness runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,16 @@ Key repo-level commands:
 - `bun run harness:check`
 - `bun run harness:audit`
 - `bun run harness:review`
+- `bun run harness:behavior --scenario <name>`
 - `bun run architecture:check`
 - `bun run pre-push:review`
 - `bun run pr:athena`
 
 `bun run harness:test` is the canonical harness implementation gate for harness scripts, graphify tooling, and pre-push review wiring.
+
+List runtime behavior scenarios with `bun run harness:behavior --list`. The bundled
+`sample-runtime-smoke` scenario boots a local fixture app, drives a browser click,
+captures runtime signals, and tears down automatically.
 
 ## Graphify
 

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,12 +1,12 @@
 # Graph Report - .  (2026-04-11)
 
 ## Corpus Check
-- 1174 files · ~0 words
+- 1178 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 2142 nodes · 4860 edges · 72 communities detected
-- Extraction: 91% EXTRACTED · 9% INFERRED · 0% AMBIGUOUS · INFERRED: 426 edges (avg confidence: 0.5)
+- 2171 nodes · 4905 edges · 74 communities detected
+- Extraction: 91% EXTRACTED · 9% INFERRED · 0% AMBIGUOUS · INFERRED: 444 edges (avg confidence: 0.5)
 - Token cost: 0 input · 0 output
 
 ## God Nodes (most connected - your core abstractions)
@@ -37,87 +37,87 @@
 
 ### Community 0 - "Community 0"
 Cohesion: 0.01
-Nodes (14): AnalyticsCombinedUsers(), processAnalyticsToUsers(), AnalyticsTopUsers(), processAnalyticsToUsers(), handleFileSelect(), validateFile(), capitalizeWords(), countGroupedAnalytics() (+6 more)
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 1 - "Community 1"
-Cohesion: 0.01
-Nodes (13): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold(), handleKeyDown(), handleRedeemPromoCode(), getPromoAlertCopy() (+5 more)
+Cohesion: 0.02
+Nodes (16): AnalyticsCombinedUsers(), processAnalyticsToUsers(), AnalyticsTopUsers(), processAnalyticsToUsers(), handleKeyDown(), handleRedeemPromoCode(), onSubmit(), saveStoreChanges() (+8 more)
 
 ### Community 2 - "Community 2"
-Cohesion: 0.01
-Nodes (71): onSubmit(), reportAuthFailure(), resendVerificationCode(), addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), listBagItems() (+63 more)
+Cohesion: 0.02
+Nodes (56): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), listBagItems(), loadBagWithItems(), removeItemFromBag(), updateBagItem() (+48 more)
 
 ### Community 3 - "Community 3"
 Cohesion: 0.02
-Nodes (17): handleNewSession(), resetAutoSessionInitialized(), Logger, handleNewSession(), resetAutoSessionInitialized(), usePOSActiveSession(), usePOSSessionComplete(), usePOSSessionCreate() (+9 more)
+Nodes (22): clearFilters(), onMobileFiltersCloseClick(), asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), asString() (+14 more)
 
 ### Community 4 - "Community 4"
-Cohesion: 0.03
-Nodes (33): checkIfItemsHaveChanged(), CheckoutSessionError, createCheckoutSession(), createOnlineOrder(), defaultCheckoutActionMessage(), findBestValuePromoCode(), getActiveCheckoutSession(), getBaseUrl() (+25 more)
+Cohesion: 0.02
+Nodes (69): onSubmit(), reportAuthFailure(), resendVerificationCode(), getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold() (+61 more)
 
 ### Community 5 - "Community 5"
+Cohesion: 0.02
+Nodes (17): handleNewSession(), resetAutoSessionInitialized(), Logger, handleNewSession(), resetAutoSessionInitialized(), usePOSActiveSession(), usePOSSessionComplete(), usePOSSessionCreate() (+9 more)
+
+### Community 6 - "Community 6"
 Cohesion: 0.04
 Nodes (67): addGroupedError(), collectLiveSurfaceEntries(), fileExists(), formatGroupedErrors(), inferGroupFromError(), loadAuditTarget(), matchesPathPrefix(), normalizeRepoPath() (+59 more)
 
-### Community 6 - "Community 6"
-Cohesion: 0.03
-Nodes (9): onSubmit(), saveStoreChanges(), calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock() (+1 more)
-
 ### Community 7 - "Community 7"
 Cohesion: 0.03
-Nodes (5): modifyProduct(), onSubmit(), saveProduct(), onSubmit(), saveStoreChanges()
+Nodes (12): getNonEmptyString(), isFailureStatus(), normalizeEvent(), handleSave(), hasReceivingAccountDetails(), normalizePrimaryAccounts(), toPatchReceivingAccounts(), trimToUndefined() (+4 more)
 
 ### Community 8 - "Community 8"
 Cohesion: 0.03
-Nodes (2): isSkuReserved(), shouldDisable()
+Nodes (4): isSkuReserved(), shouldDisable(), useBulkOperations(), validateOperationValue()
 
 ### Community 9 - "Community 9"
 Cohesion: 0.03
-Nodes (9): cancelOrder(), getErrorMessage(), placeOrder(), ValkeyClient, handleSave(), hasReceivingAccountDetails(), normalizePrimaryAccounts(), toPatchReceivingAccounts() (+1 more)
+Nodes (10): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction(), cancelOrder(), getErrorMessage() (+2 more)
 
 ### Community 10 - "Community 10"
-Cohesion: 0.05
-Nodes (21): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventoryHold(), releaseInventoryHold(), validateInventoryAvailability(), collectAllPages(), createTransactionFromSessionHandler(), listCompletedTransactionsForDay() (+13 more)
+Cohesion: 0.04
+Nodes (5): modifyProduct(), onSubmit(), saveProduct(), onSubmit(), saveStoreChanges()
 
 ### Community 11 - "Community 11"
-Cohesion: 0.04
-Nodes (7): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile(), MockImage
+Cohesion: 0.05
+Nodes (33): checkIfItemsHaveChanged(), CheckoutSessionError, createCheckoutSession(), createOnlineOrder(), defaultCheckoutActionMessage(), findBestValuePromoCode(), getActiveCheckoutSession(), getBaseUrl() (+25 more)
 
 ### Community 12 - "Community 12"
 Cohesion: 0.05
-Nodes (14): buildUsername(), normalizeNameSegment(), buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins(), getDeliveryAddress() (+6 more)
+Nodes (21): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventoryHold(), releaseInventoryHold(), validateInventoryAvailability(), collectAllPages(), createTransactionFromSessionHandler(), listCompletedTransactionsForDay() (+13 more)
 
 ### Community 13 - "Community 13"
-Cohesion: 0.05
-Nodes (7): getNonEmptyString(), isFailureStatus(), normalizeEvent(), getRiskStyles(), RiskIndicators(), getNonEmptyString(), normalizeStorefrontObservabilityEvent()
+Cohesion: 0.06
+Nodes (20): getAllColors(), getBaseUrl(), buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct() (+12 more)
 
 ### Community 14 - "Community 14"
 Cohesion: 0.08
-Nodes (45): compactContext(), createAuthEntryViewedEvent(), createAuthRequestStartedEvent(), createAuthVerificationSucceededEvent(), createAuthVerificationViewedEvent(), createBagAddSucceededEvent(), createBagMoveToSavedEvent(), createBagRemoveSucceededEvent() (+37 more)
+Nodes (35): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins(), getDeliveryAddress(), getLocationDetails(), getPickupLocation() (+27 more)
 
 ### Community 15 - "Community 15"
-Cohesion: 0.07
-Nodes (8): getAllColors(), getBaseUrl(), buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
+Cohesion: 0.05
+Nodes (7): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile(), MockImage
 
 ### Community 16 - "Community 16"
-Cohesion: 0.12
-Nodes (26): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction(), asBoolean(), asMtnMomoSetupStatus() (+18 more)
+Cohesion: 0.13
+Nodes (18): asRegExp(), collectRuntimeSignalMatches(), consumeLines(), escapeRegExp(), formatError(), HarnessBehaviorPhaseError, logPhase(), parseHarnessBehaviorArgs() (+10 more)
 
 ### Community 17 - "Community 17"
-Cohesion: 0.1
-Nodes (12): createReview(), deleteReview(), getBaseUrl(), getReviewByOrderItem(), getReviewsByProductId(), getReviewsByProductSkuId(), getUserReviews(), getUserReviewsForProduct() (+4 more)
-
-### Community 18 - "Community 18"
-Cohesion: 0.16
-Nodes (25): asArray(), asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), assignOrDelete(), asString() (+17 more)
-
-### Community 19 - "Community 19"
 Cohesion: 0.14
 Nodes (18): appendListSection(), buildMarkdownBundle(), collectCoverage(), evaluateGraphifyFreshness(), fileExists(), formatValidationCommand(), getChangedFilesFromGit(), loadSelfReviewTarget() (+10 more)
 
+### Community 18 - "Community 18"
+Cohesion: 0.22
+Nodes (9): awardPointsForGuestOrders(), awardPointsForPastOrder(), getBaseUrl(), getEligiblePastOrders(), getOrderRewardPoints(), getPointHistory(), getRewardTiers(), getUserPoints() (+1 more)
+
+### Community 19 - "Community 19"
+Cohesion: 0.16
+Nodes (2): buildUsername(), normalizeNameSegment()
+
 ### Community 20 - "Community 20"
-Cohesion: 0.27
-Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
+Cohesion: 0.18
+Nodes (0):
 
 ### Community 21 - "Community 21"
 Cohesion: 0.18
@@ -132,28 +132,28 @@ Cohesion: 0.2
 Nodes (0):
 
 ### Community 24 - "Community 24"
+Cohesion: 0.39
+Nodes (7): calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock(), validateRefund()
+
+### Community 25 - "Community 25"
 Cohesion: 0.32
 Nodes (3): fileExists(), resolveGraphifyPython(), runGraphifyRebuild()
 
-### Community 25 - "Community 25"
-Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
-
 ### Community 26 - "Community 26"
-Cohesion: 0.7
-Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 27 - "Community 27"
 Cohesion: 0.7
-Nodes (4): runTests(), testBasicOperations(), testClusterInfo(), testConnection()
+Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
 ### Community 28 - "Community 28"
-Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Cohesion: 0.7
+Nodes (4): runTests(), testBasicOperations(), testClusterInfo(), testConnection()
 
 ### Community 29 - "Community 29"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 30 - "Community 30"
 Cohesion: 1.0
@@ -323,92 +323,102 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 72 - "Community 72"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 73 - "Community 73"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
-- **Thin community `Community 29`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 30`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 30`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 31`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 31`** (2 nodes): `sessionQueryIndexes.test.ts`, `readProjectFile()`
+- **Thin community `Community 32`** (2 nodes): `sessionQueryIndexes.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 32`** (2 nodes): `foundation.test.ts`, `readProjectFile()`
+- **Thin community `Community 33`** (2 nodes): `foundation.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 33`** (2 nodes): `helperOrchestration.test.ts`, `readProjectFile()`
+- **Thin community `Community 34`** (2 nodes): `helperOrchestration.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 34`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 35`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 35`** (2 nodes): `NoResultsMessage.tsx`, `NoResultsMessage()`
+- **Thin community `Community 36`** (2 nodes): `NoResultsMessage.tsx`, `NoResultsMessage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 36`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 37`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 37`** (2 nodes): `SingleLineError.tsx`, `SingleLineError()`
+- **Thin community `Community 38`** (2 nodes): `SingleLineError.tsx`, `SingleLineError()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 38`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 39`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 39`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 40`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 40`** (2 nodes): `NotificationPill.tsx`, `NotificationPill()`
+- **Thin community `Community 41`** (2 nodes): `NotificationPill.tsx`, `NotificationPill()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 41`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 42`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 42`** (2 nodes): `FormSubmissionProvider.tsx`, `useFormSubmission()`
+- **Thin community `Community 43`** (2 nodes): `FormSubmissionProvider.tsx`, `useFormSubmission()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 43`** (2 nodes): `architecture-boundaries.test.ts`, `createSnippetLinter()`
+- **Thin community `Community 44`** (2 nodes): `architecture-boundaries.test.ts`, `createSnippetLinter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 44`** (2 nodes): `architecture-boundary-check.ts`, `run()`
+- **Thin community `Community 45`** (2 nodes): `architecture-boundary-check.ts`, `run()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 45`** (1 nodes): `auth.config.js`
+- **Thin community `Community 46`** (2 nodes): `sample-app.ts`, `shutdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 46`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 47`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 47`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 48`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 48`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 49`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 49`** (1 nodes): `customer.ts`
+- **Thin community `Community 50`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 50`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 51`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 51`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 52`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 52`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 53`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 53`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 54`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 54`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 55`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 55`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 56`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 56`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 57`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 57`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 58`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 58`** (1 nodes): `offer.ts`
+- **Thin community `Community 59`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 59`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 60`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 60`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 61`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 61`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 62`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 62`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 63`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 63`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 64`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 64`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 65`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 65`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 66`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 66`** (1 nodes): `aws.ts`
+- **Thin community `Community 67`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 67`** (1 nodes): `setup.ts`
+- **Thin community `Community 68`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 68`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 69`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 69`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 70`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 70`** (1 nodes): `global.d.ts`
+- **Thin community `Community 71`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 71`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 72`** (1 nodes): `global.d.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 73`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
@@ -427,4 +437,4 @@ _Questions this graph is uniquely positioned to answer:_
 - **Should `Community 0` be split into smaller, more focused modules?**
   _Cohesion score 0.01 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**
-  _Cohesion score 0.01 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.02 - nodes in this community are weakly interconnected._

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -57,7 +57,7 @@
       "source_file": "packages/athena-webapp/convex/auth.config.js",
       "source_location": "L1",
       "id": "auth_config",
-      "community": 45
+      "community": 47
     },
     {
       "label": "Auth.tsx",
@@ -185,7 +185,7 @@
       "source_file": "packages/storefront-webapp/src/lib/validations/email.ts",
       "source_location": "L1",
       "id": "email",
-      "community": 6
+      "community": 1
     },
     {
       "label": "ghana.ts",
@@ -289,7 +289,7 @@
       "source_file": "packages/athena-webapp/convex/emails/PosReceiptEmail.tsx",
       "source_location": "L1",
       "id": "posreceiptemail",
-      "community": 3
+      "community": 5
     },
     {
       "label": "VerificationCode.tsx",
@@ -321,7 +321,7 @@
       "source_file": "packages/storefront-webapp/src/lib/mutations.ts/analytics.ts",
       "source_location": "L1",
       "id": "analytics",
-      "community": 15
+      "community": 3
     },
     {
       "label": "bannerMessage.ts",
@@ -409,7 +409,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/checkout.ts",
       "source_location": "L1",
       "id": "checkout",
-      "community": 1
+      "community": 4
     },
     {
       "label": "hasValidCanonicalBagItem()",
@@ -417,7 +417,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/checkout.ts",
       "source_location": "L84",
       "id": "checkout_hasvalidcanonicalbagitem",
-      "community": 1
+      "community": 4
     },
     {
       "label": "hasValidSessionItems()",
@@ -425,7 +425,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/checkout.ts",
       "source_location": "L95",
       "id": "checkout_hasvalidsessionitems",
-      "community": 1
+      "community": 4
     },
     {
       "label": "hasAllVisibileSessionItems()",
@@ -433,7 +433,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/checkout.ts",
       "source_location": "L109",
       "id": "checkout_hasallvisibilesessionitems",
-      "community": 1
+      "community": 4
     },
     {
       "label": "guest.ts",
@@ -481,7 +481,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/reviews.ts",
       "source_location": "L1",
       "id": "reviews",
-      "community": 17
+      "community": 13
     },
     {
       "label": "rewards.ts",
@@ -489,7 +489,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/rewards.ts",
       "source_location": "L1",
       "id": "rewards",
-      "community": 2
+      "community": 18
     },
     {
       "label": "SavedBag.tsx",
@@ -497,7 +497,7 @@
       "source_file": "packages/storefront-webapp/src/components/saved-items/SavedBag.tsx",
       "source_location": "L1",
       "id": "savedbag",
-      "community": 2
+      "community": 4
     },
     {
       "label": "security.test.ts",
@@ -593,7 +593,7 @@
       "source_file": "packages/athena-webapp/convex/http/routerComposition.test.ts",
       "source_location": "L1",
       "id": "routercomposition_test",
-      "community": 29
+      "community": 30
     },
     {
       "label": "readProjectFile()",
@@ -601,7 +601,7 @@
       "source_file": "packages/athena-webapp/convex/http/routerComposition.test.ts",
       "source_location": "L6",
       "id": "routercomposition_test_readprojectfile",
-      "community": 29
+      "community": 30
     },
     {
       "label": "utils.ts",
@@ -609,7 +609,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L1",
       "id": "utils",
-      "community": 0
+      "community": 1
     },
     {
       "label": "getStoreDataFromRequest()",
@@ -617,7 +617,7 @@
       "source_file": "packages/athena-webapp/convex/http/utils.ts",
       "source_location": "L5",
       "id": "utils_getstoredatafromrequest",
-      "community": 0
+      "community": 1
     },
     {
       "label": "getStorefrontUserFromRequest()",
@@ -625,7 +625,7 @@
       "source_file": "packages/athena-webapp/convex/http/utils.ts",
       "source_location": "L12",
       "id": "utils_getstorefrontuserfromrequest",
-      "community": 0
+      "community": 1
     },
     {
       "label": "http.ts",
@@ -673,7 +673,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/complimentaryProduct.ts",
       "source_location": "L1",
       "id": "complimentaryproduct",
-      "community": 6
+      "community": 2
     },
     {
       "label": "expenseSessionItems.ts",
@@ -681,7 +681,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessionItems.ts",
       "source_location": "L1",
       "id": "expensesessionitems",
-      "community": 10
+      "community": 12
     },
     {
       "label": "expenseSessions.ts",
@@ -689,7 +689,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
       "source_location": "L1",
       "id": "expensesessions",
-      "community": 10
+      "community": 12
     },
     {
       "label": "buildNextExpenseSessionNumber()",
@@ -697,7 +697,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
       "source_location": "L33",
       "id": "expensesessions_buildnextexpensesessionnumber",
-      "community": 10
+      "community": 12
     },
     {
       "label": "loadExpenseSessionItems()",
@@ -705,7 +705,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
       "source_location": "L41",
       "id": "expensesessions_loadexpensesessionitems",
-      "community": 10
+      "community": 12
     },
     {
       "label": "listExpenseSessionsByStatusBefore()",
@@ -713,7 +713,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
       "source_location": "L66",
       "id": "expensesessions_listexpensesessionsbystatusbefore",
-      "community": 10
+      "community": 12
     },
     {
       "label": "expenseTransactions.ts",
@@ -737,7 +737,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionExpiration.ts",
       "source_location": "L1",
       "id": "expensesessionexpiration",
-      "community": 10
+      "community": 12
     },
     {
       "label": "calculateExpenseSessionExpiration()",
@@ -745,7 +745,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionExpiration.ts",
       "source_location": "L21",
       "id": "expensesessionexpiration_calculateexpensesessionexpiration",
-      "community": 10
+      "community": 12
     },
     {
       "label": "getExpenseSessionExpiryDuration()",
@@ -753,7 +753,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionExpiration.ts",
       "source_location": "L35",
       "id": "expensesessionexpiration_getexpensesessionexpiryduration",
-      "community": 10
+      "community": 12
     },
     {
       "label": "getExpenseSessionExpiryDurationMinutes()",
@@ -761,7 +761,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionExpiration.ts",
       "source_location": "L45",
       "id": "expensesessionexpiration_getexpensesessionexpirydurationminutes",
-      "community": 10
+      "community": 12
     },
     {
       "label": "expenseSessionValidation.ts",
@@ -769,7 +769,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
       "source_location": "L1",
       "id": "expensesessionvalidation",
-      "community": 10
+      "community": 12
     },
     {
       "label": "validateExpenseSessionExists()",
@@ -777,7 +777,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
       "source_location": "L19",
       "id": "expensesessionvalidation_validateexpensesessionexists",
-      "community": 10
+      "community": 12
     },
     {
       "label": "validateExpenseSessionActive()",
@@ -785,7 +785,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
       "source_location": "L39",
       "id": "expensesessionvalidation_validateexpensesessionactive",
-      "community": 10
+      "community": 12
     },
     {
       "label": "validateExpenseSessionModifiable()",
@@ -793,7 +793,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
       "source_location": "L92",
       "id": "expensesessionvalidation_validateexpensesessionmodifiable",
-      "community": 10
+      "community": 12
     },
     {
       "label": "validateExpenseItemBelongsToSession()",
@@ -801,7 +801,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
       "source_location": "L135",
       "id": "expensesessionvalidation_validateexpenseitembelongstosession",
-      "community": 10
+      "community": 12
     },
     {
       "label": "inventoryHolds.ts",
@@ -809,7 +809,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
       "source_location": "L1",
       "id": "inventoryholds",
-      "community": 10
+      "community": 12
     },
     {
       "label": "validateInventoryAvailability()",
@@ -817,7 +817,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
       "source_location": "L20",
       "id": "inventoryholds_validateinventoryavailability",
-      "community": 10
+      "community": 12
     },
     {
       "label": "acquireInventoryHold()",
@@ -825,7 +825,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
       "source_location": "L76",
       "id": "inventoryholds_acquireinventoryhold",
-      "community": 10
+      "community": 12
     },
     {
       "label": "releaseInventoryHold()",
@@ -833,7 +833,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
       "source_location": "L114",
       "id": "inventoryholds_releaseinventoryhold",
-      "community": 10
+      "community": 12
     },
     {
       "label": "adjustInventoryHold()",
@@ -841,7 +841,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
       "source_location": "L161",
       "id": "inventoryholds_adjustinventoryhold",
-      "community": 10
+      "community": 12
     },
     {
       "label": "acquireInventoryHoldsBatch()",
@@ -849,7 +849,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
       "source_location": "L190",
       "id": "inventoryholds_acquireinventoryholdsbatch",
-      "community": 10
+      "community": 12
     },
     {
       "label": "releaseInventoryHoldsBatch()",
@@ -857,7 +857,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
       "source_location": "L239",
       "id": "inventoryholds_releaseinventoryholdsbatch",
-      "community": 10
+      "community": 12
     },
     {
       "label": "resultTypes.ts",
@@ -865,7 +865,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L1",
       "id": "resulttypes",
-      "community": 10
+      "community": 12
     },
     {
       "label": "success()",
@@ -873,7 +873,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L21",
       "id": "resulttypes_success",
-      "community": 10
+      "community": 12
     },
     {
       "label": "error()",
@@ -881,7 +881,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L28",
       "id": "resulttypes_error",
-      "community": 10
+      "community": 12
     },
     {
       "label": "itemSuccess()",
@@ -889,7 +889,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L140",
       "id": "resulttypes_itemsuccess",
-      "community": 10
+      "community": 12
     },
     {
       "label": "operationSuccess()",
@@ -897,7 +897,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L150",
       "id": "resulttypes_operationsuccess",
-      "community": 10
+      "community": 12
     },
     {
       "label": "sessionSuccess()",
@@ -905,7 +905,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L157",
       "id": "resulttypes_sessionsuccess",
-      "community": 10
+      "community": 12
     },
     {
       "label": "isSuccess()",
@@ -913,7 +913,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L167",
       "id": "resulttypes_issuccess",
-      "community": 10
+      "community": 12
     },
     {
       "label": "isError()",
@@ -921,7 +921,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L176",
       "id": "resulttypes_iserror",
-      "community": 10
+      "community": 12
     },
     {
       "label": "expenseItemSuccess()",
@@ -929,7 +929,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L276",
       "id": "resulttypes_expenseitemsuccess",
-      "community": 10
+      "community": 12
     },
     {
       "label": "expenseSessionSuccess()",
@@ -937,7 +937,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L286",
       "id": "resulttypes_expensesessionsuccess",
-      "community": 10
+      "community": 12
     },
     {
       "label": "sessionExpiration.ts",
@@ -945,7 +945,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
       "source_location": "L1",
       "id": "sessionexpiration",
-      "community": 10
+      "community": 12
     },
     {
       "label": "calculateSessionExpiration()",
@@ -953,7 +953,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
       "source_location": "L21",
       "id": "sessionexpiration_calculatesessionexpiration",
-      "community": 10
+      "community": 12
     },
     {
       "label": "getSessionExpiryDuration()",
@@ -961,7 +961,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
       "source_location": "L35",
       "id": "sessionexpiration_getsessionexpiryduration",
-      "community": 10
+      "community": 12
     },
     {
       "label": "getSessionExpiryDurationMinutes()",
@@ -969,7 +969,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
       "source_location": "L45",
       "id": "sessionexpiration_getsessionexpirydurationminutes",
-      "community": 10
+      "community": 12
     },
     {
       "label": "sessionValidation.ts",
@@ -977,7 +977,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L1",
       "id": "sessionvalidation",
-      "community": 10
+      "community": 12
     },
     {
       "label": "validateSessionExists()",
@@ -985,7 +985,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L19",
       "id": "sessionvalidation_validatesessionexists",
-      "community": 10
+      "community": 12
     },
     {
       "label": "validateSessionActive()",
@@ -993,7 +993,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L39",
       "id": "sessionvalidation_validatesessionactive",
-      "community": 10
+      "community": 12
     },
     {
       "label": "validateSessionModifiable()",
@@ -1001,7 +1001,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L95",
       "id": "sessionvalidation_validatesessionmodifiable",
-      "community": 10
+      "community": 12
     },
     {
       "label": "validateSessionOwnership()",
@@ -1009,7 +1009,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L140",
       "id": "sessionvalidation_validatesessionownership",
-      "community": 10
+      "community": 12
     },
     {
       "label": "validateCartItems()",
@@ -1017,7 +1017,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L188",
       "id": "sessionvalidation_validatecartitems",
-      "community": 10
+      "community": 12
     },
     {
       "label": "validateItemBelongsToSession()",
@@ -1025,7 +1025,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L245",
       "id": "sessionvalidation_validateitembelongstosession",
-      "community": 10
+      "community": 12
     },
     {
       "label": "validateCustomerInfo()",
@@ -1033,7 +1033,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L272",
       "id": "sessionvalidation_validatecustomerinfo",
-      "community": 10
+      "community": 12
     },
     {
       "label": "isValidEmail()",
@@ -1041,7 +1041,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L300",
       "id": "sessionvalidation_isvalidemail",
-      "community": 10
+      "community": 12
     },
     {
       "label": "validatePaymentDetails()",
@@ -1049,7 +1049,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L308",
       "id": "sessionvalidation_validatepaymentdetails",
-      "community": 10
+      "community": 12
     },
     {
       "label": "inviteCode.ts",
@@ -1073,7 +1073,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L1",
       "id": "pos",
-      "community": 10
+      "community": 12
     },
     {
       "label": "isConvexProductId()",
@@ -1081,7 +1081,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L15",
       "id": "pos_isconvexproductid",
-      "community": 10
+      "community": 12
     },
     {
       "label": "collectAllPages()",
@@ -1089,7 +1089,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L19",
       "id": "pos_collectallpages",
-      "community": 10
+      "community": 12
     },
     {
       "label": "listProductSkusByProductId()",
@@ -1097,7 +1097,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L41",
       "id": "pos_listproductskusbyproductid",
-      "community": 10
+      "community": 12
     },
     {
       "label": "listStoreProducts()",
@@ -1105,7 +1105,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L53",
       "id": "pos_liststoreproducts",
-      "community": 10
+      "community": 12
     },
     {
       "label": "listStoreSkus()",
@@ -1113,7 +1113,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L62",
       "id": "pos_liststoreskus",
-      "community": 10
+      "community": 12
     },
     {
       "label": "listTransactionItems()",
@@ -1121,7 +1121,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L71",
       "id": "pos_listtransactionitems",
-      "community": 10
+      "community": 12
     },
     {
       "label": "listSessionItems()",
@@ -1129,7 +1129,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L83",
       "id": "pos_listsessionitems",
-      "community": 10
+      "community": 12
     },
     {
       "label": "listCompletedTransactionsForDay()",
@@ -1137,7 +1137,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L92",
       "id": "pos_listcompletedtransactionsforday",
-      "community": 10
+      "community": 12
     },
     {
       "label": "createTransactionFromSessionHandler()",
@@ -1145,7 +1145,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L939",
       "id": "pos_createtransactionfromsessionhandler",
-      "community": 10
+      "community": 12
     },
     {
       "label": "posCustomers.ts",
@@ -1161,7 +1161,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posQueryCleanup.test.ts",
       "source_location": "L1",
       "id": "posquerycleanup_test",
-      "community": 30
+      "community": 31
     },
     {
       "label": "readProjectFile()",
@@ -1169,7 +1169,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posQueryCleanup.test.ts",
       "source_location": "L8",
       "id": "posquerycleanup_test_readprojectfile",
-      "community": 30
+      "community": 31
     },
     {
       "label": "posSessionItems.ts",
@@ -1177,7 +1177,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posSessionItems.ts",
       "source_location": "L1",
       "id": "possessionitems",
-      "community": 10
+      "community": 12
     },
     {
       "label": "posSessions.ts",
@@ -1185,7 +1185,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
       "source_location": "L1",
       "id": "possessions",
-      "community": 10
+      "community": 12
     },
     {
       "label": "buildNextSessionNumber()",
@@ -1193,7 +1193,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
       "source_location": "L34",
       "id": "possessions_buildnextsessionnumber",
-      "community": 10
+      "community": 12
     },
     {
       "label": "loadPosSessionItems()",
@@ -1201,7 +1201,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
       "source_location": "L45",
       "id": "possessions_loadpossessionitems",
-      "community": 10
+      "community": 12
     },
     {
       "label": "listPosSessionsByStatusBefore()",
@@ -1209,7 +1209,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
       "source_location": "L67",
       "id": "possessions_listpossessionsbystatusbefore",
-      "community": 10
+      "community": 12
     },
     {
       "label": "listPosSessionsForStoreStatus()",
@@ -1217,7 +1217,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
       "source_location": "L93",
       "id": "possessions_listpossessionsforstorestatus",
-      "community": 10
+      "community": 12
     },
     {
       "label": "posTerminal.ts",
@@ -1281,7 +1281,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/promoCode.ts",
       "source_location": "L1",
       "id": "promocode",
-      "community": 1
+      "community": 2
     },
     {
       "label": "sessionQueryIndexes.test.ts",
@@ -1289,7 +1289,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/sessionQueryIndexes.test.ts",
       "source_location": "L1",
       "id": "sessionqueryindexes_test",
-      "community": 31
+      "community": 32
     },
     {
       "label": "readProjectFile()",
@@ -1297,7 +1297,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/sessionQueryIndexes.test.ts",
       "source_location": "L6",
       "id": "sessionqueryindexes_test_readprojectfile",
-      "community": 31
+      "community": 32
     },
     {
       "label": "stockValidation.ts",
@@ -1313,7 +1313,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.test.ts",
       "source_location": "L1",
       "id": "storeconfigv2_test",
-      "community": 18
+      "community": 14
     },
     {
       "label": "storeConfigV2.ts",
@@ -1321,7 +1321,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L1",
       "id": "storeconfigv2",
-      "community": 18
+      "community": 14
     },
     {
       "label": "isPlainObject()",
@@ -1329,7 +1329,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L53",
       "id": "storeconfigv2_isplainobject",
-      "community": 18
+      "community": 14
     },
     {
       "label": "asRecord()",
@@ -1337,7 +1337,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L57",
       "id": "storeconfigv2_asrecord",
-      "community": 18
+      "community": 14
     },
     {
       "label": "asNumber()",
@@ -1345,7 +1345,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L61",
       "id": "storeconfigv2_asnumber",
-      "community": 18
+      "community": 14
     },
     {
       "label": "asString()",
@@ -1353,7 +1353,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L65",
       "id": "storeconfigv2_asstring",
-      "community": 18
+      "community": 14
     },
     {
       "label": "asBoolean()",
@@ -1361,7 +1361,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L69",
       "id": "storeconfigv2_asboolean",
-      "community": 18
+      "community": 14
     },
     {
       "label": "asArray()",
@@ -1369,7 +1369,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L77",
       "id": "storeconfigv2_asarray",
-      "community": 18
+      "community": 14
     },
     {
       "label": "asOptionalArray()",
@@ -1377,7 +1377,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L90",
       "id": "storeconfigv2_asoptionalarray",
-      "community": 18
+      "community": 14
     },
     {
       "label": "firstDefined()",
@@ -1385,7 +1385,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L101",
       "id": "storeconfigv2_firstdefined",
-      "community": 18
+      "community": 14
     },
     {
       "label": "mapPromotion()",
@@ -1393,7 +1393,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L111",
       "id": "storeconfigv2_mappromotion",
-      "community": 18
+      "community": 14
     },
     {
       "label": "mapStreamReel()",
@@ -1401,7 +1401,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L115",
       "id": "storeconfigv2_mapstreamreel",
-      "community": 18
+      "community": 14
     },
     {
       "label": "normalizeWaiveDeliveryFees()",
@@ -1409,7 +1409,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L135",
       "id": "storeconfigv2_normalizewaivedeliveryfees",
-      "community": 18
+      "community": 14
     },
     {
       "label": "cleanUndefined()",
@@ -1417,7 +1417,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L153",
       "id": "storeconfigv2_cleanundefined",
-      "community": 18
+      "community": 14
     },
     {
       "label": "asMtnMomoSetupStatus()",
@@ -1425,7 +1425,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L165",
       "id": "storeconfigv2_asmtnmomosetupstatus",
-      "community": 18
+      "community": 14
     },
     {
       "label": "hasMtnMomoReceivingAccountDetails()",
@@ -1433,7 +1433,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L178",
       "id": "storeconfigv2_hasmtnmomoreceivingaccountdetails",
-      "community": 18
+      "community": 14
     },
     {
       "label": "mapMtnMomoReceivingAccount()",
@@ -1441,7 +1441,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L191",
       "id": "storeconfigv2_mapmtnmomoreceivingaccount",
-      "community": 18
+      "community": 14
     },
     {
       "label": "normalizeMtnMomoReceivingAccounts()",
@@ -1449,7 +1449,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L214",
       "id": "storeconfigv2_normalizemtnmomoreceivingaccounts",
-      "community": 18
+      "community": 14
     },
     {
       "label": "toV2Config()",
@@ -1457,7 +1457,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L231",
       "id": "storeconfigv2_tov2config",
-      "community": 18
+      "community": 14
     },
     {
       "label": "normalizeStoreConfig()",
@@ -1465,7 +1465,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L474",
       "id": "storeconfigv2_normalizestoreconfig",
-      "community": 18
+      "community": 14
     },
     {
       "label": "deepMerge()",
@@ -1473,7 +1473,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L478",
       "id": "storeconfigv2_deepmerge",
-      "community": 18
+      "community": 14
     },
     {
       "label": "patchV2Config()",
@@ -1481,7 +1481,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L498",
       "id": "storeconfigv2_patchv2config",
-      "community": 18
+      "community": 14
     },
     {
       "label": "assignOrDelete()",
@@ -1489,7 +1489,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L507",
       "id": "storeconfigv2_assignordelete",
-      "community": 18
+      "community": 14
     },
     {
       "label": "mirrorLegacyKeys()",
@@ -1497,7 +1497,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L520",
       "id": "storeconfigv2_mirrorlegacykeys",
-      "community": 18
+      "community": 14
     },
     {
       "label": "getUnknownStoreConfigRootKeys()",
@@ -1505,7 +1505,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L591",
       "id": "storeconfigv2_getunknownstoreconfigrootkeys",
-      "community": 18
+      "community": 14
     },
     {
       "label": "isStoreCheckoutDisabled()",
@@ -1513,7 +1513,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L597",
       "id": "storeconfigv2_isstorecheckoutdisabled",
-      "community": 18
+      "community": 14
     },
     {
       "label": "removeLegacyRootKeysFromConfig()",
@@ -1521,7 +1521,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L606",
       "id": "storeconfigv2_removelegacyrootkeysfromconfig",
-      "community": 18
+      "community": 14
     },
     {
       "label": "isLegacyRootKey()",
@@ -1529,7 +1529,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L623",
       "id": "storeconfigv2_islegacyrootkey",
-      "community": 18
+      "community": 14
     },
     {
       "label": "isV2RootKey()",
@@ -1537,7 +1537,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L627",
       "id": "storeconfigv2_isv2rootkey",
-      "community": 18
+      "community": 14
     },
     {
       "label": "toV2OnlyConfig()",
@@ -1553,7 +1553,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L17",
       "id": "utils_getdiscountvalue",
-      "community": 0
+      "community": 1
     },
     {
       "label": "getProductDiscountValue()",
@@ -1561,7 +1561,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
       "source_location": "L75",
       "id": "utils_getproductdiscountvalue",
-      "community": 0
+      "community": 1
     },
     {
       "label": "getOrderAmount()",
@@ -1569,7 +1569,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L51",
       "id": "utils_getorderamount",
-      "community": 0
+      "community": 1
     },
     {
       "label": "formatDeliveryAddress()",
@@ -1577,7 +1577,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L74",
       "id": "utils_formatdeliveryaddress",
-      "community": 0
+      "community": 1
     },
     {
       "label": "currency.test.ts",
@@ -1585,7 +1585,7 @@
       "source_file": "packages/athena-webapp/convex/lib/currency.test.ts",
       "source_location": "L1",
       "id": "currency_test",
-      "community": 12
+      "community": 14
     },
     {
       "label": "currency.ts",
@@ -1593,7 +1593,7 @@
       "source_file": "packages/storefront-webapp/src/lib/currency.ts",
       "source_location": "L1",
       "id": "currency",
-      "community": 12
+      "community": 14
     },
     {
       "label": "toPesewas()",
@@ -1601,7 +1601,7 @@
       "source_file": "packages/storefront-webapp/src/lib/currency.ts",
       "source_location": "L1",
       "id": "currency_topesewas",
-      "community": 12
+      "community": 14
     },
     {
       "label": "toDisplayAmount()",
@@ -1609,7 +1609,7 @@
       "source_file": "packages/storefront-webapp/src/lib/currency.ts",
       "source_location": "L5",
       "id": "currency_todisplayamount",
-      "community": 12
+      "community": 14
     },
     {
       "label": "callLlmProvider.ts",
@@ -1681,7 +1681,7 @@
       "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
       "source_location": "L1",
       "id": "analyticsutils",
-      "community": 6
+      "community": 2
     },
     {
       "label": "calculateDeviceDistribution()",
@@ -1689,7 +1689,7 @@
       "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
       "source_location": "L11",
       "id": "analyticsutils_calculatedevicedistribution",
-      "community": 6
+      "community": 2
     },
     {
       "label": "calculateActivityTrend()",
@@ -1697,7 +1697,7 @@
       "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
       "source_location": "L43",
       "id": "analyticsutils_calculateactivitytrend",
-      "community": 6
+      "community": 2
     },
     {
       "label": "sendVerificationCode()",
@@ -1753,7 +1753,7 @@
       "source_file": "packages/athena-webapp/convex/migrations/migrateAmountsToPesewas.ts",
       "source_location": "L1",
       "id": "migrateamountstopesewas",
-      "community": 12
+      "community": 14
     },
     {
       "label": "client.test.ts",
@@ -1761,7 +1761,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.test.ts",
       "source_location": "L1",
       "id": "client_test",
-      "community": 20
+      "community": 11
     },
     {
       "label": "client.tsx",
@@ -1769,7 +1769,7 @@
       "source_file": "packages/storefront-webapp/src/client.tsx",
       "source_location": "L1",
       "id": "client",
-      "community": 20
+      "community": 11
     },
     {
       "label": "encodeBasicAuth()",
@@ -1777,7 +1777,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L9",
       "id": "client_encodebasicauth",
-      "community": 20
+      "community": 11
     },
     {
       "label": "toError()",
@@ -1785,7 +1785,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L13",
       "id": "client_toerror",
-      "community": 20
+      "community": 11
     },
     {
       "label": "buildHeaders()",
@@ -1793,7 +1793,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L20",
       "id": "client_buildheaders",
-      "community": 20
+      "community": 11
     },
     {
       "label": "createCollectionsAccessToken()",
@@ -1801,7 +1801,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L30",
       "id": "client_createcollectionsaccesstoken",
-      "community": 20
+      "community": 11
     },
     {
       "label": "requestToPay()",
@@ -1809,7 +1809,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L65",
       "id": "client_requesttopay",
-      "community": 20
+      "community": 11
     },
     {
       "label": "getRequestToPayStatus()",
@@ -1817,7 +1817,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L115",
       "id": "client_getrequesttopaystatus",
-      "community": 20
+      "community": 11
     },
     {
       "label": "collections.ts",
@@ -1929,7 +1929,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/foundation.test.ts",
       "source_location": "L1",
       "id": "foundation_test",
-      "community": 32
+      "community": 33
     },
     {
       "label": "readProjectFile()",
@@ -1937,7 +1937,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/foundation.test.ts",
       "source_location": "L6",
       "id": "foundation_test_readprojectfile",
-      "community": 32
+      "community": 33
     },
     {
       "label": "normalize.test.ts",
@@ -1985,7 +1985,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/types.ts",
       "source_location": "L1",
       "id": "types",
-      "community": 6
+      "community": 1
     },
     {
       "label": "ResendOTP.ts",
@@ -2041,7 +2041,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/appVerificationCode.ts",
       "source_location": "L1",
       "id": "appverificationcode",
-      "community": 46
+      "community": 48
     },
     {
       "label": "category.ts",
@@ -2057,7 +2057,7 @@
       "source_file": "packages/storefront-webapp/src/api/color.ts",
       "source_location": "L1",
       "id": "color",
-      "community": 15
+      "community": 13
     },
     {
       "label": "organization.ts",
@@ -2073,7 +2073,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/organizationMember.ts",
       "source_location": "L1",
       "id": "organizationmember",
-      "community": 47
+      "community": 49
     },
     {
       "label": "product.ts",
@@ -2081,7 +2081,7 @@
       "source_file": "packages/storefront-webapp/src/lib/schemas/product.ts",
       "source_location": "L1",
       "id": "product",
-      "community": 15
+      "community": 13
     },
     {
       "label": "redeemedPromoCode.ts",
@@ -2089,7 +2089,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/redeemedPromoCode.ts",
       "source_location": "L1",
       "id": "redeemedpromocode",
-      "community": 48
+      "community": 50
     },
     {
       "label": "store.ts",
@@ -2121,7 +2121,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customer.ts",
       "source_location": "L1",
       "id": "customer",
-      "community": 49
+      "community": 51
     },
     {
       "label": "expenseSession.ts",
@@ -2129,7 +2129,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/pos/expenseSession.ts",
       "source_location": "L1",
       "id": "expensesession",
-      "community": 50
+      "community": 52
     },
     {
       "label": "expenseSessionItem.ts",
@@ -2137,7 +2137,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/pos/expenseSessionItem.ts",
       "source_location": "L1",
       "id": "expensesessionitem",
-      "community": 51
+      "community": 53
     },
     {
       "label": "expenseTransaction.ts",
@@ -2145,7 +2145,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/pos/expenseTransaction.ts",
       "source_location": "L1",
       "id": "expensetransaction",
-      "community": 52
+      "community": 54
     },
     {
       "label": "expenseTransactionItem.ts",
@@ -2153,7 +2153,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/pos/expenseTransactionItem.ts",
       "source_location": "L1",
       "id": "expensetransactionitem",
-      "community": 53
+      "community": 55
     },
     {
       "label": "posSession.ts",
@@ -2169,7 +2169,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/pos/posSessionItem.ts",
       "source_location": "L1",
       "id": "possessionitem",
-      "community": 54
+      "community": 56
     },
     {
       "label": "posTransaction.ts",
@@ -2177,7 +2177,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/pos/posTransaction.ts",
       "source_location": "L1",
       "id": "postransaction",
-      "community": 55
+      "community": 57
     },
     {
       "label": "posTransactionItem.ts",
@@ -2185,7 +2185,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/pos/posTransactionItem.ts",
       "source_location": "L1",
       "id": "postransactionitem",
-      "community": 56
+      "community": 58
     },
     {
       "label": "bagItem.ts",
@@ -2201,7 +2201,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L1",
       "id": "checkoutsession",
-      "community": 4
+      "community": 11
     },
     {
       "label": "checkoutSessionItem.ts",
@@ -2209,7 +2209,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/checkoutSessionItem.ts",
       "source_location": "L1",
       "id": "checkoutsessionitem",
-      "community": 57
+      "community": 59
     },
     {
       "label": "offer.ts",
@@ -2217,7 +2217,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/offer.ts",
       "source_location": "L1",
       "id": "offer",
-      "community": 58
+      "community": 60
     },
     {
       "label": "onlineOrderItem.ts",
@@ -2233,7 +2233,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
       "source_location": "L1",
       "id": "review",
-      "community": 1
+      "community": 3
     },
     {
       "label": "savedBagItem.ts",
@@ -2249,7 +2249,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontSession.ts",
       "source_location": "L1",
       "id": "storefrontsession",
-      "community": 59
+      "community": 61
     },
     {
       "label": "storeFrontUser.ts",
@@ -2257,7 +2257,7 @@
       "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
       "source_location": "L1",
       "id": "storefrontuser",
-      "community": 1
+      "community": 4
     },
     {
       "label": "storeFrontVerificationCode.ts",
@@ -2265,7 +2265,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontVerificationCode.ts",
       "source_location": "L1",
       "id": "storefrontverificationcode",
-      "community": 60
+      "community": 62
     },
     {
       "label": "supportTicket.ts",
@@ -2281,7 +2281,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L1",
       "id": "orderemailservice",
-      "community": 12
+      "community": 14
     },
     {
       "label": "shouldSendToAdmins()",
@@ -2289,7 +2289,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L42",
       "id": "orderemailservice_shouldsendtoadmins",
-      "community": 12
+      "community": 14
     },
     {
       "label": "buildOrderStatusMessage()",
@@ -2297,7 +2297,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L49",
       "id": "orderemailservice_buildorderstatusmessage",
-      "community": 12
+      "community": 14
     },
     {
       "label": "buildPickupDetails()",
@@ -2305,7 +2305,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L77",
       "id": "orderemailservice_buildpickupdetails",
-      "community": 12
+      "community": 14
     },
     {
       "label": "sendPODOrderEmails()",
@@ -2313,7 +2313,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L96",
       "id": "orderemailservice_sendpodorderemails",
-      "community": 12
+      "community": 14
     },
     {
       "label": "sendPaymentVerificationEmails()",
@@ -2321,7 +2321,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L217",
       "id": "orderemailservice_sendpaymentverificationemails",
-      "community": 12
+      "community": 14
     },
     {
       "label": "paystackService.ts",
@@ -2369,7 +2369,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L18",
       "id": "analytics_extractpromocodeid",
-      "community": 15
+      "community": 3
     },
     {
       "label": "getAnalyticsByStoreQuery()",
@@ -2377,7 +2377,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L28",
       "id": "analytics_getanalyticsbystorequery",
-      "community": 15
+      "community": 3
     },
     {
       "label": "getCompletedOrdersQuery()",
@@ -2385,7 +2385,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L59",
       "id": "analytics_getcompletedordersquery",
-      "community": 15
+      "community": 3
     },
     {
       "label": "getAnalyticsByStoreAndActionQuery()",
@@ -2393,7 +2393,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L97",
       "id": "analytics_getanalyticsbystoreandactionquery",
-      "community": 15
+      "community": 3
     },
     {
       "label": "getSkuMapForProducts()",
@@ -2401,7 +2401,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L132",
       "id": "analytics_getskumapforproducts",
-      "community": 15
+      "community": 3
     },
     {
       "label": "getStoreFrontActorById()",
@@ -2417,7 +2417,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L40",
       "id": "checkoutsession_listsessionitems",
-      "community": 4
+      "community": 11
     },
     {
       "label": "checkIfItemsHaveChanged()",
@@ -2425,7 +2425,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L50",
       "id": "checkoutsession_checkifitemshavechanged",
-      "community": 4
+      "community": 11
     },
     {
       "label": "createPatchObject()",
@@ -2433,7 +2433,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L651",
       "id": "checkoutsession_createpatchobject",
-      "community": 4
+      "community": 11
     },
     {
       "label": "handlePlaceOrder()",
@@ -2441,7 +2441,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L698",
       "id": "checkoutsession_handleplaceorder",
-      "community": 4
+      "community": 11
     },
     {
       "label": "handleOrderCreation()",
@@ -2449,7 +2449,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L734",
       "id": "checkoutsession_handleordercreation",
-      "community": 4
+      "community": 11
     },
     {
       "label": "createOnlineOrder()",
@@ -2457,7 +2457,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L765",
       "id": "checkoutsession_createonlineorder",
-      "community": 4
+      "community": 11
     },
     {
       "label": "retrieveActiveCheckoutSession()",
@@ -2465,7 +2465,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L951",
       "id": "checkoutsession_retrieveactivecheckoutsession",
-      "community": 4
+      "community": 11
     },
     {
       "label": "fetchProductSkus()",
@@ -2473,7 +2473,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L979",
       "id": "checkoutsession_fetchproductskus",
-      "community": 4
+      "community": 11
     },
     {
       "label": "checkAdjustedAvailability()",
@@ -2481,7 +2481,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L990",
       "id": "checkoutsession_checkadjustedavailability",
-      "community": 4
+      "community": 11
     },
     {
       "label": "updateExistingSession()",
@@ -2489,7 +2489,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1020",
       "id": "checkoutsession_updateexistingsession",
-      "community": 4
+      "community": 11
     },
     {
       "label": "createSessionItems()",
@@ -2497,7 +2497,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1102",
       "id": "checkoutsession_createsessionitems",
-      "community": 4
+      "community": 11
     },
     {
       "label": "updateProductAvailability()",
@@ -2505,7 +2505,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1123",
       "id": "checkoutsession_updateproductavailability",
-      "community": 4
+      "community": 11
     },
     {
       "label": "updateAvailability()",
@@ -2513,7 +2513,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1140",
       "id": "checkoutsession_updateavailability",
-      "community": 4
+      "community": 11
     },
     {
       "label": "handleExistingSession()",
@@ -2521,7 +2521,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1161",
       "id": "checkoutsession_handleexistingsession",
-      "community": 4
+      "community": 11
     },
     {
       "label": "validateExistingDiscount()",
@@ -2529,7 +2529,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1321",
       "id": "checkoutsession_validateexistingdiscount",
-      "community": 4
+      "community": 11
     },
     {
       "label": "calculatePromoCodeValue()",
@@ -2537,7 +2537,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1447",
       "id": "checkoutsession_calculatepromocodevalue",
-      "community": 4
+      "community": 11
     },
     {
       "label": "findBestValuePromoCode()",
@@ -2545,7 +2545,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1495",
       "id": "checkoutsession_findbestvaluepromocode",
-      "community": 4
+      "community": 11
     },
     {
       "label": "commerceQueryIndexes.test.ts",
@@ -2585,7 +2585,7 @@
       "source_file": "packages/athena-webapp/src/components/users/CustomerBehaviorTimeline.tsx",
       "source_location": "L1",
       "id": "customerbehaviortimeline",
-      "community": 13
+      "community": 7
     },
     {
       "label": "getTimeFilterForRange()",
@@ -2593,7 +2593,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
       "source_location": "L11",
       "id": "customerbehaviortimeline_gettimefilterforrange",
-      "community": 13
+      "community": 7
     },
     {
       "label": "getCustomerAnalyticsQuery()",
@@ -2601,7 +2601,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
       "source_location": "L26",
       "id": "customerbehaviortimeline_getcustomeranalyticsquery",
-      "community": 13
+      "community": 7
     },
     {
       "label": "getTimelineUserData()",
@@ -2609,7 +2609,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
       "source_location": "L42",
       "id": "customerbehaviortimeline_gettimelineuserdata",
-      "community": 13
+      "community": 7
     },
     {
       "label": "getProductInfoMaps()",
@@ -2617,7 +2617,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
       "source_location": "L66",
       "id": "customerbehaviortimeline_getproductinfomaps",
-      "community": 13
+      "community": 7
     },
     {
       "label": "customerObservabilityTimeline.test.ts",
@@ -2625,7 +2625,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimeline.test.ts",
       "source_location": "L1",
       "id": "customerobservabilitytimeline_test",
-      "community": 13
+      "community": 7
     },
     {
       "label": "createAnalyticsEvent()",
@@ -2633,7 +2633,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimeline.test.ts",
       "source_location": "L17",
       "id": "customerobservabilitytimeline_test_createanalyticsevent",
-      "community": 13
+      "community": 7
     },
     {
       "label": "customerObservabilityTimelineData.ts",
@@ -2641,7 +2641,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L1",
       "id": "customerobservabilitytimelinedata",
-      "community": 13
+      "community": 7
     },
     {
       "label": "getNonEmptyString()",
@@ -2649,7 +2649,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L64",
       "id": "customerobservabilitytimelinedata_getnonemptystring",
-      "community": 13
+      "community": 7
     },
     {
       "label": "isFailureStatus()",
@@ -2657,7 +2657,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L68",
       "id": "customerobservabilitytimelinedata_isfailurestatus",
-      "community": 13
+      "community": 7
     },
     {
       "label": "normalizeEvent()",
@@ -2665,7 +2665,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L72",
       "id": "customerobservabilitytimelinedata_normalizeevent",
-      "community": 13
+      "community": 7
     },
     {
       "label": "buildCustomerObservabilityTimeline()",
@@ -2673,7 +2673,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L118",
       "id": "customerobservabilitytimelinedata_buildcustomerobservabilitytimeline",
-      "community": 13
+      "community": 7
     },
     {
       "label": "helperOrchestration.test.ts",
@@ -2681,7 +2681,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helperOrchestration.test.ts",
       "source_location": "L1",
       "id": "helperorchestration_test",
-      "community": 33
+      "community": 34
     },
     {
       "label": "readProjectFile()",
@@ -2689,7 +2689,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helperOrchestration.test.ts",
       "source_location": "L6",
       "id": "helperorchestration_test_readprojectfile",
-      "community": 33
+      "community": 34
     },
     {
       "label": "listBagItems()",
@@ -2753,7 +2753,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L1",
       "id": "orderupdateemails",
-      "community": 12
+      "community": 14
     },
     {
       "label": "getPickupLocation()",
@@ -2761,7 +2761,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L52",
       "id": "orderupdateemails_getpickuplocation",
-      "community": 12
+      "community": 14
     },
     {
       "label": "getDeliveryAddress()",
@@ -2769,7 +2769,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L55",
       "id": "orderupdateemails_getdeliveryaddress",
-      "community": 12
+      "community": 14
     },
     {
       "label": "getLocationDetails()",
@@ -2777,7 +2777,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L58",
       "id": "orderupdateemails_getlocationdetails",
-      "community": 12
+      "community": 14
     },
     {
       "label": "formatOrderItems()",
@@ -2785,7 +2785,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L64",
       "id": "orderupdateemails_formatorderitems",
-      "community": 12
+      "community": 14
     },
     {
       "label": "handleOrderStatusUpdate()",
@@ -2793,7 +2793,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L118",
       "id": "orderupdateemails_handleorderstatusupdate",
-      "community": 12
+      "community": 14
     },
     {
       "label": "processOrderUpdateEmail()",
@@ -2801,7 +2801,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L293",
       "id": "orderupdateemails_processorderupdateemail",
-      "community": 12
+      "community": 14
     },
     {
       "label": "paymentHelpers.ts",
@@ -2913,7 +2913,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderUtilFns.ts",
       "source_location": "L1",
       "id": "onlineorderutilfns",
-      "community": 12
+      "community": 14
     },
     {
       "label": "paystackActions.ts",
@@ -2929,7 +2929,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/reviews.ts",
       "source_location": "L17",
       "id": "reviews_getstorefrontactorbyid",
-      "community": 17
+      "community": 13
     },
     {
       "label": "listSavedBagItems()",
@@ -2937,7 +2937,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/savedBag.ts",
       "source_location": "L14",
       "id": "savedbag_listsavedbagitems",
-      "community": 2
+      "community": 4
     },
     {
       "label": "storefrontObservabilityReport.test.ts",
@@ -2945,7 +2945,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.test.ts",
       "source_location": "L1",
       "id": "storefrontobservabilityreport_test",
-      "community": 13
+      "community": 7
     },
     {
       "label": "createAnalyticsEvent()",
@@ -2953,7 +2953,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.test.ts",
       "source_location": "L7",
       "id": "storefrontobservabilityreport_test_createanalyticsevent",
-      "community": 13
+      "community": 7
     },
     {
       "label": "storefrontObservabilityReport.ts",
@@ -2961,7 +2961,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
       "source_location": "L1",
       "id": "storefrontobservabilityreport",
-      "community": 13
+      "community": 7
     },
     {
       "label": "getNonEmptyString()",
@@ -2969,7 +2969,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
       "source_location": "L59",
       "id": "storefrontobservabilityreport_getnonemptystring",
-      "community": 13
+      "community": 7
     },
     {
       "label": "normalizeStorefrontObservabilityEvent()",
@@ -2977,7 +2977,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
       "source_location": "L63",
       "id": "storefrontobservabilityreport_normalizestorefrontobservabilityevent",
-      "community": 13
+      "community": 7
     },
     {
       "label": "buildStorefrontObservabilityReport()",
@@ -2985,7 +2985,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
       "source_location": "L95",
       "id": "storefrontobservabilityreport_buildstorefrontobservabilityreport",
-      "community": 13
+      "community": 7
     },
     {
       "label": "timeQueryRefactors.test.ts",
@@ -2993,7 +2993,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/timeQueryRefactors.test.ts",
       "source_location": "L1",
       "id": "timequeryrefactors_test",
-      "community": 34
+      "community": 35
     },
     {
       "label": "readSource()",
@@ -3001,7 +3001,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/timeQueryRefactors.test.ts",
       "source_location": "L5",
       "id": "timequeryrefactors_test_readsource",
-      "community": 34
+      "community": 35
     },
     {
       "label": "getStoreFrontActorById()",
@@ -3033,7 +3033,7 @@
       "source_file": "packages/athena-webapp/src/lib/utils.ts",
       "source_location": "L37",
       "id": "utils_toslug",
-      "community": 0
+      "community": 1
     },
     {
       "label": "getAddressString()",
@@ -3041,7 +3041,7 @@
       "source_file": "packages/athena-webapp/convex/utils.ts",
       "source_location": "L14",
       "id": "utils_getaddressstring",
-      "community": 0
+      "community": 1
     },
     {
       "label": "capitalizeWords()",
@@ -3049,7 +3049,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L23",
       "id": "utils_capitalizewords",
-      "community": 0
+      "community": 1
     },
     {
       "label": "currencyFormatter()",
@@ -3057,7 +3057,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L35",
       "id": "utils_currencyformatter",
-      "community": 0
+      "community": 1
     },
     {
       "label": "formatDate()",
@@ -3065,7 +3065,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L44",
       "id": "utils_formatdate",
-      "community": 0
+      "community": 1
     },
     {
       "label": "getProductName()",
@@ -3073,7 +3073,7 @@
       "source_file": "packages/athena-webapp/convex/utils.ts",
       "source_location": "L64",
       "id": "utils_getproductname",
-      "community": 0
+      "community": 1
     },
     {
       "label": "generateTransactionNumber()",
@@ -3081,7 +3081,7 @@
       "source_file": "packages/athena-webapp/convex/utils.ts",
       "source_location": "L77",
       "id": "utils_generatetransactionnumber",
-      "community": 0
+      "community": 1
     },
     {
       "label": "eslint.config.js",
@@ -3089,7 +3089,7 @@
       "source_file": "packages/storefront-webapp/eslint.config.js",
       "source_location": "L1",
       "id": "eslint_config",
-      "community": 61
+      "community": 63
     },
     {
       "label": "postcss.config.js",
@@ -3097,7 +3097,7 @@
       "source_file": "packages/athena-webapp/postcss.config.js",
       "source_location": "L1",
       "id": "postcss_config",
-      "community": 62
+      "community": 64
     },
     {
       "label": "GenericComboBox.tsx",
@@ -3105,7 +3105,7 @@
       "source_file": "packages/athena-webapp/src/components/GenericComboBox.tsx",
       "source_location": "L1",
       "id": "genericcombobox",
-      "community": 1
+      "community": 0
     },
     {
       "label": "Navbar.tsx",
@@ -3185,7 +3185,7 @@
       "source_file": "packages/athena-webapp/src/components/PermissionGate.tsx",
       "source_location": "L1",
       "id": "permissiongate",
-      "community": 6
+      "community": 0
     },
     {
       "label": "PermissionGate()",
@@ -3193,7 +3193,7 @@
       "source_file": "packages/athena-webapp/src/components/PermissionGate.tsx",
       "source_location": "L11",
       "id": "permissiongate_permissiongate",
-      "community": 6
+      "community": 0
     },
     {
       "label": "ProtectedRoute.tsx",
@@ -3201,7 +3201,7 @@
       "source_file": "packages/athena-webapp/src/components/ProtectedRoute.tsx",
       "source_location": "L1",
       "id": "protectedroute",
-      "community": 7
+      "community": 10
     },
     {
       "label": "ProtectedRoute()",
@@ -3209,7 +3209,7 @@
       "source_file": "packages/athena-webapp/src/components/ProtectedRoute.tsx",
       "source_location": "L11",
       "id": "protectedroute_protectedroute",
-      "community": 7
+      "community": 10
     },
     {
       "label": "SettingsView.tsx",
@@ -3233,7 +3233,7 @@
       "source_file": "packages/athena-webapp/src/components/StoreAccordion.tsx",
       "source_location": "L1",
       "id": "storeaccordion",
-      "community": 1
+      "community": 0
     },
     {
       "label": "StoreActions.tsx",
@@ -3241,7 +3241,7 @@
       "source_file": "packages/athena-webapp/src/components/StoreActions.tsx",
       "source_location": "L1",
       "id": "storeactions",
-      "community": 1
+      "community": 0
     },
     {
       "label": "StoreActions()",
@@ -3249,7 +3249,7 @@
       "source_file": "packages/athena-webapp/src/components/StoreActions.tsx",
       "source_location": "L12",
       "id": "storeactions_storeactions",
-      "community": 1
+      "community": 0
     },
     {
       "label": "StoreDropdown.tsx",
@@ -3257,7 +3257,7 @@
       "source_file": "packages/athena-webapp/src/components/StoreDropdown.tsx",
       "source_location": "L1",
       "id": "storedropdown",
-      "community": 1
+      "community": 0
     },
     {
       "label": "StoreDropdown()",
@@ -3265,7 +3265,7 @@
       "source_file": "packages/athena-webapp/src/components/StoreDropdown.tsx",
       "source_location": "L42",
       "id": "storedropdown_storedropdown",
-      "community": 1
+      "community": 0
     },
     {
       "label": "StoreView.tsx",
@@ -3289,7 +3289,7 @@
       "source_file": "packages/athena-webapp/src/components/StoresAccordion.tsx",
       "source_location": "L1",
       "id": "storesaccordion",
-      "community": 1
+      "community": 0
     },
     {
       "label": "StoresDropdown.tsx",
@@ -3313,7 +3313,7 @@
       "source_file": "packages/athena-webapp/src/components/ThemeToggle.tsx",
       "source_location": "L1",
       "id": "themetoggle",
-      "community": 63
+      "community": 65
     },
     {
       "label": "View.tsx",
@@ -3337,7 +3337,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
       "source_location": "L1",
       "id": "attributesmanager",
-      "community": 0
+      "community": 1
     },
     {
       "label": "Sidebar()",
@@ -3345,7 +3345,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
       "source_location": "L26",
       "id": "attributesmanager_sidebar",
-      "community": 0
+      "community": 1
     },
     {
       "label": "ColorManager()",
@@ -3353,7 +3353,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
       "source_location": "L45",
       "id": "attributesmanager_colormanager",
-      "community": 0
+      "community": 1
     },
     {
       "label": "AttributesManager()",
@@ -3361,7 +3361,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
       "source_location": "L228",
       "id": "attributesmanager_attributesmanager",
-      "community": 0
+      "community": 1
     },
     {
       "label": "AttributesTable.tsx",
@@ -3449,7 +3449,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/DefaultAttributesToggleGroup.tsx",
       "source_location": "L1",
       "id": "defaultattributestogglegroup",
-      "community": 0
+      "community": 1
     },
     {
       "label": "ProcessingFees.tsx",
@@ -3497,7 +3497,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
       "source_location": "L1",
       "id": "productavailability",
-      "community": 0
+      "community": 26
     },
     {
       "label": "ProductAvailabilityView()",
@@ -3505,7 +3505,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
       "source_location": "L5",
       "id": "productavailability_productavailabilityview",
-      "community": 0
+      "community": 26
     },
     {
       "label": "ProductAvailability()",
@@ -3513,7 +3513,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
       "source_location": "L18",
       "id": "productavailability_productavailability",
-      "community": 0
+      "community": 26
     },
     {
       "label": "ProductAvailabilityToggleGroup.tsx",
@@ -3521,7 +3521,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailabilityToggleGroup.tsx",
       "source_location": "L1",
       "id": "productavailabilitytogglegroup",
-      "community": 0
+      "community": 26
     },
     {
       "label": "ProductAvailabilityToggleGroup()",
@@ -3529,7 +3529,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailabilityToggleGroup.tsx",
       "source_location": "L5",
       "id": "productavailabilitytogglegroup_productavailabilitytogglegroup",
-      "community": 0
+      "community": 26
     },
     {
       "label": "ProductCategorization.tsx",
@@ -3577,7 +3577,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
       "source_location": "L1",
       "id": "productdetails",
-      "community": 1
+      "community": 3
     },
     {
       "label": "handleNameChange()",
@@ -3585,7 +3585,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductDetails.tsx",
       "source_location": "L10",
       "id": "productdetails_handlenamechange",
-      "community": 1
+      "community": 3
     },
     {
       "label": "ProductImages.tsx",
@@ -3785,7 +3785,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L1",
       "id": "productview",
-      "community": 7
+      "community": 10
     },
     {
       "label": "deleteActiveProduct()",
@@ -3793,7 +3793,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L82",
       "id": "productview_deleteactiveproduct",
-      "community": 7
+      "community": 10
     },
     {
       "label": "saveProduct()",
@@ -3801,7 +3801,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L115",
       "id": "productview_saveproduct",
-      "community": 7
+      "community": 10
     },
     {
       "label": "modifyProduct()",
@@ -3809,7 +3809,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L170",
       "id": "productview_modifyproduct",
-      "community": 7
+      "community": 10
     },
     {
       "label": "createVariantSku()",
@@ -3817,7 +3817,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L245",
       "id": "productview_createvariantsku",
-      "community": 7
+      "community": 10
     },
     {
       "label": "updateVariantSku()",
@@ -3825,7 +3825,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L300",
       "id": "productview_updatevariantsku",
-      "community": 7
+      "community": 10
     },
     {
       "label": "onSubmit()",
@@ -3833,7 +3833,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L369",
       "id": "productview_onsubmit",
-      "community": 7
+      "community": 10
     },
     {
       "label": "handleKeyDown()",
@@ -3841,7 +3841,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L380",
       "id": "productview_handlekeydown",
-      "community": 7
+      "community": 10
     },
     {
       "label": "updateProductVisibility()",
@@ -3849,7 +3849,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L431",
       "id": "productview_updateproductvisibility",
-      "community": 7
+      "community": 10
     },
     {
       "label": "SheetProvider.tsx",
@@ -3945,7 +3945,7 @@
       "source_file": "packages/storefront-webapp/src/lib/constants.ts",
       "source_location": "L1",
       "id": "constants",
-      "community": 1
+      "community": 3
     },
     {
       "label": "data-table-column-header.tsx",
@@ -3953,7 +3953,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "data_table_column_header",
-      "community": 0
+      "community": 1
     },
     {
       "label": "DataTableColumnHeader()",
@@ -3961,7 +3961,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-column-header.tsx",
       "source_location": "L20",
       "id": "data_table_column_header_datatablecolumnheader",
-      "community": 0
+      "community": 1
     },
     {
       "label": "data-table-faceted-filter.tsx",
@@ -3969,7 +3969,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-faceted-filter.tsx",
       "source_location": "L1",
       "id": "data_table_faceted_filter",
-      "community": 1
+      "community": 0
     },
     {
       "label": "data-table-pagination.tsx",
@@ -3977,7 +3977,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "data_table_pagination",
-      "community": 0
+      "community": 8
     },
     {
       "label": "data-table-toolbar-provider.tsx",
@@ -3985,7 +3985,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
       "source_location": "L1",
       "id": "data_table_toolbar_provider",
-      "community": 7
+      "community": 0
     },
     {
       "label": "OrdersTableToolbarProvider()",
@@ -3993,7 +3993,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
       "source_location": "L16",
       "id": "data_table_toolbar_provider_orderstabletoolbarprovider",
-      "community": 7
+      "community": 0
     },
     {
       "label": "useOrdersTableToolbar()",
@@ -4001,7 +4001,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
       "source_location": "L46",
       "id": "data_table_toolbar_provider_useorderstabletoolbar",
-      "community": 7
+      "community": 0
     },
     {
       "label": "data-table-toolbar.tsx",
@@ -4009,7 +4009,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-toolbar.tsx",
       "source_location": "L1",
       "id": "data_table_toolbar",
-      "community": 7
+      "community": 0
     },
     {
       "label": "DataTableToolbar()",
@@ -4017,7 +4017,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
       "source_location": "L23",
       "id": "data_table_toolbar_datatabletoolbar",
-      "community": 7
+      "community": 0
     },
     {
       "label": "data-table-view-options.tsx",
@@ -4065,7 +4065,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/ActivityTimeline.tsx",
       "source_location": "L1",
       "id": "activitytimeline",
-      "community": 0
+      "community": 7
     },
     {
       "label": "capitalizeFirstLetter()",
@@ -4073,7 +4073,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/ActivityTimeline.tsx",
       "source_location": "L151",
       "id": "activitytimeline_capitalizefirstletter",
-      "community": 0
+      "community": 7
     },
     {
       "label": "AnalyticsCombinedUsers.tsx",
@@ -4081,7 +4081,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
       "source_location": "L1",
       "id": "analyticscombinedusers",
-      "community": 0
+      "community": 1
     },
     {
       "label": "processAnalyticsToUsers()",
@@ -4089,7 +4089,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
       "source_location": "L10",
       "id": "analyticscombinedusers_processanalyticstousers",
-      "community": 0
+      "community": 1
     },
     {
       "label": "AnalyticsCombinedUsers()",
@@ -4097,7 +4097,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
       "source_location": "L100",
       "id": "analyticscombinedusers_analyticscombinedusers",
-      "community": 0
+      "community": 1
     },
     {
       "label": "AnalyticsItems.tsx",
@@ -4137,7 +4137,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsTopUsers.tsx",
       "source_location": "L1",
       "id": "analyticstopusers",
-      "community": 0
+      "community": 1
     },
     {
       "label": "processAnalyticsToUsers()",
@@ -4145,7 +4145,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsTopUsers.tsx",
       "source_location": "L10",
       "id": "analyticstopusers_processanalyticstousers",
-      "community": 0
+      "community": 1
     },
     {
       "label": "AnalyticsTopUsers()",
@@ -4153,7 +4153,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsTopUsers.tsx",
       "source_location": "L100",
       "id": "analyticstopusers_analyticstopusers",
-      "community": 0
+      "community": 1
     },
     {
       "label": "AnalyticsUsers.tsx",
@@ -4161,7 +4161,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsUsers.tsx",
       "source_location": "L1",
       "id": "analyticsusers",
-      "community": 0
+      "community": 1
     },
     {
       "label": "AnalyticsUsers()",
@@ -4169,7 +4169,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsUsers.tsx",
       "source_location": "L7",
       "id": "analyticsusers_analyticsusers",
-      "community": 0
+      "community": 1
     },
     {
       "label": "AnalyticsView.tsx",
@@ -4209,7 +4209,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/ConversionFunnelChart.tsx",
       "source_location": "L1",
       "id": "conversionfunnelchart",
-      "community": 0
+      "community": 7
     },
     {
       "label": "EnhancedAnalyticsView.tsx",
@@ -4217,7 +4217,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/EnhancedAnalyticsView.tsx",
       "source_location": "L1",
       "id": "enhancedanalyticsview",
-      "community": 0
+      "community": 7
     },
     {
       "label": "getDateRangeMilliseconds()",
@@ -4225,7 +4225,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/EnhancedAnalyticsView.tsx",
       "source_location": "L42",
       "id": "enhancedanalyticsview_getdaterangemilliseconds",
-      "community": 0
+      "community": 7
     },
     {
       "label": "RevenueChart.tsx",
@@ -4233,7 +4233,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/RevenueChart.tsx",
       "source_location": "L1",
       "id": "revenuechart",
-      "community": 0
+      "community": 7
     },
     {
       "label": "getTrendIcon()",
@@ -4249,7 +4249,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
       "source_location": "L1",
       "id": "storefrontobservabilitypanel",
-      "community": 0
+      "community": 7
     },
     {
       "label": "formatLabel()",
@@ -4257,7 +4257,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
       "source_location": "L15",
       "id": "storefrontobservabilitypanel_formatlabel",
-      "community": 0
+      "community": 7
     },
     {
       "label": "SummaryCard()",
@@ -4265,7 +4265,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
       "source_location": "L19",
       "id": "storefrontobservabilitypanel_summarycard",
-      "community": 0
+      "community": 7
     },
     {
       "label": "VisitorChart.tsx",
@@ -4273,7 +4273,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/VisitorChart.tsx",
       "source_location": "L1",
       "id": "visitorchart",
-      "community": 0
+      "community": 7
     },
     {
       "label": "formatHour()",
@@ -4281,7 +4281,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/VisitorChart.tsx",
       "source_location": "L18",
       "id": "visitorchart_formathour",
-      "community": 0
+      "community": 7
     },
     {
       "label": "analytics-columns.tsx",
@@ -4297,7 +4297,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-row-actions.tsx",
       "source_location": "L1",
       "id": "data_table_row_actions",
-      "community": 8
+      "community": 0
     },
     {
       "label": "DataTableRowActions()",
@@ -4305,7 +4305,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-row-actions.tsx",
       "source_location": "L25",
       "id": "data_table_row_actions_datatablerowactions",
-      "community": 8
+      "community": 0
     },
     {
       "label": "selectable-data-provider.tsx",
@@ -4313,7 +4313,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
       "source_location": "L1",
       "id": "selectable_data_provider",
-      "community": 0
+      "community": 1
     },
     {
       "label": "SelectedProductsProvider()",
@@ -4321,7 +4321,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
       "source_location": "L16",
       "id": "selectable_data_provider_selectedproductsprovider",
-      "community": 0
+      "community": 1
     },
     {
       "label": "useSelectedProducts()",
@@ -4329,7 +4329,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
       "source_location": "L37",
       "id": "selectable_data_provider_useselectedproducts",
-      "community": 0
+      "community": 1
     },
     {
       "label": "columns.tsx",
@@ -4337,7 +4337,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/columns.tsx",
       "source_location": "L1",
       "id": "columns",
-      "community": 0
+      "community": 1
     },
     {
       "label": "chart.tsx",
@@ -4345,7 +4345,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/chart.tsx",
       "source_location": "L1",
       "id": "chart",
-      "community": 6
+      "community": 1
     },
     {
       "label": "data.ts",
@@ -4353,7 +4353,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data.ts",
       "source_location": "L1",
       "id": "data",
-      "community": 7
+      "community": 0
     },
     {
       "label": "groupAnalytics()",
@@ -4361,7 +4361,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
       "source_location": "L3",
       "id": "utils_groupanalytics",
-      "community": 0
+      "community": 1
     },
     {
       "label": "countGroupedAnalytics()",
@@ -4369,7 +4369,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
       "source_location": "L52",
       "id": "utils_countgroupedanalytics",
-      "community": 0
+      "community": 1
     },
     {
       "label": "groupProductViewsByDay()",
@@ -4377,7 +4377,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
       "source_location": "L90",
       "id": "utils_groupproductviewsbyday",
-      "community": 0
+      "community": 1
     },
     {
       "label": "LogItems.tsx",
@@ -4385,7 +4385,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/LogItems.tsx",
       "source_location": "L1",
       "id": "logitems",
-      "community": 6
+      "community": 1
     },
     {
       "label": "LogItems()",
@@ -4393,7 +4393,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/LogItems.tsx",
       "source_location": "L6",
       "id": "logitems_logitems",
-      "community": 6
+      "community": 1
     },
     {
       "label": "LogView.tsx",
@@ -4401,7 +4401,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/LogView.tsx",
       "source_location": "L1",
       "id": "logview",
-      "community": 7
+      "community": 0
     },
     {
       "label": "Header()",
@@ -4409,7 +4409,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/LogView.tsx",
       "source_location": "L10",
       "id": "logview_header",
-      "community": 7
+      "community": 0
     },
     {
       "label": "LogsView.tsx",
@@ -4417,7 +4417,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
       "source_location": "L1",
       "id": "logsview",
-      "community": 6
+      "community": 1
     },
     {
       "label": "Navigation()",
@@ -4425,7 +4425,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
       "source_location": "L27",
       "id": "logsview_navigation",
-      "community": 6
+      "community": 1
     },
     {
       "label": "log-items-provider.tsx",
@@ -4433,7 +4433,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
       "source_location": "L1",
       "id": "log_items_provider",
-      "community": 6
+      "community": 1
     },
     {
       "label": "LogItemsProvider()",
@@ -4441,7 +4441,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
       "source_location": "L15",
       "id": "log_items_provider_logitemsprovider",
-      "community": 6
+      "community": 1
     },
     {
       "label": "useLogItems()",
@@ -4449,7 +4449,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
       "source_location": "L39",
       "id": "log_items_provider_uselogitems",
-      "community": 6
+      "community": 1
     },
     {
       "label": "useLoadLogItems.ts",
@@ -4513,7 +4513,7 @@
       "source_file": "packages/storefront-webapp/src/components/DefaultCatchBoundary.tsx",
       "source_location": "L1",
       "id": "defaultcatchboundary",
-      "community": 4
+      "community": 11
     },
     {
       "label": "InputOTP.tsx",
@@ -4521,7 +4521,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
       "source_location": "L1",
       "id": "inputotp",
-      "community": 12
+      "community": 19
     },
     {
       "label": "handlePinChange()",
@@ -4529,7 +4529,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
       "source_location": "L48",
       "id": "inputotp_handlepinchange",
-      "community": 12
+      "community": 19
     },
     {
       "label": "onSubmit()",
@@ -4537,7 +4537,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
       "source_location": "L56",
       "id": "inputotp_onsubmit",
-      "community": 12
+      "community": 19
     },
     {
       "label": "LoginForm.tsx",
@@ -4561,7 +4561,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsFilters.tsx",
       "source_location": "L1",
       "id": "bulkoperationsfilters",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleLoadProducts()",
@@ -4569,7 +4569,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsFilters.tsx",
       "source_location": "L49",
       "id": "bulkoperationsfilters_handleloadproducts",
-      "community": 1
+      "community": 0
     },
     {
       "label": "BulkOperationsPage.tsx",
@@ -4585,7 +4585,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.test.tsx",
       "source_location": "L1",
       "id": "bulkoperationspreview_test",
-      "community": 12
+      "community": 8
     },
     {
       "label": "makeRow()",
@@ -4593,7 +4593,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.test.tsx",
       "source_location": "L23",
       "id": "bulkoperationspreview_test_makerow",
-      "community": 12
+      "community": 8
     },
     {
       "label": "BulkOperationsPreview.tsx",
@@ -4601,7 +4601,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.tsx",
       "source_location": "L1",
       "id": "bulkoperationspreview",
-      "community": 12
+      "community": 8
     },
     {
       "label": "formatPrice()",
@@ -4609,7 +4609,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.tsx",
       "source_location": "L50",
       "id": "bulkoperationspreview_formatprice",
-      "community": 12
+      "community": 8
     },
     {
       "label": "CashierManagement.tsx",
@@ -4617,7 +4617,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L1",
       "id": "cashiermanagement",
-      "community": 12
+      "community": 19
     },
     {
       "label": "normalizeNameSegment()",
@@ -4625,7 +4625,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L42",
       "id": "cashiermanagement_normalizenamesegment",
-      "community": 12
+      "community": 19
     },
     {
       "label": "buildUsername()",
@@ -4633,7 +4633,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L50",
       "id": "cashiermanagement_buildusername",
-      "community": 12
+      "community": 19
     },
     {
       "label": "handleSubmit()",
@@ -4641,7 +4641,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L109",
       "id": "cashiermanagement_handlesubmit",
-      "community": 12
+      "community": 19
     },
     {
       "label": "handlePinKeyDown()",
@@ -4649,7 +4649,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L169",
       "id": "cashiermanagement_handlepinkeydown",
-      "community": 12
+      "community": 19
     },
     {
       "label": "handleDelete()",
@@ -4657,7 +4657,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L320",
       "id": "cashiermanagement_handledelete",
-      "community": 12
+      "community": 19
     },
     {
       "label": "CheckoutSessionsTable.tsx",
@@ -4777,7 +4777,7 @@
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseCompletion.tsx",
       "source_location": "L1",
       "id": "expensecompletion",
-      "community": 3
+      "community": 5
     },
     {
       "label": "ExpenseView.tsx",
@@ -4785,7 +4785,7 @@
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
       "source_location": "L1",
       "id": "expenseview",
-      "community": 3
+      "community": 5
     },
     {
       "label": "handleSessionLoaded()",
@@ -4793,7 +4793,7 @@
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
       "source_location": "L60",
       "id": "expenseview_handlesessionloaded",
-      "community": 3
+      "community": 5
     },
     {
       "label": "resetAutoSessionInitialized()",
@@ -4801,7 +4801,7 @@
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
       "source_location": "L64",
       "id": "expenseview_resetautosessioninitialized",
-      "community": 3
+      "community": 5
     },
     {
       "label": "handleNewSession()",
@@ -4809,7 +4809,7 @@
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
       "source_location": "L68",
       "id": "expenseview_handlenewsession",
-      "community": 3
+      "community": 5
     },
     {
       "label": "handleCashierAuthenticated()",
@@ -4817,7 +4817,7 @@
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
       "source_location": "L86",
       "id": "expenseview_handlecashierauthenticated",
-      "community": 3
+      "community": 5
     },
     {
       "label": "handleBarcodeSubmit()",
@@ -4825,7 +4825,7 @@
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
       "source_location": "L295",
       "id": "expenseview_handlebarcodesubmit",
-      "community": 3
+      "community": 5
     },
     {
       "label": "handleClearCart()",
@@ -4833,7 +4833,7 @@
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
       "source_location": "L322",
       "id": "expenseview_handleclearcart",
-      "community": 3
+      "community": 5
     },
     {
       "label": "handleCompleteExpense()",
@@ -4841,7 +4841,7 @@
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
       "source_location": "L335",
       "id": "expenseview_handlecompleteexpense",
-      "community": 3
+      "community": 5
     },
     {
       "label": "handleNavigateBack()",
@@ -4849,7 +4849,7 @@
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
       "source_location": "L383",
       "id": "expenseview_handlenavigateback",
-      "community": 3
+      "community": 5
     },
     {
       "label": "BannerMessageEditor.tsx",
@@ -4985,7 +4985,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L1",
       "id": "heroheaderimageuploader",
-      "community": 11
+      "community": 15
     },
     {
       "label": "validateFile()",
@@ -4993,7 +4993,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L50",
       "id": "heroheaderimageuploader_validatefile",
-      "community": 11
+      "community": 15
     },
     {
       "label": "uploadImage()",
@@ -5001,7 +5001,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L67",
       "id": "heroheaderimageuploader_uploadimage",
-      "community": 11
+      "community": 15
     },
     {
       "label": "resetEditState()",
@@ -5009,7 +5009,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L95",
       "id": "heroheaderimageuploader_reseteditstate",
-      "community": 11
+      "community": 15
     },
     {
       "label": "handleEditClick()",
@@ -5017,7 +5017,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L108",
       "id": "heroheaderimageuploader_handleeditclick",
-      "community": 11
+      "community": 15
     },
     {
       "label": "handleFileSelect()",
@@ -5025,7 +5025,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L113",
       "id": "heroheaderimageuploader_handlefileselect",
-      "community": 11
+      "community": 15
     },
     {
       "label": "handleUpload()",
@@ -5033,7 +5033,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L127",
       "id": "heroheaderimageuploader_handleupload",
-      "community": 11
+      "community": 15
     },
     {
       "label": "handleRevert()",
@@ -5041,7 +5041,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L163",
       "id": "heroheaderimageuploader_handlerevert",
-      "community": 11
+      "community": 15
     },
     {
       "label": "EditModeButtons()",
@@ -5049,7 +5049,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L179",
       "id": "heroheaderimageuploader_editmodebuttons",
-      "community": 11
+      "community": 15
     },
     {
       "label": "ViewModeButton()",
@@ -5057,7 +5057,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L205",
       "id": "heroheaderimageuploader_viewmodebutton",
-      "community": 11
+      "community": 15
     },
     {
       "label": "HeroSectionTabs.tsx",
@@ -5273,7 +5273,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
       "source_location": "L1",
       "id": "videoplayer",
-      "community": 1
+      "community": 3
     },
     {
       "label": "VideoPlayer()",
@@ -5281,7 +5281,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
       "source_location": "L9",
       "id": "videoplayer_videoplayer",
-      "community": 1
+      "community": 3
     },
     {
       "label": "JoinTeam()",
@@ -5465,7 +5465,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderStatus.tsx",
       "source_location": "L1",
       "id": "orderstatus",
-      "community": 0
+      "community": 1
     },
     {
       "label": "OrderSummary.tsx",
@@ -5473,7 +5473,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/OrderSummary.tsx",
       "source_location": "L1",
       "id": "ordersummary",
-      "community": 3
+      "community": 5
     },
     {
       "label": "OrderView.tsx",
@@ -5505,7 +5505,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/Orders.tsx",
       "source_location": "L1",
       "id": "orders",
-      "community": 0
+      "community": 1
     },
     {
       "label": "OrdersView.tsx",
@@ -5513,7 +5513,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
       "source_location": "L1",
       "id": "ordersview",
-      "community": 7
+      "community": 10
     },
     {
       "label": "getTimeFilter()",
@@ -5521,7 +5521,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
       "source_location": "L35",
       "id": "ordersview_gettimefilter",
-      "community": 7
+      "community": 10
     },
     {
       "label": "PickupDetailsView.tsx",
@@ -5585,7 +5585,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar.tsx",
       "source_location": "L34",
       "id": "data_table_toolbar_handleclearfilters",
-      "community": 7
+      "community": 0
     },
     {
       "label": "orderColumns.tsx",
@@ -5593,7 +5593,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/orderColumns.tsx",
       "source_location": "L1",
       "id": "ordercolumns",
-      "community": 0
+      "community": 1
     },
     {
       "label": "if()",
@@ -5601,7 +5601,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/orderColumns.tsx",
       "source_location": "L89",
       "id": "ordercolumns_if",
-      "community": 0
+      "community": 1
     },
     {
       "label": "refundUtils.ts",
@@ -5609,7 +5609,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L1",
       "id": "refundutils",
-      "community": 6
+      "community": 24
     },
     {
       "label": "refundReducer()",
@@ -5617,7 +5617,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L31",
       "id": "refundutils_refundreducer",
-      "community": 6
+      "community": 24
     },
     {
       "label": "getAmountRefunded()",
@@ -5625,7 +5625,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L98",
       "id": "refundutils_getamountrefunded",
-      "community": 6
+      "community": 24
     },
     {
       "label": "getNetAmount()",
@@ -5633,7 +5633,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L106",
       "id": "refundutils_getnetamount",
-      "community": 6
+      "community": 24
     },
     {
       "label": "getAvailableItems()",
@@ -5641,7 +5641,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L115",
       "id": "refundutils_getavailableitems",
-      "community": 6
+      "community": 24
     },
     {
       "label": "calculateRefundAmount()",
@@ -5649,7 +5649,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L124",
       "id": "refundutils_calculaterefundamount",
-      "community": 6
+      "community": 24
     },
     {
       "label": "getItemsToRefund()",
@@ -5657,7 +5657,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L174",
       "id": "refundutils_getitemstorefund",
-      "community": 6
+      "community": 24
     },
     {
       "label": "validateRefund()",
@@ -5665,7 +5665,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L199",
       "id": "refundutils_validaterefund",
-      "community": 6
+      "community": 24
     },
     {
       "label": "shouldShowReturnToStock()",
@@ -5673,7 +5673,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L255",
       "id": "refundutils_shouldshowreturntostock",
-      "community": 6
+      "community": 24
     },
     {
       "label": "getOrderState()",
@@ -5681,7 +5681,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
       "source_location": "L1",
       "id": "utils_getorderstate",
-      "community": 0
+      "community": 1
     },
     {
       "label": "getAmountPaidForOrder()",
@@ -5689,7 +5689,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
       "source_location": "L108",
       "id": "utils_getamountpaidfororder",
-      "community": 0
+      "community": 1
     },
     {
       "label": "onSubmit()",
@@ -5705,7 +5705,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/inviteColumns.tsx",
       "source_location": "L1",
       "id": "invitecolumns",
-      "community": 0
+      "community": 1
     },
     {
       "label": "membersColumns.tsx",
@@ -5713,7 +5713,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/membersColumns.tsx",
       "source_location": "L1",
       "id": "memberscolumns",
-      "community": 0
+      "community": 1
     },
     {
       "label": "organization-switcher.tsx",
@@ -5753,7 +5753,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx",
       "source_location": "L1",
       "id": "cashierauthdialog",
-      "community": 12
+      "community": 0
     },
     {
       "label": "CashierView.tsx",
@@ -5761,7 +5761,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CashierView.tsx",
       "source_location": "L1",
       "id": "cashierview",
-      "community": 3
+      "community": 5
     },
     {
       "label": "handleSignOut()",
@@ -5769,7 +5769,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CashierView.tsx",
       "source_location": "L63",
       "id": "cashierview_handlesignout",
-      "community": 3
+      "community": 5
     },
     {
       "label": "CustomerInfoPanel.tsx",
@@ -5777,7 +5777,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
       "source_location": "L1",
       "id": "customerinfopanel",
-      "community": 3
+      "community": 5
     },
     {
       "label": "handleSelectCustomer()",
@@ -5785,7 +5785,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
       "source_location": "L59",
       "id": "customerinfopanel_handleselectcustomer",
-      "community": 3
+      "community": 5
     },
     {
       "label": "handleCreateCustomer()",
@@ -5793,7 +5793,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
       "source_location": "L77",
       "id": "customerinfopanel_handlecreatecustomer",
-      "community": 3
+      "community": 5
     },
     {
       "label": "handleStartEdit()",
@@ -5801,7 +5801,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
       "source_location": "L105",
       "id": "customerinfopanel_handlestartedit",
-      "community": 3
+      "community": 5
     },
     {
       "label": "handleSaveEdit()",
@@ -5809,7 +5809,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
       "source_location": "L115",
       "id": "customerinfopanel_handlesaveedit",
-      "community": 3
+      "community": 5
     },
     {
       "label": "handleCancelEdit()",
@@ -5817,7 +5817,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
       "source_location": "L146",
       "id": "customerinfopanel_handlecanceledit",
-      "community": 3
+      "community": 5
     },
     {
       "label": "clearCustomer()",
@@ -5825,7 +5825,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
       "source_location": "L155",
       "id": "customerinfopanel_clearcustomer",
-      "community": 3
+      "community": 5
     },
     {
       "label": "DebugProducts.tsx",
@@ -5881,7 +5881,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/NoResultsMessage.tsx",
       "source_location": "L1",
       "id": "noresultsmessage",
-      "community": 35
+      "community": 36
     },
     {
       "label": "NoResultsMessage()",
@@ -5889,7 +5889,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/NoResultsMessage.tsx",
       "source_location": "L7",
       "id": "noresultsmessage_noresultsmessage",
-      "community": 35
+      "community": 36
     },
     {
       "label": "handleCompleteTransaction()",
@@ -5897,7 +5897,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
       "source_location": "L128",
       "id": "ordersummary_handlecompletetransaction",
-      "community": 3
+      "community": 5
     },
     {
       "label": "handleSelectedPaymentMethod()",
@@ -5905,7 +5905,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
       "source_location": "L150",
       "id": "ordersummary_handleselectedpaymentmethod",
-      "community": 3
+      "community": 5
     },
     {
       "label": "handleNewTransaction()",
@@ -5913,7 +5913,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
       "source_location": "L162",
       "id": "ordersummary_handlenewtransaction",
-      "community": 3
+      "community": 5
     },
     {
       "label": "POSRegisterView.tsx",
@@ -5921,7 +5921,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/POSRegisterView.tsx",
       "source_location": "L1",
       "id": "posregisterview",
-      "community": 3
+      "community": 5
     },
     {
       "label": "handleSessionLoaded()",
@@ -5929,7 +5929,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/POSRegisterView.tsx",
       "source_location": "L83",
       "id": "posregisterview_handlesessionloaded",
-      "community": 3
+      "community": 5
     },
     {
       "label": "resetAutoSessionInitialized()",
@@ -5937,7 +5937,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/POSRegisterView.tsx",
       "source_location": "L87",
       "id": "posregisterview_resetautosessioninitialized",
-      "community": 3
+      "community": 5
     },
     {
       "label": "handleNewSession()",
@@ -5945,7 +5945,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/POSRegisterView.tsx",
       "source_location": "L92",
       "id": "posregisterview_handlenewsession",
-      "community": 3
+      "community": 5
     },
     {
       "label": "handleCashierAuthenticated()",
@@ -5953,7 +5953,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/POSRegisterView.tsx",
       "source_location": "L133",
       "id": "posregisterview_handlecashierauthenticated",
-      "community": 3
+      "community": 5
     },
     {
       "label": "handleBarcodeSubmit()",
@@ -5961,7 +5961,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/POSRegisterView.tsx",
       "source_location": "L606",
       "id": "posregisterview_handlebarcodesubmit",
-      "community": 3
+      "community": 5
     },
     {
       "label": "handleClearCart()",
@@ -5969,7 +5969,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/POSRegisterView.tsx",
       "source_location": "L678",
       "id": "posregisterview_handleclearcart",
-      "community": 3
+      "community": 5
     },
     {
       "label": "handleNavigateBack()",
@@ -5977,7 +5977,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/POSRegisterView.tsx",
       "source_location": "L709",
       "id": "posregisterview_handlenavigateback",
-      "community": 3
+      "community": 5
     },
     {
       "label": "PaymentView.tsx",
@@ -5985,7 +5985,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
       "source_location": "L1",
       "id": "paymentview",
-      "community": 3
+      "community": 5
     },
     {
       "label": "handleAddPayment()",
@@ -5993,7 +5993,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
       "source_location": "L178",
       "id": "paymentview_handleaddpayment",
-      "community": 3
+      "community": 5
     },
     {
       "label": "handleClearAll()",
@@ -6001,7 +6001,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
       "source_location": "L219",
       "id": "paymentview_handleclearall",
-      "community": 3
+      "community": 5
     },
     {
       "label": "handleAmountChange()",
@@ -6009,7 +6009,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
       "source_location": "L224",
       "id": "paymentview_handleamountchange",
-      "community": 3
+      "community": 5
     },
     {
       "label": "handleAmountBlur()",
@@ -6017,7 +6017,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
       "source_location": "L253",
       "id": "paymentview_handleamountblur",
-      "community": 3
+      "community": 5
     },
     {
       "label": "PaymentsAddedList.tsx",
@@ -6025,7 +6025,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L1",
       "id": "paymentsaddedlist",
-      "community": 3
+      "community": 5
     },
     {
       "label": "getPaymentMethodLabel()",
@@ -6033,7 +6033,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L18",
       "id": "paymentsaddedlist_getpaymentmethodlabel",
-      "community": 3
+      "community": 5
     },
     {
       "label": "handleStartEdit()",
@@ -6041,7 +6041,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L57",
       "id": "paymentsaddedlist_handlestartedit",
-      "community": 3
+      "community": 5
     },
     {
       "label": "handleSaveEdit()",
@@ -6049,7 +6049,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L62",
       "id": "paymentsaddedlist_handlesaveedit",
-      "community": 3
+      "community": 5
     },
     {
       "label": "handleCancelEdit()",
@@ -6057,7 +6057,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L93",
       "id": "paymentsaddedlist_handlecanceledit",
-      "community": 3
+      "community": 5
     },
     {
       "label": "handleRemovePayment()",
@@ -6065,7 +6065,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L98",
       "id": "paymentsaddedlist_handleremovepayment",
-      "community": 3
+      "community": 5
     },
     {
       "label": "PinInput.tsx",
@@ -6073,7 +6073,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
       "source_location": "L1",
       "id": "pininput",
-      "community": 12
+      "community": 19
     },
     {
       "label": "PinInput()",
@@ -6081,7 +6081,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
       "source_location": "L13",
       "id": "pininput_pininput",
-      "community": 12
+      "community": 19
     },
     {
       "label": "PointOfSaleView.tsx",
@@ -6105,7 +6105,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
       "source_location": "L1",
       "id": "printinstructions",
-      "community": 36
+      "community": 37
     },
     {
       "label": "PrintInstructions()",
@@ -6113,7 +6113,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
       "source_location": "L3",
       "id": "printinstructions_printinstructions",
-      "community": 36
+      "community": 37
     },
     {
       "label": "ProductCard.tsx",
@@ -6121,7 +6121,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductCard.tsx",
       "source_location": "L1",
       "id": "productcard",
-      "community": 6
+      "community": 1
     },
     {
       "label": "ProductCard()",
@@ -6129,7 +6129,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/ProductCard.tsx",
       "source_location": "L14",
       "id": "productcard_productcard",
-      "community": 6
+      "community": 1
     },
     {
       "label": "ProductEntry.tsx",
@@ -6137,7 +6137,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
       "source_location": "L1",
       "id": "productentry",
-      "community": 6
+      "community": 1
     },
     {
       "label": "handleClearSearch()",
@@ -6145,7 +6145,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
       "source_location": "L86",
       "id": "productentry_handleclearsearch",
-      "community": 6
+      "community": 1
     },
     {
       "label": "ProductLookup.tsx",
@@ -6153,7 +6153,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/ProductLookup.tsx",
       "source_location": "L1",
       "id": "productlookup",
-      "community": 6
+      "community": 1
     },
     {
       "label": "QuickActionsBar.tsx",
@@ -6161,7 +6161,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/QuickActionsBar.tsx",
       "source_location": "L1",
       "id": "quickactionsbar",
-      "community": 3
+      "community": 5
     },
     {
       "label": "QuickActionsBar()",
@@ -6169,7 +6169,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/QuickActionsBar.tsx",
       "source_location": "L11",
       "id": "quickactionsbar_quickactionsbar",
-      "community": 3
+      "community": 5
     },
     {
       "label": "RegisterActions.tsx",
@@ -6177,7 +6177,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/RegisterActions.tsx",
       "source_location": "L1",
       "id": "registeractions",
-      "community": 3
+      "community": 5
     },
     {
       "label": "SearchResultsSection.tsx",
@@ -6185,7 +6185,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SearchResultsSection.tsx",
       "source_location": "L1",
       "id": "searchresultssection",
-      "community": 6
+      "community": 1
     },
     {
       "label": "SessionDemo.tsx",
@@ -6193,7 +6193,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionDemo.tsx",
       "source_location": "L1",
       "id": "sessiondemo",
-      "community": 0
+      "community": 7
     },
     {
       "label": "SessionDemo()",
@@ -6201,7 +6201,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionDemo.tsx",
       "source_location": "L15",
       "id": "sessiondemo_sessiondemo",
-      "community": 0
+      "community": 7
     },
     {
       "label": "SessionManager.tsx",
@@ -6209,7 +6209,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
       "source_location": "L1",
       "id": "sessionmanager",
-      "community": 3
+      "community": 5
     },
     {
       "label": "onHoldConfirm()",
@@ -6217,7 +6217,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
       "source_location": "L72",
       "id": "sessionmanager_onholdconfirm",
-      "community": 3
+      "community": 5
     },
     {
       "label": "onResumeSession()",
@@ -6225,7 +6225,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
       "source_location": "L77",
       "id": "sessionmanager_onresumesession",
-      "community": 3
+      "community": 5
     },
     {
       "label": "onVoidConfirm()",
@@ -6233,7 +6233,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
       "source_location": "L90",
       "id": "sessionmanager_onvoidconfirm",
-      "community": 3
+      "community": 5
     },
     {
       "label": "onNewSessionClick()",
@@ -6241,7 +6241,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
       "source_location": "L96",
       "id": "sessionmanager_onnewsessionclick",
-      "community": 3
+      "community": 5
     },
     {
       "label": "TotalsDisplay.tsx",
@@ -6249,7 +6249,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.tsx",
       "source_location": "L1",
       "id": "totalsdisplay",
-      "community": 3
+      "community": 5
     },
     {
       "label": "TotalsDisplay()",
@@ -6257,7 +6257,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.tsx",
       "source_location": "L12",
       "id": "totalsdisplay_totalsdisplay",
-      "community": 3
+      "community": 5
     },
     {
       "label": "ExpenseReportView.tsx",
@@ -6297,7 +6297,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
       "source_location": "L1",
       "id": "hooks",
-      "community": 4
+      "community": 3
     },
     {
       "label": "usePOSCashier()",
@@ -6305,7 +6305,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/hooks.ts",
       "source_location": "L5",
       "id": "hooks_useposcashier",
-      "community": 4
+      "community": 3
     },
     {
       "label": "HeldSessionsList.tsx",
@@ -6313,7 +6313,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx",
       "source_location": "L1",
       "id": "heldsessionslist",
-      "community": 3
+      "community": 5
     },
     {
       "label": "hasExpired()",
@@ -6321,7 +6321,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx",
       "source_location": "L54",
       "id": "heldsessionslist_hasexpired",
-      "community": 3
+      "community": 5
     },
     {
       "label": "getSessionCartItemsCount()",
@@ -6329,7 +6329,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx",
       "source_location": "L58",
       "id": "heldsessionslist_getsessioncartitemscount",
-      "community": 3
+      "community": 5
     },
     {
       "label": "HoldSessionDialog.tsx",
@@ -6433,7 +6433,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
       "source_location": "L1",
       "id": "transactioncolumns",
-      "community": 0
+      "community": 1
     },
     {
       "label": "getPaymentMethodIcon()",
@@ -6441,7 +6441,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
       "source_location": "L22",
       "id": "transactioncolumns_getpaymentmethodicon",
-      "community": 0
+      "community": 1
     },
     {
       "label": "AnalyticsInsights.tsx",
@@ -6529,7 +6529,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ProductStatus.tsx",
       "source_location": "L1",
       "id": "productstatus",
-      "community": 0
+      "community": 1
     },
     {
       "label": "ProductStockStatus()",
@@ -6777,7 +6777,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/complimentaryProductsColumn.tsx",
       "source_location": "L1",
       "id": "complimentaryproductscolumn",
-      "community": 0
+      "community": 1
     },
     {
       "label": "add-product-command.tsx",
@@ -6785,7 +6785,7 @@
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/add-product-command.tsx",
       "source_location": "L1",
       "id": "add_product_command",
-      "community": 1
+      "community": 0
     },
     {
       "label": "AddProductCommand()",
@@ -6793,7 +6793,7 @@
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/add-product-command.tsx",
       "source_location": "L17",
       "id": "add_product_command_addproductcommand",
-      "community": 1
+      "community": 0
     },
     {
       "label": "productColumns.tsx",
@@ -6897,7 +6897,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L1",
       "id": "promocodes",
-      "community": 25
+      "community": 2
     },
     {
       "label": "PromoCodesView.tsx",
@@ -6921,7 +6921,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/SelectableCategories.tsx",
       "source_location": "L1",
       "id": "selectablecategories",
-      "community": 12
+      "community": 1
     },
     {
       "label": "toggle()",
@@ -6929,7 +6929,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/SelectableCategories.tsx",
       "source_location": "L23",
       "id": "selectablecategories_toggle",
-      "community": 12
+      "community": 1
     },
     {
       "label": "DiscountTypeToggleGroup.tsx",
@@ -6937,7 +6937,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/DiscountTypeToggleGroup.tsx",
       "source_location": "L1",
       "id": "discounttypetogglegroup",
-      "community": 6
+      "community": 1
     },
     {
       "label": "DiscountTypeToggleGroup()",
@@ -6945,7 +6945,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/DiscountTypeToggleGroup.tsx",
       "source_location": "L5",
       "id": "discounttypetogglegroup_discounttypetogglegroup",
-      "community": 6
+      "community": 1
     },
     {
       "label": "PromoCodeSpanToggleGroup.tsx",
@@ -6953,7 +6953,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/PromoCodeSpanToggleGroup.tsx",
       "source_location": "L1",
       "id": "promocodespantogglegroup",
-      "community": 6
+      "community": 1
     },
     {
       "label": "PromoCodeSpanToggleGroup()",
@@ -6961,7 +6961,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/PromoCodeSpanToggleGroup.tsx",
       "source_location": "L4",
       "id": "promocodespantogglegroup_promocodespantogglegroup",
-      "community": 6
+      "community": 1
     },
     {
       "label": "PromoCodeAnalytics.tsx",
@@ -6993,7 +6993,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/captured/captured-emails-columns.tsx",
       "source_location": "L1",
       "id": "captured_emails_columns",
-      "community": 0
+      "community": 1
     },
     {
       "label": "color-picker.tsx",
@@ -7001,7 +7001,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
       "source_location": "L1",
       "id": "color_picker",
-      "community": 11
+      "community": 1
     },
     {
       "label": "handleInputChange()",
@@ -7009,7 +7009,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
       "source_location": "L20",
       "id": "color_picker_handleinputchange",
-      "community": 11
+      "community": 1
     },
     {
       "label": "handleBlur()",
@@ -7017,7 +7017,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
       "source_location": "L24",
       "id": "color_picker_handleblur",
-      "community": 11
+      "community": 1
     },
     {
       "label": "promo-code-modal.tsx",
@@ -7025,7 +7025,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/promo-code-modal.tsx",
       "source_location": "L1",
       "id": "promo_code_modal",
-      "community": 11
+      "community": 1
     },
     {
       "label": "PromoCodeModal()",
@@ -7033,7 +7033,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/promo-code-modal.tsx",
       "source_location": "L29",
       "id": "promo_code_modal_promocodemodal",
-      "community": 11
+      "community": 1
     },
     {
       "label": "welcome-offer-modal.tsx",
@@ -7041,7 +7041,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L1",
       "id": "welcome_offer_modal",
-      "community": 11
+      "community": 15
     },
     {
       "label": "handleChange()",
@@ -7049,7 +7049,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L76",
       "id": "welcome_offer_modal_handlechange",
-      "community": 11
+      "community": 15
     },
     {
       "label": "handleNumberChange()",
@@ -7057,7 +7057,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L83",
       "id": "welcome_offer_modal_handlenumberchange",
-      "community": 11
+      "community": 15
     },
     {
       "label": "handleSwitchChange()",
@@ -7065,7 +7065,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L88",
       "id": "welcome_offer_modal_handleswitchchange",
-      "community": 11
+      "community": 15
     },
     {
       "label": "handleColorChange()",
@@ -7073,7 +7073,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L92",
       "id": "welcome_offer_modal_handlecolorchange",
-      "community": 11
+      "community": 15
     },
     {
       "label": "handleSelectChange()",
@@ -7081,7 +7081,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L96",
       "id": "welcome_offer_modal_handleselectchange",
-      "community": 11
+      "community": 15
     },
     {
       "label": "updateImages()",
@@ -7089,7 +7089,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L100",
       "id": "welcome_offer_modal_updateimages",
-      "community": 11
+      "community": 15
     },
     {
       "label": "handleSubmit()",
@@ -7097,7 +7097,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L104",
       "id": "welcome_offer_modal_handlesubmit",
-      "community": 11
+      "community": 15
     },
     {
       "label": "welcome-offer-card.tsx",
@@ -7113,7 +7113,7 @@
       "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
       "source_location": "L1",
       "id": "currency_provider",
-      "community": 1
+      "community": 20
     },
     {
       "label": "useStoreCurrency()",
@@ -7121,7 +7121,7 @@
       "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
       "source_location": "L17",
       "id": "currency_provider_usestorecurrency",
-      "community": 1
+      "community": 20
     },
     {
       "label": "CurrencyProvider()",
@@ -7129,7 +7129,7 @@
       "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
       "source_location": "L25",
       "id": "currency_provider_currencyprovider",
-      "community": 1
+      "community": 20
     },
     {
       "label": "RatingStars.tsx",
@@ -7137,7 +7137,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/RatingStars.tsx",
       "source_location": "L1",
       "id": "ratingstars",
-      "community": 6
+      "community": 9
     },
     {
       "label": "ReviewActions.tsx",
@@ -7145,7 +7145,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewActions.tsx",
       "source_location": "L1",
       "id": "reviewactions",
-      "community": 6
+      "community": 9
     },
     {
       "label": "ReviewActions()",
@@ -7153,7 +7153,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewActions.tsx",
       "source_location": "L20",
       "id": "reviewactions_reviewactions",
-      "community": 6
+      "community": 9
     },
     {
       "label": "ReviewCard.tsx",
@@ -7161,7 +7161,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewCard.tsx",
       "source_location": "L1",
       "id": "reviewcard",
-      "community": 6
+      "community": 9
     },
     {
       "label": "ReviewMetadata.tsx",
@@ -7169,7 +7169,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewMetadata.tsx",
       "source_location": "L1",
       "id": "reviewmetadata",
-      "community": 6
+      "community": 9
     },
     {
       "label": "ReviewsView.tsx",
@@ -7177,7 +7177,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L1",
       "id": "reviewsview",
-      "community": 6
+      "community": 9
     },
     {
       "label": "Header()",
@@ -7185,7 +7185,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L13",
       "id": "reviewsview_header",
-      "community": 6
+      "community": 9
     },
     {
       "label": "handleApprove()",
@@ -7193,7 +7193,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L42",
       "id": "reviewsview_handleapprove",
-      "community": 6
+      "community": 9
     },
     {
       "label": "handleReject()",
@@ -7201,7 +7201,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L58",
       "id": "reviewsview_handlereject",
-      "community": 6
+      "community": 9
     },
     {
       "label": "handlePublish()",
@@ -7209,7 +7209,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L74",
       "id": "reviewsview_handlepublish",
-      "community": 6
+      "community": 9
     },
     {
       "label": "handleUnpublish()",
@@ -7217,7 +7217,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L90",
       "id": "reviewsview_handleunpublish",
-      "community": 6
+      "community": 9
     },
     {
       "label": "empty-state.tsx",
@@ -7241,7 +7241,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/error/SingleLineError.tsx",
       "source_location": "L1",
       "id": "singlelineerror",
-      "community": 37
+      "community": 38
     },
     {
       "label": "SingleLineError()",
@@ -7249,7 +7249,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/error/SingleLineError.tsx",
       "source_location": "L3",
       "id": "singlelineerror_singlelineerror",
-      "community": 37
+      "community": 38
     },
     {
       "label": "ErrorPage()",
@@ -7329,7 +7329,7 @@
       "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermission.tsx",
       "source_location": "L1",
       "id": "nopermission",
-      "community": 7
+      "community": 10
     },
     {
       "label": "NoPermission()",
@@ -7337,7 +7337,7 @@
       "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermission.tsx",
       "source_location": "L3",
       "id": "nopermission_nopermission",
-      "community": 7
+      "community": 10
     },
     {
       "label": "NoPermissionView.tsx",
@@ -7345,7 +7345,7 @@
       "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermissionView.tsx",
       "source_location": "L1",
       "id": "nopermissionview",
-      "community": 7
+      "community": 10
     },
     {
       "label": "NoPermissionView()",
@@ -7353,7 +7353,7 @@
       "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermissionView.tsx",
       "source_location": "L4",
       "id": "nopermissionview_nopermissionview",
-      "community": 7
+      "community": 10
     },
     {
       "label": "NotFound.tsx",
@@ -7361,7 +7361,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/not-found/NotFound.tsx",
       "source_location": "L1",
       "id": "notfound",
-      "community": 1
+      "community": 3
     },
     {
       "label": "NotFound()",
@@ -7369,7 +7369,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/not-found/NotFound.tsx",
       "source_location": "L4",
       "id": "notfound_notfound",
-      "community": 1
+      "community": 3
     },
     {
       "label": "NotFoundView.tsx",
@@ -7377,7 +7377,7 @@
       "source_file": "packages/athena-webapp/src/components/states/not-found/NotFoundView.tsx",
       "source_location": "L1",
       "id": "notfoundview",
-      "community": 7
+      "community": 10
     },
     {
       "label": "NotFoundView()",
@@ -7385,7 +7385,7 @@
       "source_file": "packages/athena-webapp/src/components/states/not-found/NotFoundView.tsx",
       "source_location": "L4",
       "id": "notfoundview_notfoundview",
-      "community": 7
+      "community": 10
     },
     {
       "label": "ContactView.tsx",
@@ -7433,7 +7433,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L1",
       "id": "fulfillmentview",
-      "community": 16
+      "community": 9
     },
     {
       "label": "saveEnableStorePickupChanges()",
@@ -7441,7 +7441,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L43",
       "id": "fulfillmentview_saveenablestorepickupchanges",
-      "community": 16
+      "community": 9
     },
     {
       "label": "saveEnableDeliveryChanges()",
@@ -7449,7 +7449,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L75",
       "id": "fulfillmentview_saveenabledeliverychanges",
-      "community": 16
+      "community": 9
     },
     {
       "label": "savePickupRestriction()",
@@ -7457,7 +7457,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L107",
       "id": "fulfillmentview_savepickuprestriction",
-      "community": 16
+      "community": 9
     },
     {
       "label": "saveDeliveryRestriction()",
@@ -7465,7 +7465,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L132",
       "id": "fulfillmentview_savedeliveryrestriction",
-      "community": 16
+      "community": 9
     },
     {
       "label": "handlePickupRestrictionToggle()",
@@ -7473,7 +7473,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L157",
       "id": "fulfillmentview_handlepickuprestrictiontoggle",
-      "community": 16
+      "community": 9
     },
     {
       "label": "handleDeliveryRestrictionToggle()",
@@ -7481,7 +7481,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L196",
       "id": "fulfillmentview_handledeliveryrestrictiontoggle",
-      "community": 16
+      "community": 9
     },
     {
       "label": "handleSavePickupRestriction()",
@@ -7489,7 +7489,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L235",
       "id": "fulfillmentview_handlesavepickuprestriction",
-      "community": 16
+      "community": 9
     },
     {
       "label": "handleSaveDeliveryRestriction()",
@@ -7497,7 +7497,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L244",
       "id": "fulfillmentview_handlesavedeliveryrestriction",
-      "community": 16
+      "community": 9
     },
     {
       "label": "Header.tsx",
@@ -7537,7 +7537,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.test.tsx",
       "source_location": "L1",
       "id": "mtnmomoview_test",
-      "community": 9
+      "community": 7
     },
     {
       "label": "MtnMomoView.tsx",
@@ -7545,7 +7545,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L1",
       "id": "mtnmomoview",
-      "community": 9
+      "community": 7
     },
     {
       "label": "cloneReceivingAccount()",
@@ -7553,7 +7553,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L27",
       "id": "mtnmomoview_clonereceivingaccount",
-      "community": 9
+      "community": 7
     },
     {
       "label": "createEmptyReceivingAccount()",
@@ -7561,7 +7561,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L35",
       "id": "mtnmomoview_createemptyreceivingaccount",
-      "community": 9
+      "community": 7
     },
     {
       "label": "trimToUndefined()",
@@ -7569,7 +7569,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L47",
       "id": "mtnmomoview_trimtoundefined",
-      "community": 9
+      "community": 7
     },
     {
       "label": "cleanUndefinedFields()",
@@ -7577,7 +7577,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L52",
       "id": "mtnmomoview_cleanundefinedfields",
-      "community": 9
+      "community": 7
     },
     {
       "label": "hasReceivingAccountDetails()",
@@ -7585,7 +7585,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L64",
       "id": "mtnmomoview_hasreceivingaccountdetails",
-      "community": 9
+      "community": 7
     },
     {
       "label": "normalizePrimaryAccounts()",
@@ -7593,7 +7593,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L77",
       "id": "mtnmomoview_normalizeprimaryaccounts",
-      "community": 9
+      "community": 7
     },
     {
       "label": "toPatchReceivingAccounts()",
@@ -7601,7 +7601,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L93",
       "id": "mtnmomoview_topatchreceivingaccounts",
-      "community": 9
+      "community": 7
     },
     {
       "label": "getStatusBadgeVariant()",
@@ -7609,7 +7609,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L114",
       "id": "mtnmomoview_getstatusbadgevariant",
-      "community": 9
+      "community": 7
     },
     {
       "label": "updateAccount()",
@@ -7617,7 +7617,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L141",
       "id": "mtnmomoview_updateaccount",
-      "community": 9
+      "community": 7
     },
     {
       "label": "handleAddAccount()",
@@ -7625,7 +7625,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L152",
       "id": "mtnmomoview_handleaddaccount",
-      "community": 9
+      "community": 7
     },
     {
       "label": "handleMakePrimary()",
@@ -7633,7 +7633,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L159",
       "id": "mtnmomoview_handlemakeprimary",
-      "community": 9
+      "community": 7
     },
     {
       "label": "handleRemoveAccount()",
@@ -7641,7 +7641,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L168",
       "id": "mtnmomoview_handleremoveaccount",
-      "community": 9
+      "community": 7
     },
     {
       "label": "handleSave()",
@@ -7649,7 +7649,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L188",
       "id": "mtnmomoview_handlesave",
-      "community": 9
+      "community": 7
     },
     {
       "label": "TaxView.tsx",
@@ -7689,7 +7689,7 @@
       "source_file": "packages/athena-webapp/src/components/store-switcher.tsx",
       "source_location": "L1",
       "id": "store_switcher",
-      "community": 1
+      "community": 20
     },
     {
       "label": "onStoreSelect()",
@@ -7697,7 +7697,7 @@
       "source_file": "packages/athena-webapp/src/components/store-switcher.tsx",
       "source_location": "L63",
       "id": "store_switcher_onstoreselect",
-      "community": 1
+      "community": 20
     },
     {
       "label": "accordion.tsx",
@@ -7705,7 +7705,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/accordion.tsx",
       "source_location": "L1",
       "id": "accordion",
-      "community": 1
+      "community": 0
     },
     {
       "label": "app-context-menu.tsx",
@@ -7713,7 +7713,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/app-context-menu.tsx",
       "source_location": "L1",
       "id": "app_context_menu",
-      "community": 11
+      "community": 15
     },
     {
       "label": "AppContextMenu()",
@@ -7721,7 +7721,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/app-context-menu.tsx",
       "source_location": "L20",
       "id": "app_context_menu_appcontextmenu",
-      "community": 11
+      "community": 15
     },
     {
       "label": "badge.tsx",
@@ -7729,7 +7729,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/badge.tsx",
       "source_location": "L1",
       "id": "badge",
-      "community": 0
+      "community": 1
     },
     {
       "label": "Badge()",
@@ -7737,7 +7737,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/badge.tsx",
       "source_location": "L30",
       "id": "badge_badge",
-      "community": 0
+      "community": 1
     },
     {
       "label": "button.test.tsx",
@@ -7745,7 +7745,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/button.test.tsx",
       "source_location": "L1",
       "id": "button_test",
-      "community": 1
+      "community": 0
     },
     {
       "label": "button.tsx",
@@ -7753,7 +7753,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/button.tsx",
       "source_location": "L1",
       "id": "button",
-      "community": 1
+      "community": 0
     },
     {
       "label": "calendar.test.tsx",
@@ -7777,7 +7777,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/card.tsx",
       "source_location": "L1",
       "id": "card",
-      "community": 0
+      "community": 7
     },
     {
       "label": "useChart()",
@@ -7785,7 +7785,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/chart.tsx",
       "source_location": "L25",
       "id": "chart_usechart",
-      "community": 6
+      "community": 1
     },
     {
       "label": "checkbox.tsx",
@@ -7793,7 +7793,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/checkbox.tsx",
       "source_location": "L1",
       "id": "checkbox",
-      "community": 12
+      "community": 1
     },
     {
       "label": "collapsible.tsx",
@@ -7801,7 +7801,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/collapsible.tsx",
       "source_location": "L1",
       "id": "collapsible",
-      "community": 64
+      "community": 66
     },
     {
       "label": "command.tsx",
@@ -7809,7 +7809,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/command.tsx",
       "source_location": "L1",
       "id": "command",
-      "community": 1
+      "community": 0
     },
     {
       "label": "context-menu.tsx",
@@ -7817,7 +7817,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/context-menu.tsx",
       "source_location": "L1",
       "id": "context_menu",
-      "community": 11
+      "community": 15
     },
     {
       "label": "copy-button.tsx",
@@ -7897,7 +7897,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/icons.tsx",
       "source_location": "L1",
       "id": "icons",
-      "community": 1
+      "community": 20
     },
     {
       "label": "image-uploader.tsx",
@@ -7905,7 +7905,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1",
       "id": "image_uploader",
-      "community": 11
+      "community": 15
     },
     {
       "label": "onDrop()",
@@ -7913,7 +7913,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L20",
       "id": "image_uploader_ondrop",
-      "community": 11
+      "community": 15
     },
     {
       "label": "removeImage()",
@@ -7921,7 +7921,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L31",
       "id": "image_uploader_removeimage",
-      "community": 11
+      "community": 15
     },
     {
       "label": "unmarkForDeletion()",
@@ -7929,7 +7929,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L46",
       "id": "image_uploader_unmarkfordeletion",
-      "community": 11
+      "community": 15
     },
     {
       "label": "onDragEnd()",
@@ -7937,7 +7937,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L100",
       "id": "image_uploader_ondragend",
-      "community": 11
+      "community": 15
     },
     {
       "label": "input-otp.tsx",
@@ -7945,7 +7945,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/input-otp.tsx",
       "source_location": "L1",
       "id": "input_otp",
-      "community": 12
+      "community": 19
     },
     {
       "label": "input.tsx",
@@ -8017,7 +8017,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/alert-modal.tsx",
       "source_location": "L1",
       "id": "alert_modal",
-      "community": 8
+      "community": 0
     },
     {
       "label": "AlertModal()",
@@ -8025,7 +8025,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/alert-modal.tsx",
       "source_location": "L20",
       "id": "alert_modal_alertmodal",
-      "community": 8
+      "community": 0
     },
     {
       "label": "custom-modal-example.tsx",
@@ -8033,7 +8033,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
       "source_location": "L1",
       "id": "custom_modal_example",
-      "community": 11
+      "community": 15
     },
     {
       "label": "BasicModalExample()",
@@ -8041,7 +8041,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
       "source_location": "L7",
       "id": "custom_modal_example_basicmodalexample",
-      "community": 11
+      "community": 15
     },
     {
       "label": "CustomPositionModalExample()",
@@ -8049,7 +8049,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
       "source_location": "L44",
       "id": "custom_modal_example_custompositionmodalexample",
-      "community": 11
+      "community": 15
     },
     {
       "label": "CustomCloseButtonExample()",
@@ -8057,7 +8057,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
       "source_location": "L69",
       "id": "custom_modal_example_customclosebuttonexample",
-      "community": 11
+      "community": 15
     },
     {
       "label": "FullScreenModalExample()",
@@ -8065,7 +8065,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
       "source_location": "L103",
       "id": "custom_modal_example_fullscreenmodalexample",
-      "community": 11
+      "community": 15
     },
     {
       "label": "custom-modal.tsx",
@@ -8073,7 +8073,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
       "source_location": "L1",
       "id": "custom_modal",
-      "community": 11
+      "community": 15
     },
     {
       "label": "CustomModal()",
@@ -8081,7 +8081,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
       "source_location": "L25",
       "id": "custom_modal_custommodal",
-      "community": 11
+      "community": 15
     },
     {
       "label": "organization-modal.tsx",
@@ -8121,7 +8121,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/store-modal.tsx",
       "source_location": "L1",
       "id": "store_modal",
-      "community": 1
+      "community": 0
     },
     {
       "label": "onSubmit()",
@@ -8129,7 +8129,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/store-modal.tsx",
       "source_location": "L63",
       "id": "store_modal_onsubmit",
-      "community": 1
+      "community": 0
     },
     {
       "label": "welcome-back-modal-example.tsx",
@@ -8137,7 +8137,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal-example.tsx",
       "source_location": "L1",
       "id": "welcome_back_modal_example",
-      "community": 11
+      "community": 15
     },
     {
       "label": "WelcomeBackModalExample()",
@@ -8145,7 +8145,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal-example.tsx",
       "source_location": "L5",
       "id": "welcome_back_modal_example_welcomebackmodalexample",
-      "community": 11
+      "community": 15
     },
     {
       "label": "welcome-back-modal.tsx",
@@ -8153,7 +8153,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal.tsx",
       "source_location": "L1",
       "id": "welcome_back_modal",
-      "community": 11
+      "community": 15
     },
     {
       "label": "WelcomeBackModal()",
@@ -8161,7 +8161,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal.tsx",
       "source_location": "L12",
       "id": "welcome_back_modal_welcomebackmodal",
-      "community": 11
+      "community": 15
     },
     {
       "label": "popover.tsx",
@@ -8177,7 +8177,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/radio-group.tsx",
       "source_location": "L1",
       "id": "radio_group",
-      "community": 0
+      "community": 1
     },
     {
       "label": "scroll-area.tsx",
@@ -8193,7 +8193,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/select-native.tsx",
       "source_location": "L1",
       "id": "select_native",
-      "community": 0
+      "community": 1
     },
     {
       "label": "cn()",
@@ -8201,7 +8201,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/select-native.tsx",
       "source_location": "L15",
       "id": "select_native_cn",
-      "community": 0
+      "community": 1
     },
     {
       "label": "select.tsx",
@@ -8313,7 +8313,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/spinner.tsx",
       "source_location": "L1",
       "id": "spinner",
-      "community": 1
+      "community": 20
     },
     {
       "label": "Spinner()",
@@ -8321,7 +8321,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/spinner.tsx",
       "source_location": "L3",
       "id": "spinner_spinner",
-      "community": 1
+      "community": 20
     },
     {
       "label": "switch.tsx",
@@ -8337,7 +8337,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/table.tsx",
       "source_location": "L1",
       "id": "table",
-      "community": 12
+      "community": 8
     },
     {
       "label": "tabs.tsx",
@@ -8361,7 +8361,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/timeline-item.tsx",
       "source_location": "L1",
       "id": "timeline_item",
-      "community": 38
+      "community": 39
     },
     {
       "label": "TimelineItem()",
@@ -8369,7 +8369,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/timeline-item.tsx",
       "source_location": "L3",
       "id": "timeline_item_timelineitem",
-      "community": 38
+      "community": 39
     },
     {
       "label": "toggle-group.tsx",
@@ -8377,7 +8377,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/toggle-group.tsx",
       "source_location": "L1",
       "id": "toggle_group",
-      "community": 0
+      "community": 1
     },
     {
       "label": "toggle.tsx",
@@ -8385,7 +8385,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/toggle.tsx",
       "source_location": "L1",
       "id": "toggle",
-      "community": 0
+      "community": 1
     },
     {
       "label": "tooltip.tsx",
@@ -8401,7 +8401,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/webp-image.tsx",
       "source_location": "L1",
       "id": "webp_image",
-      "community": 39
+      "community": 40
     },
     {
       "label": "WebpImage()",
@@ -8409,7 +8409,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/webp-image.tsx",
       "source_location": "L1",
       "id": "webp_image_webpimage",
-      "community": 39
+      "community": 40
     },
     {
       "label": "upload-button.tsx",
@@ -8425,7 +8425,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/BagItems.tsx",
       "source_location": "L1",
       "id": "bagitems",
-      "community": 0
+      "community": 1
     },
     {
       "label": "BagItems()",
@@ -8433,7 +8433,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/BagItems.tsx",
       "source_location": "L5",
       "id": "bagitems_bagitems",
-      "community": 0
+      "community": 1
     },
     {
       "label": "BagItemsView.tsx",
@@ -8465,7 +8465,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
       "source_location": "L1",
       "id": "bags",
-      "community": 0
+      "community": 1
     },
     {
       "label": "Bags()",
@@ -8473,7 +8473,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
       "source_location": "L4",
       "id": "bags_bags",
-      "community": 0
+      "community": 1
     },
     {
       "label": "bag-columns.tsx",
@@ -8481,7 +8481,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bag-columns.tsx",
       "source_location": "L1",
       "id": "bag_columns",
-      "community": 0
+      "community": 1
     },
     {
       "label": "bags-table.tsx",
@@ -8489,7 +8489,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bags-table.tsx",
       "source_location": "L1",
       "id": "bags_table",
-      "community": 0
+      "community": 8
     },
     {
       "label": "ActivitySummaryCards.tsx",
@@ -8497,7 +8497,7 @@
       "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
       "source_location": "L1",
       "id": "activitysummarycards",
-      "community": 6
+      "community": 7
     },
     {
       "label": "SummaryCard()",
@@ -8505,7 +8505,7 @@
       "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
       "source_location": "L19",
       "id": "activitysummarycards_summarycard",
-      "community": 6
+      "community": 7
     },
     {
       "label": "ActivitySummaryCards()",
@@ -8513,7 +8513,7 @@
       "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
       "source_location": "L44",
       "id": "activitysummarycards_activitysummarycards",
-      "community": 6
+      "community": 7
     },
     {
       "label": "String()",
@@ -8521,7 +8521,7 @@
       "source_file": "packages/athena-webapp/src/components/users/CustomerBehaviorTimeline.tsx",
       "source_location": "L110",
       "id": "customerbehaviortimeline_string",
-      "community": 13
+      "community": 7
     },
     {
       "label": "LinkedAccounts.tsx",
@@ -8537,7 +8537,7 @@
       "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.test.tsx",
       "source_location": "L1",
       "id": "timelineeventcard_test",
-      "community": 13
+      "community": 7
     },
     {
       "label": "TimelineEventCard.tsx",
@@ -8545,7 +8545,7 @@
       "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
       "source_location": "L1",
       "id": "timelineeventcard",
-      "community": 13
+      "community": 7
     },
     {
       "label": "formatObservabilityLabel()",
@@ -8553,7 +8553,7 @@
       "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
       "source_location": "L139",
       "id": "timelineeventcard_formatobservabilitylabel",
-      "community": 13
+      "community": 7
     },
     {
       "label": "loadMore()",
@@ -8561,7 +8561,7 @@
       "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
       "source_location": "L175",
       "id": "timelineeventcard_loadmore",
-      "community": 13
+      "community": 7
     },
     {
       "label": "UserActivity.tsx",
@@ -8657,7 +8657,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserStatus.tsx",
       "source_location": "L1",
       "id": "userstatus",
-      "community": 0
+      "community": 1
     },
     {
       "label": "UserStatus()",
@@ -8665,7 +8665,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserStatus.tsx",
       "source_location": "L7",
       "id": "userstatus_userstatus",
-      "community": 0
+      "community": 1
     },
     {
       "label": "UserView.tsx",
@@ -8689,7 +8689,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/CustomerJourneyStage.tsx",
       "source_location": "L1",
       "id": "customerjourneystage",
-      "community": 13
+      "community": 7
     },
     {
       "label": "CustomerJourneyStageCard()",
@@ -8697,7 +8697,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/CustomerJourneyStage.tsx",
       "source_location": "L13",
       "id": "customerjourneystage_customerjourneystagecard",
-      "community": 13
+      "community": 7
     },
     {
       "label": "EngagementMetrics.tsx",
@@ -8705,7 +8705,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
       "source_location": "L1",
       "id": "engagementmetrics",
-      "community": 13
+      "community": 7
     },
     {
       "label": "formatLastActivity()",
@@ -8713,7 +8713,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
       "source_location": "L75",
       "id": "engagementmetrics_formatlastactivity",
-      "community": 13
+      "community": 7
     },
     {
       "label": "getDeviceIcon()",
@@ -8721,7 +8721,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
       "source_location": "L82",
       "id": "engagementmetrics_getdeviceicon",
-      "community": 13
+      "community": 7
     },
     {
       "label": "getDeviceLabel()",
@@ -8729,7 +8729,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
       "source_location": "L93",
       "id": "engagementmetrics_getdevicelabel",
-      "community": 13
+      "community": 7
     },
     {
       "label": "RiskIndicators.tsx",
@@ -8737,7 +8737,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
       "source_location": "L1",
       "id": "riskindicators",
-      "community": 13
+      "community": 7
     },
     {
       "label": "getRiskIcon()",
@@ -8745,7 +8745,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
       "source_location": "L15",
       "id": "riskindicators_getriskicon",
-      "community": 13
+      "community": 7
     },
     {
       "label": "getRiskStyles()",
@@ -8753,7 +8753,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
       "source_location": "L28",
       "id": "riskindicators_getriskstyles",
-      "community": 13
+      "community": 7
     },
     {
       "label": "RiskIndicators()",
@@ -8761,7 +8761,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
       "source_location": "L54",
       "id": "riskindicators_riskindicators",
-      "community": 13
+      "community": 7
     },
     {
       "label": "UserBehaviorInsights.tsx",
@@ -8769,7 +8769,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/UserBehaviorInsights.tsx",
       "source_location": "L1",
       "id": "userbehaviorinsights",
-      "community": 13
+      "community": 7
     },
     {
       "label": "OnlineOrderContext.tsx",
@@ -8801,7 +8801,7 @@
       "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
       "source_location": "L1",
       "id": "permissionscontext",
-      "community": 6
+      "community": 0
     },
     {
       "label": "PermissionsProvider()",
@@ -8809,7 +8809,7 @@
       "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
       "source_location": "L23",
       "id": "permissionscontext_permissionsprovider",
-      "community": 6
+      "community": 0
     },
     {
       "label": "usePermissionsContext()",
@@ -8817,7 +8817,7 @@
       "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
       "source_location": "L51",
       "id": "permissionscontext_usepermissionscontext",
-      "community": 6
+      "community": 0
     },
     {
       "label": "ProductContext.tsx",
@@ -8849,7 +8849,7 @@
       "source_file": "packages/athena-webapp/src/contexts/ThemeContext.tsx",
       "source_location": "L1",
       "id": "themecontext",
-      "community": 65
+      "community": 67
     },
     {
       "label": "UserContext.tsx",
@@ -8857,7 +8857,7 @@
       "source_file": "packages/athena-webapp/src/contexts/UserContext.tsx",
       "source_location": "L1",
       "id": "usercontext",
-      "community": 1
+      "community": 20
     },
     {
       "label": "UserProvider()",
@@ -8865,7 +8865,7 @@
       "source_file": "packages/athena-webapp/src/contexts/UserContext.tsx",
       "source_location": "L12",
       "id": "usercontext_userprovider",
-      "community": 1
+      "community": 20
     },
     {
       "label": "useUserContext()",
@@ -8873,7 +8873,7 @@
       "source_file": "packages/athena-webapp/src/contexts/UserContext.tsx",
       "source_location": "L37",
       "id": "usercontext_useusercontext",
-      "community": 1
+      "community": 20
     },
     {
       "label": "use-image-upload.ts",
@@ -8929,7 +8929,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-navigation-keyboard-shortcuts.ts",
       "source_location": "L1",
       "id": "use_navigation_keyboard_shortcuts",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useNavigationKeyboardShortcuts()",
@@ -8937,7 +8937,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-navigation-keyboard-shortcuts.ts",
       "source_location": "L7",
       "id": "use_navigation_keyboard_shortcuts_usenavigationkeyboardshortcuts",
-      "community": 4
+      "community": 3
     },
     {
       "label": "use-pagination-persistence.ts",
@@ -8961,7 +8961,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/use-store-modal.tsx",
       "source_location": "L1",
       "id": "use_store_modal",
-      "community": 1
+      "community": 0
     },
     {
       "label": "use-table-keyboard-pagination.ts",
@@ -8969,7 +8969,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-table-keyboard-pagination.ts",
       "source_location": "L1",
       "id": "use_table_keyboard_pagination",
-      "community": 0
+      "community": 8
     },
     {
       "label": "useTableKeyboardPagination()",
@@ -8977,7 +8977,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-table-keyboard-pagination.ts",
       "source_location": "L6",
       "id": "use_table_keyboard_pagination_usetablekeyboardpagination",
-      "community": 0
+      "community": 8
     },
     {
       "label": "useAuth.ts",
@@ -8985,7 +8985,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useAuth.ts",
       "source_location": "L1",
       "id": "useauth",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useAuth()",
@@ -8993,7 +8993,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useAuth.ts",
       "source_location": "L4",
       "id": "useauth_useauth",
-      "community": 1
+      "community": 0
     },
     {
       "label": "useBulkOperations.test.ts",
@@ -9001,7 +9001,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.test.ts",
       "source_location": "L1",
       "id": "usebulkoperations_test",
-      "community": 12
+      "community": 8
     },
     {
       "label": "makeSku()",
@@ -9009,7 +9009,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.test.ts",
       "source_location": "L168",
       "id": "usebulkoperations_test_makesku",
-      "community": 12
+      "community": 8
     },
     {
       "label": "useBulkOperations.ts",
@@ -9017,7 +9017,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L1",
       "id": "usebulkoperations",
-      "community": 12
+      "community": 8
     },
     {
       "label": "applyOperation()",
@@ -9025,7 +9025,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L56",
       "id": "usebulkoperations_applyoperation",
-      "community": 12
+      "community": 8
     },
     {
       "label": "calculatePriceWithFee()",
@@ -9033,7 +9033,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L87",
       "id": "usebulkoperations_calculatepricewithfee",
-      "community": 12
+      "community": 8
     },
     {
       "label": "computePreview()",
@@ -9041,7 +9041,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L101",
       "id": "usebulkoperations_computepreview",
-      "community": 12
+      "community": 8
     },
     {
       "label": "validateOperationValue()",
@@ -9049,7 +9049,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L139",
       "id": "usebulkoperations_validateoperationvalue",
-      "community": 12
+      "community": 8
     },
     {
       "label": "useBulkOperations()",
@@ -9057,7 +9057,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L158",
       "id": "usebulkoperations_usebulkoperations",
-      "community": 12
+      "community": 8
     },
     {
       "label": "useCartOperations.ts",
@@ -9065,7 +9065,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useCartOperations.ts",
       "source_location": "L1",
       "id": "usecartoperations",
-      "community": 3
+      "community": 5
     },
     {
       "label": "useCartOperations()",
@@ -9073,7 +9073,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useCartOperations.ts",
       "source_location": "L23",
       "id": "usecartoperations_usecartoperations",
-      "community": 3
+      "community": 5
     },
     {
       "label": "useCopyText.ts",
@@ -9113,7 +9113,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useCustomerOperations.ts",
       "source_location": "L1",
       "id": "usecustomeroperations",
-      "community": 3
+      "community": 5
     },
     {
       "label": "useCustomerOperations()",
@@ -9121,7 +9121,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useCustomerOperations.ts",
       "source_location": "L21",
       "id": "usecustomeroperations_usecustomeroperations",
-      "community": 3
+      "community": 5
     },
     {
       "label": "useDebounce.ts",
@@ -9129,7 +9129,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useDebounce.ts",
       "source_location": "L1",
       "id": "usedebounce",
-      "community": 3
+      "community": 5
     },
     {
       "label": "useDebounce()",
@@ -9137,7 +9137,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useDebounce.ts",
       "source_location": "L12",
       "id": "usedebounce_usedebounce",
-      "community": 3
+      "community": 5
     },
     {
       "label": "useExpenseOperations.ts",
@@ -9145,7 +9145,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
       "source_location": "L1",
       "id": "useexpenseoperations",
-      "community": 3
+      "community": 5
     },
     {
       "label": "useExpenseOperations()",
@@ -9153,7 +9153,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
       "source_location": "L23",
       "id": "useexpenseoperations_useexpenseoperations",
-      "community": 3
+      "community": 5
     },
     {
       "label": "useExpenseSessions.ts",
@@ -9161,7 +9161,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L1",
       "id": "useexpensesessions",
-      "community": 3
+      "community": 5
     },
     {
       "label": "useExpenseStoreSessions()",
@@ -9169,7 +9169,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L7",
       "id": "useexpensesessions_useexpensestoresessions",
-      "community": 3
+      "community": 5
     },
     {
       "label": "useExpenseSession()",
@@ -9177,7 +9177,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L23",
       "id": "useexpensesessions_useexpensesession",
-      "community": 3
+      "community": 5
     },
     {
       "label": "useExpenseActiveSession()",
@@ -9185,7 +9185,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L33",
       "id": "useexpensesessions_useexpenseactivesession",
-      "community": 3
+      "community": 5
     },
     {
       "label": "useExpenseSessionCreate()",
@@ -9193,7 +9193,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L48",
       "id": "useexpensesessions_useexpensesessioncreate",
-      "community": 3
+      "community": 5
     },
     {
       "label": "useExpenseSessionUpdate()",
@@ -9201,7 +9201,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L85",
       "id": "useexpensesessions_useexpensesessionupdate",
-      "community": 3
+      "community": 5
     },
     {
       "label": "useGetActiveProduct.ts",
@@ -9417,7 +9417,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L1",
       "id": "useposcustomers",
-      "community": 3
+      "community": 5
     },
     {
       "label": "usePOSCustomerSearch()",
@@ -9425,7 +9425,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L7",
       "id": "useposcustomers_useposcustomersearch",
-      "community": 3
+      "community": 5
     },
     {
       "label": "usePOSCustomer()",
@@ -9433,7 +9433,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L18",
       "id": "useposcustomers_useposcustomer",
-      "community": 3
+      "community": 5
     },
     {
       "label": "usePOSCustomerCreate()",
@@ -9441,7 +9441,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L26",
       "id": "useposcustomers_useposcustomercreate",
-      "community": 3
+      "community": 5
     },
     {
       "label": "usePOSCustomerUpdate()",
@@ -9449,7 +9449,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L57",
       "id": "useposcustomers_useposcustomerupdate",
-      "community": 3
+      "community": 5
     },
     {
       "label": "usePOSCustomerTransactions()",
@@ -9457,7 +9457,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L90",
       "id": "useposcustomers_useposcustomertransactions",
-      "community": 3
+      "community": 5
     },
     {
       "label": "usePOSOperations.ts",
@@ -9465,7 +9465,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSOperations.ts",
       "source_location": "L1",
       "id": "useposoperations",
-      "community": 3
+      "community": 5
     },
     {
       "label": "usePOSOperations()",
@@ -9473,7 +9473,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSOperations.ts",
       "source_location": "L30",
       "id": "useposoperations_useposoperations",
-      "community": 3
+      "community": 5
     },
     {
       "label": "usePOSState()",
@@ -9481,7 +9481,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSOperations.ts",
       "source_location": "L580",
       "id": "useposoperations_useposstate",
-      "community": 3
+      "community": 5
     },
     {
       "label": "usePOSProducts.ts",
@@ -9489,7 +9489,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L1",
       "id": "useposproducts",
-      "community": 6
+      "community": 5
     },
     {
       "label": "usePOSProductSearch()",
@@ -9497,7 +9497,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L10",
       "id": "useposproducts_useposproductsearch",
-      "community": 6
+      "community": 5
     },
     {
       "label": "usePOSBarcodeSearch()",
@@ -9505,7 +9505,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L30",
       "id": "useposproducts_useposbarcodesearch",
-      "community": 6
+      "community": 5
     },
     {
       "label": "usePOSProductIdSearch()",
@@ -9513,7 +9513,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L41",
       "id": "useposproducts_useposproductidsearch",
-      "community": 6
+      "community": 5
     },
     {
       "label": "usePOSTransactionComplete()",
@@ -9521,7 +9521,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L100",
       "id": "useposproducts_usepostransactioncomplete",
-      "community": 6
+      "community": 5
     },
     {
       "label": "usePOSSessions.ts",
@@ -9529,7 +9529,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L1",
       "id": "usepossessions",
-      "community": 3
+      "community": 5
     },
     {
       "label": "usePOSStoreSessions()",
@@ -9537,7 +9537,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L8",
       "id": "usepossessions_useposstoresessions",
-      "community": 3
+      "community": 5
     },
     {
       "label": "usePOSSession()",
@@ -9545,7 +9545,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L24",
       "id": "usepossessions_usepossession",
-      "community": 3
+      "community": 5
     },
     {
       "label": "usePOSActiveSession()",
@@ -9553,7 +9553,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L32",
       "id": "usepossessions_useposactivesession",
-      "community": 3
+      "community": 5
     },
     {
       "label": "usePOSSessionCreate()",
@@ -9561,7 +9561,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L47",
       "id": "usepossessions_usepossessioncreate",
-      "community": 3
+      "community": 5
     },
     {
       "label": "usePOSSessionUpdate()",
@@ -9569,7 +9569,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L82",
       "id": "usepossessions_usepossessionupdate",
-      "community": 3
+      "community": 5
     },
     {
       "label": "usePOSSessionHold()",
@@ -9577,7 +9577,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L117",
       "id": "usepossessions_usepossessionhold",
-      "community": 3
+      "community": 5
     },
     {
       "label": "usePOSSessionResume()",
@@ -9585,7 +9585,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L137",
       "id": "usepossessions_usepossessionresume",
-      "community": 3
+      "community": 5
     },
     {
       "label": "usePOSSessionComplete()",
@@ -9593,7 +9593,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L157",
       "id": "usepossessions_usepossessioncomplete",
-      "community": 3
+      "community": 5
     },
     {
       "label": "usePOSSessionVoid()",
@@ -9601,7 +9601,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L191",
       "id": "usepossessions_usepossessionvoid",
-      "community": 3
+      "community": 5
     },
     {
       "label": "usePOSSessionManager()",
@@ -9609,7 +9609,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L207",
       "id": "usepossessions_usepossessionmanager",
-      "community": 3
+      "community": 5
     },
     {
       "label": "usePermissions.ts",
@@ -9617,7 +9617,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePermissions.ts",
       "source_location": "L1",
       "id": "usepermissions",
-      "community": 6
+      "community": 0
     },
     {
       "label": "usePermissions()",
@@ -9625,7 +9625,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePermissions.ts",
       "source_location": "L12",
       "id": "usepermissions_usepermissions",
-      "community": 6
+      "community": 0
     },
     {
       "label": "usePrint.ts",
@@ -9633,7 +9633,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
       "source_location": "L1",
       "id": "useprint",
-      "community": 3
+      "community": 5
     },
     {
       "label": "usePrint()",
@@ -9641,7 +9641,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
       "source_location": "L3",
       "id": "useprint_useprint",
-      "community": 3
+      "community": 5
     },
     {
       "label": "useProductSearchResults.ts",
@@ -9649,7 +9649,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
       "source_location": "L1",
       "id": "useproductsearchresults",
-      "community": 6
+      "community": 1
     },
     {
       "label": "useProductSearchResults()",
@@ -9657,7 +9657,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
       "source_location": "L26",
       "id": "useproductsearchresults_useproductsearchresults",
-      "community": 6
+      "community": 1
     },
     {
       "label": "useProductWithNoImagesNotification.tsx",
@@ -9681,7 +9681,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSessionManagement.ts",
       "source_location": "L1",
       "id": "usesessionmanagement",
-      "community": 3
+      "community": 5
     },
     {
       "label": "useSessionManagement()",
@@ -9689,7 +9689,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSessionManagement.ts",
       "source_location": "L17",
       "id": "usesessionmanagement_usesessionmanagement",
-      "community": 3
+      "community": 5
     },
     {
       "label": "useSessionManagementExpense.ts",
@@ -9697,7 +9697,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSessionManagementExpense.ts",
       "source_location": "L1",
       "id": "usesessionmanagementexpense",
-      "community": 3
+      "community": 5
     },
     {
       "label": "useSessionManagementExpense()",
@@ -9705,7 +9705,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSessionManagementExpense.ts",
       "source_location": "L17",
       "id": "usesessionmanagementexpense_usesessionmanagementexpense",
-      "community": 3
+      "community": 5
     },
     {
       "label": "useSessionManagerOperations.ts",
@@ -9713,7 +9713,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSessionManagerOperations.ts",
       "source_location": "L1",
       "id": "usesessionmanageroperations",
-      "community": 3
+      "community": 5
     },
     {
       "label": "useSessionManagerOperations()",
@@ -9721,7 +9721,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSessionManagerOperations.ts",
       "source_location": "L16",
       "id": "usesessionmanageroperations_usesessionmanageroperations",
-      "community": 3
+      "community": 5
     },
     {
       "label": "useSkusReservedInCheckout.ts",
@@ -9777,7 +9777,7 @@
       "source_file": "packages/athena-webapp/src/lib/aws.ts",
       "source_location": "L1",
       "id": "aws",
-      "community": 66
+      "community": 68
     },
     {
       "label": "behaviorUtils.ts",
@@ -9785,7 +9785,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L1",
       "id": "behaviorutils",
-      "community": 13
+      "community": 7
     },
     {
       "label": "getCustomerJourneyStage()",
@@ -9793,7 +9793,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L36",
       "id": "behaviorutils_getcustomerjourneystage",
-      "community": 13
+      "community": 7
     },
     {
       "label": "calculateRiskIndicators()",
@@ -9801,7 +9801,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L71",
       "id": "behaviorutils_calculateriskindicators",
-      "community": 13
+      "community": 7
     },
     {
       "label": "calculateEngagementMetrics()",
@@ -9809,7 +9809,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L173",
       "id": "behaviorutils_calculateengagementmetrics",
-      "community": 13
+      "community": 7
     },
     {
       "label": "getActivityPriority()",
@@ -9817,7 +9817,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L251",
       "id": "behaviorutils_getactivitypriority",
-      "community": 13
+      "community": 7
     },
     {
       "label": "getJourneyStageInfo()",
@@ -9825,7 +9825,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L277",
       "id": "behaviorutils_getjourneystageinfo",
-      "community": 13
+      "community": 7
     },
     {
       "label": "browserFingerprint.ts",
@@ -9833,7 +9833,7 @@
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
       "source_location": "L1",
       "id": "browserfingerprint",
-      "community": 26
+      "community": 27
     },
     {
       "label": "bufferToHex()",
@@ -9841,7 +9841,7 @@
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
       "source_location": "L18",
       "id": "browserfingerprint_buffertohex",
-      "community": 26
+      "community": 27
     },
     {
       "label": "collectBrowserInfo()",
@@ -9849,7 +9849,7 @@
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
       "source_location": "L23",
       "id": "browserfingerprint_collectbrowserinfo",
-      "community": 26
+      "community": 27
     },
     {
       "label": "hashFingerprintSource()",
@@ -9857,7 +9857,7 @@
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
       "source_location": "L45",
       "id": "browserfingerprint_hashfingerprintsource",
-      "community": 26
+      "community": 27
     },
     {
       "label": "generateBrowserFingerprint()",
@@ -9865,7 +9865,7 @@
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
       "source_location": "L65",
       "id": "browserfingerprint_generatebrowserfingerprint",
-      "community": 26
+      "community": 27
     },
     {
       "label": "customerObservabilityTimeline.ts",
@@ -9873,7 +9873,7 @@
       "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
       "source_location": "L1",
       "id": "customerobservabilitytimeline",
-      "community": 13
+      "community": 7
     },
     {
       "label": "formatObservabilityLabel()",
@@ -9881,7 +9881,7 @@
       "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
       "source_location": "L59",
       "id": "customerobservabilitytimeline_formatobservabilitylabel",
-      "community": 13
+      "community": 7
     },
     {
       "label": "getObservabilityStatusStyles()",
@@ -9889,7 +9889,7 @@
       "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
       "source_location": "L67",
       "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
-      "community": 13
+      "community": 7
     },
     {
       "label": "getDeviceIcon()",
@@ -9897,7 +9897,7 @@
       "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
       "source_location": "L114",
       "id": "customerobservabilitytimeline_getdeviceicon",
-      "community": 13
+      "community": 7
     },
     {
       "label": "ghanaRegions.ts",
@@ -9913,7 +9913,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
       "source_location": "L1",
       "id": "imageutils_test",
-      "community": 11
+      "community": 15
     },
     {
       "label": "constructor()",
@@ -9921,7 +9921,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
       "source_location": "L74",
       "id": "imageutils_test_constructor",
-      "community": 11
+      "community": 15
     },
     {
       "label": "arrayBuffer()",
@@ -9929,7 +9929,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
       "source_location": "L78",
       "id": "imageutils_test_arraybuffer",
-      "community": 11
+      "community": 15
     },
     {
       "label": "MockImage",
@@ -9937,7 +9937,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
       "source_location": "L103",
       "id": "imageutils_test_mockimage",
-      "community": 11
+      "community": 15
     },
     {
       "label": ".src()",
@@ -9945,7 +9945,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
       "source_location": "L109",
       "id": "imageutils_test_mockimage_src",
-      "community": 11
+      "community": 15
     },
     {
       "label": "imageUtils.ts",
@@ -9953,7 +9953,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
       "source_location": "L1",
       "id": "imageutils",
-      "community": 11
+      "community": 15
     },
     {
       "label": "getUploadImagesData()",
@@ -9961,7 +9961,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
       "source_location": "L4",
       "id": "imageutils_getuploadimagesdata",
-      "community": 11
+      "community": 15
     },
     {
       "label": "convertImagesToWebp()",
@@ -9969,7 +9969,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
       "source_location": "L26",
       "id": "imageutils_convertimagestowebp",
-      "community": 11
+      "community": 15
     },
     {
       "label": "convertToJpg()",
@@ -9977,7 +9977,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
       "source_location": "L38",
       "id": "imageutils_converttojpg",
-      "community": 11
+      "community": 15
     },
     {
       "label": "convertImagesToJpg()",
@@ -9985,7 +9985,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
       "source_location": "L75",
       "id": "imageutils_convertimagestojpg",
-      "community": 11
+      "community": 15
     },
     {
       "label": "logger.ts",
@@ -9993,7 +9993,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L1",
       "id": "logger",
-      "community": 3
+      "community": 5
     },
     {
       "label": "Logger",
@@ -10001,7 +10001,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L12",
       "id": "logger_logger",
-      "community": 3
+      "community": 5
     },
     {
       "label": ".constructor()",
@@ -10009,7 +10009,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L15",
       "id": "logger_logger_constructor",
-      "community": 3
+      "community": 5
     },
     {
       "label": ".shouldLog()",
@@ -10017,7 +10017,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L20",
       "id": "logger_logger_shouldlog",
-      "community": 3
+      "community": 5
     },
     {
       "label": ".formatMessage()",
@@ -10025,7 +10025,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L30",
       "id": "logger_logger_formatmessage",
-      "community": 3
+      "community": 5
     },
     {
       "label": ".debug()",
@@ -10033,7 +10033,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L45",
       "id": "logger_logger_debug",
-      "community": 3
+      "community": 5
     },
     {
       "label": ".info()",
@@ -10041,7 +10041,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L51",
       "id": "logger_logger_info",
-      "community": 3
+      "community": 5
     },
     {
       "label": ".warn()",
@@ -10049,7 +10049,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L57",
       "id": "logger_logger_warn",
-      "community": 3
+      "community": 5
     },
     {
       "label": ".error()",
@@ -10057,7 +10057,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L63",
       "id": "logger_logger_error",
-      "community": 3
+      "community": 5
     },
     {
       "label": "maintenanceUtils.ts",
@@ -10065,7 +10065,7 @@
       "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.ts",
       "source_location": "L1",
       "id": "maintenanceutils",
-      "community": 16
+      "community": 3
     },
     {
       "label": "isInMaintenanceMode()",
@@ -10073,7 +10073,7 @@
       "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.ts",
       "source_location": "L7",
       "id": "maintenanceutils_isinmaintenancemode",
-      "community": 16
+      "community": 3
     },
     {
       "label": "navigationUtils.ts",
@@ -10097,7 +10097,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
       "source_location": "L1",
       "id": "barcodeutils",
-      "community": 6
+      "community": 5
     },
     {
       "label": "isValidConvexId()",
@@ -10105,7 +10105,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
       "source_location": "L16",
       "id": "barcodeutils_isvalidconvexid",
-      "community": 6
+      "community": 5
     },
     {
       "label": "extractBarcodeFromInput()",
@@ -10113,7 +10113,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
       "source_location": "L51",
       "id": "barcodeutils_extractbarcodefrominput",
-      "community": 6
+      "community": 5
     },
     {
       "label": "isUrlOrBarcode()",
@@ -10121,7 +10121,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
       "source_location": "L92",
       "id": "barcodeutils_isurlorbarcode",
-      "community": 6
+      "community": 5
     },
     {
       "label": "calculations.ts",
@@ -10129,7 +10129,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/calculations.ts",
       "source_location": "L1",
       "id": "calculations",
-      "community": 6
+      "community": 1
     },
     {
       "label": "calculateCartTotals()",
@@ -10137,7 +10137,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/calculations.ts",
       "source_location": "L10",
       "id": "calculations_calculatecarttotals",
-      "community": 6
+      "community": 1
     },
     {
       "label": "calculationService.ts",
@@ -10145,7 +10145,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
       "source_location": "L1",
       "id": "calculationservice",
-      "community": 3
+      "community": 5
     },
     {
       "label": "calculateCartTotals()",
@@ -10153,7 +10153,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
       "source_location": "L30",
       "id": "calculationservice_calculatecarttotals",
-      "community": 3
+      "community": 5
     },
     {
       "label": "calculateItemTotal()",
@@ -10161,7 +10161,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
       "source_location": "L61",
       "id": "calculationservice_calculateitemtotal",
-      "community": 3
+      "community": 5
     },
     {
       "label": "calculateChange()",
@@ -10169,7 +10169,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
       "source_location": "L68",
       "id": "calculationservice_calculatechange",
-      "community": 3
+      "community": 5
     },
     {
       "label": "formatCurrency()",
@@ -10177,7 +10177,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
       "source_location": "L75",
       "id": "calculationservice_formatcurrency",
-      "community": 3
+      "community": 5
     },
     {
       "label": "isPaymentSufficient()",
@@ -10185,7 +10185,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
       "source_location": "L85",
       "id": "calculationservice_ispaymentsufficient",
-      "community": 3
+      "community": 5
     },
     {
       "label": "getEffectivePrice()",
@@ -10193,7 +10193,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
       "source_location": "L96",
       "id": "calculationservice_geteffectiveprice",
-      "community": 3
+      "community": 5
     },
     {
       "label": "toastService.ts",
@@ -10201,7 +10201,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L1",
       "id": "toastservice",
-      "community": 3
+      "community": 5
     },
     {
       "label": "handlePOSOperation()",
@@ -10209,7 +10209,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L171",
       "id": "toastservice_handleposoperation",
-      "community": 3
+      "community": 5
     },
     {
       "label": "showValidationError()",
@@ -10217,7 +10217,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L293",
       "id": "toastservice_showvalidationerror",
-      "community": 3
+      "community": 5
     },
     {
       "label": "showInventoryError()",
@@ -10225,7 +10225,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L302",
       "id": "toastservice_showinventoryerror",
-      "community": 3
+      "community": 5
     },
     {
       "label": "showSessionExpiredError()",
@@ -10233,7 +10233,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L312",
       "id": "toastservice_showsessionexpirederror",
-      "community": 3
+      "community": 5
     },
     {
       "label": "showNoActiveSessionError()",
@@ -10241,7 +10241,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L319",
       "id": "toastservice_shownoactivesessionerror",
-      "community": 3
+      "community": 5
     },
     {
       "label": "transactionUtils.ts",
@@ -10249,7 +10249,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
       "source_location": "L1",
       "id": "transactionutils",
-      "community": 3
+      "community": 5
     },
     {
       "label": "generateTransactionNumber()",
@@ -10257,7 +10257,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
       "source_location": "L14",
       "id": "transactionutils_generatetransactionnumber",
-      "community": 3
+      "community": 5
     },
     {
       "label": "formatCurrency()",
@@ -10265,7 +10265,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
       "source_location": "L29",
       "id": "transactionutils_formatcurrency",
-      "community": 3
+      "community": 5
     },
     {
       "label": "calculateChange()",
@@ -10273,7 +10273,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
       "source_location": "L42",
       "id": "transactionutils_calculatechange",
-      "community": 3
+      "community": 5
     },
     {
       "label": "formatTimestamp()",
@@ -10281,7 +10281,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
       "source_location": "L49",
       "id": "transactionutils_formattimestamp",
-      "community": 3
+      "community": 5
     },
     {
       "label": "validation.ts",
@@ -10289,7 +10289,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L1",
       "id": "validation",
-      "community": 3
+      "community": 5
     },
     {
       "label": "validateCart()",
@@ -10297,7 +10297,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L21",
       "id": "validation_validatecart",
-      "community": 3
+      "community": 5
     },
     {
       "label": "validateProduct()",
@@ -10305,7 +10305,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L68",
       "id": "validation_validateproduct",
-      "community": 3
+      "community": 5
     },
     {
       "label": "validateCustomer()",
@@ -10313,7 +10313,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L108",
       "id": "validation_validatecustomer",
-      "community": 3
+      "community": 5
     },
     {
       "label": "validatePayment()",
@@ -10321,7 +10321,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L146",
       "id": "validation_validatepayment",
-      "community": 3
+      "community": 5
     },
     {
       "label": "validateBarcode()",
@@ -10329,7 +10329,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L185",
       "id": "validation_validatebarcode",
-      "community": 3
+      "community": 5
     },
     {
       "label": "validateQuantity()",
@@ -10337,7 +10337,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L213",
       "id": "validation_validatequantity",
-      "community": 3
+      "community": 5
     },
     {
       "label": "isValidEmail()",
@@ -10345,7 +10345,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L244",
       "id": "validation_isvalidemail",
-      "community": 3
+      "community": 5
     },
     {
       "label": "validateSession()",
@@ -10353,7 +10353,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L252",
       "id": "validation_validatesession",
-      "community": 3
+      "community": 5
     },
     {
       "label": "isValidPhone()",
@@ -10361,7 +10361,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L304",
       "id": "validation_isvalidphone",
-      "community": 3
+      "community": 5
     },
     {
       "label": "validatePaymentAmount()",
@@ -10369,7 +10369,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L317",
       "id": "validation_validatepaymentamount",
-      "community": 3
+      "community": 5
     },
     {
       "label": "validatePayments()",
@@ -10377,7 +10377,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L359",
       "id": "validation_validatepayments",
-      "community": 3
+      "community": 5
     },
     {
       "label": "canCompleteTransaction()",
@@ -10385,7 +10385,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L404",
       "id": "validation_cancompletetransaction",
-      "community": 3
+      "community": 5
     },
     {
       "label": "productUtils.test.ts",
@@ -10393,7 +10393,7 @@
       "source_file": "packages/athena-webapp/src/lib/productUtils.test.ts",
       "source_location": "L1",
       "id": "productutils_test",
-      "community": 1
+      "community": 3
     },
     {
       "label": "productUtils.ts",
@@ -10401,7 +10401,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L1",
       "id": "productutils",
-      "community": 1
+      "community": 3
     },
     {
       "label": "getProductName()",
@@ -10409,7 +10409,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L18",
       "id": "productutils_getproductname",
-      "community": 1
+      "community": 3
     },
     {
       "label": "sortProduct()",
@@ -10417,7 +10417,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L66",
       "id": "productutils_sortproduct",
-      "community": 1
+      "community": 3
     },
     {
       "label": "pinHash.ts",
@@ -10425,7 +10425,7 @@
       "source_file": "packages/athena-webapp/src/lib/security/pinHash.ts",
       "source_location": "L1",
       "id": "pinhash",
-      "community": 12
+      "community": 19
     },
     {
       "label": "hashPin()",
@@ -10433,7 +10433,7 @@
       "source_file": "packages/athena-webapp/src/lib/security/pinHash.ts",
       "source_location": "L12",
       "id": "pinhash_hashpin",
-      "community": 12
+      "community": 19
     },
     {
       "label": "storeConfig.test.ts",
@@ -10441,7 +10441,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.test.ts",
       "source_location": "L1",
       "id": "storeconfig_test",
-      "community": 16
+      "community": 3
     },
     {
       "label": "storeConfig.ts",
@@ -10449,7 +10449,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L1",
       "id": "storeconfig",
-      "community": 16
+      "community": 3
     },
     {
       "label": "asRecord()",
@@ -10457,7 +10457,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L103",
       "id": "storeconfig_asrecord",
-      "community": 16
+      "community": 3
     },
     {
       "label": "asString()",
@@ -10465,7 +10465,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L111",
       "id": "storeconfig_asstring",
-      "community": 16
+      "community": 3
     },
     {
       "label": "asNumber()",
@@ -10473,7 +10473,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L114",
       "id": "storeconfig_asnumber",
-      "community": 16
+      "community": 3
     },
     {
       "label": "asBoolean()",
@@ -10481,7 +10481,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L117",
       "id": "storeconfig_asboolean",
-      "community": 16
+      "community": 3
     },
     {
       "label": "asOptionalArray()",
@@ -10489,7 +10489,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L132",
       "id": "storeconfig_asoptionalarray",
-      "community": 16
+      "community": 3
     },
     {
       "label": "firstDefined()",
@@ -10497,7 +10497,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L120",
       "id": "storeconfig_firstdefined",
-      "community": 16
+      "community": 3
     },
     {
       "label": "cleanUndefined()",
@@ -10505,7 +10505,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L143",
       "id": "storeconfig_cleanundefined",
-      "community": 16
+      "community": 3
     },
     {
       "label": "asMtnMomoSetupStatus()",
@@ -10513,7 +10513,7 @@
       "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L80",
       "id": "storeconfig_asmtnmomosetupstatus",
-      "community": 16
+      "community": 3
     },
     {
       "label": "hasMtnMomoReceivingAccountDetails()",
@@ -10521,7 +10521,7 @@
       "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L93",
       "id": "storeconfig_hasmtnmomoreceivingaccountdetails",
-      "community": 16
+      "community": 3
     },
     {
       "label": "mapMtnMomoReceivingAccount()",
@@ -10529,7 +10529,7 @@
       "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L106",
       "id": "storeconfig_mapmtnmomoreceivingaccount",
-      "community": 16
+      "community": 3
     },
     {
       "label": "normalizeMtnMomoReceivingAccounts()",
@@ -10537,7 +10537,7 @@
       "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L126",
       "id": "storeconfig_normalizemtnmomoreceivingaccounts",
-      "community": 16
+      "community": 3
     },
     {
       "label": "getRawConfig()",
@@ -10545,7 +10545,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L196",
       "id": "storeconfig_getrawconfig",
-      "community": 16
+      "community": 3
     },
     {
       "label": "mapStreamReel()",
@@ -10553,7 +10553,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L155",
       "id": "storeconfig_mapstreamreel",
-      "community": 16
+      "community": 3
     },
     {
       "label": "mapPromotion()",
@@ -10561,7 +10561,7 @@
       "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L172",
       "id": "storeconfig_mappromotion",
-      "community": 16
+      "community": 3
     },
     {
       "label": "normalizeWaiveDeliveryFees()",
@@ -10569,7 +10569,7 @@
       "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L177",
       "id": "storeconfig_normalizewaivedeliveryfees",
-      "community": 16
+      "community": 3
     },
     {
       "label": "getStoreConfigV2()",
@@ -10577,7 +10577,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L208",
       "id": "storeconfig_getstoreconfigv2",
-      "community": 16
+      "community": 3
     },
     {
       "label": "timelineUtils.ts",
@@ -10585,7 +10585,7 @@
       "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
       "source_location": "L1",
       "id": "timelineutils",
-      "community": 13
+      "community": 7
     },
     {
       "label": "enrichTimelineEvent()",
@@ -10593,7 +10593,7 @@
       "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
       "source_location": "L184",
       "id": "timelineutils_enrichtimelineevent",
-      "community": 13
+      "community": 7
     },
     {
       "label": "enrichTimelineEvents()",
@@ -10601,7 +10601,7 @@
       "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
       "source_location": "L200",
       "id": "timelineutils_enrichtimelineevents",
-      "community": 13
+      "community": 7
     },
     {
       "label": "groupEventsByTimeframe()",
@@ -10609,7 +10609,7 @@
       "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
       "source_location": "L206",
       "id": "timelineutils_groupeventsbytimeframe",
-      "community": 13
+      "community": 7
     },
     {
       "label": "getTimeRangeLabel()",
@@ -10617,7 +10617,7 @@
       "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
       "source_location": "L244",
       "id": "timelineutils_gettimerangelabel",
-      "community": 13
+      "community": 7
     },
     {
       "label": "utils.test.ts",
@@ -10625,7 +10625,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.test.ts",
       "source_location": "L1",
       "id": "utils_test",
-      "community": 6
+      "community": 1
     },
     {
       "label": "cn()",
@@ -10633,7 +10633,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L9",
       "id": "utils_cn",
-      "community": 0
+      "community": 1
     },
     {
       "label": "getErrorForField()",
@@ -10641,7 +10641,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L14",
       "id": "utils_geterrorforfield",
-      "community": 0
+      "community": 1
     },
     {
       "label": "capitalizeFirstLetter()",
@@ -10649,7 +10649,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L18",
       "id": "utils_capitalizefirstletter",
-      "community": 0
+      "community": 1
     },
     {
       "label": "slugToWords()",
@@ -10657,7 +10657,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L31",
       "id": "utils_slugtowords",
-      "community": 0
+      "community": 1
     },
     {
       "label": "snakeCaseToWords()",
@@ -10665,7 +10665,7 @@
       "source_file": "packages/athena-webapp/src/lib/utils.ts",
       "source_location": "L50",
       "id": "utils_snakecasetowords",
-      "community": 0
+      "community": 1
     },
     {
       "label": "getRelativeTime()",
@@ -10673,7 +10673,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L67",
       "id": "utils_getrelativetime",
-      "community": 0
+      "community": 1
     },
     {
       "label": "getTimeRemaining()",
@@ -10681,7 +10681,7 @@
       "source_file": "packages/athena-webapp/src/lib/utils.ts",
       "source_location": "L71",
       "id": "utils_gettimeremaining",
-      "community": 0
+      "community": 1
     },
     {
       "label": "formatUserId()",
@@ -10689,7 +10689,7 @@
       "source_file": "packages/athena-webapp/src/lib/utils.ts",
       "source_location": "L91",
       "id": "utils_formatuserid",
-      "community": 0
+      "community": 1
     },
     {
       "label": "main.tsx",
@@ -10697,7 +10697,7 @@
       "source_file": "packages/storefront-webapp/src/main.tsx",
       "source_location": "L1",
       "id": "main",
-      "community": 20
+      "community": 11
     },
     {
       "label": "App()",
@@ -10705,7 +10705,7 @@
       "source_file": "packages/storefront-webapp/src/main.tsx",
       "source_location": "L38",
       "id": "main_app",
-      "community": 20
+      "community": 11
     },
     {
       "label": "routeTree.gen.ts",
@@ -10713,7 +10713,7 @@
       "source_file": "packages/storefront-webapp/src/routeTree.gen.ts",
       "source_location": "L1",
       "id": "routetree_gen",
-      "community": 7
+      "community": 10
     },
     {
       "label": "__root.tsx",
@@ -10721,7 +10721,7 @@
       "source_file": "packages/storefront-webapp/src/routes/__root.tsx",
       "source_location": "L1",
       "id": "root",
-      "community": 4
+      "community": 3
     },
     {
       "label": "$storeUrlSlug.tsx",
@@ -10729,7 +10729,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/stores/$storeUrlSlug.tsx",
       "source_location": "L1",
       "id": "storeurlslug",
-      "community": 7
+      "community": 10
     },
     {
       "label": "assets.index.tsx",
@@ -10737,7 +10737,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/assets.index.tsx",
       "source_location": "L1",
       "id": "assets_index",
-      "community": 7
+      "community": 10
     },
     {
       "label": "bags.$bagId.tsx",
@@ -10745,7 +10745,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.$bagId.tsx",
       "source_location": "L1",
       "id": "bags_bagid",
-      "community": 7
+      "community": 10
     },
     {
       "label": "bags.index.tsx",
@@ -10753,7 +10753,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.index.tsx",
       "source_location": "L1",
       "id": "bags_index",
-      "community": 7
+      "community": 10
     },
     {
       "label": "checkout-sessions.index.tsx",
@@ -10761,7 +10761,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/checkout-sessions.index.tsx",
       "source_location": "L1",
       "id": "checkout_sessions_index",
-      "community": 7
+      "community": 10
     },
     {
       "label": "configuration.index.tsx",
@@ -10769,7 +10769,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/configuration.index.tsx",
       "source_location": "L1",
       "id": "configuration_index",
-      "community": 7
+      "community": 10
     },
     {
       "label": "dashboard.index.tsx",
@@ -10793,7 +10793,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.$logId.tsx",
       "source_location": "L1",
       "id": "logs_logid",
-      "community": 7
+      "community": 10
     },
     {
       "label": "logs.index.tsx",
@@ -10801,7 +10801,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.index.tsx",
       "source_location": "L1",
       "id": "logs_index",
-      "community": 6
+      "community": 1
     },
     {
       "label": "members.index.tsx",
@@ -10809,7 +10809,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/members.index.tsx",
       "source_location": "L1",
       "id": "members_index",
-      "community": 7
+      "community": 10
     },
     {
       "label": "all.index.tsx",
@@ -10817,7 +10817,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/all.index.tsx",
       "source_location": "L1",
       "id": "all_index",
-      "community": 7
+      "community": 10
     },
     {
       "label": "cancelled.index.tsx",
@@ -10825,7 +10825,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/cancelled.index.tsx",
       "source_location": "L1",
       "id": "cancelled_index",
-      "community": 7
+      "community": 10
     },
     {
       "label": "completed.index.tsx",
@@ -10833,7 +10833,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/completed.index.tsx",
       "source_location": "L1",
       "id": "completed_index",
-      "community": 7
+      "community": 10
     },
     {
       "label": "open.index.tsx",
@@ -10841,7 +10841,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/open.index.tsx",
       "source_location": "L1",
       "id": "open_index",
-      "community": 7
+      "community": 10
     },
     {
       "label": "out-for-delivery.index.tsx",
@@ -10849,7 +10849,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/out-for-delivery.index.tsx",
       "source_location": "L1",
       "id": "out_for_delivery_index",
-      "community": 7
+      "community": 10
     },
     {
       "label": "ready.index.tsx",
@@ -10857,7 +10857,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/ready.index.tsx",
       "source_location": "L1",
       "id": "ready_index",
-      "community": 7
+      "community": 10
     },
     {
       "label": "refunded.index.tsx",
@@ -10865,7 +10865,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/refunded.index.tsx",
       "source_location": "L1",
       "id": "refunded_index",
-      "community": 7
+      "community": 10
     },
     {
       "label": "$reportId.tsx",
@@ -10873,7 +10873,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports/$reportId.tsx",
       "source_location": "L1",
       "id": "reportid",
-      "community": 7
+      "community": 10
     },
     {
       "label": "expense-reports.index.tsx",
@@ -10881,7 +10881,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports.index.tsx",
       "source_location": "L1",
       "id": "expense_reports_index",
-      "community": 7
+      "community": 10
     },
     {
       "label": "expense.index.tsx",
@@ -10889,7 +10889,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense.index.tsx",
       "source_location": "L1",
       "id": "expense_index",
-      "community": 7
+      "community": 10
     },
     {
       "label": "register.index.tsx",
@@ -10897,7 +10897,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/register.index.tsx",
       "source_location": "L1",
       "id": "register_index",
-      "community": 7
+      "community": 10
     },
     {
       "label": "settings.index.tsx",
@@ -10905,7 +10905,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/settings.index.tsx",
       "source_location": "L1",
       "id": "settings_index",
-      "community": 7
+      "community": 10
     },
     {
       "label": "$transactionId.tsx",
@@ -10913,7 +10913,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId.tsx",
       "source_location": "L1",
       "id": "transactionid",
-      "community": 7
+      "community": 10
     },
     {
       "label": "transactions.index.tsx",
@@ -10921,7 +10921,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions.index.tsx",
       "source_location": "L1",
       "id": "transactions_index",
-      "community": 7
+      "community": 10
     },
     {
       "label": "edit.tsx",
@@ -10929,7 +10929,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/edit.tsx",
       "source_location": "L1",
       "id": "edit",
-      "community": 7
+      "community": 10
     },
     {
       "label": "new.tsx",
@@ -10945,7 +10945,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/unresolved.tsx",
       "source_location": "L1",
       "id": "unresolved",
-      "community": 7
+      "community": 10
     },
     {
       "label": "$promoCodeSlug.tsx",
@@ -10961,7 +10961,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/new.index.tsx",
       "source_location": "L1",
       "id": "new_index",
-      "community": 6
+      "community": 9
     },
     {
       "label": "published.index.tsx",
@@ -10969,7 +10969,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/published.index.tsx",
       "source_location": "L1",
       "id": "published_index",
-      "community": 7
+      "community": 10
     },
     {
       "label": "RouteComponent()",
@@ -10977,7 +10977,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/published.index.tsx",
       "source_location": "L9",
       "id": "published_index_routecomponent",
-      "community": 7
+      "community": 10
     },
     {
       "label": "users.$userId.tsx",
@@ -10985,7 +10985,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/users.$userId.tsx",
       "source_location": "L1",
       "id": "users_userid",
-      "community": 7
+      "community": 10
     },
     {
       "label": "_authed.tsx",
@@ -10993,7 +10993,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed.tsx",
       "source_location": "L1",
       "id": "authed",
-      "community": 8
+      "community": 0
     },
     {
       "label": "AuthedComponent()",
@@ -11001,7 +11001,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed.tsx",
       "source_location": "L18",
       "id": "authed_authedcomponent",
-      "community": 8
+      "community": 0
     },
     {
       "label": "Layout()",
@@ -11009,7 +11009,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed.tsx",
       "source_location": "L38",
       "id": "authed_layout",
-      "community": 8
+      "community": 0
     },
     {
       "label": "Index()",
@@ -11025,7 +11025,7 @@
       "source_file": "packages/athena-webapp/src/routes/join-team.index.tsx",
       "source_location": "L1",
       "id": "join_team_index",
-      "community": 7
+      "community": 10
     },
     {
       "label": "_layout.index.tsx",
@@ -11033,7 +11033,7 @@
       "source_file": "packages/athena-webapp/src/routes/login/_layout.index.tsx",
       "source_location": "L1",
       "id": "layout_index",
-      "community": 1
+      "community": 4
     },
     {
       "label": "_layout.tsx",
@@ -11041,7 +11041,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout.tsx",
       "source_location": "L1",
       "id": "layout",
-      "community": 4
+      "community": 3
     },
     {
       "label": "LoginLayout()",
@@ -11049,7 +11049,7 @@
       "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
       "source_location": "L36",
       "id": "layout_loginlayout",
-      "community": 4
+      "community": 3
     },
     {
       "label": "OrganizationSettingsView.tsx",
@@ -11057,7 +11057,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L1",
       "id": "organizationsettingsview",
-      "community": 6
+      "community": 1
     },
     {
       "label": "OrganizationSettings()",
@@ -11065,7 +11065,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L24",
       "id": "organizationsettingsview_organizationsettings",
-      "community": 6
+      "community": 1
     },
     {
       "label": "saveStoreChanges()",
@@ -11073,7 +11073,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L71",
       "id": "organizationsettingsview_savestorechanges",
-      "community": 6
+      "community": 1
     },
     {
       "label": "onSubmit()",
@@ -11081,7 +11081,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L105",
       "id": "organizationsettingsview_onsubmit",
-      "community": 6
+      "community": 1
     },
     {
       "label": "handleDeleteStore()",
@@ -11089,7 +11089,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L156",
       "id": "organizationsettingsview_handledeletestore",
-      "community": 6
+      "community": 1
     },
     {
       "label": "Navigation()",
@@ -11097,7 +11097,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L198",
       "id": "organizationsettingsview_navigation",
-      "community": 6
+      "community": 1
     },
     {
       "label": "OrganizationsSettingsAccordion.tsx",
@@ -11105,7 +11105,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationsSettingsAccordion.tsx",
       "source_location": "L1",
       "id": "organizationssettingsaccordion",
-      "community": 1
+      "community": 0
     },
     {
       "label": "OrganizationSettingsAccordion()",
@@ -11113,7 +11113,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationsSettingsAccordion.tsx",
       "source_location": "L13",
       "id": "organizationssettingsaccordion_organizationsettingsaccordion",
-      "community": 1
+      "community": 0
     },
     {
       "label": "StoreSettingsView.tsx",
@@ -11121,7 +11121,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L1",
       "id": "storesettingsview",
-      "community": 7
+      "community": 10
     },
     {
       "label": "StoreSettings()",
@@ -11129,7 +11129,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L28",
       "id": "storesettingsview_storesettings",
-      "community": 7
+      "community": 10
     },
     {
       "label": "saveStoreChanges()",
@@ -11137,7 +11137,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L82",
       "id": "storesettingsview_savestorechanges",
-      "community": 7
+      "community": 10
     },
     {
       "label": "onSubmit()",
@@ -11145,7 +11145,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L116",
       "id": "storesettingsview_onsubmit",
-      "community": 7
+      "community": 10
     },
     {
       "label": "handleDeleteStore()",
@@ -11153,7 +11153,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L167",
       "id": "storesettingsview_handledeletestore",
-      "community": 7
+      "community": 10
     },
     {
       "label": "handleDeleteAllProductsInStore()",
@@ -11161,7 +11161,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L232",
       "id": "storesettingsview_handledeleteallproductsinstore",
-      "community": 7
+      "community": 10
     },
     {
       "label": "StoresSettingsAccordion.tsx",
@@ -11169,7 +11169,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoresSettingsAccordion.tsx",
       "source_location": "L1",
       "id": "storessettingsaccordion",
-      "community": 1
+      "community": 0
     },
     {
       "label": "expenseStore.ts",
@@ -11177,7 +11177,7 @@
       "source_file": "packages/athena-webapp/src/stores/expenseStore.ts",
       "source_location": "L1",
       "id": "expensestore",
-      "community": 3
+      "community": 5
     },
     {
       "label": "posStore.ts",
@@ -11185,7 +11185,7 @@
       "source_file": "packages/athena-webapp/src/stores/posStore.ts",
       "source_location": "L1",
       "id": "posstore",
-      "community": 3
+      "community": 5
     },
     {
       "label": "setup.ts",
@@ -11193,7 +11193,7 @@
       "source_file": "packages/athena-webapp/src/test/setup.ts",
       "source_location": "L1",
       "id": "setup",
-      "community": 67
+      "community": 69
     },
     {
       "label": "backend.test.ts",
@@ -11289,7 +11289,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/inventoryValidationLogic.test.ts",
       "source_location": "L1",
       "id": "inventoryvalidationlogic_test",
-      "community": 28
+      "community": 29
     },
     {
       "label": "validateInventoryForTransaction()",
@@ -11297,7 +11297,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/inventoryValidationLogic.test.ts",
       "source_location": "L20",
       "id": "inventoryvalidationlogic_test_validateinventoryfortransaction",
-      "community": 28
+      "community": 29
     },
     {
       "label": "mockGetSku()",
@@ -11305,7 +11305,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/inventoryValidationLogic.test.ts",
       "source_location": "L66",
       "id": "inventoryvalidationlogic_test_mockgetsku",
-      "community": 28
+      "community": 29
     },
     {
       "label": "simple.test.ts",
@@ -11393,7 +11393,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/usePrint.test.ts",
       "source_location": "L1",
       "id": "useprint_test",
-      "community": 3
+      "community": 5
     },
     {
       "label": "formatNumber.ts",
@@ -11401,7 +11401,7 @@
       "source_file": "packages/athena-webapp/src/utils/formatNumber.ts",
       "source_location": "L1",
       "id": "formatnumber",
-      "community": 0
+      "community": 7
     },
     {
       "label": "formatNumber()",
@@ -11409,7 +11409,7 @@
       "source_file": "packages/athena-webapp/src/utils/formatNumber.ts",
       "source_location": "L1",
       "id": "formatnumber_formatnumber",
-      "community": 0
+      "community": 7
     },
     {
       "label": "hashPassword()",
@@ -11441,7 +11441,7 @@
       "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
       "source_location": "L1",
       "id": "versionchecker",
-      "community": 20
+      "community": 11
     },
     {
       "label": "createVersionChecker()",
@@ -11449,7 +11449,7 @@
       "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
       "source_location": "L16",
       "id": "versionchecker_createversionchecker",
-      "community": 20
+      "community": 11
     },
     {
       "label": "tailwind.config.js",
@@ -11457,7 +11457,7 @@
       "source_file": "packages/storefront-webapp/tailwind.config.js",
       "source_location": "L1",
       "id": "tailwind_config",
-      "community": 68
+      "community": 70
     },
     {
       "label": "vite.config.ts",
@@ -11489,7 +11489,7 @@
       "source_file": "packages/storefront-webapp/vitest.setup.ts",
       "source_location": "L1",
       "id": "vitest_setup",
-      "community": 69
+      "community": 71
     },
     {
       "label": "global.d.ts",
@@ -11497,7 +11497,7 @@
       "source_file": "packages/storefront-webapp/global.d.ts",
       "source_location": "L1",
       "id": "global_d",
-      "community": 70
+      "community": 72
     },
     {
       "label": "playwright.config.ts",
@@ -11505,7 +11505,7 @@
       "source_file": "packages/storefront-webapp/playwright.config.ts",
       "source_location": "L1",
       "id": "playwright_config",
-      "community": 71
+      "community": 73
     },
     {
       "label": "postAnalytics()",
@@ -11513,7 +11513,7 @@
       "source_file": "packages/storefront-webapp/src/api/analytics.ts",
       "source_location": "L3",
       "id": "analytics_postanalytics",
-      "community": 15
+      "community": 3
     },
     {
       "label": "updateAnalyticsOwner()",
@@ -11521,7 +11521,7 @@
       "source_file": "packages/storefront-webapp/src/api/analytics.ts",
       "source_location": "L32",
       "id": "analytics_updateanalyticsowner",
-      "community": 15
+      "community": 3
     },
     {
       "label": "logout()",
@@ -11529,7 +11529,7 @@
       "source_file": "packages/storefront-webapp/src/api/analytics.ts",
       "source_location": "L60",
       "id": "analytics_logout",
-      "community": 15
+      "community": 3
     },
     {
       "label": "getProductViewCount()",
@@ -11537,7 +11537,7 @@
       "source_file": "packages/storefront-webapp/src/api/analytics.ts",
       "source_location": "L78",
       "id": "analytics_getproductviewcount",
-      "community": 15
+      "community": 3
     },
     {
       "label": "verifyUserAccount()",
@@ -11657,7 +11657,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.test.ts",
       "source_location": "L1",
       "id": "checkoutsession_test",
-      "community": 4
+      "community": 11
     },
     {
       "label": "jsonResponse()",
@@ -11665,7 +11665,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.test.ts",
       "source_location": "L27",
       "id": "checkoutsession_test_jsonresponse",
-      "community": 4
+      "community": 11
     },
     {
       "label": "getBaseUrl()",
@@ -11673,7 +11673,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L5",
       "id": "checkoutsession_getbaseurl",
-      "community": 4
+      "community": 11
     },
     {
       "label": "CheckoutSessionError",
@@ -11681,7 +11681,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L64",
       "id": "checkoutsession_checkoutsessionerror",
-      "community": 4
+      "community": 11
     },
     {
       "label": ".constructor()",
@@ -11689,7 +11689,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L69",
       "id": "checkoutsession_checkoutsessionerror_constructor",
-      "community": 4
+      "community": 11
     },
     {
       "label": "isRecord()",
@@ -11697,7 +11697,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L78",
       "id": "checkoutsession_isrecord",
-      "community": 4
+      "community": 11
     },
     {
       "label": "parseJson()",
@@ -11705,7 +11705,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L81",
       "id": "checkoutsession_parsejson",
-      "community": 4
+      "community": 11
     },
     {
       "label": "getCheckoutErrorMessageFromPayload()",
@@ -11713,7 +11713,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L98",
       "id": "checkoutsession_getcheckouterrormessagefrompayload",
-      "community": 4
+      "community": 11
     },
     {
       "label": "parseCheckoutResponse()",
@@ -11721,7 +11721,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L115",
       "id": "checkoutsession_parsecheckoutresponse",
-      "community": 4
+      "community": 11
     },
     {
       "label": "defaultCheckoutActionMessage()",
@@ -11729,7 +11729,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L135",
       "id": "checkoutsession_defaultcheckoutactionmessage",
-      "community": 4
+      "community": 11
     },
     {
       "label": "getCheckoutActionErrorMessage()",
@@ -11737,7 +11737,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L147",
       "id": "checkoutsession_getcheckoutactionerrormessage",
-      "community": 4
+      "community": 11
     },
     {
       "label": "createCheckoutSession()",
@@ -11745,7 +11745,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L184",
       "id": "checkoutsession_createcheckoutsession",
-      "community": 4
+      "community": 11
     },
     {
       "label": "getActiveCheckoutSession()",
@@ -11753,7 +11753,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L204",
       "id": "checkoutsession_getactivecheckoutsession",
-      "community": 4
+      "community": 11
     },
     {
       "label": "getPendingCheckoutSessions()",
@@ -11761,7 +11761,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L215",
       "id": "checkoutsession_getpendingcheckoutsessions",
-      "community": 4
+      "community": 11
     },
     {
       "label": "getCheckoutSession()",
@@ -11769,7 +11769,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L226",
       "id": "checkoutsession_getcheckoutsession",
-      "community": 4
+      "community": 11
     },
     {
       "label": "updateCheckoutSession()",
@@ -11777,7 +11777,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L239",
       "id": "checkoutsession_updatecheckoutsession",
-      "community": 4
+      "community": 11
     },
     {
       "label": "verifyCheckoutSessionPayment()",
@@ -11785,7 +11785,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L274",
       "id": "checkoutsession_verifycheckoutsessionpayment",
-      "community": 4
+      "community": 11
     },
     {
       "label": "getBaseUrl()",
@@ -11793,7 +11793,7 @@
       "source_file": "packages/storefront-webapp/src/api/color.ts",
       "source_location": "L5",
       "id": "color_getbaseurl",
-      "community": 15
+      "community": 13
     },
     {
       "label": "getAllColors()",
@@ -11801,7 +11801,7 @@
       "source_file": "packages/storefront-webapp/src/api/color.ts",
       "source_location": "L7",
       "id": "color_getallcolors",
-      "community": 15
+      "community": 13
     },
     {
       "label": "updateGuest()",
@@ -11889,7 +11889,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L5",
       "id": "product_buildquerystring",
-      "community": 15
+      "community": 13
     },
     {
       "label": "getBaseUrl()",
@@ -11897,7 +11897,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L18",
       "id": "product_getbaseurl",
-      "community": 15
+      "community": 13
     },
     {
       "label": "getAllProducts()",
@@ -11905,7 +11905,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L20",
       "id": "product_getallproducts",
-      "community": 15
+      "community": 13
     },
     {
       "label": "getProduct()",
@@ -11913,7 +11913,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L40",
       "id": "product_getproduct",
-      "community": 15
+      "community": 13
     },
     {
       "label": "getBestSellers()",
@@ -11921,7 +11921,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L59",
       "id": "product_getbestsellers",
-      "community": 15
+      "community": 13
     },
     {
       "label": "getFeatured()",
@@ -11929,7 +11929,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L73",
       "id": "product_getfeatured",
-      "community": 15
+      "community": 13
     },
     {
       "label": "getInventoryBySkuIds()",
@@ -11937,7 +11937,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L93",
       "id": "product_getinventorybyskuids",
-      "community": 15
+      "community": 13
     },
     {
       "label": "getBaseUrl()",
@@ -11945,7 +11945,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L4",
       "id": "promocodes_getbaseurl",
-      "community": 25
+      "community": 2
     },
     {
       "label": "redeemPromoCode()",
@@ -11953,7 +11953,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L6",
       "id": "promocodes_redeempromocode",
-      "community": 25
+      "community": 2
     },
     {
       "label": "getPromoCodes()",
@@ -11961,7 +11961,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L34",
       "id": "promocodes_getpromocodes",
-      "community": 25
+      "community": 2
     },
     {
       "label": "getPromoCodeItems()",
@@ -11969,7 +11969,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L49",
       "id": "promocodes_getpromocodeitems",
-      "community": 25
+      "community": 2
     },
     {
       "label": "getRedeemedPromoCodes()",
@@ -11977,7 +11977,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L74",
       "id": "promocodes_getredeemedpromocodes",
-      "community": 25
+      "community": 2
     },
     {
       "label": "getBaseUrl()",
@@ -11985,7 +11985,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L4",
       "id": "reviews_getbaseurl",
-      "community": 17
+      "community": 13
     },
     {
       "label": "createReview()",
@@ -11993,7 +11993,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L13",
       "id": "reviews_createreview",
-      "community": 17
+      "community": 13
     },
     {
       "label": "getReviewByOrderItem()",
@@ -12001,7 +12001,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L32",
       "id": "reviews_getreviewbyorderitem",
-      "community": 17
+      "community": 13
     },
     {
       "label": "updateReview()",
@@ -12009,7 +12009,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L48",
       "id": "reviews_updatereview",
-      "community": 17
+      "community": 13
     },
     {
       "label": "deleteReview()",
@@ -12017,7 +12017,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L69",
       "id": "reviews_deletereview",
-      "community": 17
+      "community": 13
     },
     {
       "label": "getReviewsByProductSkuId()",
@@ -12025,7 +12025,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L83",
       "id": "reviews_getreviewsbyproductskuid",
-      "community": 17
+      "community": 13
     },
     {
       "label": "getUserReviews()",
@@ -12033,7 +12033,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L99",
       "id": "reviews_getuserreviews",
-      "community": 17
+      "community": 13
     },
     {
       "label": "getUserReviewsForProduct()",
@@ -12041,7 +12041,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L113",
       "id": "reviews_getuserreviewsforproduct",
-      "community": 17
+      "community": 13
     },
     {
       "label": "getReviewsByProductId()",
@@ -12049,7 +12049,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L132",
       "id": "reviews_getreviewsbyproductid",
-      "community": 17
+      "community": 13
     },
     {
       "label": "markReviewHelpful()",
@@ -12057,7 +12057,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L148",
       "id": "reviews_markreviewhelpful",
-      "community": 17
+      "community": 13
     },
     {
       "label": "hasReviewForOrderItem()",
@@ -12065,7 +12065,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L164",
       "id": "reviews_hasreviewfororderitem",
-      "community": 17
+      "community": 13
     },
     {
       "label": "hasUserReviewForOrderItem()",
@@ -12073,7 +12073,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L183",
       "id": "reviews_hasuserreviewfororderitem",
-      "community": 17
+      "community": 13
     },
     {
       "label": "getBaseUrl()",
@@ -12081,7 +12081,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L3",
       "id": "rewards_getbaseurl",
-      "community": 2
+      "community": 18
     },
     {
       "label": "getUserPoints()",
@@ -12089,7 +12089,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L54",
       "id": "rewards_getuserpoints",
-      "community": 2
+      "community": 18
     },
     {
       "label": "getPointHistory()",
@@ -12097,7 +12097,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L71",
       "id": "rewards_getpointhistory",
-      "community": 2
+      "community": 18
     },
     {
       "label": "getRewardTiers()",
@@ -12105,7 +12105,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L90",
       "id": "rewards_getrewardtiers",
-      "community": 2
+      "community": 18
     },
     {
       "label": "redeemRewardPoints()",
@@ -12113,7 +12113,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L107",
       "id": "rewards_redeemrewardpoints",
-      "community": 2
+      "community": 18
     },
     {
       "label": "getEligiblePastOrders()",
@@ -12121,7 +12121,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L129",
       "id": "rewards_geteligiblepastorders",
-      "community": 2
+      "community": 18
     },
     {
       "label": "awardPointsForPastOrder()",
@@ -12129,7 +12129,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L151",
       "id": "rewards_awardpointsforpastorder",
-      "community": 2
+      "community": 18
     },
     {
       "label": "getOrderRewardPoints()",
@@ -12137,7 +12137,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L175",
       "id": "rewards_getorderrewardpoints",
-      "community": 2
+      "community": 18
     },
     {
       "label": "awardPointsForGuestOrders()",
@@ -12145,7 +12145,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L198",
       "id": "rewards_awardpointsforguestorders",
-      "community": 2
+      "community": 18
     },
     {
       "label": "getBaseUrl()",
@@ -12153,7 +12153,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L8",
       "id": "savedbag_getbaseurl",
-      "community": 2
+      "community": 4
     },
     {
       "label": "getActiveSavedBag()",
@@ -12161,7 +12161,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L10",
       "id": "savedbag_getactivesavedbag",
-      "community": 2
+      "community": 4
     },
     {
       "label": "addItemToSavedBag()",
@@ -12169,7 +12169,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L25",
       "id": "savedbag_additemtosavedbag",
-      "community": 2
+      "community": 4
     },
     {
       "label": "updateSavedBagItem()",
@@ -12177,7 +12177,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L61",
       "id": "savedbag_updatesavedbagitem",
-      "community": 2
+      "community": 4
     },
     {
       "label": "removeItemFromSavedBag()",
@@ -12185,7 +12185,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L91",
       "id": "savedbag_removeitemfromsavedbag",
-      "community": 2
+      "community": 4
     },
     {
       "label": "updateSavedBagOwner()",
@@ -12193,7 +12193,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L109",
       "id": "savedbag_updatesavedbagowner",
-      "community": 2
+      "community": 4
     },
     {
       "label": "getBaseUrl()",
@@ -12201,7 +12201,7 @@
       "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
       "source_location": "L5",
       "id": "storefrontuser_getbaseurl",
-      "community": 1
+      "community": 4
     },
     {
       "label": "getGuest()",
@@ -12209,7 +12209,7 @@
       "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
       "source_location": "L7",
       "id": "storefrontuser_getguest",
-      "community": 1
+      "community": 4
     },
     {
       "label": "getActiveUser()",
@@ -12217,7 +12217,7 @@
       "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
       "source_location": "L28",
       "id": "storefrontuser_getactiveuser",
-      "community": 1
+      "community": 4
     },
     {
       "label": "updateUser()",
@@ -12225,7 +12225,7 @@
       "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
       "source_location": "L46",
       "id": "storefrontuser_updateuser",
-      "community": 1
+      "community": 4
     },
     {
       "label": "getStore()",
@@ -12321,7 +12321,7 @@
       "source_file": "packages/storefront-webapp/src/assets/icons/HeartIconFilled.tsx",
       "source_location": "L1",
       "id": "hearticonfilled",
-      "community": 1
+      "community": 8
     },
     {
       "label": "EntityPage.tsx",
@@ -12329,7 +12329,7 @@
       "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
       "source_location": "L1",
       "id": "entitypage",
-      "community": 15
+      "community": 4
     },
     {
       "label": "EntityPage()",
@@ -12337,7 +12337,7 @@
       "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
       "source_location": "L10",
       "id": "entitypage_entitypage",
-      "community": 15
+      "community": 4
     },
     {
       "label": "HomePage.tsx",
@@ -12345,7 +12345,7 @@
       "source_file": "packages/storefront-webapp/src/components/HomePage.tsx",
       "source_location": "L1",
       "id": "homepage",
-      "community": 1
+      "community": 3
     },
     {
       "label": "handleScroll()",
@@ -12353,7 +12353,7 @@
       "source_file": "packages/storefront-webapp/src/components/HomePage.tsx",
       "source_location": "L106",
       "id": "homepage_handlescroll",
-      "community": 1
+      "community": 3
     },
     {
       "label": "handleClickOnDiscountCode()",
@@ -12361,7 +12361,7 @@
       "source_file": "packages/storefront-webapp/src/components/HomePage.tsx",
       "source_location": "L155",
       "id": "homepage_handleclickondiscountcode",
-      "community": 1
+      "community": 3
     },
     {
       "label": "handleClickOnLeaveReviewButton()",
@@ -12369,7 +12369,7 @@
       "source_file": "packages/storefront-webapp/src/components/HomePage.tsx",
       "source_location": "L167",
       "id": "homepage_handleclickonleavereviewbutton",
-      "community": 1
+      "community": 3
     },
     {
       "label": "ProductActionBar.tsx",
@@ -12377,7 +12377,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
       "source_location": "L1",
       "id": "productactionbar",
-      "community": 1
+      "community": 3
     },
     {
       "label": "checkScroll()",
@@ -12385,7 +12385,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
       "source_location": "L50",
       "id": "productactionbar_checkscroll",
-      "community": 1
+      "community": 3
     },
     {
       "label": "handleDismiss()",
@@ -12393,7 +12393,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
       "source_location": "L74",
       "id": "productactionbar_handledismiss",
-      "community": 1
+      "community": 3
     },
     {
       "label": "handleAction()",
@@ -12401,7 +12401,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
       "source_location": "L92",
       "id": "productactionbar_handleaction",
-      "community": 1
+      "community": 3
     },
     {
       "label": "ProductReminderBar.tsx",
@@ -12409,7 +12409,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
       "source_location": "L1",
       "id": "productreminderbar",
-      "community": 1
+      "community": 3
     },
     {
       "label": "checkScroll()",
@@ -12417,7 +12417,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
       "source_location": "L62",
       "id": "productreminderbar_checkscroll",
-      "community": 1
+      "community": 3
     },
     {
       "label": "handleAddToBag()",
@@ -12425,7 +12425,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
       "source_location": "L109",
       "id": "productreminderbar_handleaddtobag",
-      "community": 1
+      "community": 3
     },
     {
       "label": "handleDismiss()",
@@ -12433,7 +12433,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
       "source_location": "L177",
       "id": "productreminderbar_handledismiss",
-      "community": 1
+      "community": 3
     },
     {
       "label": "ProductsPage.tsx",
@@ -12441,7 +12441,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductsPage.tsx",
       "source_location": "L1",
       "id": "productspage",
-      "community": 15
+      "community": 3
     },
     {
       "label": "ProductCardLoadingSkeleton()",
@@ -12449,7 +12449,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductsPage.tsx",
       "source_location": "L10",
       "id": "productspage_productcardloadingskeleton",
-      "community": 15
+      "community": 3
     },
     {
       "label": "Upsell.tsx",
@@ -12585,7 +12585,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/CheckoutProvider.tsx",
       "source_location": "L1",
       "id": "checkoutprovider",
-      "community": 1
+      "community": 4
     },
     {
       "label": "CheckoutProvider()",
@@ -12593,7 +12593,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/CheckoutProvider.tsx",
       "source_location": "L71",
       "id": "checkoutprovider_checkoutprovider",
-      "community": 1
+      "community": 4
     },
     {
       "label": "CustomerDetails.tsx",
@@ -12681,7 +12681,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/PickupOptions.tsx",
       "source_location": "L1",
       "id": "pickupoptions",
-      "community": 1
+      "community": 4
     },
     {
       "label": "isWithinRestrictionTime()",
@@ -12689,7 +12689,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/PickupOptions.tsx",
       "source_location": "L12",
       "id": "pickupoptions_iswithinrestrictiontime",
-      "community": 1
+      "community": 4
     },
     {
       "label": "DeliveryDetailsSection.tsx",
@@ -12745,7 +12745,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/OrderSummary.tsx",
       "source_location": "L18",
       "id": "ordersummary_ordersummary",
-      "community": 3
+      "community": 5
     },
     {
       "label": "PickupDetails()",
@@ -12777,7 +12777,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/PaymentSection.tsx",
       "source_location": "L1",
       "id": "paymentsection",
-      "community": 1
+      "community": 4
     },
     {
       "label": "PaymentSection()",
@@ -12785,7 +12785,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/PaymentSection.tsx",
       "source_location": "L27",
       "id": "paymentsection_paymentsection",
-      "community": 1
+      "community": 4
     },
     {
       "label": "checkoutStorage.test.ts",
@@ -12793,7 +12793,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.test.ts",
       "source_location": "L1",
       "id": "checkoutstorage_test",
-      "community": 1
+      "community": 3
     },
     {
       "label": "checkoutStorage.ts",
@@ -12801,7 +12801,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
       "source_location": "L1",
       "id": "checkoutstorage",
-      "community": 1
+      "community": 3
     },
     {
       "label": "loadCheckoutState()",
@@ -12809,7 +12809,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
       "source_location": "L4",
       "id": "checkoutstorage_loadcheckoutstate",
-      "community": 1
+      "community": 3
     },
     {
       "label": "saveCheckoutState()",
@@ -12817,7 +12817,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
       "source_location": "L24",
       "id": "checkoutstorage_savecheckoutstate",
-      "community": 1
+      "community": 3
     },
     {
       "label": "deliveryFees.test.ts",
@@ -12825,7 +12825,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.test.ts",
       "source_location": "L1",
       "id": "deliveryfees_test",
-      "community": 6
+      "community": 4
     },
     {
       "label": "deliveryFees.ts",
@@ -12833,7 +12833,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.ts",
       "source_location": "L1",
       "id": "deliveryfees",
-      "community": 6
+      "community": 4
     },
     {
       "label": "calculateDeliveryFee()",
@@ -12841,7 +12841,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.ts",
       "source_location": "L40",
       "id": "deliveryfees_calculatedeliveryfee",
-      "community": 6
+      "community": 4
     },
     {
       "label": "deriveCheckoutState.test.ts",
@@ -12849,7 +12849,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.test.ts",
       "source_location": "L1",
       "id": "derivecheckoutstate_test",
-      "community": 6
+      "community": 1
     },
     {
       "label": "deriveCheckoutState.ts",
@@ -12857,7 +12857,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
       "source_location": "L1",
       "id": "derivecheckoutstate",
-      "community": 6
+      "community": 1
     },
     {
       "label": "deriveCheckoutState()",
@@ -12865,7 +12865,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
       "source_location": "L3",
       "id": "derivecheckoutstate_derivecheckoutstate",
-      "community": 6
+      "community": 1
     },
     {
       "label": "billingDetailsSchema.ts",
@@ -12873,7 +12873,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/billingDetailsSchema.ts",
       "source_location": "L1",
       "id": "billingdetailsschema",
-      "community": 1
+      "community": 4
     },
     {
       "label": "checkoutFormSchema.ts",
@@ -12881,7 +12881,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutFormSchema.ts",
       "source_location": "L1",
       "id": "checkoutformschema",
-      "community": 1
+      "community": 4
     },
     {
       "label": "checkoutSchemas.test.ts",
@@ -12889,7 +12889,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutSchemas.test.ts",
       "source_location": "L1",
       "id": "checkoutschemas_test",
-      "community": 1
+      "community": 4
     },
     {
       "label": "getIssueMap()",
@@ -12897,7 +12897,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutSchemas.test.ts",
       "source_location": "L8",
       "id": "checkoutschemas_test_getissuemap",
-      "community": 1
+      "community": 4
     },
     {
       "label": "customerDetailsSchema.ts",
@@ -12905,7 +12905,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/customerDetailsSchema.ts",
       "source_location": "L1",
       "id": "customerdetailsschema",
-      "community": 1
+      "community": 4
     },
     {
       "label": "deliveryDetailsSchema.ts",
@@ -12913,7 +12913,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/deliveryDetailsSchema.ts",
       "source_location": "L1",
       "id": "deliverydetailsschema",
-      "community": 1
+      "community": 4
     },
     {
       "label": "webOrderSchema.test.ts",
@@ -12921,7 +12921,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.test.ts",
       "source_location": "L1",
       "id": "weborderschema_test",
-      "community": 1
+      "community": 4
     },
     {
       "label": "getIssueMap()",
@@ -12929,7 +12929,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.test.ts",
       "source_location": "L12",
       "id": "weborderschema_test_getissuemap",
-      "community": 1
+      "community": 4
     },
     {
       "label": "webOrderSchema.ts",
@@ -12937,7 +12937,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.ts",
       "source_location": "L1",
       "id": "weborderschema",
-      "community": 1
+      "community": 4
     },
     {
       "label": "getPotentialPoints()",
@@ -12945,7 +12945,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L107",
       "id": "utils_getpotentialpoints",
-      "community": 0
+      "community": 1
     },
     {
       "label": "CustomerDetailsForm.tsx",
@@ -12985,7 +12985,7 @@
       "source_file": "packages/storefront-webapp/src/components/common/hooks.ts",
       "source_location": "L3",
       "id": "hooks_usecountdown",
-      "community": 4
+      "community": 3
     },
     {
       "label": "TrustSignals.tsx",
@@ -13009,7 +13009,7 @@
       "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
       "source_location": "L1",
       "id": "productfilter",
-      "community": 4
+      "community": 1
     },
     {
       "label": "ProductFilter()",
@@ -13017,7 +13017,7 @@
       "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
       "source_location": "L14",
       "id": "productfilter_productfilter",
-      "community": 4
+      "community": 1
     },
     {
       "label": "ProductFilterBar.tsx",
@@ -13025,7 +13025,7 @@
       "source_file": "packages/storefront-webapp/src/components/filter/ProductFilterBar.tsx",
       "source_location": "L1",
       "id": "productfilterbar",
-      "community": 4
+      "community": 3
     },
     {
       "label": "Filter.tsx",
@@ -13033,7 +13033,7 @@
       "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
       "source_location": "L1",
       "id": "filter",
-      "community": 12
+      "community": 1
     },
     {
       "label": "handleCheckboxChange()",
@@ -13041,7 +13041,7 @@
       "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
       "source_location": "L27",
       "id": "filter_handlecheckboxchange",
-      "community": 12
+      "community": 1
     },
     {
       "label": "Footer.tsx",
@@ -13049,7 +13049,7 @@
       "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
       "source_location": "L1",
       "id": "footer",
-      "community": 1
+      "community": 3
     },
     {
       "label": "LinkGroup()",
@@ -13057,7 +13057,7 @@
       "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
       "source_location": "L13",
       "id": "footer_linkgroup",
-      "community": 1
+      "community": 3
     },
     {
       "label": "BestSellersSection.tsx",
@@ -13065,7 +13065,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.tsx",
       "source_location": "L1",
       "id": "bestsellerssection",
-      "community": 1
+      "community": 3
     },
     {
       "label": "BestSellersSection()",
@@ -13073,7 +13073,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.tsx",
       "source_location": "L17",
       "id": "bestsellerssection_bestsellerssection",
-      "community": 1
+      "community": 3
     },
     {
       "label": "FeaturedProductsSection.tsx",
@@ -13081,7 +13081,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
       "source_location": "L1",
       "id": "featuredproductssection",
-      "community": 1
+      "community": 3
     },
     {
       "label": "FeaturedProductsSection()",
@@ -13089,7 +13089,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
       "source_location": "L20",
       "id": "featuredproductssection_featuredproductssection",
-      "community": 1
+      "community": 3
     },
     {
       "label": "FeaturedSection()",
@@ -13097,7 +13097,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
       "source_location": "L46",
       "id": "featuredproductssection_featuredsection",
-      "community": 1
+      "community": 3
     },
     {
       "label": "HomeHero.tsx",
@@ -13105,7 +13105,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/HomeHero.tsx",
       "source_location": "L1",
       "id": "homehero",
-      "community": 1
+      "community": 3
     },
     {
       "label": "HomeHeroSection.tsx",
@@ -13113,7 +13113,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/HomeHeroSection.tsx",
       "source_location": "L1",
       "id": "homeherosection",
-      "community": 1
+      "community": 3
     },
     {
       "label": "PromoAlert.tsx",
@@ -13121,7 +13121,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
       "source_location": "L1",
       "id": "promoalert",
-      "community": 1
+      "community": 4
     },
     {
       "label": "getPromoAlertCopy()",
@@ -13129,7 +13129,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
       "source_location": "L20",
       "id": "promoalert_getpromoalertcopy",
-      "community": 1
+      "community": 4
     },
     {
       "label": "PromoAlert()",
@@ -13137,7 +13137,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
       "source_location": "L59",
       "id": "promoalert_promoalert",
-      "community": 1
+      "community": 4
     },
     {
       "label": "RewardsAlert.tsx",
@@ -13145,7 +13145,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
       "source_location": "L1",
       "id": "rewardsalert",
-      "community": 1
+      "community": 4
     },
     {
       "label": "onRewardsAlertClose()",
@@ -13153,7 +13153,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
       "source_location": "L20",
       "id": "rewardsalert_onrewardsalertclose",
-      "community": 1
+      "community": 4
     },
     {
       "label": "handleShopNow()",
@@ -13161,7 +13161,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
       "source_location": "L25",
       "id": "rewardsalert_handleshopnow",
-      "community": 1
+      "community": 4
     },
     {
       "label": "useGetStoreSubcategories()",
@@ -13169,7 +13169,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
       "source_location": "L10",
       "id": "hooks_usegetstoresubcategories",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useGetStoreCategories()",
@@ -13177,7 +13177,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
       "source_location": "L21",
       "id": "hooks_usegetstorecategories",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useGetShopSearchParams()",
@@ -13185,7 +13185,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
       "source_location": "L55",
       "id": "hooks_usegetshopsearchparams",
-      "community": 4
+      "community": 3
     },
     {
       "label": "BagMenu.tsx",
@@ -13193,7 +13193,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/BagMenu.tsx",
       "source_location": "L1",
       "id": "bagmenu",
-      "community": 1
+      "community": 3
     },
     {
       "label": "handleOnLinkClick()",
@@ -13201,7 +13201,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/BagMenu.tsx",
       "source_location": "L47",
       "id": "bagmenu_handleonlinkclick",
-      "community": 1
+      "community": 3
     },
     {
       "label": "MobileBagMenu.tsx",
@@ -13209,7 +13209,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileBagMenu.tsx",
       "source_location": "L1",
       "id": "mobilebagmenu",
-      "community": 1
+      "community": 3
     },
     {
       "label": "MobileBagMenu()",
@@ -13217,7 +13217,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileBagMenu.tsx",
       "source_location": "L7",
       "id": "mobilebagmenu_mobilebagmenu",
-      "community": 1
+      "community": 3
     },
     {
       "label": "MobileMenu.tsx",
@@ -13225,7 +13225,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileMenu.tsx",
       "source_location": "L1",
       "id": "mobilemenu",
-      "community": 4
+      "community": 3
     },
     {
       "label": "NavigationBar.tsx",
@@ -13233,7 +13233,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/NavigationBar.tsx",
       "source_location": "L1",
       "id": "navigationbar",
-      "community": 4
+      "community": 3
     },
     {
       "label": "StoreCategoriesSubmenu()",
@@ -13241,7 +13241,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/NavigationBar.tsx",
       "source_location": "L62",
       "id": "navigationbar_storecategoriessubmenu",
-      "community": 4
+      "community": 3
     },
     {
       "label": "SiteBanner.tsx",
@@ -13249,7 +13249,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/SiteBanner.tsx",
       "source_location": "L1",
       "id": "sitebanner",
-      "community": 4
+      "community": 3
     },
     {
       "label": "SiteBanner()",
@@ -13257,7 +13257,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/SiteBanner.tsx",
       "source_location": "L17",
       "id": "sitebanner_sitebanner",
-      "community": 4
+      "community": 3
     },
     {
       "label": "navBarConstants.ts",
@@ -13265,7 +13265,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarConstants.ts",
       "source_location": "L1",
       "id": "navbarconstants",
-      "community": 4
+      "community": 3
     },
     {
       "label": "navBarStyles.ts",
@@ -13273,7 +13273,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L1",
       "id": "navbarstyles",
-      "community": 4
+      "community": 3
     },
     {
       "label": "getMainWrapperClass()",
@@ -13281,7 +13281,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L28",
       "id": "navbarstyles_getmainwrapperclass",
-      "community": 4
+      "community": 3
     },
     {
       "label": "getNavBGClass()",
@@ -13289,7 +13289,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L43",
       "id": "navbarstyles_getnavbgclass",
-      "community": 4
+      "community": 3
     },
     {
       "label": "getHoverClass()",
@@ -13297,7 +13297,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L76",
       "id": "navbarstyles_gethoverclass",
-      "community": 4
+      "community": 3
     },
     {
       "label": "getSubmenuBGClass()",
@@ -13305,7 +13305,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L93",
       "id": "navbarstyles_getsubmenubgclass",
-      "community": 4
+      "community": 3
     },
     {
       "label": "getBannerTextClass()",
@@ -13313,7 +13313,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L119",
       "id": "navbarstyles_getbannertextclass",
-      "community": 4
+      "community": 3
     },
     {
       "label": "getBannerBGClass()",
@@ -13321,7 +13321,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L136",
       "id": "navbarstyles_getbannerbgclass",
-      "community": 4
+      "community": 3
     },
     {
       "label": "getBannerAnimationDelay()",
@@ -13329,7 +13329,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L152",
       "id": "navbarstyles_getbanneranimationdelay",
-      "community": 4
+      "community": 3
     },
     {
       "label": "getNavBarWrapperClass()",
@@ -13337,7 +13337,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L163",
       "id": "navbarstyles_getnavbarwrapperclass",
-      "community": 4
+      "community": 3
     },
     {
       "label": "getNavBarAnimationDelay()",
@@ -13345,7 +13345,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L174",
       "id": "navbarstyles_getnavbaranimationdelay",
-      "community": 4
+      "community": 3
     },
     {
       "label": "getOverlayClass()",
@@ -13353,7 +13353,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L184",
       "id": "navbarstyles_getoverlayclass",
-      "community": 4
+      "community": 3
     },
     {
       "label": "NotificationPill.tsx",
@@ -13361,7 +13361,7 @@
       "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
       "source_location": "L1",
       "id": "notificationpill",
-      "community": 40
+      "community": 41
     },
     {
       "label": "NotificationPill()",
@@ -13369,7 +13369,7 @@
       "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
       "source_location": "L1",
       "id": "notificationpill_notificationpill",
-      "community": 40
+      "community": 41
     },
     {
       "label": "About.tsx",
@@ -13393,7 +13393,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
       "source_location": "L1",
       "id": "dimensionbar",
-      "community": 17
+      "community": 13
     },
     {
       "label": "mapValueToLabelIndex()",
@@ -13401,7 +13401,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
       "source_location": "L12",
       "id": "dimensionbar_mapvaluetolabelindex",
-      "community": 17
+      "community": 13
     },
     {
       "label": "DiscountBadge.tsx",
@@ -13409,7 +13409,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/DiscountBadge.tsx",
       "source_location": "L1",
       "id": "discountbadge",
-      "community": 1
+      "community": 4
     },
     {
       "label": "DiscountBadge()",
@@ -13417,7 +13417,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/DiscountBadge.tsx",
       "source_location": "L7",
       "id": "discountbadge_discountbadge",
-      "community": 1
+      "community": 4
     },
     {
       "label": "GalleryViewer.tsx",
@@ -13441,7 +13441,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
       "source_location": "L1",
       "id": "inventorylevelbadge",
-      "community": 17
+      "community": 13
     },
     {
       "label": "SoldOutBadge()",
@@ -13449,7 +13449,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
       "source_location": "L3",
       "id": "inventorylevelbadge_soldoutbadge",
-      "community": 17
+      "community": 13
     },
     {
       "label": "LowStockBadge()",
@@ -13457,7 +13457,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
       "source_location": "L14",
       "id": "inventorylevelbadge_lowstockbadge",
-      "community": 17
+      "community": 13
     },
     {
       "label": "SellingFastBadge()",
@@ -13465,7 +13465,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
       "source_location": "L22",
       "id": "inventorylevelbadge_sellingfastbadge",
-      "community": 17
+      "community": 13
     },
     {
       "label": "SellingFastSignal()",
@@ -13473,7 +13473,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
       "source_location": "L30",
       "id": "inventorylevelbadge_sellingfastsignal",
-      "community": 17
+      "community": 13
     },
     {
       "label": "OnSaleProduct.tsx",
@@ -13545,7 +13545,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
       "source_location": "L13",
       "id": "productdetails_pickupdetails",
-      "community": 1
+      "community": 3
     },
     {
       "label": "BagProduct()",
@@ -13553,7 +13553,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
       "source_location": "L43",
       "id": "productdetails_bagproduct",
-      "community": 1
+      "community": 3
     },
     {
       "label": "ShippingPolicy()",
@@ -13561,7 +13561,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
       "source_location": "L88",
       "id": "productdetails_shippingpolicy",
-      "community": 1
+      "community": 3
     },
     {
       "label": "ProductInfo.tsx",
@@ -13569,7 +13569,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductInfo.tsx",
       "source_location": "L1",
       "id": "productinfo",
-      "community": 17
+      "community": 13
     },
     {
       "label": "showShippingPolicy()",
@@ -13585,7 +13585,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductReview.tsx",
       "source_location": "L1",
       "id": "productreview",
-      "community": 17
+      "community": 13
     },
     {
       "label": "handleHelpful()",
@@ -13593,7 +13593,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductReview.tsx",
       "source_location": "L87",
       "id": "productreview_handlehelpful",
-      "community": 17
+      "community": 13
     },
     {
       "label": "ProductReviews.tsx",
@@ -13601,7 +13601,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductReviews.tsx",
       "source_location": "L1",
       "id": "productreviews",
-      "community": 17
+      "community": 13
     },
     {
       "label": "ProductsNavigationBar.tsx",
@@ -13609,7 +13609,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductsNavigationBar.tsx",
       "source_location": "L1",
       "id": "productsnavigationbar",
-      "community": 9
+      "community": 13
     },
     {
       "label": "ReviewSummary.tsx",
@@ -13617,7 +13617,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
       "source_location": "L1",
       "id": "reviewsummary",
-      "community": 17
+      "community": 13
     },
     {
       "label": "ReviewSummary()",
@@ -13625,7 +13625,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
       "source_location": "L8",
       "id": "reviewsummary_reviewsummary",
-      "community": 17
+      "community": 13
     },
     {
       "label": "ErrorMessage.tsx",
@@ -13633,7 +13633,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ErrorMessage.tsx",
       "source_location": "L1",
       "id": "errormessage",
-      "community": 1
+      "community": 3
     },
     {
       "label": "ExistingReviewMessage.tsx",
@@ -13641,7 +13641,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ExistingReviewMessage.tsx",
       "source_location": "L1",
       "id": "existingreviewmessage",
-      "community": 1
+      "community": 3
     },
     {
       "label": "OrderItem.tsx",
@@ -13649,7 +13649,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
       "source_location": "L1",
       "id": "orderitem",
-      "community": 1
+      "community": 3
     },
     {
       "label": "OrderItem()",
@@ -13657,7 +13657,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
       "source_location": "L12",
       "id": "orderitem_orderitem",
-      "community": 1
+      "community": 3
     },
     {
       "label": "RatingSelector.tsx",
@@ -13665,7 +13665,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/RatingSelector.tsx",
       "source_location": "L1",
       "id": "ratingselector",
-      "community": 6
+      "community": 1
     },
     {
       "label": "RatingSelector()",
@@ -13673,7 +13673,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/RatingSelector.tsx",
       "source_location": "L18",
       "id": "ratingselector_ratingselector",
-      "community": 6
+      "community": 1
     },
     {
       "label": "ReviewEditor.tsx",
@@ -13681,7 +13681,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
       "source_location": "L1",
       "id": "revieweditor",
-      "community": 1
+      "community": 3
     },
     {
       "label": "handleFormDataChange()",
@@ -13689,7 +13689,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
       "source_location": "L150",
       "id": "revieweditor_handleformdatachange",
-      "community": 1
+      "community": 3
     },
     {
       "label": "handleSubmit()",
@@ -13697,7 +13697,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
       "source_location": "L157",
       "id": "revieweditor_handlesubmit",
-      "community": 1
+      "community": 3
     },
     {
       "label": "ReviewForm.tsx",
@@ -13713,7 +13713,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/SuccessMessage.tsx",
       "source_location": "L1",
       "id": "successmessage",
-      "community": 1
+      "community": 3
     },
     {
       "label": "GuestRewardsPrompt.tsx",
@@ -13721,7 +13721,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/GuestRewardsPrompt.tsx",
       "source_location": "L1",
       "id": "guestrewardsprompt",
-      "community": 1
+      "community": 9
     },
     {
       "label": "GuestRewardsPrompt()",
@@ -13729,7 +13729,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/GuestRewardsPrompt.tsx",
       "source_location": "L10",
       "id": "guestrewardsprompt_guestrewardsprompt",
-      "community": 1
+      "community": 9
     },
     {
       "label": "OrderPointsDisplay.tsx",
@@ -13737,7 +13737,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
       "source_location": "L1",
       "id": "orderpointsdisplay",
-      "community": 2
+      "community": 18
     },
     {
       "label": "OrderPointsDisplay()",
@@ -13745,7 +13745,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
       "source_location": "L11",
       "id": "orderpointsdisplay_orderpointsdisplay",
-      "community": 2
+      "community": 18
     },
     {
       "label": "PastOrdersRewards.tsx",
@@ -13753,7 +13753,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/PastOrdersRewards.tsx",
       "source_location": "L1",
       "id": "pastordersrewards",
-      "community": 1
+      "community": 18
     },
     {
       "label": "handleClaimPoints()",
@@ -13761,7 +13761,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/PastOrdersRewards.tsx",
       "source_location": "L59",
       "id": "pastordersrewards_handleclaimpoints",
-      "community": 1
+      "community": 18
     },
     {
       "label": "RewardsPanel.tsx",
@@ -13769,7 +13769,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/RewardsPanel.tsx",
       "source_location": "L1",
       "id": "rewardspanel",
-      "community": 1
+      "community": 0
     },
     {
       "label": "handleRedeemReward()",
@@ -13777,7 +13777,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/RewardsPanel.tsx",
       "source_location": "L33",
       "id": "rewardspanel_handleredeemreward",
-      "community": 1
+      "community": 0
     },
     {
       "label": "SavedIcon.tsx",
@@ -13785,7 +13785,7 @@
       "source_file": "packages/storefront-webapp/src/components/saved-items/SavedIcon.tsx",
       "source_location": "L1",
       "id": "savedicon",
-      "community": 1
+      "community": 8
     },
     {
       "label": "BagItem()",
@@ -13801,7 +13801,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/CartIcon.tsx",
       "source_location": "L1",
       "id": "carticon",
-      "community": 4
+      "community": 3
     },
     {
       "label": "ShoppingBag.tsx",
@@ -13809,7 +13809,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L1",
       "id": "shoppingbag",
-      "community": 1
+      "community": 4
     },
     {
       "label": "PendingItem()",
@@ -13817,7 +13817,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L62",
       "id": "shoppingbag_pendingitem",
-      "community": 1
+      "community": 4
     },
     {
       "label": "handleOnCheckoutClick()",
@@ -13825,7 +13825,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L476",
       "id": "shoppingbag_handleoncheckoutclick",
-      "community": 1
+      "community": 4
     },
     {
       "label": "handleClickOnDiscountCode()",
@@ -13833,7 +13833,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L525",
       "id": "shoppingbag_handleclickondiscountcode",
-      "community": 1
+      "community": 4
     },
     {
       "label": "isSkuUnavailable()",
@@ -13841,7 +13841,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L537",
       "id": "shoppingbag_isskuunavailable",
-      "community": 1
+      "community": 4
     },
     {
       "label": "handleMoveToSaved()",
@@ -13849,7 +13849,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L552",
       "id": "shoppingbag_handlemovetosaved",
-      "community": 1
+      "community": 4
     },
     {
       "label": "handleDeleteItem()",
@@ -13857,7 +13857,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L566",
       "id": "shoppingbag_handledeleteitem",
-      "community": 1
+      "community": 4
     },
     {
       "label": "CheckoutUnavailable.tsx",
@@ -13865,7 +13865,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout unavailable/CheckoutUnavailable.tsx",
       "source_location": "L1",
       "id": "checkoutunavailable",
-      "community": 1
+      "community": 4
     },
     {
       "label": "CheckoutUnavailable()",
@@ -13873,7 +13873,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout unavailable/CheckoutUnavailable.tsx",
       "source_location": "L4",
       "id": "checkoutunavailable_checkoutunavailable",
-      "community": 1
+      "community": 4
     },
     {
       "label": "CheckoutExpired.tsx",
@@ -13881,7 +13881,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L1",
       "id": "checkoutexpired",
-      "community": 1
+      "community": 4
     },
     {
       "label": "CheckoutExpired()",
@@ -13889,7 +13889,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L9",
       "id": "checkoutexpired_checkoutexpired",
-      "community": 1
+      "community": 4
     },
     {
       "label": "NoCheckoutSession()",
@@ -13897,7 +13897,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L33",
       "id": "checkoutexpired_nocheckoutsession",
-      "community": 1
+      "community": 4
     },
     {
       "label": "CheckoutSessionNotFound()",
@@ -13905,7 +13905,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L54",
       "id": "checkoutexpired_checkoutsessionnotfound",
-      "community": 1
+      "community": 4
     },
     {
       "label": "CheckoutSessionGeneric()",
@@ -13913,7 +13913,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L73",
       "id": "checkoutexpired_checkoutsessiongeneric",
-      "community": 1
+      "community": 4
     },
     {
       "label": "handleSendEmail()",
@@ -13921,7 +13921,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L98",
       "id": "checkoutexpired_handlesendemail",
-      "community": 1
+      "community": 4
     },
     {
       "label": "ErrorBoundary.tsx",
@@ -13929,7 +13929,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/error/ErrorBoundary.tsx",
       "source_location": "L1",
       "id": "errorboundary",
-      "community": 4
+      "community": 3
     },
     {
       "label": "ErrorBoundary()",
@@ -13937,7 +13937,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/error/ErrorBoundary.tsx",
       "source_location": "L22",
       "id": "errorboundary_errorboundary",
-      "community": 4
+      "community": 3
     },
     {
       "label": "Maintenance.tsx",
@@ -13945,7 +13945,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/maintenance/Maintenance.tsx",
       "source_location": "L1",
       "id": "maintenance",
-      "community": 4
+      "community": 3
     },
     {
       "label": "AnimatedCard.tsx",
@@ -13953,7 +13953,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/AnimatedCard.tsx",
       "source_location": "L1",
       "id": "animatedcard",
-      "community": 1
+      "community": 4
     },
     {
       "label": "ScrollDownButton.tsx",
@@ -13961,7 +13961,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/ScrollDownButton.tsx",
       "source_location": "L1",
       "id": "scrolldownbutton",
-      "community": 15
+      "community": 3
     },
     {
       "label": "ScrollDownButton()",
@@ -13969,7 +13969,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/ScrollDownButton.tsx",
       "source_location": "L11",
       "id": "scrolldownbutton_scrolldownbutton",
-      "community": 15
+      "community": 3
     },
     {
       "label": "alert.tsx",
@@ -13977,7 +13977,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/alert.tsx",
       "source_location": "L1",
       "id": "alert",
-      "community": 0
+      "community": 1
     },
     {
       "label": "breadcrumb.tsx",
@@ -13985,7 +13985,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/breadcrumb.tsx",
       "source_location": "L1",
       "id": "breadcrumb",
-      "community": 9
+      "community": 13
     },
     {
       "label": "country-select.tsx",
@@ -14041,7 +14041,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/image-with-fallback.tsx",
       "source_location": "L1",
       "id": "image_with_fallback",
-      "community": 1
+      "community": 3
     },
     {
       "label": "input-with-end-button.tsx",
@@ -14057,7 +14057,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
       "source_location": "L1",
       "id": "leaveareviewmodal",
-      "community": 6
+      "community": 1
     },
     {
       "label": "handleClose()",
@@ -14065,7 +14065,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
       "source_location": "L66",
       "id": "leaveareviewmodal_handleclose",
-      "community": 6
+      "community": 1
     },
     {
       "label": "LeaveAReviewModalForm.tsx",
@@ -14073,7 +14073,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModalForm.tsx",
       "source_location": "L1",
       "id": "leaveareviewmodalform",
-      "community": 6
+      "community": 1
     },
     {
       "label": "UpsellModal.tsx",
@@ -14137,7 +14137,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalSuccess.tsx",
       "source_location": "L1",
       "id": "upsellmodalsuccess",
-      "community": 1
+      "community": 4
     },
     {
       "label": "UpsellModalSuccess()",
@@ -14145,7 +14145,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalSuccess.tsx",
       "source_location": "L19",
       "id": "upsellmodalsuccess_upsellmodalsuccess",
-      "community": 1
+      "community": 4
     },
     {
       "label": "WelcomeBackModal.tsx",
@@ -14177,7 +14177,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
       "source_location": "L1",
       "id": "welcomebackmodalform",
-      "community": 6
+      "community": 1
     },
     {
       "label": "handleSubmit()",
@@ -14185,7 +14185,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
       "source_location": "L36",
       "id": "welcomebackmodalform_handlesubmit",
-      "community": 6
+      "community": 1
     },
     {
       "label": "handleInputChange()",
@@ -14193,7 +14193,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
       "source_location": "L51",
       "id": "welcomebackmodalform_handleinputchange",
-      "community": 6
+      "community": 1
     },
     {
       "label": "WelcomeBackModalSuccess.tsx",
@@ -14225,7 +14225,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/config/leaveReviewModalConfig.tsx",
       "source_location": "L1",
       "id": "leavereviewmodalconfig",
-      "community": 6
+      "community": 1
     },
     {
       "label": "getModalConfig()",
@@ -14233,7 +14233,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/config/leaveReviewModalConfig.tsx",
       "source_location": "L46",
       "id": "leavereviewmodalconfig_getmodalconfig",
-      "community": 6
+      "community": 1
     },
     {
       "label": "welcomeBackModalConfig.tsx",
@@ -14241,7 +14241,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/config/welcomeBackModalConfig.tsx",
       "source_location": "L1",
       "id": "welcomebackmodalconfig",
-      "community": 6
+      "community": 1
     },
     {
       "label": "getModalConfig()",
@@ -14249,7 +14249,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/config/welcomeBackModalConfig.tsx",
       "source_location": "L46",
       "id": "welcomebackmodalconfig_getmodalconfig",
-      "community": 6
+      "community": 1
     },
     {
       "label": "navigation-menu.tsx",
@@ -14257,7 +14257,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/navigation-menu.tsx",
       "source_location": "L1",
       "id": "navigation_menu",
-      "community": 0
+      "community": 1
     },
     {
       "label": "webp-jpg.tsx",
@@ -14265,7 +14265,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/webp-jpg.tsx",
       "source_location": "L1",
       "id": "webp_jpg",
-      "community": 41
+      "community": 42
     },
     {
       "label": "WebpImage()",
@@ -14273,7 +14273,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/webp-jpg.tsx",
       "source_location": "L1",
       "id": "webp_jpg_webpimage",
-      "community": 41
+      "community": 42
     },
     {
       "label": "FormSubmissionProvider.tsx",
@@ -14281,7 +14281,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/FormSubmissionProvider.tsx",
       "source_location": "L1",
       "id": "formsubmissionprovider",
-      "community": 42
+      "community": 43
     },
     {
       "label": "useFormSubmission()",
@@ -14289,7 +14289,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/FormSubmissionProvider.tsx",
       "source_location": "L15",
       "id": "formsubmissionprovider_useformsubmission",
-      "community": 42
+      "community": 43
     },
     {
       "label": "NavigationBarProvider.tsx",
@@ -14297,7 +14297,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
       "source_location": "L1",
       "id": "navigationbarprovider",
-      "community": 4
+      "community": 3
     },
     {
       "label": "NavigationBarProvider()",
@@ -14305,7 +14305,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
       "source_location": "L16",
       "id": "navigationbarprovider_navigationbarprovider",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useNavigationBarContext()",
@@ -14313,7 +14313,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
       "source_location": "L39",
       "id": "navigationbarprovider_usenavigationbarcontext",
-      "community": 4
+      "community": 3
     },
     {
       "label": "StoreContext.tsx",
@@ -14321,7 +14321,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
       "source_location": "L1",
       "id": "storecontext",
-      "community": 1
+      "community": 3
     },
     {
       "label": "StoreProvider()",
@@ -14329,7 +14329,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
       "source_location": "L25",
       "id": "storecontext_storeprovider",
-      "community": 1
+      "community": 3
     },
     {
       "label": "useStoreContext()",
@@ -14337,7 +14337,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
       "source_location": "L82",
       "id": "storecontext_usestorecontext",
-      "community": 1
+      "community": 3
     },
     {
       "label": "StorefrontObservabilityProvider.tsx",
@@ -14345,7 +14345,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
       "source_location": "L1",
       "id": "storefrontobservabilityprovider",
-      "community": 4
+      "community": 11
     },
     {
       "label": "StorefrontObservabilityProvider()",
@@ -14353,7 +14353,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
       "source_location": "L20",
       "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
-      "community": 4
+      "community": 11
     },
     {
       "label": "useStorefrontObservability()",
@@ -14361,7 +14361,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
       "source_location": "L55",
       "id": "storefrontobservabilityprovider_usestorefrontobservability",
-      "community": 4
+      "community": 11
     },
     {
       "label": "useCheckout.ts",
@@ -14401,7 +14401,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useEnhancedTracking.ts",
       "source_location": "L1",
       "id": "useenhancedtracking",
-      "community": 15
+      "community": 3
     },
     {
       "label": "useEnhancedTracking()",
@@ -14409,7 +14409,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useEnhancedTracking.ts",
       "source_location": "L29",
       "id": "useenhancedtracking_useenhancedtracking",
-      "community": 15
+      "community": 3
     },
     {
       "label": "useGetActiveCheckoutSession.tsx",
@@ -14417,7 +14417,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetActiveCheckoutSession.tsx",
       "source_location": "L1",
       "id": "usegetactivecheckoutsession",
-      "community": 1
+      "community": 4
     },
     {
       "label": "useGetActiveCheckoutSession()",
@@ -14425,7 +14425,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetActiveCheckoutSession.tsx",
       "source_location": "L5",
       "id": "usegetactivecheckoutsession_usegetactivecheckoutsession",
-      "community": 1
+      "community": 4
     },
     {
       "label": "useGetProduct.tsx",
@@ -14433,7 +14433,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetProduct.tsx",
       "source_location": "L1",
       "id": "usegetproduct",
-      "community": 1
+      "community": 13
     },
     {
       "label": "useGetProductQuery()",
@@ -14441,7 +14441,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetProduct.tsx",
       "source_location": "L5",
       "id": "usegetproduct_usegetproductquery",
-      "community": 1
+      "community": 13
     },
     {
       "label": "useGetProductFilters.ts",
@@ -14449,7 +14449,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetProductFilters.ts",
       "source_location": "L1",
       "id": "usegetproductfilters",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useGetProductFilters()",
@@ -14457,7 +14457,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetProductFilters.ts",
       "source_location": "L3",
       "id": "usegetproductfilters_usegetproductfilters",
-      "community": 4
+      "community": 3
     },
     {
       "label": "useGetProductReviews.ts",
@@ -14465,7 +14465,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetProductReviews.ts",
       "source_location": "L1",
       "id": "usegetproductreviews",
-      "community": 17
+      "community": 13
     },
     {
       "label": "useGetProductReviewsQuery()",
@@ -14473,7 +14473,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetProductReviews.ts",
       "source_location": "L4",
       "id": "usegetproductreviews_usegetproductreviewsquery",
-      "community": 17
+      "community": 13
     },
     {
       "label": "useGetStore.ts",
@@ -14497,7 +14497,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useInventoryStatus.ts",
       "source_location": "L1",
       "id": "useinventorystatus",
-      "community": 15
+      "community": 13
     },
     {
       "label": "useInventoryStatus()",
@@ -14505,7 +14505,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useInventoryStatus.ts",
       "source_location": "L9",
       "id": "useinventorystatus_useinventorystatus",
-      "community": 15
+      "community": 13
     },
     {
       "label": "useLeaveAReviewModal.tsx",
@@ -14513,7 +14513,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useLeaveAReviewModal.tsx",
       "source_location": "L1",
       "id": "useleaveareviewmodal",
-      "community": 1
+      "community": 3
     },
     {
       "label": "useLeaveAReviewModal()",
@@ -14521,7 +14521,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useLeaveAReviewModal.tsx",
       "source_location": "L17",
       "id": "useleaveareviewmodal_useleaveareviewmodal",
-      "community": 1
+      "community": 3
     },
     {
       "label": "useLogout.ts",
@@ -14529,7 +14529,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useLogout.ts",
       "source_location": "L1",
       "id": "uselogout",
-      "community": 1
+      "community": 3
     },
     {
       "label": "useLogout()",
@@ -14537,7 +14537,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useLogout.ts",
       "source_location": "L5",
       "id": "uselogout_uselogout",
-      "community": 1
+      "community": 3
     },
     {
       "label": "useModalState.tsx",
@@ -14545,7 +14545,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useModalState.tsx",
       "source_location": "L1",
       "id": "usemodalstate",
-      "community": 1
+      "community": 3
     },
     {
       "label": "useModalState()",
@@ -14553,7 +14553,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useModalState.tsx",
       "source_location": "L15",
       "id": "usemodalstate_usemodalstate",
-      "community": 1
+      "community": 3
     },
     {
       "label": "useProductDiscount.ts",
@@ -14561,7 +14561,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
       "source_location": "L1",
       "id": "useproductdiscount",
-      "community": 1
+      "community": 4
     },
     {
       "label": "useProductDiscounts()",
@@ -14569,7 +14569,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
       "source_location": "L25",
       "id": "useproductdiscount_useproductdiscounts",
-      "community": 1
+      "community": 4
     },
     {
       "label": "useProductDiscount()",
@@ -14577,7 +14577,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
       "source_location": "L107",
       "id": "useproductdiscount_useproductdiscount",
-      "community": 1
+      "community": 4
     },
     {
       "label": "useProductPageLogic.ts",
@@ -14585,7 +14585,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useProductPageLogic.ts",
       "source_location": "L1",
       "id": "useproductpagelogic",
-      "community": 1
+      "community": 4
     },
     {
       "label": "useProductPageLogic()",
@@ -14593,7 +14593,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useProductPageLogic.ts",
       "source_location": "L18",
       "id": "useproductpagelogic_useproductpagelogic",
-      "community": 1
+      "community": 4
     },
     {
       "label": "useProductReminder.tsx",
@@ -14617,7 +14617,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/usePromoAlert.tsx",
       "source_location": "L1",
       "id": "usepromoalert",
-      "community": 1
+      "community": 3
     },
     {
       "label": "usePromoAlert()",
@@ -14625,7 +14625,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/usePromoAlert.tsx",
       "source_location": "L16",
       "id": "usepromoalert_usepromoalert",
-      "community": 1
+      "community": 3
     },
     {
       "label": "useQueryEnabled.ts",
@@ -14649,7 +14649,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useRewardsAlert.tsx",
       "source_location": "L1",
       "id": "userewardsalert",
-      "community": 1
+      "community": 3
     },
     {
       "label": "useRewardsAlert()",
@@ -14657,7 +14657,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useRewardsAlert.tsx",
       "source_location": "L11",
       "id": "userewardsalert_userewardsalert",
-      "community": 1
+      "community": 3
     },
     {
       "label": "useScrollToTop.ts",
@@ -14665,7 +14665,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useScrollToTop.ts",
       "source_location": "L1",
       "id": "usescrolltotop",
-      "community": 7
+      "community": 10
     },
     {
       "label": "useScrollToTop()",
@@ -14673,7 +14673,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useScrollToTop.ts",
       "source_location": "L3",
       "id": "usescrolltotop_usescrolltotop",
-      "community": 7
+      "community": 10
     },
     {
       "label": "useShoppingBag.ts",
@@ -14681,7 +14681,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
       "source_location": "L1",
       "id": "useshoppingbag",
-      "community": 1
+      "community": 4
     },
     {
       "label": "useShoppingBag()",
@@ -14689,7 +14689,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
       "source_location": "L52",
       "id": "useshoppingbag_useshoppingbag",
-      "community": 1
+      "community": 4
     },
     {
       "label": "isUnavailableProductList()",
@@ -14697,7 +14697,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
       "source_location": "L540",
       "id": "useshoppingbag_isunavailableproductlist",
-      "community": 1
+      "community": 4
     },
     {
       "label": "useStorefrontObservability.ts",
@@ -14705,7 +14705,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useStorefrontObservability.ts",
       "source_location": "L1",
       "id": "usestorefrontobservability",
-      "community": 1
+      "community": 4
     },
     {
       "label": "useTrackAction.ts",
@@ -14713,7 +14713,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useTrackAction.ts",
       "source_location": "L1",
       "id": "usetrackaction",
-      "community": 15
+      "community": 3
     },
     {
       "label": "useTrackAction()",
@@ -14721,7 +14721,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useTrackAction.ts",
       "source_location": "L5",
       "id": "usetrackaction_usetrackaction",
-      "community": 15
+      "community": 3
     },
     {
       "label": "useTrackEvent.ts",
@@ -14729,7 +14729,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useTrackEvent.ts",
       "source_location": "L1",
       "id": "usetrackevent",
-      "community": 1
+      "community": 3
     },
     {
       "label": "useTrackEvent()",
@@ -14737,7 +14737,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useTrackEvent.ts",
       "source_location": "L5",
       "id": "usetrackevent_usetrackevent",
-      "community": 1
+      "community": 3
     },
     {
       "label": "useUpsellModal.tsx",
@@ -14745,7 +14745,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useUpsellModal.tsx",
       "source_location": "L1",
       "id": "useupsellmodal",
-      "community": 1
+      "community": 3
     },
     {
       "label": "useUpsellModal()",
@@ -14753,7 +14753,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useUpsellModal.tsx",
       "source_location": "L14",
       "id": "useupsellmodal_useupsellmodal",
-      "community": 1
+      "community": 3
     },
     {
       "label": "feeUtils.test.ts",
@@ -14761,7 +14761,7 @@
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.test.ts",
       "source_location": "L1",
       "id": "feeutils_test",
-      "community": 1
+      "community": 4
     },
     {
       "label": "feeUtils.ts",
@@ -14769,7 +14769,7 @@
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L1",
       "id": "feeutils",
-      "community": 1
+      "community": 4
     },
     {
       "label": "meetsThreshold()",
@@ -14777,7 +14777,7 @@
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L17",
       "id": "feeutils_meetsthreshold",
-      "community": 1
+      "community": 4
     },
     {
       "label": "isFeeWaived()",
@@ -14785,7 +14785,7 @@
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L34",
       "id": "feeutils_isfeewaived",
-      "community": 1
+      "community": 4
     },
     {
       "label": "isAnyFeeWaived()",
@@ -14793,7 +14793,7 @@
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L74",
       "id": "feeutils_isanyfeewaived",
-      "community": 1
+      "community": 4
     },
     {
       "label": "hasWaiverConfigured()",
@@ -14801,7 +14801,7 @@
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L100",
       "id": "feeutils_haswaiverconfigured",
-      "community": 1
+      "community": 4
     },
     {
       "label": "getRemainingForFreeDelivery()",
@@ -14809,7 +14809,7 @@
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L138",
       "id": "feeutils_getremainingforfreedelivery",
-      "community": 1
+      "community": 4
     },
     {
       "label": "maintenanceUtils.test.ts",
@@ -14817,7 +14817,7 @@
       "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.test.ts",
       "source_location": "L1",
       "id": "maintenanceutils_test",
-      "community": 16
+      "community": 3
     },
     {
       "label": "usePostAnalytics()",
@@ -14825,7 +14825,7 @@
       "source_file": "packages/storefront-webapp/src/lib/mutations.ts/analytics.ts",
       "source_location": "L4",
       "id": "analytics_usepostanalytics",
-      "community": 15
+      "community": 3
     },
     {
       "label": "isSoldOut()",
@@ -14833,7 +14833,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L45",
       "id": "productutils_issoldout",
-      "community": 1
+      "community": 3
     },
     {
       "label": "hasLowStock()",
@@ -14841,7 +14841,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L52",
       "id": "productutils_haslowstock",
-      "community": 1
+      "community": 3
     },
     {
       "label": "sortSkusByLength()",
@@ -14849,7 +14849,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L62",
       "id": "productutils_sortskusbylength",
-      "community": 1
+      "community": 3
     },
     {
       "label": "useBagQueries()",
@@ -14873,7 +14873,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/checkout.ts",
       "source_location": "L10",
       "id": "checkout_usecheckoutsessionqueries",
-      "community": 1
+      "community": 4
     },
     {
       "label": "inventory.ts",
@@ -14905,7 +14905,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/product.ts",
       "source_location": "L14",
       "id": "product_useproductqueries",
-      "community": 15
+      "community": 13
     },
     {
       "label": "usePromoCodesQueries()",
@@ -14913,7 +14913,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/promoCode.ts",
       "source_location": "L9",
       "id": "promocode_usepromocodesqueries",
-      "community": 1
+      "community": 2
     },
     {
       "label": "useReviewQueries()",
@@ -14921,7 +14921,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/reviews.ts",
       "source_location": "L10",
       "id": "reviews_usereviewqueries",
-      "community": 17
+      "community": 13
     },
     {
       "label": "useRewardsQueries()",
@@ -14929,7 +14929,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/rewards.ts",
       "source_location": "L11",
       "id": "rewards_userewardsqueries",
-      "community": 2
+      "community": 18
     },
     {
       "label": "useUpsellsQueries()",
@@ -14969,7 +14969,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.test.ts",
       "source_location": "L10",
       "id": "storeconfig_test_buildv2config",
-      "community": 16
+      "community": 3
     },
     {
       "label": "mapPromo()",
@@ -14977,7 +14977,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L172",
       "id": "storeconfig_mappromo",
-      "community": 16
+      "community": 3
     },
     {
       "label": "isStoreReadOnlyMode()",
@@ -14985,7 +14985,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L461",
       "id": "storeconfig_isstorereadonlymode",
-      "community": 16
+      "community": 3
     },
     {
       "label": "isStoreMaintenanceMode()",
@@ -14993,7 +14993,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L465",
       "id": "storeconfig_isstoremaintenancemode",
-      "community": 16
+      "community": 3
     },
     {
       "label": "getStoreFallbackImageUrl()",
@@ -15001,7 +15001,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L479",
       "id": "storeconfig_getstorefallbackimageurl",
-      "community": 16
+      "community": 3
     },
     {
       "label": "storefrontFailureObservability.test.ts",
@@ -15009,7 +15009,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.test.ts",
       "source_location": "L1",
       "id": "storefrontfailureobservability_test",
-      "community": 4
+      "community": 11
     },
     {
       "label": "storefrontFailureObservability.ts",
@@ -15057,7 +15057,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.test.ts",
       "source_location": "L1",
       "id": "storefrontjourneyevents_test",
-      "community": 14
+      "community": 4
     },
     {
       "label": "storefrontJourneyEvents.ts",
@@ -15065,7 +15065,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L1",
       "id": "storefrontjourneyevents",
-      "community": 14
+      "community": 4
     },
     {
       "label": "compactContext()",
@@ -15073,7 +15073,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L7",
       "id": "storefrontjourneyevents_compactcontext",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createJourneyEvent()",
@@ -15081,7 +15081,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L19",
       "id": "storefrontjourneyevents_createjourneyevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createLandingPageViewedEvent()",
@@ -15089,7 +15089,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L33",
       "id": "storefrontjourneyevents_createlandingpageviewedevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createCategoryBrowseViewedEvent()",
@@ -15097,7 +15097,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L41",
       "id": "storefrontjourneyevents_createcategorybrowseviewedevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createProductDetailViewedEvent()",
@@ -15105,7 +15105,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L59",
       "id": "storefrontjourneyevents_createproductdetailviewedevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createBagViewedEvent()",
@@ -15113,7 +15113,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L83",
       "id": "storefrontjourneyevents_createbagviewedevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createBagAddSucceededEvent()",
@@ -15121,7 +15121,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L101",
       "id": "storefrontjourneyevents_createbagaddsucceededevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createBagRemoveSucceededEvent()",
@@ -15129,7 +15129,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L122",
       "id": "storefrontjourneyevents_createbagremovesucceededevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createCheckoutStartEvent()",
@@ -15137,7 +15137,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L143",
       "id": "storefrontjourneyevents_createcheckoutstartevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createCheckoutDetailsViewedEvent()",
@@ -15145,7 +15145,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L164",
       "id": "storefrontjourneyevents_createcheckoutdetailsviewedevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createOrderReviewViewedEvent()",
@@ -15153,7 +15153,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L179",
       "id": "storefrontjourneyevents_createorderreviewviewedevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createPaymentSubmissionStartedEvent()",
@@ -15161,7 +15161,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L194",
       "id": "storefrontjourneyevents_createpaymentsubmissionstartedevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createPaymentVerificationStartedEvent()",
@@ -15169,7 +15169,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L215",
       "id": "storefrontjourneyevents_createpaymentverificationstartedevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createCheckoutCompletionEvent()",
@@ -15177,7 +15177,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L233",
       "id": "storefrontjourneyevents_createcheckoutcompletionevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createCheckoutCompletionSucceededEvent()",
@@ -15185,7 +15185,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L256",
       "id": "storefrontjourneyevents_createcheckoutcompletionsucceededevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createCheckoutCompletionBlockedEvent()",
@@ -15193,7 +15193,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L273",
       "id": "storefrontjourneyevents_createcheckoutcompletionblockedevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createCheckoutCompletionCanceledEvent()",
@@ -15201,7 +15201,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L290",
       "id": "storefrontjourneyevents_createcheckoutcompletioncanceledevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "getAuthEntryStep()",
@@ -15209,7 +15209,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L307",
       "id": "storefrontjourneyevents_getauthentrystep",
-      "community": 14
+      "community": 4
     },
     {
       "label": "getAuthRequestStep()",
@@ -15217,7 +15217,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L311",
       "id": "storefrontjourneyevents_getauthrequeststep",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createAuthEntryViewedEvent()",
@@ -15225,7 +15225,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L315",
       "id": "storefrontjourneyevents_createauthentryviewedevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createAuthRequestStartedEvent()",
@@ -15233,7 +15233,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L335",
       "id": "storefrontjourneyevents_createauthrequeststartedevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createAuthVerificationViewedEvent()",
@@ -15241,7 +15241,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L355",
       "id": "storefrontjourneyevents_createauthverificationviewedevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createAuthVerificationSucceededEvent()",
@@ -15249,7 +15249,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L370",
       "id": "storefrontjourneyevents_createauthverificationsucceededevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createRewardsAlertViewedEvent()",
@@ -15257,7 +15257,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L387",
       "id": "storefrontjourneyevents_createrewardsalertviewedevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createRewardsAlertDismissedEvent()",
@@ -15265,7 +15265,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L395",
       "id": "storefrontjourneyevents_createrewardsalertdismissedevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createRewardsAlertShopNowEvent()",
@@ -15273,7 +15273,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L403",
       "id": "storefrontjourneyevents_createrewardsalertshopnowevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createPromoAlertViewedEvent()",
@@ -15281,7 +15281,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L411",
       "id": "storefrontjourneyevents_createpromoalertviewedevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createPromoAlertDismissedEvent()",
@@ -15289,7 +15289,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L435",
       "id": "storefrontjourneyevents_createpromoalertdismissedevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createPromoAlertShopNowEvent()",
@@ -15297,7 +15297,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L459",
       "id": "storefrontjourneyevents_createpromoalertshopnowevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createWelcomeBackModalViewedEvent()",
@@ -15305,7 +15305,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L483",
       "id": "storefrontjourneyevents_createwelcomebackmodalviewedevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createWelcomeBackModalDismissedEvent()",
@@ -15313,7 +15313,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L501",
       "id": "storefrontjourneyevents_createwelcomebackmodaldismissedevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createWelcomeBackModalSubmittedEvent()",
@@ -15321,7 +15321,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L519",
       "id": "storefrontjourneyevents_createwelcomebackmodalsubmittedevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createLeaveReviewModalViewedEvent()",
@@ -15329,7 +15329,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L537",
       "id": "storefrontjourneyevents_createleavereviewmodalviewedevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createLeaveReviewModalDismissedEvent()",
@@ -15337,7 +15337,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L555",
       "id": "storefrontjourneyevents_createleavereviewmodaldismissedevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createUpsellModalViewedEvent()",
@@ -15345,7 +15345,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L573",
       "id": "storefrontjourneyevents_createupsellmodalviewedevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createUpsellModalDismissedEvent()",
@@ -15353,7 +15353,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L600",
       "id": "storefrontjourneyevents_createupsellmodaldismissedevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createUpsellModalSubmittedEvent()",
@@ -15361,7 +15361,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L627",
       "id": "storefrontjourneyevents_createupsellmodalsubmittedevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createUpsellModalAddToBagEvent()",
@@ -15369,7 +15369,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L654",
       "id": "storefrontjourneyevents_createupsellmodaladdtobagevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createSavedBagViewedEvent()",
@@ -15377,7 +15377,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L676",
       "id": "storefrontjourneyevents_createsavedbagviewedevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createSavedBagMoveToBagEvent()",
@@ -15385,7 +15385,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L684",
       "id": "storefrontjourneyevents_createsavedbagmovetobagevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createSavedBagRemoveEvent()",
@@ -15393,7 +15393,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L705",
       "id": "storefrontjourneyevents_createsavedbagremoveevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createBagMoveToSavedEvent()",
@@ -15401,7 +15401,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L726",
       "id": "storefrontjourneyevents_createbagmovetosavedevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createDiscountCodeTriggerEvent()",
@@ -15409,7 +15409,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L747",
       "id": "storefrontjourneyevents_creatediscountcodetriggerevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createReviewEditorViewedEvent()",
@@ -15417,7 +15417,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L762",
       "id": "storefrontjourneyevents_createrevieweditorviewedevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "createReviewSubmittedEvent()",
@@ -15425,7 +15425,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L786",
       "id": "storefrontjourneyevents_createreviewsubmittedevent",
-      "community": 14
+      "community": 4
     },
     {
       "label": "storefrontObservability.test.ts",
@@ -15433,7 +15433,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.test.ts",
       "source_location": "L1",
       "id": "storefrontobservability_test",
-      "community": 4
+      "community": 11
     },
     {
       "label": "createMemoryStorage()",
@@ -15441,7 +15441,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.test.ts",
       "source_location": "L12",
       "id": "storefrontobservability_test_creatememorystorage",
-      "community": 4
+      "community": 11
     },
     {
       "label": "storefrontObservability.ts",
@@ -15449,7 +15449,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L1",
       "id": "storefrontobservability",
-      "community": 4
+      "community": 11
     },
     {
       "label": "getOrCreateStorefrontObservabilitySessionId()",
@@ -15457,7 +15457,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L109",
       "id": "storefrontobservability_getorcreatestorefrontobservabilitysessionid",
-      "community": 4
+      "community": 11
     },
     {
       "label": "createStorefrontObservabilityContext()",
@@ -15465,7 +15465,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L134",
       "id": "storefrontobservability_createstorefrontobservabilitycontext",
-      "community": 4
+      "community": 11
     },
     {
       "label": "createStorefrontObservabilityPayload()",
@@ -15473,7 +15473,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L157",
       "id": "storefrontobservability_createstorefrontobservabilitypayload",
-      "community": 4
+      "community": 11
     },
     {
       "label": "trackStorefrontEvent()",
@@ -15481,7 +15481,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L193",
       "id": "storefrontobservability_trackstorefrontevent",
-      "community": 4
+      "community": 11
     },
     {
       "label": "getStoreDetails()",
@@ -15489,7 +15489,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L53",
       "id": "utils_getstoredetails",
-      "community": 0
+      "community": 1
     },
     {
       "label": "enableQuery()",
@@ -15497,7 +15497,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.ts",
       "source_location": "L60",
       "id": "utils_enablequery",
-      "community": 0
+      "community": 1
     },
     {
       "label": "validateEmail()",
@@ -15505,7 +15505,7 @@
       "source_file": "packages/storefront-webapp/src/lib/validations/email.ts",
       "source_location": "L14",
       "id": "email_validateemail",
-      "community": 6
+      "community": 1
     },
     {
       "label": "router.tsx",
@@ -15513,7 +15513,7 @@
       "source_file": "packages/storefront-webapp/src/router.tsx",
       "source_location": "L1",
       "id": "router",
-      "community": 4
+      "community": 11
     },
     {
       "label": "createRouter()",
@@ -15521,7 +15521,7 @@
       "source_file": "packages/storefront-webapp/src/router.tsx",
       "source_location": "L5",
       "id": "router_createrouter",
-      "community": 4
+      "community": 11
     },
     {
       "label": "$orderItemId.review.tsx",
@@ -15529,7 +15529,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/$orderItemId.review.tsx",
       "source_location": "L1",
       "id": "orderitemid_review",
-      "community": 1
+      "community": 3
     },
     {
       "label": "getPaymentText()",
@@ -15553,7 +15553,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
       "source_location": "L46",
       "id": "review_ordernavigation",
-      "community": 1
+      "community": 3
     },
     {
       "label": "getOrderMessage()",
@@ -15561,7 +15561,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
       "source_location": "L250",
       "id": "review_getordermessage",
-      "community": 1
+      "community": 3
     },
     {
       "label": "_ordersLayout.tsx",
@@ -15569,7 +15569,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout.tsx",
       "source_location": "L1",
       "id": "orderslayout",
-      "community": 7
+      "community": 10
     },
     {
       "label": "LayoutComponent()",
@@ -15577,7 +15577,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout.tsx",
       "source_location": "L8",
       "id": "orderslayout_layoutcomponent",
-      "community": 7
+      "community": 10
     },
     {
       "label": "$subcategorySlug.tsx",
@@ -15585,7 +15585,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout/shop/$categorySlug/$subcategorySlug.tsx",
       "source_location": "L1",
       "id": "subcategoryslug",
-      "community": 15
+      "community": 4
     },
     {
       "label": "_shopLayout.tsx",
@@ -15593,7 +15593,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
       "source_location": "L1",
       "id": "shoplayout",
-      "community": 4
+      "community": 3
     },
     {
       "label": "onClickOnMobileFilters()",
@@ -15601,7 +15601,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
       "source_location": "L105",
       "id": "shoplayout_onclickonmobilefilters",
-      "community": 4
+      "community": 3
     },
     {
       "label": "onMobileFiltersCloseClick()",
@@ -15609,7 +15609,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
       "source_location": "L110",
       "id": "shoplayout_onmobilefilterscloseclick",
-      "community": 4
+      "community": 3
     },
     {
       "label": "clearFilters()",
@@ -15617,7 +15617,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
       "source_location": "L115",
       "id": "shoplayout_clearfilters",
-      "community": 4
+      "community": 3
     },
     {
       "label": "account.tsx",
@@ -15625,7 +15625,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
       "source_location": "L1",
       "id": "account",
-      "community": 1
+      "community": 3
     },
     {
       "label": "accountBeforeLoad()",
@@ -15633,7 +15633,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
       "source_location": "L17",
       "id": "account_accountbeforeload",
-      "community": 1
+      "community": 3
     },
     {
       "label": "handleOnSubmitForm()",
@@ -15641,7 +15641,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
       "source_location": "L63",
       "id": "account_handleonsubmitform",
-      "community": 1
+      "community": 3
     },
     {
       "label": "contact-us.tsx",
@@ -15649,7 +15649,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/contact-us.tsx",
       "source_location": "L1",
       "id": "contact_us",
-      "community": 1
+      "community": 3
     },
     {
       "label": "ContactUs()",
@@ -15657,7 +15657,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/contact-us.tsx",
       "source_location": "L14",
       "id": "contact_us_contactus",
-      "community": 1
+      "community": 3
     },
     {
       "label": "delivery-returns-exchanges.index.tsx",
@@ -15665,7 +15665,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/delivery-returns-exchanges.index.tsx",
       "source_location": "L1",
       "id": "delivery_returns_exchanges_index",
-      "community": 7
+      "community": 10
     },
     {
       "label": "OnlineOrderPolicy()",
@@ -15673,7 +15673,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/delivery-returns-exchanges.index.tsx",
       "source_location": "L13",
       "id": "delivery_returns_exchanges_index_onlineorderpolicy",
-      "community": 7
+      "community": 10
     },
     {
       "label": "privacy.index.tsx",
@@ -15681,7 +15681,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/privacy.index.tsx",
       "source_location": "L1",
       "id": "privacy_index",
-      "community": 7
+      "community": 10
     },
     {
       "label": "PrivacyPolicy()",
@@ -15689,7 +15689,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/privacy.index.tsx",
       "source_location": "L9",
       "id": "privacy_index_privacypolicy",
-      "community": 7
+      "community": 10
     },
     {
       "label": "tos.index.tsx",
@@ -15697,7 +15697,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
       "source_location": "L1",
       "id": "tos_index",
-      "community": 7
+      "community": 10
     },
     {
       "label": "TosSection()",
@@ -15705,7 +15705,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
       "source_location": "L15",
       "id": "tos_index_tossection",
-      "community": 7
+      "community": 10
     },
     {
       "label": "rewards.index.tsx",
@@ -15713,7 +15713,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/rewards.index.tsx",
       "source_location": "L1",
       "id": "rewards_index",
-      "community": 1
+      "community": 0
     },
     {
       "label": "shop.product.$productSlug.tsx",
@@ -15721,7 +15721,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/shop.product.$productSlug.tsx",
       "source_location": "L1",
       "id": "shop_product_productslug",
-      "community": 9
+      "community": 13
     },
     {
       "label": "Component()",
@@ -15729,7 +15729,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/shop.product.$productSlug.tsx",
       "source_location": "L16",
       "id": "shop_product_productslug_component",
-      "community": 9
+      "community": 13
     },
     {
       "label": "shop.saved.index.tsx",
@@ -15737,7 +15737,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/shop.saved.index.tsx",
       "source_location": "L1",
       "id": "shop_saved_index",
-      "community": 2
+      "community": 4
     },
     {
       "label": "LayoutComponent()",
@@ -15745,7 +15745,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout.tsx",
       "source_location": "L6",
       "id": "layout_layoutcomponent",
-      "community": 4
+      "community": 3
     },
     {
       "label": "auth.verify.tsx",
@@ -15753,7 +15753,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L1",
       "id": "auth_verify",
-      "community": 2
+      "community": 4
     },
     {
       "label": "reportAuthFailure()",
@@ -15761,7 +15761,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L93",
       "id": "auth_verify_reportauthfailure",
-      "community": 2
+      "community": 4
     },
     {
       "label": "formatTime()",
@@ -15769,7 +15769,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L149",
       "id": "auth_verify_formattime",
-      "community": 2
+      "community": 4
     },
     {
       "label": "handleCodeChange()",
@@ -15777,7 +15777,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L156",
       "id": "auth_verify_handlecodechange",
-      "community": 2
+      "community": 4
     },
     {
       "label": "onSubmit()",
@@ -15785,7 +15785,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L201",
       "id": "auth_verify_onsubmit",
-      "community": 2
+      "community": 4
     },
     {
       "label": "resendVerificationCode()",
@@ -15793,7 +15793,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L282",
       "id": "auth_verify_resendverificationcode",
-      "community": 2
+      "community": 4
     },
     {
       "label": "login.tsx",
@@ -15801,7 +15801,7 @@
       "source_file": "packages/storefront-webapp/src/routes/login.tsx",
       "source_location": "L1",
       "id": "login",
-      "community": 1
+      "community": 4
     },
     {
       "label": "loginBeforeLoad()",
@@ -15809,7 +15809,7 @@
       "source_file": "packages/storefront-webapp/src/routes/login.tsx",
       "source_location": "L47",
       "id": "login_loginbeforeload",
-      "community": 1
+      "community": 4
     },
     {
       "label": "onSubmit()",
@@ -15817,7 +15817,7 @@
       "source_file": "packages/storefront-webapp/src/routes/login.tsx",
       "source_location": "L141",
       "id": "login_onsubmit",
-      "community": 1
+      "community": 4
     },
     {
       "label": "bag.index.tsx",
@@ -15825,7 +15825,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/bag.index.tsx",
       "source_location": "L1",
       "id": "bag_index",
-      "community": 1
+      "community": 4
     },
     {
       "label": "canceled.tsx",
@@ -15833,7 +15833,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/canceled.tsx",
       "source_location": "L1",
       "id": "canceled",
-      "community": 1
+      "community": 4
     },
     {
       "label": "CheckoutCanceledView()",
@@ -15841,7 +15841,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/canceled.tsx",
       "source_location": "L21",
       "id": "canceled_checkoutcanceledview",
-      "community": 1
+      "community": 4
     },
     {
       "label": "complete.tsx",
@@ -15889,7 +15889,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/complete.index.tsx",
       "source_location": "L1",
       "id": "complete_index",
-      "community": 1
+      "community": 4
     },
     {
       "label": "CheckoutComplete()",
@@ -15897,7 +15897,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/complete.index.tsx",
       "source_location": "L33",
       "id": "complete_index_checkoutcomplete",
-      "community": 1
+      "community": 4
     },
     {
       "label": "pending.tsx",
@@ -15905,7 +15905,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/pending.tsx",
       "source_location": "L1",
       "id": "pending",
-      "community": 1
+      "community": 4
     },
     {
       "label": "pod-confirmation.tsx",
@@ -15929,7 +15929,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
       "source_location": "L1",
       "id": "verify_index",
-      "community": 1
+      "community": 4
     },
     {
       "label": "Verify()",
@@ -15937,7 +15937,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
       "source_location": "L21",
       "id": "verify_index_verify",
-      "community": 1
+      "community": 4
     },
     {
       "label": "VerifyCheckoutSessionPayment()",
@@ -15945,7 +15945,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
       "source_location": "L107",
       "id": "verify_index_verifycheckoutsessionpayment",
-      "community": 1
+      "community": 4
     },
     {
       "label": "signup.tsx",
@@ -15953,7 +15953,7 @@
       "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
       "source_location": "L1",
       "id": "signup",
-      "community": 1
+      "community": 4
     },
     {
       "label": "signupBeforeLoad()",
@@ -15961,7 +15961,7 @@
       "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
       "source_location": "L66",
       "id": "signup_signupbeforeload",
-      "community": 1
+      "community": 4
     },
     {
       "label": "onSubmit()",
@@ -15969,7 +15969,7 @@
       "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
       "source_location": "L161",
       "id": "signup_onsubmit",
-      "community": 1
+      "community": 4
     },
     {
       "label": "ssr.tsx",
@@ -15977,7 +15977,7 @@
       "source_file": "packages/storefront-webapp/src/ssr.tsx",
       "source_location": "L1",
       "id": "ssr",
-      "community": 4
+      "community": 11
     },
     {
       "label": "bootstrap.ts",
@@ -16033,7 +16033,7 @@
       "source_file": "packages/valkey-proxy-server/test-connection.js",
       "source_location": "L1",
       "id": "test_connection",
-      "community": 27
+      "community": 28
     },
     {
       "label": "testConnection()",
@@ -16041,7 +16041,7 @@
       "source_file": "packages/valkey-proxy-server/test-connection.js",
       "source_location": "L40",
       "id": "test_connection_testconnection",
-      "community": 27
+      "community": 28
     },
     {
       "label": "testClusterInfo()",
@@ -16049,7 +16049,7 @@
       "source_file": "packages/valkey-proxy-server/test-connection.js",
       "source_location": "L52",
       "id": "test_connection_testclusterinfo",
-      "community": 27
+      "community": 28
     },
     {
       "label": "testBasicOperations()",
@@ -16057,7 +16057,7 @@
       "source_file": "packages/valkey-proxy-server/test-connection.js",
       "source_location": "L64",
       "id": "test_connection_testbasicoperations",
-      "community": 27
+      "community": 28
     },
     {
       "label": "runTests()",
@@ -16065,7 +16065,7 @@
       "source_file": "packages/valkey-proxy-server/test-connection.js",
       "source_location": "L89",
       "id": "test_connection_runtests",
-      "community": 27
+      "community": 28
     },
     {
       "label": "architecture-boundaries.test.ts",
@@ -16073,7 +16073,7 @@
       "source_file": "scripts/architecture-boundaries.test.ts",
       "source_location": "L1",
       "id": "architecture_boundaries_test",
-      "community": 43
+      "community": 44
     },
     {
       "label": "createSnippetLinter()",
@@ -16081,7 +16081,7 @@
       "source_file": "scripts/architecture-boundaries.test.ts",
       "source_location": "L10",
       "id": "architecture_boundaries_test_createsnippetlinter",
-      "community": 43
+      "community": 44
     },
     {
       "label": "architecture-boundary-check.ts",
@@ -16089,7 +16089,7 @@
       "source_file": "scripts/architecture-boundary-check.ts",
       "source_location": "L1",
       "id": "architecture_boundary_check",
-      "community": 44
+      "community": 45
     },
     {
       "label": "run()",
@@ -16097,7 +16097,7 @@
       "source_file": "scripts/architecture-boundary-check.ts",
       "source_location": "L29",
       "id": "architecture_boundary_check_run",
-      "community": 44
+      "community": 45
     },
     {
       "label": "graphify-rebuild.test.ts",
@@ -16105,7 +16105,7 @@
       "source_file": "scripts/graphify-rebuild.test.ts",
       "source_location": "L1",
       "id": "graphify_rebuild_test",
-      "community": 24
+      "community": 25
     },
     {
       "label": "write()",
@@ -16113,7 +16113,7 @@
       "source_file": "scripts/graphify-rebuild.test.ts",
       "source_location": "L10",
       "id": "graphify_rebuild_test_write",
-      "community": 24
+      "community": 25
     },
     {
       "label": "createFixtureRoot()",
@@ -16121,7 +16121,7 @@
       "source_file": "scripts/graphify-rebuild.test.ts",
       "source_location": "L16",
       "id": "graphify_rebuild_test_createfixtureroot",
-      "community": 24
+      "community": 25
     },
     {
       "label": "spawn()",
@@ -16129,7 +16129,7 @@
       "source_file": "scripts/graphify-rebuild.test.ts",
       "source_location": "L38",
       "id": "graphify_rebuild_test_spawn",
-      "community": 24
+      "community": 25
     },
     {
       "label": "graphify-rebuild.ts",
@@ -16137,7 +16137,7 @@
       "source_file": "scripts/graphify-rebuild.ts",
       "source_location": "L1",
       "id": "graphify_rebuild",
-      "community": 24
+      "community": 25
     },
     {
       "label": "fileExists()",
@@ -16145,7 +16145,7 @@
       "source_file": "scripts/graphify-rebuild.ts",
       "source_location": "L67",
       "id": "graphify_rebuild_fileexists",
-      "community": 24
+      "community": 25
     },
     {
       "label": "resolveGraphifyPython()",
@@ -16153,7 +16153,7 @@
       "source_file": "scripts/graphify-rebuild.ts",
       "source_location": "L76",
       "id": "graphify_rebuild_resolvegraphifypython",
-      "community": 24
+      "community": 25
     },
     {
       "label": "runGraphifyRebuild()",
@@ -16161,7 +16161,7 @@
       "source_file": "scripts/graphify-rebuild.ts",
       "source_location": "L86",
       "id": "graphify_rebuild_rungraphifyrebuild",
-      "community": 24
+      "community": 25
     },
     {
       "label": "harness-app-registry.ts",
@@ -16169,7 +16169,7 @@
       "source_file": "scripts/harness-app-registry.ts",
       "source_location": "L1",
       "id": "harness_app_registry",
-      "community": 5
+      "community": 6
     },
     {
       "label": "buildHarnessDocPaths()",
@@ -16177,7 +16177,7 @@
       "source_file": "scripts/harness-app-registry.ts",
       "source_location": "L103",
       "id": "harness_app_registry_buildharnessdocpaths",
-      "community": 5
+      "community": 6
     },
     {
       "label": "getHarnessPackageRegistration()",
@@ -16185,7 +16185,7 @@
       "source_file": "scripts/harness-app-registry.ts",
       "source_location": "L375",
       "id": "harness_app_registry_getharnesspackageregistration",
-      "community": 5
+      "community": 6
     },
     {
       "label": "harness-audit.test.ts",
@@ -16193,7 +16193,7 @@
       "source_file": "scripts/harness-audit.test.ts",
       "source_location": "L1",
       "id": "harness_audit_test",
-      "community": 5
+      "community": 6
     },
     {
       "label": "write()",
@@ -16201,7 +16201,7 @@
       "source_file": "scripts/harness-audit.test.ts",
       "source_location": "L11",
       "id": "harness_audit_test_write",
-      "community": 5
+      "community": 6
     },
     {
       "label": "createFixtureRepo()",
@@ -16209,7 +16209,7 @@
       "source_file": "scripts/harness-audit.test.ts",
       "source_location": "L17",
       "id": "harness_audit_test_createfixturerepo",
-      "community": 5
+      "community": 6
     },
     {
       "label": "harness-audit.ts",
@@ -16217,7 +16217,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L1",
       "id": "harness_audit",
-      "community": 5
+      "community": 6
     },
     {
       "label": "normalizeRepoPath()",
@@ -16225,7 +16225,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L38",
       "id": "harness_audit_normalizerepopath",
-      "community": 5
+      "community": 6
     },
     {
       "label": "matchesPathPrefix()",
@@ -16233,7 +16233,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L42",
       "id": "harness_audit_matchespathprefix",
-      "community": 5
+      "community": 6
     },
     {
       "label": "fileExists()",
@@ -16241,7 +16241,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L56",
       "id": "harness_audit_fileexists",
-      "community": 5
+      "community": 6
     },
     {
       "label": "readJsonFile()",
@@ -16249,7 +16249,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L65",
       "id": "harness_audit_readjsonfile",
-      "community": 5
+      "community": 6
     },
     {
       "label": "normalizeValidationCommand()",
@@ -16257,7 +16257,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L69",
       "id": "harness_audit_normalizevalidationcommand",
-      "community": 5
+      "community": 6
     },
     {
       "label": "addGroupedError()",
@@ -16265,7 +16265,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L77",
       "id": "harness_audit_addgroupederror",
-      "community": 5
+      "community": 6
     },
     {
       "label": "inferGroupFromError()",
@@ -16273,7 +16273,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L91",
       "id": "harness_audit_infergroupfromerror",
-      "community": 5
+      "community": 6
     },
     {
       "label": "shouldSkipSurfaceEntry()",
@@ -16281,7 +16281,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L96",
       "id": "harness_audit_shouldskipsurfaceentry",
-      "community": 5
+      "community": 6
     },
     {
       "label": "collectLiveSurfaceEntries()",
@@ -16289,7 +16289,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L107",
       "id": "harness_audit_collectlivesurfaceentries",
-      "community": 5
+      "community": 6
     },
     {
       "label": "loadAuditTarget()",
@@ -16297,7 +16297,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L136",
       "id": "harness_audit_loadaudittarget",
-      "community": 5
+      "community": 6
     },
     {
       "label": "formatGroupedErrors()",
@@ -16305,7 +16305,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L290",
       "id": "harness_audit_formatgroupederrors",
-      "community": 5
+      "community": 6
     },
     {
       "label": "runHarnessAudit()",
@@ -16313,7 +16313,239 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L305",
       "id": "harness_audit_runharnessaudit",
-      "community": 5
+      "community": 6
+    },
+    {
+      "label": "sample-app.ts",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior-fixtures/sample-app.ts",
+      "source_location": "L1",
+      "id": "sample_app",
+      "community": 46
+    },
+    {
+      "label": "shutdown()",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior-fixtures/sample-app.ts",
+      "source_location": "L85",
+      "id": "sample_app_shutdown",
+      "community": 46
+    },
+    {
+      "label": "harness-behavior-scenarios.ts",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L1",
+      "id": "harness_behavior_scenarios",
+      "community": 16
+    },
+    {
+      "label": "harness-behavior.test.ts",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior.test.ts",
+      "source_location": "L1",
+      "id": "harness_behavior_test",
+      "community": 16
+    },
+    {
+      "label": "write()",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior.test.ts",
+      "source_location": "L14",
+      "id": "harness_behavior_test_write",
+      "community": 16
+    },
+    {
+      "label": "createFixtureRoot()",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior.test.ts",
+      "source_location": "L20",
+      "id": "harness_behavior_test_createfixtureroot",
+      "community": 16
+    },
+    {
+      "label": "log()",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior.test.ts",
+      "source_location": "L112",
+      "id": "harness_behavior_test_log",
+      "community": 16
+    },
+    {
+      "label": "error()",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior.test.ts",
+      "source_location": "L115",
+      "id": "harness_behavior_test_error",
+      "community": 16
+    },
+    {
+      "label": "harness-behavior.ts",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L1",
+      "id": "harness_behavior",
+      "community": 16
+    },
+    {
+      "label": "HarnessBehaviorPhaseError",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L142",
+      "id": "harness_behavior_harnessbehaviorphaseerror",
+      "community": 16
+    },
+    {
+      "label": ".constructor()",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L146",
+      "id": "harness_behavior_harnessbehaviorphaseerror_constructor",
+      "community": 16
+    },
+    {
+      "label": "logPhase()",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L197",
+      "id": "harness_behavior_logphase",
+      "community": 16
+    },
+    {
+      "label": "sleep()",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L205",
+      "id": "harness_behavior_sleep",
+      "community": 16
+    },
+    {
+      "label": "asRegExp()",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L211",
+      "id": "harness_behavior_asregexp",
+      "community": 16
+    },
+    {
+      "label": "escapeRegExp()",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L219",
+      "id": "harness_behavior_escaperegexp",
+      "community": 16
+    },
+    {
+      "label": "formatError()",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L223",
+      "id": "harness_behavior_formaterror",
+      "community": 16
+    },
+    {
+      "label": "getLinesForSource()",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L231",
+      "id": "harness_behavior_getlinesforsource",
+      "community": 16
+    },
+    {
+      "label": "consumeLines()",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L244",
+      "id": "harness_behavior_consumelines",
+      "community": 16
+    },
+    {
+      "label": "stopProcess()",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L310",
+      "id": "harness_behavior_stopprocess",
+      "community": 16
+    },
+    {
+      "label": "startProcess()",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L332",
+      "id": "harness_behavior_startprocess",
+      "community": 16
+    },
+    {
+      "label": "spawnCommand()",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L466",
+      "id": "harness_behavior_spawncommand",
+      "community": 16
+    },
+    {
+      "label": "runHttpReadinessCheck()",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L517",
+      "id": "harness_behavior_runhttpreadinesscheck",
+      "community": 16
+    },
+    {
+      "label": "collectRuntimeSignalMatches()",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L549",
+      "id": "harness_behavior_collectruntimesignalmatches",
+      "community": 16
+    },
+    {
+      "label": "runPlaywrightFlow()",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L636",
+      "id": "harness_behavior_runplaywrightflow",
+      "community": 16
+    },
+    {
+      "label": "wrapPhaseError()",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L679",
+      "id": "harness_behavior_wrapphaseerror",
+      "community": 16
+    },
+    {
+      "label": "runHarnessBehaviorScenario()",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L690",
+      "id": "harness_behavior_runharnessbehaviorscenario",
+      "community": 16
+    },
+    {
+      "label": "parseHarnessBehaviorArgs()",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L842",
+      "id": "harness_behavior_parseharnessbehaviorargs",
+      "community": 16
+    },
+    {
+      "label": "printHarnessBehaviorUsage()",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L890",
+      "id": "harness_behavior_printharnessbehaviorusage",
+      "community": 16
+    },
+    {
+      "label": "runHarnessBehaviorCli()",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L897",
+      "id": "harness_behavior_runharnessbehaviorcli",
+      "community": 16
     },
     {
       "label": "harness-check.test.ts",
@@ -16321,7 +16553,7 @@
       "source_file": "scripts/harness-check.test.ts",
       "source_location": "L1",
       "id": "harness_check_test",
-      "community": 5
+      "community": 6
     },
     {
       "label": "write()",
@@ -16329,7 +16561,7 @@
       "source_file": "scripts/harness-check.test.ts",
       "source_location": "L29",
       "id": "harness_check_test_write",
-      "community": 5
+      "community": 6
     },
     {
       "label": "createFixtureRepo()",
@@ -16337,7 +16569,7 @@
       "source_file": "scripts/harness-check.test.ts",
       "source_location": "L35",
       "id": "harness_check_test_createfixturerepo",
-      "community": 5
+      "community": 6
     },
     {
       "label": "harness-check.ts",
@@ -16345,7 +16577,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L1",
       "id": "harness_check",
-      "community": 5
+      "community": 6
     },
     {
       "label": "stripLinkDecorations()",
@@ -16353,7 +16585,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L28",
       "id": "harness_check_striplinkdecorations",
-      "community": 5
+      "community": 6
     },
     {
       "label": "isRelativeLink()",
@@ -16361,7 +16593,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L32",
       "id": "harness_check_isrelativelink",
-      "community": 5
+      "community": 6
     },
     {
       "label": "fileExists()",
@@ -16369,7 +16601,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L40",
       "id": "harness_check_fileexists",
-      "community": 5
+      "community": 6
     },
     {
       "label": "collectMarkdownLinkErrors()",
@@ -16377,7 +16609,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L49",
       "id": "harness_check_collectmarkdownlinkerrors",
-      "community": 5
+      "community": 6
     },
     {
       "label": "extractInlineCode()",
@@ -16385,7 +16617,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L78",
       "id": "harness_check_extractinlinecode",
-      "community": 5
+      "community": 6
     },
     {
       "label": "normalizePathReference()",
@@ -16393,7 +16625,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L84",
       "id": "harness_check_normalizepathreference",
-      "community": 5
+      "community": 6
     },
     {
       "label": "isLikelyPathReference()",
@@ -16401,7 +16633,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L97",
       "id": "harness_check_islikelypathreference",
-      "community": 5
+      "community": 6
     },
     {
       "label": "resolvePathReference()",
@@ -16409,7 +16641,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L122",
       "id": "harness_check_resolvepathreference",
-      "community": 5
+      "community": 6
     },
     {
       "label": "collectReferencedPathErrors()",
@@ -16417,7 +16649,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L148",
       "id": "harness_check_collectreferencedpatherrors",
-      "community": 5
+      "community": 6
     },
     {
       "label": "readPackageConfig()",
@@ -16425,7 +16657,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L183",
       "id": "harness_check_readpackageconfig",
-      "community": 5
+      "community": 6
     },
     {
       "label": "listWorkspacePackageDirs()",
@@ -16433,7 +16665,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L211",
       "id": "harness_check_listworkspacepackagedirs",
-      "community": 5
+      "community": 6
     },
     {
       "label": "collectHarnessOnboardingErrors()",
@@ -16441,7 +16673,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L234",
       "id": "harness_check_collectharnessonboardingerrors",
-      "community": 5
+      "community": 6
     },
     {
       "label": "extractTestScriptFromCommand()",
@@ -16449,7 +16681,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L265",
       "id": "harness_check_extracttestscriptfromcommand",
-      "community": 5
+      "community": 6
     },
     {
       "label": "walkFiles()",
@@ -16457,7 +16689,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L297",
       "id": "harness_check_walkfiles",
-      "community": 5
+      "community": 6
     },
     {
       "label": "collectTestSurfaceRoots()",
@@ -16465,7 +16697,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L317",
       "id": "harness_check_collecttestsurfaceroots",
-      "community": 5
+      "community": 6
     },
     {
       "label": "collectTestingDocErrors()",
@@ -16473,7 +16705,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L359",
       "id": "harness_check_collecttestingdocerrors",
-      "community": 5
+      "community": 6
     },
     {
       "label": "validateHarnessDocs()",
@@ -16481,7 +16713,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L404",
       "id": "harness_check_validateharnessdocs",
-      "community": 5
+      "community": 6
     },
     {
       "label": "runHarnessCheck()",
@@ -16489,7 +16721,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L538",
       "id": "harness_check_runharnesscheck",
-      "community": 5
+      "community": 6
     },
     {
       "label": "harness-generate.test.ts",
@@ -16497,7 +16729,7 @@
       "source_file": "scripts/harness-generate.test.ts",
       "source_location": "L1",
       "id": "harness_generate_test",
-      "community": 5
+      "community": 6
     },
     {
       "label": "write()",
@@ -16505,7 +16737,7 @@
       "source_file": "scripts/harness-generate.test.ts",
       "source_location": "L10",
       "id": "harness_generate_test_write",
-      "community": 5
+      "community": 6
     },
     {
       "label": "createFixtureRepo()",
@@ -16513,7 +16745,7 @@
       "source_file": "scripts/harness-generate.test.ts",
       "source_location": "L16",
       "id": "harness_generate_test_createfixturerepo",
-      "community": 5
+      "community": 6
     },
     {
       "label": "harness-generate.ts",
@@ -16521,7 +16753,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L1",
       "id": "harness_generate",
-      "community": 5
+      "community": 6
     },
     {
       "label": "normalizeRepoPath()",
@@ -16529,7 +16761,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L23",
       "id": "harness_generate_normalizerepopath",
-      "community": 5
+      "community": 6
     },
     {
       "label": "shouldSkipGeneratedEntry()",
@@ -16537,7 +16769,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L27",
       "id": "harness_generate_shouldskipgeneratedentry",
-      "community": 5
+      "community": 6
     },
     {
       "label": "fileExists()",
@@ -16545,7 +16777,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L31",
       "id": "harness_generate_fileexists",
-      "community": 5
+      "community": 6
     },
     {
       "label": "walkFiles()",
@@ -16553,7 +16785,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L40",
       "id": "harness_generate_walkfiles",
-      "community": 5
+      "community": 6
     },
     {
       "label": "readPackageConfig()",
@@ -16561,7 +16793,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L62",
       "id": "harness_generate_readpackageconfig",
-      "community": 5
+      "community": 6
     },
     {
       "label": "toDocPath()",
@@ -16569,7 +16801,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L80",
       "id": "harness_generate_todocpath",
-      "community": 5
+      "community": 6
     },
     {
       "label": "formatMarkdownLink()",
@@ -16577,7 +16809,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L84",
       "id": "harness_generate_formatmarkdownlink",
-      "community": 5
+      "community": 6
     },
     {
       "label": "headingFromSegment()",
@@ -16585,7 +16817,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L88",
       "id": "harness_generate_headingfromsegment",
-      "community": 5
+      "community": 6
     },
     {
       "label": "summarizeChildren()",
@@ -16593,7 +16825,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L96",
       "id": "harness_generate_summarizechildren",
-      "community": 5
+      "community": 6
     },
     {
       "label": "collectRouteGroups()",
@@ -16601,7 +16833,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L104",
       "id": "harness_generate_collectroutegroups",
-      "community": 5
+      "community": 6
     },
     {
       "label": "collectTestFiles()",
@@ -16609,7 +16841,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L130",
       "id": "harness_generate_collecttestfiles",
-      "community": 5
+      "community": 6
     },
     {
       "label": "collectTestSurfaceRoots()",
@@ -16617,7 +16849,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L160",
       "id": "harness_generate_collecttestsurfaceroots",
-      "community": 5
+      "community": 6
     },
     {
       "label": "collectFolderFacts()",
@@ -16625,7 +16857,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L202",
       "id": "harness_generate_collectfolderfacts",
-      "community": 5
+      "community": 6
     },
     {
       "label": "formatScriptCommand()",
@@ -16633,7 +16865,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L225",
       "id": "harness_generate_formatscriptcommand",
-      "community": 5
+      "community": 6
     },
     {
       "label": "toRepoValidationPath()",
@@ -16641,7 +16873,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L235",
       "id": "harness_generate_torepovalidationpath",
-      "community": 5
+      "community": 6
     },
     {
       "label": "slugifyTitle()",
@@ -16649,7 +16881,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L240",
       "id": "harness_generate_slugifytitle",
-      "community": 5
+      "community": 6
     },
     {
       "label": "formatValidationCommandForDoc()",
@@ -16657,7 +16889,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L247",
       "id": "harness_generate_formatvalidationcommandfordoc",
-      "community": 5
+      "community": 6
     },
     {
       "label": "toGeneratedValidationMap()",
@@ -16665,7 +16897,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L256",
       "id": "harness_generate_togeneratedvalidationmap",
-      "community": 5
+      "community": 6
     },
     {
       "label": "buildGeneratedDoc()",
@@ -16673,7 +16905,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L283",
       "id": "harness_generate_buildgenerateddoc",
-      "community": 5
+      "community": 6
     },
     {
       "label": "buildRouteIndex()",
@@ -16681,7 +16913,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L293",
       "id": "harness_generate_buildrouteindex",
-      "community": 5
+      "community": 6
     },
     {
       "label": "buildTestIndex()",
@@ -16689,7 +16921,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L320",
       "id": "harness_generate_buildtestindex",
-      "community": 5
+      "community": 6
     },
     {
       "label": "buildKeyFolderIndex()",
@@ -16697,7 +16929,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L365",
       "id": "harness_generate_buildkeyfolderindex",
-      "community": 5
+      "community": 6
     },
     {
       "label": "buildValidationGuide()",
@@ -16705,7 +16937,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L398",
       "id": "harness_generate_buildvalidationguide",
-      "community": 5
+      "community": 6
     },
     {
       "label": "buildValidationMap()",
@@ -16713,7 +16945,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L431",
       "id": "harness_generate_buildvalidationmap",
-      "community": 5
+      "community": 6
     },
     {
       "label": "generateHarnessDocs()",
@@ -16721,7 +16953,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L438",
       "id": "harness_generate_generateharnessdocs",
-      "community": 5
+      "community": 6
     },
     {
       "label": "writeGeneratedHarnessDocs()",
@@ -16729,7 +16961,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L468",
       "id": "harness_generate_writegeneratedharnessdocs",
-      "community": 5
+      "community": 6
     },
     {
       "label": "harness-review.test.ts",
@@ -16737,7 +16969,7 @@
       "source_file": "scripts/harness-review.test.ts",
       "source_location": "L1",
       "id": "harness_review_test",
-      "community": 5
+      "community": 6
     },
     {
       "label": "write()",
@@ -16745,7 +16977,7 @@
       "source_file": "scripts/harness-review.test.ts",
       "source_location": "L10",
       "id": "harness_review_test_write",
-      "community": 5
+      "community": 6
     },
     {
       "label": "createFixtureRepo()",
@@ -16753,7 +16985,7 @@
       "source_file": "scripts/harness-review.test.ts",
       "source_location": "L16",
       "id": "harness_review_test_createfixturerepo",
-      "community": 5
+      "community": 6
     },
     {
       "label": "log()",
@@ -16761,7 +16993,7 @@
       "source_file": "scripts/harness-review.test.ts",
       "source_location": "L152",
       "id": "harness_review_test_log",
-      "community": 5
+      "community": 6
     },
     {
       "label": "error()",
@@ -16769,7 +17001,7 @@
       "source_file": "scripts/harness-review.test.ts",
       "source_location": "L153",
       "id": "harness_review_test_error",
-      "community": 5
+      "community": 6
     },
     {
       "label": "harness-review.ts",
@@ -16777,7 +17009,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L1",
       "id": "harness_review",
-      "community": 5
+      "community": 6
     },
     {
       "label": "normalizeRepoPath()",
@@ -16785,7 +17017,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L42",
       "id": "harness_review_normalizerepopath",
-      "community": 5
+      "community": 6
     },
     {
       "label": "matchesPathPrefix()",
@@ -16793,7 +17025,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L46",
       "id": "harness_review_matchespathprefix",
-      "community": 5
+      "community": 6
     },
     {
       "label": "normalizeValidationCommand()",
@@ -16801,7 +17033,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L60",
       "id": "harness_review_normalizevalidationcommand",
-      "community": 5
+      "community": 6
     },
     {
       "label": "fileExists()",
@@ -16809,7 +17041,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L68",
       "id": "harness_review_fileexists",
-      "community": 5
+      "community": 6
     },
     {
       "label": "readJsonFile()",
@@ -16817,7 +17049,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L77",
       "id": "harness_review_readjsonfile",
-      "community": 5
+      "community": 6
     },
     {
       "label": "loadReviewTarget()",
@@ -16825,7 +17057,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L81",
       "id": "harness_review_loadreviewtarget",
-      "community": 5
+      "community": 6
     },
     {
       "label": "loadReviewTargets()",
@@ -16833,7 +17065,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L185",
       "id": "harness_review_loadreviewtargets",
-      "community": 5
+      "community": 6
     },
     {
       "label": "collectCommandsForChangedFiles()",
@@ -16841,7 +17073,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L201",
       "id": "harness_review_collectcommandsforchangedfiles",
-      "community": 5
+      "community": 6
     },
     {
       "label": "getChangedFilesFromGit()",
@@ -16849,7 +17081,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L274",
       "id": "harness_review_getchangedfilesfromgit",
-      "community": 5
+      "community": 6
     },
     {
       "label": "runPackageScript()",
@@ -16857,7 +17089,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L312",
       "id": "harness_review_runpackagescript",
-      "community": 5
+      "community": 6
     },
     {
       "label": "runRawCommand()",
@@ -16865,7 +17097,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L326",
       "id": "harness_review_runrawcommand",
-      "community": 5
+      "community": 6
     },
     {
       "label": "runHarnessReview()",
@@ -16873,7 +17105,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L339",
       "id": "harness_review_runharnessreview",
-      "community": 5
+      "community": 6
     },
     {
       "label": "harness-self-review.test.ts",
@@ -16881,7 +17113,7 @@
       "source_file": "scripts/harness-self-review.test.ts",
       "source_location": "L1",
       "id": "harness_self_review_test",
-      "community": 19
+      "community": 17
     },
     {
       "label": "write()",
@@ -16889,7 +17121,7 @@
       "source_file": "scripts/harness-self-review.test.ts",
       "source_location": "L10",
       "id": "harness_self_review_test_write",
-      "community": 19
+      "community": 17
     },
     {
       "label": "createFixtureRepo()",
@@ -16897,7 +17129,7 @@
       "source_file": "scripts/harness-self-review.test.ts",
       "source_location": "L16",
       "id": "harness_self_review_test_createfixturerepo",
-      "community": 19
+      "community": 17
     },
     {
       "label": "harness-self-review.ts",
@@ -16905,7 +17137,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L1",
       "id": "harness_self_review",
-      "community": 19
+      "community": 17
     },
     {
       "label": "normalizeRepoPath()",
@@ -16913,7 +17145,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L91",
       "id": "harness_self_review_normalizerepopath",
-      "community": 19
+      "community": 17
     },
     {
       "label": "sortUniquePaths()",
@@ -16921,7 +17153,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L95",
       "id": "harness_self_review_sortuniquepaths",
-      "community": 19
+      "community": 17
     },
     {
       "label": "matchesPathPrefix()",
@@ -16929,7 +17161,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L101",
       "id": "harness_self_review_matchespathprefix",
-      "community": 19
+      "community": 17
     },
     {
       "label": "normalizeValidationCommand()",
@@ -16937,7 +17169,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L115",
       "id": "harness_self_review_normalizevalidationcommand",
-      "community": 19
+      "community": 17
     },
     {
       "label": "formatValidationCommand()",
@@ -16945,7 +17177,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L123",
       "id": "harness_self_review_formatvalidationcommand",
-      "community": 19
+      "community": 17
     },
     {
       "label": "quoteCode()",
@@ -16953,7 +17185,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L131",
       "id": "harness_self_review_quotecode",
-      "community": 19
+      "community": 17
     },
     {
       "label": "fileExists()",
@@ -16961,7 +17193,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L135",
       "id": "harness_self_review_fileexists",
-      "community": 19
+      "community": 17
     },
     {
       "label": "readJsonFile()",
@@ -16969,7 +17201,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L144",
       "id": "harness_self_review_readjsonfile",
-      "community": 19
+      "community": 17
     },
     {
       "label": "runCommand()",
@@ -16977,7 +17209,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L148",
       "id": "harness_self_review_runcommand",
-      "community": 19
+      "community": 17
     },
     {
       "label": "getChangedFilesFromGit()",
@@ -16985,7 +17217,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L168",
       "id": "harness_self_review_getchangedfilesfromgit",
-      "community": 19
+      "community": 17
     },
     {
       "label": "parseRuntimeScenarios()",
@@ -16993,7 +17225,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L232",
       "id": "harness_self_review_parseruntimescenarios",
-      "community": 19
+      "community": 17
     },
     {
       "label": "loadSelfReviewTarget()",
@@ -17001,7 +17233,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L238",
       "id": "harness_self_review_loadselfreviewtarget",
-      "community": 19
+      "community": 17
     },
     {
       "label": "loadSelfReviewTargets()",
@@ -17009,7 +17241,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L350",
       "id": "harness_self_review_loadselfreviewtargets",
-      "community": 19
+      "community": 17
     },
     {
       "label": "collectCoverage()",
@@ -17017,7 +17249,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L369",
       "id": "harness_self_review_collectcoverage",
-      "community": 19
+      "community": 17
     },
     {
       "label": "isLikelyCodeOrConfig()",
@@ -17025,7 +17257,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L447",
       "id": "harness_self_review_islikelycodeorconfig",
-      "community": 19
+      "community": 17
     },
     {
       "label": "evaluateGraphifyFreshness()",
@@ -17033,7 +17265,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L468",
       "id": "harness_self_review_evaluategraphifyfreshness",
-      "community": 19
+      "community": 17
     },
     {
       "label": "runQuietHarnessCheck()",
@@ -17041,7 +17273,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L532",
       "id": "harness_self_review_runquietharnesscheck",
-      "community": 19
+      "community": 17
     },
     {
       "label": "appendListSection()",
@@ -17049,7 +17281,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L541",
       "id": "harness_self_review_appendlistsection",
-      "community": 19
+      "community": 17
     },
     {
       "label": "buildMarkdownBundle()",
@@ -17057,7 +17289,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L560",
       "id": "harness_self_review_buildmarkdownbundle",
-      "community": 19
+      "community": 17
     },
     {
       "label": "parseCliArguments()",
@@ -17065,7 +17297,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L717",
       "id": "harness_self_review_parsecliarguments",
-      "community": 19
+      "community": 17
     },
     {
       "label": "runHarnessSelfReview()",
@@ -17073,7 +17305,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L766",
       "id": "harness_self_review_runharnessselfreview",
-      "community": 19
+      "community": 17
     },
     {
       "label": "pre-push-review.test.ts",
@@ -17081,7 +17313,7 @@
       "source_file": "scripts/pre-push-review.test.ts",
       "source_location": "L1",
       "id": "pre_push_review_test",
-      "community": 5
+      "community": 6
     },
     {
       "label": "log()",
@@ -17089,7 +17321,7 @@
       "source_file": "scripts/pre-push-review.test.ts",
       "source_location": "L81",
       "id": "pre_push_review_test_log",
-      "community": 5
+      "community": 6
     },
     {
       "label": "warn()",
@@ -17097,7 +17329,7 @@
       "source_file": "scripts/pre-push-review.test.ts",
       "source_location": "L82",
       "id": "pre_push_review_test_warn",
-      "community": 5
+      "community": 6
     },
     {
       "label": "error()",
@@ -17105,7 +17337,7 @@
       "source_file": "scripts/pre-push-review.test.ts",
       "source_location": "L83",
       "id": "pre_push_review_test_error",
-      "community": 5
+      "community": 6
     },
     {
       "label": "pre-push-review.ts",
@@ -17113,7 +17345,7 @@
       "source_file": "scripts/pre-push-review.ts",
       "source_location": "L1",
       "id": "pre_push_review",
-      "community": 5
+      "community": 6
     },
     {
       "label": "getChangedFilesVsOriginMain()",
@@ -17121,7 +17353,7 @@
       "source_file": "scripts/pre-push-review.ts",
       "source_location": "L24",
       "id": "pre_push_review_getchangedfilesvsoriginmain",
-      "community": 5
+      "community": 6
     },
     {
       "label": "runArchitectureCheck()",
@@ -17129,7 +17361,7 @@
       "source_file": "scripts/pre-push-review.ts",
       "source_location": "L65",
       "id": "pre_push_review_runarchitecturecheck",
-      "community": 5
+      "community": 6
     },
     {
       "label": "runPrePushReview()",
@@ -17137,7 +17369,7 @@
       "source_file": "scripts/pre-push-review.ts",
       "source_location": "L77",
       "id": "pre_push_review_runprepushreview",
-      "community": 5
+      "community": 6
     }
   ],
   "links": [
@@ -73119,6 +73351,546 @@
       "_tgt": "harness_audit_formatgroupederrors",
       "source": "harness_audit_formatgroupederrors",
       "target": "harness_audit_runharnessaudit",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior-fixtures/sample-app.ts",
+      "source_location": "L85",
+      "weight": 1.0,
+      "_src": "sample_app",
+      "_tgt": "sample_app_shutdown",
+      "source": "sample_app",
+      "target": "sample_app_shutdown",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L4",
+      "weight": 1.0,
+      "_src": "harness_behavior",
+      "_tgt": "harness_behavior_scenarios",
+      "source": "harness_behavior_scenarios",
+      "target": "harness_behavior",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior.test.ts",
+      "source_location": "L6",
+      "weight": 1.0,
+      "_src": "harness_behavior_test",
+      "_tgt": "harness_behavior",
+      "source": "harness_behavior_test",
+      "target": "harness_behavior",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior.test.ts",
+      "source_location": "L14",
+      "weight": 1.0,
+      "_src": "harness_behavior_test",
+      "_tgt": "harness_behavior_test_write",
+      "source": "harness_behavior_test",
+      "target": "harness_behavior_test_write",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior.test.ts",
+      "source_location": "L20",
+      "weight": 1.0,
+      "_src": "harness_behavior_test",
+      "_tgt": "harness_behavior_test_createfixtureroot",
+      "source": "harness_behavior_test",
+      "target": "harness_behavior_test_createfixtureroot",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior.test.ts",
+      "source_location": "L112",
+      "weight": 1.0,
+      "_src": "harness_behavior_test",
+      "_tgt": "harness_behavior_test_log",
+      "source": "harness_behavior_test",
+      "target": "harness_behavior_test_log",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior.test.ts",
+      "source_location": "L115",
+      "weight": 1.0,
+      "_src": "harness_behavior_test",
+      "_tgt": "harness_behavior_test_error",
+      "source": "harness_behavior_test",
+      "target": "harness_behavior_test_error",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L142",
+      "weight": 1.0,
+      "_src": "harness_behavior",
+      "_tgt": "harness_behavior_harnessbehaviorphaseerror",
+      "source": "harness_behavior",
+      "target": "harness_behavior_harnessbehaviorphaseerror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L197",
+      "weight": 1.0,
+      "_src": "harness_behavior",
+      "_tgt": "harness_behavior_logphase",
+      "source": "harness_behavior",
+      "target": "harness_behavior_logphase",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L205",
+      "weight": 1.0,
+      "_src": "harness_behavior",
+      "_tgt": "harness_behavior_sleep",
+      "source": "harness_behavior",
+      "target": "harness_behavior_sleep",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L211",
+      "weight": 1.0,
+      "_src": "harness_behavior",
+      "_tgt": "harness_behavior_asregexp",
+      "source": "harness_behavior",
+      "target": "harness_behavior_asregexp",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L219",
+      "weight": 1.0,
+      "_src": "harness_behavior",
+      "_tgt": "harness_behavior_escaperegexp",
+      "source": "harness_behavior",
+      "target": "harness_behavior_escaperegexp",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L223",
+      "weight": 1.0,
+      "_src": "harness_behavior",
+      "_tgt": "harness_behavior_formaterror",
+      "source": "harness_behavior",
+      "target": "harness_behavior_formaterror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L231",
+      "weight": 1.0,
+      "_src": "harness_behavior",
+      "_tgt": "harness_behavior_getlinesforsource",
+      "source": "harness_behavior",
+      "target": "harness_behavior_getlinesforsource",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L244",
+      "weight": 1.0,
+      "_src": "harness_behavior",
+      "_tgt": "harness_behavior_consumelines",
+      "source": "harness_behavior",
+      "target": "harness_behavior_consumelines",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L310",
+      "weight": 1.0,
+      "_src": "harness_behavior",
+      "_tgt": "harness_behavior_stopprocess",
+      "source": "harness_behavior",
+      "target": "harness_behavior_stopprocess",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L332",
+      "weight": 1.0,
+      "_src": "harness_behavior",
+      "_tgt": "harness_behavior_startprocess",
+      "source": "harness_behavior",
+      "target": "harness_behavior_startprocess",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L466",
+      "weight": 1.0,
+      "_src": "harness_behavior",
+      "_tgt": "harness_behavior_spawncommand",
+      "source": "harness_behavior",
+      "target": "harness_behavior_spawncommand",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L517",
+      "weight": 1.0,
+      "_src": "harness_behavior",
+      "_tgt": "harness_behavior_runhttpreadinesscheck",
+      "source": "harness_behavior",
+      "target": "harness_behavior_runhttpreadinesscheck",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L549",
+      "weight": 1.0,
+      "_src": "harness_behavior",
+      "_tgt": "harness_behavior_collectruntimesignalmatches",
+      "source": "harness_behavior",
+      "target": "harness_behavior_collectruntimesignalmatches",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L636",
+      "weight": 1.0,
+      "_src": "harness_behavior",
+      "_tgt": "harness_behavior_runplaywrightflow",
+      "source": "harness_behavior",
+      "target": "harness_behavior_runplaywrightflow",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L679",
+      "weight": 1.0,
+      "_src": "harness_behavior",
+      "_tgt": "harness_behavior_wrapphaseerror",
+      "source": "harness_behavior",
+      "target": "harness_behavior_wrapphaseerror",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L690",
+      "weight": 1.0,
+      "_src": "harness_behavior",
+      "_tgt": "harness_behavior_runharnessbehaviorscenario",
+      "source": "harness_behavior",
+      "target": "harness_behavior_runharnessbehaviorscenario",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L842",
+      "weight": 1.0,
+      "_src": "harness_behavior",
+      "_tgt": "harness_behavior_parseharnessbehaviorargs",
+      "source": "harness_behavior",
+      "target": "harness_behavior_parseharnessbehaviorargs",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L890",
+      "weight": 1.0,
+      "_src": "harness_behavior",
+      "_tgt": "harness_behavior_printharnessbehaviorusage",
+      "source": "harness_behavior",
+      "target": "harness_behavior_printharnessbehaviorusage",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L897",
+      "weight": 1.0,
+      "_src": "harness_behavior",
+      "_tgt": "harness_behavior_runharnessbehaviorcli",
+      "source": "harness_behavior",
+      "target": "harness_behavior_runharnessbehaviorcli",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L146",
+      "weight": 1.0,
+      "_src": "harness_behavior_harnessbehaviorphaseerror",
+      "_tgt": "harness_behavior_harnessbehaviorphaseerror_constructor",
+      "source": "harness_behavior_harnessbehaviorphaseerror",
+      "target": "harness_behavior_harnessbehaviorphaseerror_constructor",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L343",
+      "weight": 0.8,
+      "_src": "harness_behavior_startprocess",
+      "_tgt": "harness_behavior_logphase",
+      "source": "harness_behavior_logphase",
+      "target": "harness_behavior_startprocess",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L728",
+      "weight": 0.8,
+      "_src": "harness_behavior_runharnessbehaviorscenario",
+      "_tgt": "harness_behavior_logphase",
+      "source": "harness_behavior_logphase",
+      "target": "harness_behavior_runharnessbehaviorscenario",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L321",
+      "weight": 0.8,
+      "_src": "harness_behavior_stopprocess",
+      "_tgt": "harness_behavior_sleep",
+      "source": "harness_behavior_sleep",
+      "target": "harness_behavior_stopprocess",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L216",
+      "weight": 0.8,
+      "_src": "harness_behavior_asregexp",
+      "_tgt": "harness_behavior_escaperegexp",
+      "source": "harness_behavior_asregexp",
+      "target": "harness_behavior_escaperegexp",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L438",
+      "weight": 0.8,
+      "_src": "harness_behavior_startprocess",
+      "_tgt": "harness_behavior_asregexp",
+      "source": "harness_behavior_asregexp",
+      "target": "harness_behavior_startprocess",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L557",
+      "weight": 0.8,
+      "_src": "harness_behavior_collectruntimesignalmatches",
+      "_tgt": "harness_behavior_asregexp",
+      "source": "harness_behavior_asregexp",
+      "target": "harness_behavior_collectruntimesignalmatches",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L536",
+      "weight": 0.8,
+      "_src": "harness_behavior_runhttpreadinesscheck",
+      "_tgt": "harness_behavior_formaterror",
+      "source": "harness_behavior_formaterror",
+      "target": "harness_behavior_runhttpreadinesscheck",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L667",
+      "weight": 0.8,
+      "_src": "harness_behavior_runplaywrightflow",
+      "_tgt": "harness_behavior_formaterror",
+      "source": "harness_behavior_formaterror",
+      "target": "harness_behavior_runplaywrightflow",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L687",
+      "weight": 0.8,
+      "_src": "harness_behavior_wrapphaseerror",
+      "_tgt": "harness_behavior_formaterror",
+      "source": "harness_behavior_formaterror",
+      "target": "harness_behavior_wrapphaseerror",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L368",
+      "weight": 0.8,
+      "_src": "harness_behavior_startprocess",
+      "_tgt": "harness_behavior_consumelines",
+      "source": "harness_behavior_consumelines",
+      "target": "harness_behavior_startprocess",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L345",
+      "weight": 0.8,
+      "_src": "harness_behavior_startprocess",
+      "_tgt": "harness_behavior_spawncommand",
+      "source": "harness_behavior_startprocess",
+      "target": "harness_behavior_spawncommand",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L730",
+      "weight": 0.8,
+      "_src": "harness_behavior_runharnessbehaviorscenario",
+      "_tgt": "harness_behavior_startprocess",
+      "source": "harness_behavior_startprocess",
+      "target": "harness_behavior_runharnessbehaviorscenario",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L743",
+      "weight": 0.8,
+      "_src": "harness_behavior_runharnessbehaviorscenario",
+      "_tgt": "harness_behavior_runhttpreadinesscheck",
+      "source": "harness_behavior_runhttpreadinesscheck",
+      "target": "harness_behavior_runharnessbehaviorscenario",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L779",
+      "weight": 0.8,
+      "_src": "harness_behavior_runharnessbehaviorscenario",
+      "_tgt": "harness_behavior_collectruntimesignalmatches",
+      "source": "harness_behavior_collectruntimesignalmatches",
+      "target": "harness_behavior_runharnessbehaviorscenario",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L800",
+      "weight": 0.8,
+      "_src": "harness_behavior_runharnessbehaviorscenario",
+      "_tgt": "harness_behavior_wrapphaseerror",
+      "source": "harness_behavior_wrapphaseerror",
+      "target": "harness_behavior_runharnessbehaviorscenario",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L937",
+      "weight": 0.8,
+      "_src": "harness_behavior_runharnessbehaviorcli",
+      "_tgt": "harness_behavior_runharnessbehaviorscenario",
+      "source": "harness_behavior_runharnessbehaviorscenario",
+      "target": "harness_behavior_runharnessbehaviorcli",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L907",
+      "weight": 0.8,
+      "_src": "harness_behavior_runharnessbehaviorcli",
+      "_tgt": "harness_behavior_parseharnessbehaviorargs",
+      "source": "harness_behavior_parseharnessbehaviorargs",
+      "target": "harness_behavior_runharnessbehaviorcli",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L910",
+      "weight": 0.8,
+      "_src": "harness_behavior_runharnessbehaviorcli",
+      "_tgt": "harness_behavior_printharnessbehaviorusage",
+      "source": "harness_behavior_printharnessbehaviorusage",
+      "target": "harness_behavior_runharnessbehaviorcli",
       "confidence_score": 0.5
     },
     {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "architecture:check": "bun scripts/architecture-boundary-check.ts",
     "graphify:rebuild": "bun scripts/graphify-rebuild.ts",
     "harness:audit": "bun scripts/harness-audit.ts",
+    "harness:behavior": "bun scripts/harness-behavior.ts",
     "harness:check": "bun scripts/harness-check.ts",
     "harness:generate": "bun scripts/harness-generate.ts",
     "harness:self-review": "bun scripts/harness-self-review.ts",

--- a/packages/athena-webapp/docs/agent/testing.md
+++ b/packages/athena-webapp/docs/agent/testing.md
@@ -5,6 +5,7 @@ Use the repo-root harness commands together:
 - `bun run harness:check` validates the docs themselves: required files, links, path references, and documented test commands.
 - `bun run harness:review` is the touched-file pass. It always runs `bun run harness:check` first, then uses the machine-readable [validation map](./validation-map.json) to decide whether `@athena/webapp` baseline validations should run for the files you changed.
 - `bun run harness:audit` is the full-app pass. It scans the current `athena-webapp` surface even when nothing is touched and fails on stale harness docs, stale validation-map paths, or live surfaces that the validation map does not cover yet.
+- `bun run harness:behavior --scenario <name>` runs shared runtime behavior scenarios that boot app processes, wait for readiness, drive browser interactions, assert runtime signals, and clean up automatically.
 
 - [Test index](./test-index.md)
 - [Validation guide](./validation-guide.md)
@@ -12,6 +13,10 @@ Use the repo-root harness commands together:
 If `bun run harness:review` reports a coverage gap, the touched `packages/athena-webapp` file is not represented in the validation map yet. Update the map and this testing guide together before handoff so the harness stays honest.
 
 If `bun run harness:audit` reports a coverage gap, a live `src/` or `convex/` surface exists without a corresponding validation-map entry. Add or tighten the affected surface mapping before handoff so future agents can trust the repo-wide scan.
+
+Use `bun run harness:behavior --list` to inspect available runtime scenarios. The
+repo ships with `sample-runtime-smoke` as a shared contract example; follow-on
+Athena and Storefront journey scenarios should build on the same runner.
 
 Start with the package suite in [vitest.config.ts](../../vitest.config.ts): `bun run --filter '@athena/webapp' test`. It covers both `src/**/*.test.{ts,tsx}` and `convex/**/*.test.{ts,tsx}`, so it is the default regression pass for mixed UI and backend changes.
 

--- a/packages/storefront-webapp/docs/agent/testing.md
+++ b/packages/storefront-webapp/docs/agent/testing.md
@@ -5,6 +5,7 @@ Use the repo-root harness commands together:
 - `bun run harness:check` validates the docs themselves: required files, links, path references, and documented test commands.
 - `bun run harness:review` is the touched-file pass. It always runs `bun run harness:check` first, then uses the machine-readable [validation map](./validation-map.json) to decide whether `@athena/storefront-webapp` baseline validations should run for the files you changed.
 - `bun run harness:audit` is the full-app pass. It scans the current `storefront-webapp` surface even when nothing is touched and fails on stale harness docs, stale validation-map paths, or live surfaces that the validation map does not cover yet.
+- `bun run harness:behavior --scenario <name>` runs shared runtime behavior scenarios that boot app processes, wait for readiness, drive browser interactions, assert runtime signals, and clean up automatically.
 
 - [Test index](./test-index.md)
 - [Validation guide](./validation-guide.md)
@@ -12,6 +13,10 @@ Use the repo-root harness commands together:
 If `bun run harness:review` reports a coverage gap, the touched `packages/storefront-webapp` file is not represented in the validation map yet. Update the map and this testing guide together before handoff so the harness stays honest.
 
 If `bun run harness:audit` reports a coverage gap, a live `src/` or `tests/` surface exists without a corresponding validation-map entry. Add or tighten the affected surface mapping before handoff so future agents can trust the repo-wide scan.
+
+Use `bun run harness:behavior --list` to inspect available runtime scenarios. The
+repo ships with `sample-runtime-smoke` as a shared contract example; follow-on
+Athena and Storefront journey scenarios should build on the same runner.
 
 Start with the package suite in [vitest.config.ts](../../vitest.config.ts): `bun run --filter '@athena/storefront-webapp' test`. It is the default regression pass for API wrappers, route helpers, checkout state, and shared utility logic.
 

--- a/scripts/harness-behavior-fixtures/sample-app.ts
+++ b/scripts/harness-behavior-fixtures/sample-app.ts
@@ -1,0 +1,91 @@
+const port = Number.parseInt(process.env.HARNESS_BEHAVIOR_PORT ?? "4311", 10);
+
+const html = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Harness Behavior Fixture</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      body {
+        font-family: ui-sans-serif, system-ui, sans-serif;
+        margin: 2rem;
+      }
+      button {
+        border: 1px solid #222;
+        background: #f3f3f3;
+        border-radius: 6px;
+        padding: 0.6rem 0.9rem;
+        cursor: pointer;
+      }
+      [data-signal="done"] {
+        display: inline-block;
+        margin-left: 0.6rem;
+        font-weight: 600;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Harness Behavior Fixture</h1>
+    <p>This minimal app emits runtime signals for harness verification.</p>
+    <button id="trigger" type="button">Trigger runtime signal</button>
+    <span data-signal="done">pending</span>
+    <script>
+      const triggerButton = document.getElementById("trigger");
+      const signalNode = document.querySelector("[data-signal='done']");
+
+      async function triggerSignal() {
+        signalNode.textContent = "running";
+        try {
+          const response = await fetch("/signal", {
+            method: "POST",
+          });
+          signalNode.textContent = await response.text();
+        } catch (error) {
+          signalNode.textContent = "failed";
+          console.error("signal request failed", error);
+        }
+      }
+
+      triggerButton.addEventListener("click", triggerSignal);
+    </script>
+  </body>
+</html>`;
+
+const server = Bun.serve({
+  port,
+  async fetch(request) {
+    const requestUrl = new URL(request.url);
+
+    if (requestUrl.pathname === "/health") {
+      return new Response("ok");
+    }
+
+    if (requestUrl.pathname === "/signal" && request.method === "POST") {
+      console.log("RUNTIME_SIGNAL:browser-clicked");
+      return new Response("signal-recorded");
+    }
+
+    if (requestUrl.pathname === "/") {
+      return new Response(html, {
+        headers: {
+          "content-type": "text/html; charset=utf-8",
+        },
+      });
+    }
+
+    return new Response("not found", {
+      status: 404,
+    });
+  },
+});
+
+console.log(`SERVER_READY:${port}`);
+
+async function shutdown() {
+  server.stop(true);
+  process.exit(0);
+}
+
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);

--- a/scripts/harness-behavior-scenarios.ts
+++ b/scripts/harness-behavior-scenarios.ts
@@ -1,0 +1,91 @@
+import type { HarnessBehaviorScenario } from "./harness-behavior";
+
+const SAMPLE_RUNTIME_PORT = Number.parseInt(
+  process.env.HARNESS_BEHAVIOR_SAMPLE_PORT ?? "4311",
+  10
+);
+
+type SampleScenarioBrowserResult = {
+  signalStatus: string;
+  consoleMessages: string[];
+};
+
+export const SAMPLE_RUNTIME_SMOKE_SCENARIO: HarnessBehaviorScenario<SampleScenarioBrowserResult> =
+  {
+    name: "sample-runtime-smoke",
+    description:
+      "Boots a minimal local app, drives a browser click, captures runtime logs, asserts signal propagation, and tears down automatically.",
+    processes: [
+      {
+        id: "sample-app",
+        command: "bun scripts/harness-behavior-fixtures/sample-app.ts",
+        env: {
+          HARNESS_BEHAVIOR_PORT: String(SAMPLE_RUNTIME_PORT),
+        },
+        readyPattern: `SERVER_READY:${SAMPLE_RUNTIME_PORT}`,
+        readyTimeoutMs: 20_000,
+      },
+    ],
+    readiness: [
+      {
+        kind: "http",
+        name: "sample-app-health",
+        url: `http://127.0.0.1:${SAMPLE_RUNTIME_PORT}/health`,
+        expectedStatus: 200,
+        timeoutMs: 20_000,
+        intervalMs: 250,
+      },
+    ],
+    browser: async ({ runPlaywrightFlow }) => {
+      const flowResult = await runPlaywrightFlow({
+        url: `http://127.0.0.1:${SAMPLE_RUNTIME_PORT}/`,
+        steps: async ({ page }) => {
+          await page.getByRole("button", {
+            name: "Trigger runtime signal",
+          }).click({
+            timeout: 5_000,
+          });
+          await page.waitForSelector("[data-signal='done']", {
+            timeout: 5_000,
+          });
+          const signalStatus =
+            (await page.textContent("[data-signal='done']"))?.trim() ?? "";
+          return {
+            signalStatus,
+          };
+        },
+      });
+
+      return {
+        signalStatus: flowResult.stepResult.signalStatus,
+        consoleMessages: flowResult.consoleMessages,
+      };
+    },
+    runtimeSignals: [
+      {
+        name: "browser-clicked-signal",
+        processId: "sample-app",
+        source: "stdout",
+        pattern: "RUNTIME_SIGNAL:browser-clicked",
+        minMatches: 1,
+      },
+    ],
+    assert: async ({ browserResult, runtimeSignals }) => {
+      if (browserResult.signalStatus !== "signal-recorded") {
+        throw new Error(
+          `Expected sample signal status "signal-recorded", received "${browserResult.signalStatus}".`
+        );
+      }
+
+      const signalResult = runtimeSignals["browser-clicked-signal"];
+      if (!signalResult || signalResult.matchCount < 1) {
+        throw new Error(
+          "Expected browser-clicked runtime signal to appear in sample app logs."
+        );
+      }
+    },
+  };
+
+export const HARNESS_BEHAVIOR_SCENARIOS: HarnessBehaviorScenario[] = [
+  SAMPLE_RUNTIME_SMOKE_SCENARIO,
+];

--- a/scripts/harness-behavior.test.ts
+++ b/scripts/harness-behavior.test.ts
@@ -1,0 +1,273 @@
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  HarnessBehaviorPhaseError,
+  parseHarnessBehaviorArgs,
+  runHarnessBehaviorScenario,
+} from "./harness-behavior";
+
+const tempRoots: string[] = [];
+
+async function write(relativePath: string, contents: string, rootDir: string) {
+  const filePath = path.join(rootDir, relativePath);
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, contents);
+}
+
+async function createFixtureRoot(prefix: string) {
+  const rootDir = await mkdtemp(path.join(tmpdir(), prefix));
+  tempRoots.push(rootDir);
+  return rootDir;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((rootDir) =>
+      rm(rootDir, { recursive: true, force: true })
+    )
+  );
+});
+
+describe("runHarnessBehaviorScenario", () => {
+  it("runs boot/readiness/browser/runtime/assertion/cleanup and captures runtime signals", async () => {
+    const rootDir = await createFixtureRoot("athena-harness-behavior-ok-");
+    const stopFile = path.join(rootDir, "stop.log");
+    const appScriptPath = path.join(rootDir, "fixtures", "runtime-app.ts");
+
+    await write(
+      "fixtures/runtime-app.ts",
+      [
+        'console.log("APP_READY");',
+        'console.log("RUNTIME_SIGNAL:booted");',
+        "const stopFile = process.env.STOP_FILE;",
+        "setInterval(() => {",
+        '  console.log("RUNTIME_SIGNAL:heartbeat");',
+        "}, 20);",
+        "process.on(\"SIGTERM\", async () => {",
+        "  if (stopFile) {",
+        '    await Bun.write(stopFile, "stopped");',
+        "  }",
+        "  process.exit(0);",
+        "});",
+      ].join("\n"),
+      rootDir
+    );
+
+    const executionOrder: string[] = [];
+    const logs: string[] = [];
+
+    await runHarnessBehaviorScenario(
+      rootDir,
+      {
+        name: "unit-happy-path",
+        processes: [
+          {
+            id: "runtime-app",
+            command: `bun ${appScriptPath}`,
+            env: {
+              STOP_FILE: stopFile,
+            },
+            readyPattern: "APP_READY",
+            readyTimeoutMs: 2_000,
+          },
+        ],
+        readiness: [
+          {
+            name: "custom-ready-check",
+            kind: "custom",
+            check: async () => {
+              executionOrder.push("readiness");
+            },
+          },
+        ],
+        browser: async () => {
+          executionOrder.push("browser");
+          return {
+            clicked: true,
+          };
+        },
+        runtimeSignals: [
+          {
+            name: "heartbeat-signal",
+            processId: "runtime-app",
+            source: "stdout",
+            pattern: "RUNTIME_SIGNAL:booted",
+            minMatches: 1,
+          },
+        ],
+        assert: async ({ browserResult, runtimeSignals }) => {
+          executionOrder.push("assertion");
+          expect(browserResult).toEqual({ clicked: true });
+          expect(runtimeSignals["heartbeat-signal"]?.matchCount ?? 0).toBeGreaterThan(0);
+        },
+        cleanup: async () => {
+          executionOrder.push("cleanup");
+        },
+      },
+      {
+        logger: {
+          log(message) {
+            logs.push(String(message));
+          },
+          error(message) {
+            logs.push(String(message));
+          },
+        },
+      }
+    );
+
+    expect(executionOrder).toEqual([
+      "readiness",
+      "browser",
+      "assertion",
+      "cleanup",
+    ]);
+    expect(logs.some((line) => line.includes("[boot]"))).toBe(true);
+    expect(logs.some((line) => line.includes("[readiness]"))).toBe(true);
+    expect(logs.some((line) => line.includes("[browser]"))).toBe(true);
+    expect(logs.some((line) => line.includes("[runtime]"))).toBe(true);
+    expect(logs.some((line) => line.includes("[assertion]"))).toBe(true);
+    expect(await readFile(stopFile, "utf8")).toBe("stopped");
+  });
+
+  it("fails in readiness phase and still performs cleanup", async () => {
+    const rootDir = await createFixtureRoot("athena-harness-behavior-ready-fail-");
+    const stopFile = path.join(rootDir, "stop.log");
+    const appScriptPath = path.join(rootDir, "fixtures", "runtime-app.ts");
+
+    await write(
+      "fixtures/runtime-app.ts",
+      [
+        'console.log("APP_READY");',
+        "const stopFile = process.env.STOP_FILE;",
+        "setInterval(() => {}, 50);",
+        "process.on(\"SIGTERM\", async () => {",
+        "  if (stopFile) {",
+        '    await Bun.write(stopFile, "stopped");',
+        "  }",
+        "  process.exit(0);",
+        "});",
+      ].join("\n"),
+      rootDir
+    );
+
+    let cleanupCalled = false;
+
+    await expect(
+      runHarnessBehaviorScenario(rootDir, {
+        name: "unit-readiness-failure",
+        processes: [
+          {
+            id: "runtime-app",
+            command: `bun ${appScriptPath}`,
+            env: {
+              STOP_FILE: stopFile,
+            },
+            readyPattern: "APP_READY",
+            readyTimeoutMs: 2_000,
+          },
+        ],
+        readiness: [
+          {
+            name: "failing-ready-check",
+            kind: "custom",
+            check: async () => {
+              throw new Error("readiness exploded");
+            },
+          },
+        ],
+        browser: async () => ({}),
+        assert: async () => {},
+        cleanup: async () => {
+          cleanupCalled = true;
+        },
+      })
+    ).rejects.toMatchObject({
+      phase: "readiness",
+    } satisfies Partial<HarnessBehaviorPhaseError>);
+
+    expect(cleanupCalled).toBe(true);
+    expect(await readFile(stopFile, "utf8")).toBe("stopped");
+  });
+
+  it("fails in assertion phase and still terminates spawned processes", async () => {
+    const rootDir = await createFixtureRoot("athena-harness-behavior-assert-fail-");
+    const stopFile = path.join(rootDir, "stop.log");
+    const appScriptPath = path.join(rootDir, "fixtures", "runtime-app.ts");
+
+    await write(
+      "fixtures/runtime-app.ts",
+      [
+        'console.log("APP_READY");',
+        "const stopFile = process.env.STOP_FILE;",
+        "setInterval(() => {}, 50);",
+        "process.on(\"SIGTERM\", async () => {",
+        "  if (stopFile) {",
+        '    await Bun.write(stopFile, "stopped");',
+        "  }",
+        "  process.exit(0);",
+        "});",
+      ].join("\n"),
+      rootDir
+    );
+
+    await expect(
+      runHarnessBehaviorScenario(rootDir, {
+        name: "unit-assertion-failure",
+        processes: [
+          {
+            id: "runtime-app",
+            command: `bun ${appScriptPath}`,
+            env: {
+              STOP_FILE: stopFile,
+            },
+            readyPattern: "APP_READY",
+            readyTimeoutMs: 2_000,
+          },
+        ],
+        readiness: [
+          {
+            name: "pass-ready",
+            kind: "custom",
+            check: async () => {},
+          },
+        ],
+        browser: async () => ({ ok: false }),
+        assert: async () => {
+          throw new Error("assertion failed");
+        },
+      })
+    ).rejects.toMatchObject({
+      phase: "assertion",
+    } satisfies Partial<HarnessBehaviorPhaseError>);
+
+    expect(await readFile(stopFile, "utf8")).toBe("stopped");
+  });
+});
+
+describe("parseHarnessBehaviorArgs", () => {
+  it("parses --scenario <name>", () => {
+    expect(parseHarnessBehaviorArgs(["--scenario", "sample-runtime-smoke"])).toEqual({
+      help: false,
+      list: false,
+      scenarioName: "sample-runtime-smoke",
+    });
+  });
+
+  it("parses --list", () => {
+    expect(parseHarnessBehaviorArgs(["--list"])).toEqual({
+      help: false,
+      list: true,
+      scenarioName: null,
+    });
+  });
+
+  it("throws when --scenario is provided without a value", () => {
+    expect(() => parseHarnessBehaviorArgs(["--scenario"])).toThrow(
+      "Missing scenario name after --scenario."
+    );
+  });
+});

--- a/scripts/harness-behavior.ts
+++ b/scripts/harness-behavior.ts
@@ -1,0 +1,958 @@
+import path from "node:path";
+import { spawn as spawnChildProcess } from "node:child_process";
+
+import { HARNESS_BEHAVIOR_SCENARIOS } from "./harness-behavior-scenarios";
+
+const DEFAULT_READY_TIMEOUT_MS = 30_000;
+const DEFAULT_HTTP_TIMEOUT_MS = 30_000;
+const DEFAULT_HTTP_INTERVAL_MS = 250;
+const DEFAULT_STOP_TIMEOUT_MS = 5_000;
+
+type LineSource = "stdout" | "stderr";
+
+export type HarnessBehaviorSignalSource = LineSource | "combined";
+
+export type HarnessBehaviorLogger = Pick<Console, "log" | "error">;
+
+export type HarnessBehaviorProcessDefinition = {
+  id: string;
+  command: string;
+  cwd?: string;
+  env?: Record<string, string>;
+  readyPattern?: string | RegExp;
+  readyTimeoutMs?: number;
+};
+
+export type HarnessBehaviorHttpReadinessCheck = {
+  kind: "http";
+  name: string;
+  url: string;
+  expectedStatus?: number;
+  timeoutMs?: number;
+  intervalMs?: number;
+};
+
+export type HarnessBehaviorLogReadinessCheck = {
+  kind: "log";
+  name: string;
+  processId: string;
+  pattern: string | RegExp;
+  source?: HarnessBehaviorSignalSource;
+  timeoutMs?: number;
+};
+
+export type HarnessBehaviorCustomReadinessCheck = {
+  kind: "custom";
+  name: string;
+  check: (context: HarnessBehaviorReadinessContext) => Promise<void>;
+};
+
+export type HarnessBehaviorReadinessCheck =
+  | HarnessBehaviorHttpReadinessCheck
+  | HarnessBehaviorLogReadinessCheck
+  | HarnessBehaviorCustomReadinessCheck;
+
+export type HarnessBehaviorRuntimeSignalExpectation = {
+  name: string;
+  pattern: string | RegExp;
+  processId?: string;
+  source?: HarnessBehaviorSignalSource;
+  minMatches?: number;
+};
+
+export type HarnessBehaviorRuntimeSignalResult = {
+  name: string;
+  processId: string | null;
+  source: HarnessBehaviorSignalSource;
+  pattern: RegExp;
+  matchCount: number;
+  matchedLines: string[];
+};
+
+export type HarnessBehaviorPlaywrightFlowOptions<TStepResult> = {
+  url: string;
+  headless?: boolean;
+  steps: (context: { page: HarnessBehaviorPlaywrightPage }) => Promise<TStepResult>;
+};
+
+export type HarnessBehaviorPlaywrightFlowResult<TStepResult> = {
+  consoleMessages: string[];
+  stepResult: TStepResult;
+};
+
+export type HarnessBehaviorProcessHandle = {
+  id: string;
+  command: string;
+  cwd: string;
+  pid: number;
+  getOutputLines: (source?: HarnessBehaviorSignalSource) => string[];
+  waitForOutput: (
+    pattern: string | RegExp,
+    options?: { source?: HarnessBehaviorSignalSource; timeoutMs?: number }
+  ) => Promise<void>;
+};
+
+export type HarnessBehaviorReadinessContext = {
+  rootDir: string;
+  scenarioName: string;
+  logger: HarnessBehaviorLogger;
+  processes: Record<string, HarnessBehaviorProcessHandle>;
+};
+
+export type HarnessBehaviorBrowserContext = HarnessBehaviorReadinessContext & {
+  runPlaywrightFlow: <TStepResult>(
+    options: HarnessBehaviorPlaywrightFlowOptions<TStepResult>
+  ) => Promise<HarnessBehaviorPlaywrightFlowResult<TStepResult>>;
+};
+
+export type HarnessBehaviorAssertionContext<TBrowserResult> =
+  HarnessBehaviorReadinessContext & {
+    browserResult: TBrowserResult;
+    runtimeSignals: Record<string, HarnessBehaviorRuntimeSignalResult>;
+  };
+
+export type HarnessBehaviorCleanupContext<TBrowserResult> =
+  HarnessBehaviorAssertionContext<TBrowserResult>;
+
+export type HarnessBehaviorScenario<TBrowserResult = unknown> = {
+  name: string;
+  description?: string;
+  processes: HarnessBehaviorProcessDefinition[];
+  readiness: HarnessBehaviorReadinessCheck[];
+  browser: (
+    context: HarnessBehaviorBrowserContext
+  ) => Promise<TBrowserResult>;
+  runtimeSignals?: HarnessBehaviorRuntimeSignalExpectation[];
+  assert: (
+    context: HarnessBehaviorAssertionContext<TBrowserResult>
+  ) => Promise<void>;
+  cleanup?: (
+    context: HarnessBehaviorCleanupContext<TBrowserResult>
+  ) => Promise<void>;
+};
+
+export type HarnessBehaviorPhase =
+  | "boot"
+  | "readiness"
+  | "browser"
+  | "runtime"
+  | "assertion"
+  | "cleanup";
+
+export class HarnessBehaviorPhaseError extends Error {
+  phase: HarnessBehaviorPhase;
+  details: string;
+
+  constructor(
+    phase: HarnessBehaviorPhase,
+    details: string,
+    cause?: unknown
+  ) {
+    const formattedDetails = details.trim();
+    super(
+      `Harness behavior failed in ${phase} phase${
+        formattedDetails ? `: ${formattedDetails}` : "."
+      }`,
+      cause ? { cause } : undefined
+    );
+    this.name = "HarnessBehaviorPhaseError";
+    this.phase = phase;
+    this.details = formattedDetails;
+  }
+}
+
+type ProcessOutputLine = {
+  source: LineSource;
+  line: string;
+};
+
+type ProcessOutputWaiter = {
+  pattern: RegExp;
+  source: HarnessBehaviorSignalSource;
+  resolve: () => void;
+  reject: (error: Error) => void;
+  timeout: ReturnType<typeof setTimeout>;
+};
+
+type RunningProcess = {
+  handle: HarnessBehaviorProcessHandle;
+  stop: () => Promise<void>;
+};
+
+type RunHarnessBehaviorOptions = {
+  logger?: HarnessBehaviorLogger;
+  fetchImpl?: typeof fetch;
+  sleep?: (durationMs: number) => Promise<void>;
+  runPlaywrightFlow?: <TStepResult>(
+    options: HarnessBehaviorPlaywrightFlowOptions<TStepResult>
+  ) => Promise<HarnessBehaviorPlaywrightFlowResult<TStepResult>>;
+};
+
+export type ParsedHarnessBehaviorArgs = {
+  help: boolean;
+  list: boolean;
+  scenarioName: string | null;
+};
+
+function logPhase(
+  logger: HarnessBehaviorLogger,
+  phase: HarnessBehaviorPhase,
+  message: string
+) {
+  logger.log(`[${phase}] ${message}`);
+}
+
+function sleep(durationMs: number) {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, durationMs);
+  });
+}
+
+function asRegExp(pattern: string | RegExp) {
+  if (pattern instanceof RegExp) {
+    return pattern;
+  }
+
+  return new RegExp(escapeRegExp(pattern));
+}
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function formatError(error: unknown) {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+}
+
+function getLinesForSource(
+  outputLines: ProcessOutputLine[],
+  source: HarnessBehaviorSignalSource
+) {
+  if (source === "combined") {
+    return outputLines.map((entry) => entry.line);
+  }
+
+  return outputLines
+    .filter((entry) => entry.source === source)
+    .map((entry) => entry.line);
+}
+
+async function consumeLines(
+  stream: ReadableStream<Uint8Array> | NodeJS.ReadableStream | null | undefined,
+  source: LineSource,
+  onLine: (source: LineSource, line: string) => void
+) {
+  if (!stream) {
+    return;
+  }
+
+  if ("getReader" in stream && typeof stream.getReader === "function") {
+    const reader = stream.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+
+      buffer += decoder.decode(value, { stream: true });
+
+      let newlineIndex = buffer.indexOf("\n");
+      while (newlineIndex >= 0) {
+        const rawLine = buffer.slice(0, newlineIndex);
+        buffer = buffer.slice(newlineIndex + 1);
+        onLine(source, rawLine.replace(/\r$/, ""));
+        newlineIndex = buffer.indexOf("\n");
+      }
+    }
+
+    const trailing = `${buffer}${decoder.decode()}`.replace(/\r$/, "");
+    if (trailing) {
+      onLine(source, trailing);
+    }
+    return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    let buffer = "";
+
+    stream.setEncoding("utf8");
+    stream.on("data", (chunk: string) => {
+      buffer += chunk;
+
+      let newlineIndex = buffer.indexOf("\n");
+      while (newlineIndex >= 0) {
+        const rawLine = buffer.slice(0, newlineIndex);
+        buffer = buffer.slice(newlineIndex + 1);
+        onLine(source, rawLine.replace(/\r$/, ""));
+        newlineIndex = buffer.indexOf("\n");
+      }
+    });
+
+    stream.on("end", () => {
+      const trailing = buffer.replace(/\r$/, "");
+      if (trailing) {
+        onLine(source, trailing);
+      }
+      resolve();
+    });
+
+    stream.on("error", reject);
+  });
+}
+
+async function stopProcess(
+  processRef: {
+    kill: (signal?: string) => void;
+    exited: Promise<number>;
+  },
+  timeoutMs: number
+) {
+  processRef.kill();
+
+  const exitCode = await Promise.race([
+    processRef.exited,
+    sleep(timeoutMs).then(() => Number.NaN),
+  ]);
+
+  if (!Number.isNaN(exitCode)) {
+    return;
+  }
+
+  processRef.kill("SIGKILL");
+  await processRef.exited;
+}
+
+async function startProcess(
+  rootDir: string,
+  definition: HarnessBehaviorProcessDefinition,
+  logger: HarnessBehaviorLogger
+): Promise<RunningProcess> {
+  const processCwd = definition.cwd
+    ? path.resolve(rootDir, definition.cwd)
+    : rootDir;
+  const outputLines: ProcessOutputLine[] = [];
+  const outputWaiters = new Set<ProcessOutputWaiter>();
+
+  logPhase(logger, "boot", `starting ${definition.id}: ${definition.command}`);
+
+  const subprocess = spawnCommand(definition.command, processCwd, definition.env);
+
+  const maybeResolveWaiters = (source: LineSource, line: string) => {
+    for (const waiter of [...outputWaiters]) {
+      if (waiter.source !== "combined" && waiter.source !== source) {
+        continue;
+      }
+
+      if (!waiter.pattern.test(line)) {
+        continue;
+      }
+
+      clearTimeout(waiter.timeout);
+      outputWaiters.delete(waiter);
+      waiter.resolve();
+    }
+  };
+
+  const appendOutputLine = (source: LineSource, line: string) => {
+    outputLines.push({ source, line });
+    maybeResolveWaiters(source, line);
+  };
+
+  const stdoutPump = consumeLines(subprocess.stdout, "stdout", appendOutputLine);
+  const stderrPump = consumeLines(subprocess.stderr, "stderr", appendOutputLine);
+
+  void Promise.all([stdoutPump, stderrPump]).catch((error: unknown) => {
+    logger.error(
+      `[boot] output capture failed for ${definition.id}: ${formatError(error)}`
+    );
+  });
+
+  void subprocess.exited.then((exitCode) => {
+    for (const waiter of [...outputWaiters]) {
+      clearTimeout(waiter.timeout);
+      outputWaiters.delete(waiter);
+      waiter.reject(
+        new Error(
+          `Process "${definition.id}" exited (${exitCode}) before output match was observed.`
+        )
+      );
+    }
+  });
+
+  const handle: HarnessBehaviorProcessHandle = {
+    id: definition.id,
+    command: definition.command,
+    cwd: processCwd,
+    pid: subprocess.pid,
+    getOutputLines(source = "combined") {
+      return getLinesForSource(outputLines, source);
+    },
+    waitForOutput(pattern, options = {}) {
+      const source = options.source ?? "combined";
+      const regex = asRegExp(pattern);
+
+      if (getLinesForSource(outputLines, source).some((line) => regex.test(line))) {
+        return Promise.resolve();
+      }
+
+      const timeoutMs = options.timeoutMs ?? DEFAULT_READY_TIMEOUT_MS;
+
+      return new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          outputWaiters.delete(waiter);
+          reject(
+            new Error(
+              `Timed out waiting for ${source} output to match ${regex} from process "${definition.id}".`
+            )
+          );
+        }, timeoutMs);
+
+        const waiter: ProcessOutputWaiter = {
+          pattern: regex,
+          source,
+          resolve,
+          reject,
+          timeout,
+        };
+
+        outputWaiters.add(waiter);
+      });
+    },
+  };
+
+  if (definition.readyPattern) {
+    await handle.waitForOutput(definition.readyPattern, {
+      timeoutMs: definition.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS,
+      source: "combined",
+    });
+    logPhase(
+      logger,
+      "boot",
+      `${definition.id} emitted readiness pattern ${asRegExp(
+        definition.readyPattern
+      )}`
+    );
+  }
+
+  let stopping = false;
+  return {
+    handle,
+    stop: async () => {
+      if (stopping) {
+        return;
+      }
+      stopping = true;
+
+      try {
+        await stopProcess(subprocess, DEFAULT_STOP_TIMEOUT_MS);
+      } catch (error) {
+        throw new Error(
+          `Failed to stop process "${definition.id}" (pid ${subprocess.pid}): ${formatError(
+            error
+          )}`
+        );
+      }
+    },
+  };
+}
+
+function spawnCommand(
+  command: string,
+  cwd: string,
+  envOverrides: Record<string, string> | undefined
+) {
+  const runtime = (globalThis as { Bun?: typeof Bun }).Bun;
+  const mergedEnv = {
+    ...process.env,
+    ...envOverrides,
+  };
+
+  if (runtime) {
+    const bunSubprocess = runtime.spawn(["/bin/zsh", "-lc", command], {
+      cwd,
+      env: mergedEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    return {
+      pid: bunSubprocess.pid,
+      stdout: bunSubprocess.stdout,
+      stderr: bunSubprocess.stderr,
+      kill: (signal?: string) => {
+        bunSubprocess.kill(signal);
+      },
+      exited: bunSubprocess.exited,
+    };
+  }
+
+  const nodeSubprocess = spawnChildProcess("/bin/zsh", ["-lc", command], {
+    cwd,
+    env: mergedEnv,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  return {
+    pid: nodeSubprocess.pid ?? -1,
+    stdout: nodeSubprocess.stdout,
+    stderr: nodeSubprocess.stderr,
+    kill: (signal?: string) => {
+      nodeSubprocess.kill(signal as NodeJS.Signals | undefined);
+    },
+    exited: new Promise<number>((resolve) => {
+      nodeSubprocess.once("close", (code) => {
+        resolve(code ?? 0);
+      });
+    }),
+  };
+}
+
+async function runHttpReadinessCheck(
+  check: HarnessBehaviorHttpReadinessCheck,
+  fetchImpl: typeof fetch,
+  sleepImpl: (durationMs: number) => Promise<void>
+) {
+  const timeoutMs = check.timeoutMs ?? DEFAULT_HTTP_TIMEOUT_MS;
+  const intervalMs = check.intervalMs ?? DEFAULT_HTTP_INTERVAL_MS;
+  const expectedStatus = check.expectedStatus ?? 200;
+  const startedAt = Date.now();
+  let lastError: string | null = null;
+
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      const response = await fetchImpl(check.url);
+      if (response.status === expectedStatus) {
+        return;
+      }
+      lastError = `received status ${response.status}`;
+    } catch (error) {
+      lastError = formatError(error);
+    }
+
+    await sleepImpl(intervalMs);
+  }
+
+  throw new Error(
+    `Timed out waiting for ${check.url} (expected status ${expectedStatus}). Last observation: ${
+      lastError ?? "no response"
+    }.`
+  );
+}
+
+function collectRuntimeSignalMatches(
+  expectations: HarnessBehaviorRuntimeSignalExpectation[],
+  processes: Record<string, HarnessBehaviorProcessHandle>
+) {
+  const results: Record<string, HarnessBehaviorRuntimeSignalResult> = {};
+
+  for (const expectation of expectations) {
+    const source = expectation.source ?? "combined";
+    const regex = asRegExp(expectation.pattern);
+    const processIds = expectation.processId
+      ? [expectation.processId]
+      : Object.keys(processes);
+
+    if (processIds.length === 0) {
+      throw new Error(
+        `Runtime signal "${expectation.name}" cannot be evaluated because no processes are running.`
+      );
+    }
+
+    const matchedLines: string[] = [];
+    for (const processId of processIds) {
+      const processHandle = processes[processId];
+      if (!processHandle) {
+        throw new Error(
+          `Runtime signal "${expectation.name}" references unknown process "${processId}".`
+        );
+      }
+
+      const processMatches = processHandle
+        .getOutputLines(source)
+        .filter((line) => regex.test(line));
+      matchedLines.push(...processMatches);
+    }
+
+    const minMatches = expectation.minMatches ?? 1;
+    if (matchedLines.length < minMatches) {
+      throw new Error(
+        `Runtime signal "${expectation.name}" expected at least ${minMatches} match(es) for ${regex}, found ${matchedLines.length}.`
+      );
+    }
+
+    results[expectation.name] = {
+      name: expectation.name,
+      processId: expectation.processId ?? null,
+      source,
+      pattern: regex,
+      matchCount: matchedLines.length,
+      matchedLines,
+    };
+  }
+
+  return results;
+}
+
+type HarnessBehaviorPlaywrightBrowser = {
+  close: () => Promise<void>;
+  newContext: () => Promise<HarnessBehaviorPlaywrightContext>;
+};
+
+type HarnessBehaviorPlaywrightContext = {
+  close: () => Promise<void>;
+  newPage: () => Promise<HarnessBehaviorPlaywrightPage>;
+};
+
+export type HarnessBehaviorPlaywrightPage = {
+  goto: (
+    url: string,
+    options?: { waitUntil?: "load" | "domcontentloaded" | "networkidle"; timeout?: number }
+  ) => Promise<unknown>;
+  on: (event: "console", handler: (message: { text: () => string }) => void) => void;
+  getByRole: (
+    role: string,
+    options: { name: string | RegExp }
+  ) => { click: (options?: { timeout?: number }) => Promise<void> };
+  waitForSelector: (
+    selector: string,
+    options?: { timeout?: number }
+  ) => Promise<unknown>;
+  textContent: (selector: string) => Promise<string | null>;
+};
+
+type HarnessBehaviorPlaywrightModule = {
+  chromium: {
+    launch: (options?: { headless?: boolean }) => Promise<HarnessBehaviorPlaywrightBrowser>;
+  };
+};
+
+export async function runPlaywrightFlow<TStepResult>(
+  options: HarnessBehaviorPlaywrightFlowOptions<TStepResult>
+) {
+  let browser: HarnessBehaviorPlaywrightBrowser | null = null;
+  let browserContext: HarnessBehaviorPlaywrightContext | null = null;
+
+  try {
+    const playwright = (await import(
+      "@playwright/test"
+    )) as unknown as HarnessBehaviorPlaywrightModule;
+
+    browser = await playwright.chromium.launch({
+      headless: options.headless ?? true,
+    });
+    browserContext = await browser.newContext();
+    const page = await browserContext.newPage();
+    const consoleMessages: string[] = [];
+    page.on("console", (message) => {
+      consoleMessages.push(message.text());
+    });
+    await page.goto(options.url, {
+      waitUntil: "networkidle",
+    });
+
+    const stepResult = await options.steps({ page });
+    return {
+      consoleMessages,
+      stepResult,
+    } satisfies HarnessBehaviorPlaywrightFlowResult<TStepResult>;
+  } catch (error) {
+    throw new Error(
+      `Playwright browser flow failed: ${formatError(error)}`
+    );
+  } finally {
+    if (browserContext) {
+      await browserContext.close();
+    }
+    if (browser) {
+      await browser.close();
+    }
+  }
+}
+
+function wrapPhaseError(
+  phase: HarnessBehaviorPhase,
+  error: unknown
+): HarnessBehaviorPhaseError {
+  if (error instanceof HarnessBehaviorPhaseError) {
+    return error;
+  }
+
+  return new HarnessBehaviorPhaseError(phase, formatError(error), error);
+}
+
+export async function runHarnessBehaviorScenario<TBrowserResult>(
+  rootDir: string,
+  scenario: HarnessBehaviorScenario<TBrowserResult>,
+  options: RunHarnessBehaviorOptions = {}
+) {
+  const logger = options.logger ?? console;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const sleepImpl = options.sleep ?? sleep;
+  const runPlaywrightImpl = options.runPlaywrightFlow ?? runPlaywrightFlow;
+  const runningProcesses = new Map<string, RunningProcess>();
+  let browserResult: TBrowserResult | undefined;
+  let runtimeSignals: Record<string, HarnessBehaviorRuntimeSignalResult> = {};
+  let pendingError: HarnessBehaviorPhaseError | null = null;
+  let currentPhase: HarnessBehaviorPhase = "boot";
+
+  const processHandles = () =>
+    Object.fromEntries(
+      [...runningProcesses.entries()].map(([processId, runningProcess]) => [
+        processId,
+        runningProcess.handle,
+      ])
+    ) satisfies Record<string, HarnessBehaviorProcessHandle>;
+
+  const baseContext = () =>
+    ({
+      rootDir,
+      scenarioName: scenario.name,
+      logger,
+      processes: processHandles(),
+    }) satisfies HarnessBehaviorReadinessContext;
+
+  logger.log(`[harness:behavior] Scenario: ${scenario.name}`);
+  if (scenario.description) {
+    logger.log(`[harness:behavior] ${scenario.description}`);
+  }
+
+  try {
+    currentPhase = "boot";
+    logPhase(logger, "boot", "booting scenario processes");
+    for (const processDefinition of scenario.processes) {
+      const runningProcess = await startProcess(rootDir, processDefinition, logger);
+      runningProcesses.set(processDefinition.id, runningProcess);
+    }
+
+    currentPhase = "readiness";
+    logPhase(logger, "readiness", "running readiness checks");
+    for (const check of scenario.readiness) {
+      if (check.kind === "http") {
+        logPhase(
+          logger,
+          "readiness",
+          `check "${check.name}" -> ${check.url} (expect ${check.expectedStatus ?? 200})`
+        );
+        await runHttpReadinessCheck(check, fetchImpl, sleepImpl);
+        continue;
+      }
+
+      if (check.kind === "log") {
+        const processHandle = processHandles()[check.processId];
+        if (!processHandle) {
+          throw new Error(
+            `Readiness check "${check.name}" references unknown process "${check.processId}".`
+          );
+        }
+        logPhase(
+          logger,
+          "readiness",
+          `check "${check.name}" waiting for ${check.processId} output`
+        );
+        await processHandle.waitForOutput(check.pattern, {
+          source: check.source ?? "combined",
+          timeoutMs: check.timeoutMs ?? DEFAULT_READY_TIMEOUT_MS,
+        });
+        continue;
+      }
+
+      logPhase(logger, "readiness", `check "${check.name}" (custom)`);
+      await check.check(baseContext());
+    }
+
+    currentPhase = "browser";
+    logPhase(logger, "browser", "running browser flow");
+    browserResult = await scenario.browser({
+      ...baseContext(),
+      runPlaywrightFlow: runPlaywrightImpl,
+    });
+
+    currentPhase = "runtime";
+    logPhase(logger, "runtime", "collecting runtime signals");
+    runtimeSignals = collectRuntimeSignalMatches(
+      scenario.runtimeSignals ?? [],
+      processHandles()
+    );
+
+    for (const runtimeSignal of Object.values(runtimeSignals)) {
+      logPhase(
+        logger,
+        "runtime",
+        `${runtimeSignal.name}: matched ${runtimeSignal.matchCount} line(s)`
+      );
+    }
+
+    currentPhase = "assertion";
+    logPhase(logger, "assertion", "running scenario assertions");
+    await scenario.assert({
+      ...baseContext(),
+      browserResult: browserResult as TBrowserResult,
+      runtimeSignals,
+    });
+  } catch (error) {
+    pendingError = wrapPhaseError(currentPhase, error);
+  } finally {
+    try {
+      currentPhase = "cleanup";
+      logPhase(logger, "cleanup", "tearing down scenario resources");
+
+      if (scenario.cleanup && browserResult !== undefined) {
+        await scenario.cleanup({
+          ...baseContext(),
+          browserResult,
+          runtimeSignals,
+        });
+      } else if (scenario.cleanup) {
+        await scenario.cleanup({
+          ...baseContext(),
+          browserResult: undefined as TBrowserResult,
+          runtimeSignals,
+        });
+      }
+
+      for (const runningProcess of [...runningProcesses.values()].reverse()) {
+        await runningProcess.stop();
+      }
+    } catch (cleanupError) {
+      const wrappedCleanupError = wrapPhaseError("cleanup", cleanupError);
+      if (pendingError) {
+        logger.error(
+          `[cleanup] additional cleanup failure: ${wrappedCleanupError.details}`
+        );
+      } else {
+        pendingError = wrappedCleanupError;
+      }
+    }
+  }
+
+  if (pendingError) {
+    throw pendingError;
+  }
+
+  logger.log(`[harness:behavior] Scenario ${scenario.name} passed.`);
+}
+
+export function parseHarnessBehaviorArgs(
+  args: string[]
+): ParsedHarnessBehaviorArgs {
+  let scenarioName: string | null = null;
+  let list = false;
+  let help = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    if (arg === "--help" || arg === "-h") {
+      help = true;
+      continue;
+    }
+
+    if (arg === "--list") {
+      list = true;
+      continue;
+    }
+
+    if (arg === "--scenario") {
+      const nextValue = args[index + 1];
+      if (!nextValue || nextValue.startsWith("-")) {
+        throw new Error("Missing scenario name after --scenario.");
+      }
+      scenarioName = nextValue;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith("--scenario=")) {
+      scenarioName = arg.split("=", 2)[1] ?? null;
+      if (!scenarioName) {
+        throw new Error("Missing scenario name after --scenario=.");
+      }
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return {
+    help,
+    list,
+    scenarioName,
+  };
+}
+
+function printHarnessBehaviorUsage(logger: HarnessBehaviorLogger) {
+  logger.log("Usage:");
+  logger.log("  bun run harness:behavior --scenario <name>");
+  logger.log("  bun run harness:behavior --list");
+  logger.log("  bun run harness:behavior --help");
+}
+
+export async function runHarnessBehaviorCli(
+  rootDir: string,
+  args: string[],
+  options: Omit<RunHarnessBehaviorOptions, "logger"> & {
+    logger?: HarnessBehaviorLogger;
+    scenarios?: HarnessBehaviorScenario[];
+  } = {}
+) {
+  const logger = options.logger ?? console;
+  const scenarios = options.scenarios ?? HARNESS_BEHAVIOR_SCENARIOS;
+  const parsedArgs = parseHarnessBehaviorArgs(args);
+
+  if (parsedArgs.help) {
+    printHarnessBehaviorUsage(logger);
+    return;
+  }
+
+  if (parsedArgs.list) {
+    logger.log("Available harness behavior scenarios:");
+    for (const scenario of scenarios) {
+      const suffix = scenario.description ? ` - ${scenario.description}` : "";
+      logger.log(`- ${scenario.name}${suffix}`);
+    }
+    return;
+  }
+
+  if (!parsedArgs.scenarioName) {
+    throw new Error("Missing required argument: --scenario <name>.");
+  }
+
+  const selectedScenario = scenarios.find(
+    (scenario) => scenario.name === parsedArgs.scenarioName
+  );
+
+  if (!selectedScenario) {
+    throw new Error(
+      `Unknown scenario "${parsedArgs.scenarioName}". Run with --list to inspect available scenarios.`
+    );
+  }
+
+  await runHarnessBehaviorScenario(rootDir, selectedScenario, {
+    logger,
+    fetchImpl: options.fetchImpl,
+    sleep: options.sleep,
+    runPlaywrightFlow: options.runPlaywrightFlow,
+  });
+}
+
+if (import.meta.main) {
+  runHarnessBehaviorCli(process.cwd(), Bun.argv.slice(2)).catch(
+    (error: unknown) => {
+      if (error instanceof HarnessBehaviorPhaseError) {
+        console.error(
+          `[harness:behavior] Failed in ${error.phase} phase: ${error.details}`
+        );
+      } else {
+        console.error(`[harness:behavior] ${formatError(error)}`);
+      }
+      process.exit(1);
+    }
+  );
+}


### PR DESCRIPTION
## Summary
- add a shared runtime behavior runner at `bun run harness:behavior --scenario <name>` with explicit phases: boot, readiness, browser, runtime signal capture, assertion, and cleanup
- add reusable scenario contract + registry and a minimal self-contained `sample-runtime-smoke` scenario backed by a local fixture app process
- add test coverage for happy path orchestration plus readiness/assertion failure behavior with guaranteed cleanup
- document runtime behavior harness usage in root and package harness docs for both Athena and Storefront
- rebuild graphify artifacts after code changes

## Why
- establish one reusable runtime harness contract for browser-flow validation before app-specific journey tickets (`V26-202`, `V26-203`)
- provide phase-oriented failure output so root cause is obvious (boot/readiness/browser/runtime/assertion/cleanup)
- prove the runner end-to-end locally without requiring manual server setup

## Validation
- `bunx vitest run scripts/harness-behavior.test.ts scripts/harness-check.test.ts scripts/harness-review.test.ts scripts/harness-audit.test.ts scripts/harness-generate.test.ts`
- `bun run harness:behavior --list`
- `bun run harness:behavior --scenario sample-runtime-smoke`
- `bun run harness:check`
- `bun run harness:audit`
- `bun run harness:review`
- `bun run graphify:rebuild`
- `bun run pr:athena`
- `git diff --check`

https://linear.app/v26-labs/issue/V26-200/add-a-shared-runtime-behavior-harness-runner-for-browser-app-flows
