### PR TITLE
[V26-202]: cover storefront runtime checkout behavior scenarios

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1181 files · ~0 words
+- 1183 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 2591 nodes · 1985 edges · 1096 communities detected
+- 2601 nodes · 1999 edges · 1098 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1106,6 +1106,8 @@
 - [[_COMMUNITY_Community 1093|Community 1093]]
 - [[_COMMUNITY_Community 1094|Community 1094]]
 - [[_COMMUNITY_Community 1095|Community 1095]]
+- [[_COMMUNITY_Community 1096|Community 1096]]
+- [[_COMMUNITY_Community 1097|Community 1097]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -1151,11 +1153,11 @@ Nodes (20): asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), 
 
 ### Community 4 - "Community 4"
 Cohesion: 0.17
-Nodes (16): appendListSection(), buildMarkdownBundle(), collectCoverage(), evaluateGraphifyFreshness(), fileExists(), formatValidationCommand(), getChangedFilesFromGit(), loadSelfReviewTarget() (+8 more)
+Nodes (19): asRegExp(), collectRuntimeSignalMatches(), consumeLines(), escapeRegExp(), formatError(), HarnessBehaviorPhaseError, logPhase(), parseHarnessBehaviorArgs() (+11 more)
 
 ### Community 5 - "Community 5"
-Cohesion: 0.18
-Nodes (18): asRegExp(), collectRuntimeSignalMatches(), consumeLines(), escapeRegExp(), formatError(), HarnessBehaviorPhaseError, logPhase(), parseHarnessBehaviorArgs() (+10 more)
+Cohesion: 0.17
+Nodes (16): appendListSection(), buildMarkdownBundle(), collectCoverage(), evaluateGraphifyFreshness(), fileExists(), formatValidationCommand(), getChangedFilesFromGit(), loadSelfReviewTarget() (+8 more)
 
 ### Community 6 - "Community 6"
 Cohesion: 0.11
@@ -1322,52 +1324,52 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 47 - "Community 47"
-Cohesion: 0.52
-Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
-
-### Community 48 - "Community 48"
-Cohesion: 0.29
-Nodes (0):
-
-### Community 49 - "Community 49"
 Cohesion: 0.33
 Nodes (2): getProductName(), sortProduct()
 
+### Community 48 - "Community 48"
+Cohesion: 0.52
+Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
+
+### Community 49 - "Community 49"
+Cohesion: 0.29
+Nodes (0):
+
 ### Community 50 - "Community 50"
-Cohesion: 0.33
-Nodes (1): ValkeyClient
+Cohesion: 0.52
+Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
 ### Community 51 - "Community 51"
 Cohesion: 0.33
-Nodes (0):
+Nodes (1): ValkeyClient
 
 ### Community 52 - "Community 52"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 53 - "Community 53"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
-### Community 53 - "Community 53"
+### Community 54 - "Community 54"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 54 - "Community 54"
+### Community 55 - "Community 55"
 Cohesion: 0.47
 Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
 
-### Community 55 - "Community 55"
+### Community 56 - "Community 56"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 56 - "Community 56"
+### Community 57 - "Community 57"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
-### Community 57 - "Community 57"
+### Community 58 - "Community 58"
 Cohesion: 0.4
 Nodes (2): buildUsername(), normalizeNameSegment()
-
-### Community 58 - "Community 58"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 59 - "Community 59"
 Cohesion: 0.33
@@ -1378,20 +1380,20 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 61 - "Community 61"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 62 - "Community 62"
 Cohesion: 0.47
 Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
-### Community 62 - "Community 62"
+### Community 63 - "Community 63"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 63 - "Community 63"
-Cohesion: 0.4
-Nodes (2): useBulkOperations(), validateOperationValue()
 
 ### Community 64 - "Community 64"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): useBulkOperations(), validateOperationValue()
 
 ### Community 65 - "Community 65"
 Cohesion: 0.33
@@ -1406,40 +1408,40 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 68 - "Community 68"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 69 - "Community 69"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 70 - "Community 70"
-Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 71 - "Community 71"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
 ### Community 72 - "Community 72"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 73 - "Community 73"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 74 - "Community 74"
 Cohesion: 0.53
 Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
-### Community 74 - "Community 74"
+### Community 75 - "Community 75"
 Cohesion: 0.47
 Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
-### Community 75 - "Community 75"
+### Community 76 - "Community 76"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
-
-### Community 76 - "Community 76"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 77 - "Community 77"
 Cohesion: 0.4
@@ -1454,24 +1456,24 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 80 - "Community 80"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 81 - "Community 81"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 81 - "Community 81"
+### Community 82 - "Community 82"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 82 - "Community 82"
-Cohesion: 0.6
-Nodes (3): getNonEmptyString(), isFailureStatus(), normalizeEvent()
 
 ### Community 83 - "Community 83"
 Cohesion: 0.6
-Nodes (3): createOffer(), isDuplicate(), updateStoreFrontActorEmail()
+Nodes (3): getNonEmptyString(), isFailureStatus(), normalizeEvent()
 
 ### Community 84 - "Community 84"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (3): createOffer(), isDuplicate(), updateStoreFrontActorEmail()
 
 ### Community 85 - "Community 85"
 Cohesion: 0.4
@@ -1479,23 +1481,23 @@ Nodes (0):
 
 ### Community 86 - "Community 86"
 Cohesion: 0.4
-Nodes (1): Header()
+Nodes (0):
 
 ### Community 87 - "Community 87"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): Header()
 
 ### Community 88 - "Community 88"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 89 - "Community 89"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
-
-### Community 90 - "Community 90"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 90 - "Community 90"
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 91 - "Community 91"
 Cohesion: 0.4
@@ -1526,16 +1528,16 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 98 - "Community 98"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 99 - "Community 99"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 99 - "Community 99"
-Cohesion: 0.4
-Nodes (1): MockImage
-
 ### Community 100 - "Community 100"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): MockImage
 
 ### Community 101 - "Community 101"
 Cohesion: 0.4
@@ -1550,44 +1552,44 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 104 - "Community 104"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 105 - "Community 105"
 Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 106 - "Community 106"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 107 - "Community 107"
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+
+### Community 108 - "Community 108"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 108 - "Community 108"
+### Community 109 - "Community 109"
 Cohesion: 0.7
 Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
-### Community 109 - "Community 109"
+### Community 110 - "Community 110"
 Cohesion: 0.6
 Nodes (4): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), trackStorefrontEvent()
 
-### Community 110 - "Community 110"
+### Community 111 - "Community 111"
 Cohesion: 0.7
 Nodes (4): runTests(), testBasicOperations(), testClusterInfo(), testConnection()
 
-### Community 111 - "Community 111"
+### Community 112 - "Community 112"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 112 - "Community 112"
-Cohesion: 0.5
-Nodes (2): createFixtureRepo(), write()
-
 ### Community 113 - "Community 113"
 Cohesion: 0.5
-Nodes (0):
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 114 - "Community 114"
 Cohesion: 0.5
@@ -1602,28 +1604,28 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 117 - "Community 117"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 118 - "Community 118"
 Cohesion: 0.67
 Nodes (2): toDisplayAmount(), toPesewas()
 
-### Community 118 - "Community 118"
+### Community 119 - "Community 119"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 119 - "Community 119"
+### Community 120 - "Community 120"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 120 - "Community 120"
+### Community 121 - "Community 121"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 121 - "Community 121"
+### Community 122 - "Community 122"
 Cohesion: 0.67
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
-
-### Community 122 - "Community 122"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 123 - "Community 123"
 Cohesion: 0.5
@@ -1638,12 +1640,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 126 - "Community 126"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
-
-### Community 127 - "Community 127"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 127 - "Community 127"
+Cohesion: 0.67
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 128 - "Community 128"
 Cohesion: 0.5
@@ -1674,32 +1676,32 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 135 - "Community 135"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
-
-### Community 136 - "Community 136"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 136 - "Community 136"
+Cohesion: 0.67
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 137 - "Community 137"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 138 - "Community 138"
-Cohesion: 0.83
-Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 139 - "Community 139"
 Cohesion: 0.83
-Nodes (3): getAllStores(), getBaseUrl(), getStore()
+Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 140 - "Community 140"
 Cohesion: 0.83
-Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
 ### Community 141 - "Community 141"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
 
 ### Community 142 - "Community 142"
 Cohesion: 0.5
@@ -1726,39 +1728,39 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 148 - "Community 148"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 149 - "Community 149"
 Cohesion: 0.67
 Nodes (2): clearFilters(), onMobileFiltersCloseClick()
 
-### Community 149 - "Community 149"
+### Community 150 - "Community 150"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 150 - "Community 150"
+### Community 151 - "Community 151"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 151 - "Community 151"
+### Community 152 - "Community 152"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 152 - "Community 152"
-Cohesion: 0.83
-Nodes (3): fileExists(), resolveGraphifyPython(), runGraphifyRebuild()
 
 ### Community 153 - "Community 153"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): fileExists(), resolveGraphifyPython(), runGraphifyRebuild()
 
 ### Community 154 - "Community 154"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 155 - "Community 155"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 156 - "Community 156"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 157 - "Community 157"
@@ -1774,20 +1776,20 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 160 - "Community 160"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 161 - "Community 161"
 Cohesion: 0.67
-Nodes (1): View()
+Nodes (0):
 
 ### Community 162 - "Community 162"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 163 - "Community 163"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 164 - "Community 164"
 Cohesion: 0.67
@@ -1798,20 +1800,20 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 166 - "Community 166"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 167 - "Community 167"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 168 - "Community 168"
 Cohesion: 1.0
 Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
 
-### Community 167 - "Community 167"
+### Community 169 - "Community 169"
 Cohesion: 1.0
 Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
-
-### Community 168 - "Community 168"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 169 - "Community 169"
-Cohesion: 0.67
-Nodes (0):
 
 ### Community 170 - "Community 170"
 Cohesion: 0.67
@@ -1819,7 +1821,7 @@ Nodes (0):
 
 ### Community 171 - "Community 171"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 172 - "Community 172"
 Cohesion: 0.67
@@ -1827,11 +1829,11 @@ Nodes (0):
 
 ### Community 173 - "Community 173"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 174 - "Community 174"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 175 - "Community 175"
 Cohesion: 0.67
@@ -1839,7 +1841,7 @@ Nodes (0):
 
 ### Community 176 - "Community 176"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 177 - "Community 177"
 Cohesion: 0.67
@@ -1879,79 +1881,79 @@ Nodes (0):
 
 ### Community 186 - "Community 186"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 187 - "Community 187"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (0):
 
 ### Community 188 - "Community 188"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): SingleLineError()
 
 ### Community 189 - "Community 189"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 190 - "Community 190"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 191 - "Community 191"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 192 - "Community 192"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TableSkeleton()
 
 ### Community 193 - "Community 193"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): TransactionsSkeleton()
 
 ### Community 194 - "Community 194"
 Cohesion: 0.67
-Nodes (1): AppContextMenu()
+Nodes (1): NotFound()
 
 ### Community 195 - "Community 195"
 Cohesion: 0.67
-Nodes (1): Badge()
+Nodes (0):
 
 ### Community 196 - "Community 196"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (1): AppContextMenu()
 
 ### Community 197 - "Community 197"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (1): Badge()
 
 ### Community 198 - "Community 198"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): LoadingButton()
 
 ### Community 199 - "Community 199"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): onChange()
 
 ### Community 200 - "Community 200"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): AlertModal()
 
 ### Community 201 - "Community 201"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): OverlayModal()
 
 ### Community 202 - "Community 202"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Skeleton()
 
 ### Community 203 - "Community 203"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Toaster()
 
 ### Community 204 - "Community 204"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 205 - "Community 205"
 Cohesion: 0.67
@@ -1975,7 +1977,7 @@ Nodes (0):
 
 ### Community 210 - "Community 210"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 211 - "Community 211"
 Cohesion: 0.67
@@ -1983,7 +1985,7 @@ Nodes (0):
 
 ### Community 212 - "Community 212"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 213 - "Community 213"
 Cohesion: 0.67
@@ -1995,43 +1997,43 @@ Nodes (0):
 
 ### Community 215 - "Community 215"
 Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
+Nodes (0):
 
 ### Community 216 - "Community 216"
 Cohesion: 0.67
-Nodes (1): App()
+Nodes (0):
 
 ### Community 217 - "Community 217"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): isInMaintenanceMode()
 
 ### Community 218 - "Community 218"
-Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Cohesion: 0.67
+Nodes (1): App()
 
 ### Community 219 - "Community 219"
 Cohesion: 0.67
-Nodes (1): hashPassword()
+Nodes (0):
 
 ### Community 220 - "Community 220"
-Cohesion: 0.67
-Nodes (1): useAppSession()
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 221 - "Community 221"
 Cohesion: 0.67
-Nodes (1): createVersionChecker()
+Nodes (1): hashPassword()
 
 ### Community 222 - "Community 222"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (1): useAppSession()
 
 ### Community 223 - "Community 223"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): createVersionChecker()
 
 ### Community 224 - "Community 224"
-Cohesion: 1.0
-Nodes (2): getAllColors(), getBaseUrl()
+Cohesion: 0.67
+Nodes (1): manualChunks()
 
 ### Community 225 - "Community 225"
 Cohesion: 0.67
@@ -2039,47 +2041,47 @@ Nodes (0):
 
 ### Community 226 - "Community 226"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
+Nodes (2): getAllColors(), getBaseUrl()
 
 ### Community 227 - "Community 227"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 228 - "Community 228"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 229 - "Community 229"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 230 - "Community 230"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 231 - "Community 231"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 232 - "Community 232"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 233 - "Community 233"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 234 - "Community 234"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 235 - "Community 235"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 236 - "Community 236"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 237 - "Community 237"
 Cohesion: 0.67
@@ -2146,8 +2148,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 253 - "Community 253"
-Cohesion: 1.0
-Nodes (2): createFixtureRoot(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 254 - "Community 254"
 Cohesion: 0.67
@@ -2155,7 +2157,7 @@ Nodes (0):
 
 ### Community 255 - "Community 255"
 Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Nodes (2): createFixtureRoot(), write()
 
 ### Community 256 - "Community 256"
 Cohesion: 0.67
@@ -2175,7 +2177,7 @@ Nodes (2): createFixtureRepo(), write()
 
 ### Community 260 - "Community 260"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 261 - "Community 261"
 Cohesion: 1.0
@@ -5517,1678 +5519,1688 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1096 - "Community 1096"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1097 - "Community 1097"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
-- **Thin community `Community 260`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 261`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 261`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 262`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 262`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 263`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 263`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 264`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 264`** (2 nodes): `authenticateHandler()`, `cashier.ts`
+- **Thin community `Community 265`** (2 nodes): `authenticateHandler()`, `cashier.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 265`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 266`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 266`** (2 nodes): `sessionQueryIndexes.test.ts`, `readProjectFile()`
+- **Thin community `Community 267`** (2 nodes): `sessionQueryIndexes.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 267`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 268`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 268`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 269`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 269`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 270`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 270`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 271`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 271`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 272`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 272`** (2 nodes): `VerificationCodeEmail.tsx`, `VerificationCodeEmail()`
+- **Thin community `Community 273`** (2 nodes): `VerificationCodeEmail.tsx`, `VerificationCodeEmail()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 273`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 274`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 274`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 275`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 275`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 276`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 276`** (2 nodes): `listOrderItems()`, `onlineOrder.ts`
+- **Thin community `Community 277`** (2 nodes): `listOrderItems()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 277`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 278`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 278`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 279`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 279`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 280`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 280`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 281`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 281`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 282`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 282`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 283`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 283`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 284`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 284`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 285`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 285`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 286`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 286`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 287`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 287`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 288`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 288`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 289`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 289`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 290`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 290`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 291`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 291`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 292`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 292`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 293`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 293`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 294`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 294`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 295`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 295`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
+- **Thin community `Community 296`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 296`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 297`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 297`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 298`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 298`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 299`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 299`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 300`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 300`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 301`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 301`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 302`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 302`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 303`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 303`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 304`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 304`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 305`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 305`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 306`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 306`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 307`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 307`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 308`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 308`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 309`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 309`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 310`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 310`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 311`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 311`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 312`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 312`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 313`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 313`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 314`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 314`** (2 nodes): `Login()`, `index.tsx`
+- **Thin community `Community 315`** (2 nodes): `Login()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 315`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 316`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 316`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 317`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 317`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 318`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 318`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 319`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 319`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 320`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 320`** (2 nodes): `PageHeader.tsx`, `PageHeader()`
+- **Thin community `Community 321`** (2 nodes): `PageHeader.tsx`, `PageHeader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 321`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 322`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 322`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 323`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 323`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 324`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 324`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 325`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 325`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 326`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 326`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 327`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 327`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 328`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 328`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 329`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 329`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 330`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 330`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 331`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 331`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 332`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 332`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 333`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 333`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 334`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 334`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 335`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 335`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 336`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 336`** (2 nodes): `handleSignOut()`, `CashierView.tsx`
+- **Thin community `Community 337`** (2 nodes): `handleSignOut()`, `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 337`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 338`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 338`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 339`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 339`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 340`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 340`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
+- **Thin community `Community 341`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 341`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 342`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 342`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
+- **Thin community `Community 343`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 343`** (2 nodes): `ProductEntry.tsx`, `handleClearSearch()`
+- **Thin community `Community 344`** (2 nodes): `ProductEntry.tsx`, `handleClearSearch()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 344`** (2 nodes): `QuickActionsBar.tsx`, `QuickActionsBar()`
+- **Thin community `Community 345`** (2 nodes): `QuickActionsBar.tsx`, `QuickActionsBar()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 345`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 346`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 346`** (2 nodes): `TotalsDisplay.tsx`, `TotalsDisplay()`
+- **Thin community `Community 347`** (2 nodes): `TotalsDisplay.tsx`, `TotalsDisplay()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 347`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
+- **Thin community `Community 348`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 348`** (2 nodes): `usePOSCashier()`, `hooks.ts`
+- **Thin community `Community 349`** (2 nodes): `usePOSCashier()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 349`** (2 nodes): `HoldSessionDialog()`, `HoldSessionDialog.tsx`
+- **Thin community `Community 350`** (2 nodes): `HoldSessionDialog()`, `HoldSessionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 350`** (2 nodes): `VoidSessionDialog.tsx`, `VoidSessionDialog()`
+- **Thin community `Community 351`** (2 nodes): `VoidSessionDialog.tsx`, `VoidSessionDialog()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 351`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 352`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 352`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 353`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 353`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 354`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 354`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 355`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 355`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 356`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 356`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
+- **Thin community `Community 357`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 357`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 358`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 358`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 359`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 359`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 360`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 360`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 361`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 361`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 362`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 362`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 363`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 363`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 364`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 364`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 365`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 365`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 366`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 366`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 367`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 367`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 368`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 368`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 369`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 369`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 370`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 370`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 371`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 371`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 372`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 372`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 373`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 373`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 374`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 374`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 375`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 375`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 376`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 376`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 377`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 377`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 378`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 378`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 379`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 379`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 380`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 380`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 381`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 381`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 382`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 382`** (2 nodes): `DateTimePicker()`, `date-time-picker.tsx`
+- **Thin community `Community 383`** (2 nodes): `DateTimePicker()`, `date-time-picker.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 383`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 384`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 384`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 385`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 385`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 386`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 386`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 387`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 387`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 388`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 388`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 389`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 389`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 390`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 390`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 391`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 391`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 392`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 392`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 393`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 393`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 394`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 394`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 395`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 395`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 396`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 396`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 397`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 397`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 398`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 398`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 399`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 399`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 400`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 400`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 401`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 401`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 402`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 402`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 403`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 403`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 404`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 404`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 405`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 405`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 406`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 406`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 407`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 407`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 408`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 408`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 409`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 409`** (2 nodes): `useCartOperations.ts`, `useCartOperations()`
+- **Thin community `Community 410`** (2 nodes): `useCartOperations.ts`, `useCartOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 410`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 411`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 411`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 412`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 412`** (2 nodes): `useCustomerOperations.ts`, `useCustomerOperations()`
+- **Thin community `Community 413`** (2 nodes): `useCustomerOperations.ts`, `useCustomerOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 413`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 414`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 414`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
+- **Thin community `Community 415`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 415`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 416`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 416`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 417`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 417`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 418`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 418`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 419`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 419`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 420`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 420`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 421`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 421`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 422`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 422`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 423`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 423`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 424`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 424`** (2 nodes): `usePrint.ts`, `usePrint()`
+- **Thin community `Community 425`** (2 nodes): `usePrint.ts`, `usePrint()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 425`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 426`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 426`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 427`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 427`** (2 nodes): `useSessionManagement.ts`, `useSessionManagement()`
+- **Thin community `Community 428`** (2 nodes): `useSessionManagement.ts`, `useSessionManagement()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 428`** (2 nodes): `useSessionManagementExpense.ts`, `useSessionManagementExpense()`
+- **Thin community `Community 429`** (2 nodes): `useSessionManagementExpense.ts`, `useSessionManagementExpense()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 429`** (2 nodes): `useSessionManagerOperations.ts`, `useSessionManagerOperations()`
+- **Thin community `Community 430`** (2 nodes): `useSessionManagerOperations.ts`, `useSessionManagerOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 430`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 431`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 431`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 432`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 432`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 433`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 433`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 434`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 434`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 435`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 435`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 436`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 436`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 437`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 437`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 438`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 438`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 439`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 439`** (2 nodes): `LoginLayout()`, `_layout.tsx`
+- **Thin community `Community 440`** (2 nodes): `LoginLayout()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 440`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 441`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 441`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 442`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 442`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 443`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 443`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 444`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 444`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 445`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 445`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 446`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 446`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 447`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 447`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 448`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 448`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 449`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 449`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 450`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 450`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 451`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 451`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 452`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 452`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
+- **Thin community `Community 453`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 453`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 454`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 454`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 455`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 455`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 456`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 456`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 457`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 457`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 458`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 458`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 459`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 459`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 460`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 460`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 461`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 461`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 462`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 462`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 463`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 463`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 464`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 464`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 465`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 465`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 466`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 466`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 467`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 467`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 468`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 468`** (2 nodes): `LinkGroup()`, `Footer.tsx`
+- **Thin community `Community 469`** (2 nodes): `LinkGroup()`, `Footer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 469`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 470`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 470`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 471`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 471`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 472`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 472`** (2 nodes): `StoreCategoriesSubmenu()`, `NavigationBar.tsx`
+- **Thin community `Community 473`** (2 nodes): `StoreCategoriesSubmenu()`, `NavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 473`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 474`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 474`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 475`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 475`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 476`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 476`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 477`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 477`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 478`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 478`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 479`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 479`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 480`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 480`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 481`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 481`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 482`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 482`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 483`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 483`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 484`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 484`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 485`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 485`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 486`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 486`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 487`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 487`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 488`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 488`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 489`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 489`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 490`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 490`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 491`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 491`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 492`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 492`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 493`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 493`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 494`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 494`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 495`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 495`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 496`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 496`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 497`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 497`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 498`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 498`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 499`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 499`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 500`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 500`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 501`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 501`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 502`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 502`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 503`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 503`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 504`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 504`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 505`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 505`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 506`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 506`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 507`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 507`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 508`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 508`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 509`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 509`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 510`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 510`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 511`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 511`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 512`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 512`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 513`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 513`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 514`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 514`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 515`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 515`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 516`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 516`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 517`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 517`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 518`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 518`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 519`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 519`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 520`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 520`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 521`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 521`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 522`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 522`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 523`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 523`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 524`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 524`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 525`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 525`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 526`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 526`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 527`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 527`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 528`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 528`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 529`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 529`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 530`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 530`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 531`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 531`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 532`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 532`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 533`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 533`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 534`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 534`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 535`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 535`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 536`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 536`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 537`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 537`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 538`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 538`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 539`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 539`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 540`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 540`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 541`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 541`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 542`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 542`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 543`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 543`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 544`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 544`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 545`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 545`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 546`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 546`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 547`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 547`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 548`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 548`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 549`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 550`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 551`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 552`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 553`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 554`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 555`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 556`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (1 nodes): `api.d.ts`
+- **Thin community `Community 557`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (1 nodes): `api.js`
+- **Thin community `Community 558`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 559`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (1 nodes): `server.d.ts`
+- **Thin community `Community 560`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (1 nodes): `server.js`
+- **Thin community `Community 561`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (1 nodes): `app.ts`
+- **Thin community `Community 562`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (1 nodes): `auth.config.js`
+- **Thin community `Community 563`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (1 nodes): `auth.ts`
+- **Thin community `Community 564`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (1 nodes): `countries.ts`
+- **Thin community `Community 565`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (1 nodes): `email.ts`
+- **Thin community `Community 566`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (1 nodes): `ghana.ts`
+- **Thin community `Community 567`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (1 nodes): `payment.ts`
+- **Thin community `Community 568`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (1 nodes): `crons.ts`
+- **Thin community `Community 569`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 570`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 571`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 572`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 573`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (1 nodes): `env.ts`
+- **Thin community `Community 574`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (1 nodes): `analytics.ts`
+- **Thin community `Community 575`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (1 nodes): `auth.ts`
+- **Thin community `Community 576`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 577`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (1 nodes): `categories.ts`
+- **Thin community `Community 578`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (1 nodes): `colors.ts`
+- **Thin community `Community 579`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (1 nodes): `index.ts`
+- **Thin community `Community 580`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (1 nodes): `organizations.ts`
+- **Thin community `Community 581`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (1 nodes): `products.ts`
+- **Thin community `Community 582`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (1 nodes): `stores.ts`
+- **Thin community `Community 583`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 584`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (1 nodes): `index.ts`
+- **Thin community `Community 585`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (1 nodes): `bag.ts`
+- **Thin community `Community 586`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (1 nodes): `guest.ts`
+- **Thin community `Community 587`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (1 nodes): `index.ts`
+- **Thin community `Community 588`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (1 nodes): `me.ts`
+- **Thin community `Community 589`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (1 nodes): `offers.ts`
+- **Thin community `Community 590`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 591`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (1 nodes): `paystack.ts`
+- **Thin community `Community 592`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (1 nodes): `reviews.ts`
+- **Thin community `Community 593`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (1 nodes): `rewards.ts`
+- **Thin community `Community 594`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 595`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (1 nodes): `security.test.ts`
+- **Thin community `Community 596`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (1 nodes): `storefront.ts`
+- **Thin community `Community 597`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (1 nodes): `upsells.ts`
+- **Thin community `Community 598`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (1 nodes): `user.ts`
+- **Thin community `Community 599`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 600`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (1 nodes): `http.ts`
+- **Thin community `Community 601`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 602`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (1 nodes): `auth.ts`
+- **Thin community `Community 603`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 604`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 605`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (1 nodes): `categories.ts`
+- **Thin community `Community 606`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (1 nodes): `colors.ts`
+- **Thin community `Community 607`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 608`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (1 nodes): `expenseSessionItems.ts`
+- **Thin community `Community 609`** (1 nodes): `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (1 nodes): `expenseTransactions.ts`
+- **Thin community `Community 610`** (1 nodes): `expenseTransactions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 611`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 612`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 613`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (1 nodes): `organizations.ts`
+- **Thin community `Community 614`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 615`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (1 nodes): `posSessionItems.ts`
+- **Thin community `Community 616`** (1 nodes): `posSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 617`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (1 nodes): `productSku.ts`
+- **Thin community `Community 618`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (1 nodes): `productUtil.ts`
+- **Thin community `Community 619`** (1 nodes): `productUtil.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 620`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 621`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 622`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 623`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 624`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 625`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 626`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 627`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (1 nodes): `client.test.ts`
+- **Thin community `Community 628`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (1 nodes): `config.test.ts`
+- **Thin community `Community 629`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 630`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (1 nodes): `types.ts`
+- **Thin community `Community 631`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (1 nodes): `ResendOTP.ts`
+- **Thin community `Community 632`** (1 nodes): `ResendOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (1 nodes): `schema.ts`
+- **Thin community `Community 633`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 634`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 635`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 636`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 637`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (1 nodes): `cashier.ts`
+- **Thin community `Community 638`** (1 nodes): `cashier.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (1 nodes): `category.ts`
+- **Thin community `Community 639`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (1 nodes): `color.ts`
+- **Thin community `Community 640`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 641`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 642`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (1 nodes): `index.ts`
+- **Thin community `Community 643`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 644`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (1 nodes): `organization.ts`
+- **Thin community `Community 645`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 646`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (1 nodes): `product.ts`
+- **Thin community `Community 647`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 648`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 649`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (1 nodes): `store.ts`
+- **Thin community `Community 650`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 651`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 652`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (1 nodes): `customer.ts`
+- **Thin community `Community 653`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 654`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 655`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 656`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 657`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (1 nodes): `index.ts`
+- **Thin community `Community 658`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (1 nodes): `posSession.ts`
+- **Thin community `Community 659`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 660`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 661`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 662`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 663`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (1 nodes): `analytics.ts`
+- **Thin community `Community 664`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (1 nodes): `bag.ts`
+- **Thin community `Community 665`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 666`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 667`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 668`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (1 nodes): `customer.ts`
+- **Thin community `Community 669`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (1 nodes): `guest.ts`
+- **Thin community `Community 670`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (1 nodes): `index.ts`
+- **Thin community `Community 671`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (1 nodes): `offer.ts`
+- **Thin community `Community 672`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 673`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 674`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (1 nodes): `review.ts`
+- **Thin community `Community 675`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (1 nodes): `rewards.ts`
+- **Thin community `Community 676`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 677`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 678`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 679`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 680`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 681`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 682`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (1 nodes): `bag.ts`
+- **Thin community `Community 683`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 684`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (1 nodes): `customer.ts`
+- **Thin community `Community 685`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (1 nodes): `guest.ts`
+- **Thin community `Community 686`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 687`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (1 nodes): `payment.ts`
+- **Thin community `Community 688`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 689`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (1 nodes): `rewards.ts`
+- **Thin community `Community 690`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 691`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 692`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (1 nodes): `users.ts`
+- **Thin community `Community 693`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (1 nodes): `payment.ts`
+- **Thin community `Community 694`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 695`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (1 nodes): `index.ts`
+- **Thin community `Community 696`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 697`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 698`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 699`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 700`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 701`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 702`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 703`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (1 nodes): `constants.ts`
+- **Thin community `Community 704`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 705`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 706`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 707`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (1 nodes): `types.ts`
+- **Thin community `Community 708`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 709`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 710`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 711`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 712`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 713`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 714`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 715`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 716`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (1 nodes): `columns.tsx`
+- **Thin community `Community 717`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 718`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 719`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 720`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 721`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (1 nodes): `columns.tsx`
+- **Thin community `Community 722`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 723`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 724`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (1 nodes): `chart.tsx`
+- **Thin community `Community 725`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (1 nodes): `columns.tsx`
+- **Thin community `Community 726`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 727`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 728`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (1 nodes): `columns.tsx`
+- **Thin community `Community 729`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (1 nodes): `constants.ts`
+- **Thin community `Community 730`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 731`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 732`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 733`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (1 nodes): `data.ts`
+- **Thin community `Community 734`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (1 nodes): `columns.tsx`
+- **Thin community `Community 735`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 736`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 737`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (1 nodes): `columns.tsx`
+- **Thin community `Community 738`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 739`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 740`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 741`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 742`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 743`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (1 nodes): `app-sidebar.tsx`
+- **Thin community `Community 744`** (1 nodes): `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 745`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (1 nodes): `constants.ts`
+- **Thin community `Community 746`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 747`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 748`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 749`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (1 nodes): `data.ts`
+- **Thin community `Community 750`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 751`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 752`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (1 nodes): `columns.tsx`
+- **Thin community `Community 753`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 754`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 755`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 756`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 757`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 758`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (1 nodes): `columns.tsx`
+- **Thin community `Community 759`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (1 nodes): `constants.ts`
+- **Thin community `Community 760`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 761`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 762`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 763`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 764`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (1 nodes): `index.tsx`
+- **Thin community `Community 765`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (1 nodes): `columns.tsx`
+- **Thin community `Community 766`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 767`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 768`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 769`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (1 nodes): `ExpenseCompletion.tsx`
+- **Thin community `Community 770`** (1 nodes): `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 771`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 772`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 773`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (1 nodes): `constants.ts`
+- **Thin community `Community 774`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 775`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 776`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 777`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (1 nodes): `data.ts`
+- **Thin community `Community 778`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (1 nodes): `constants.ts`
+- **Thin community `Community 779`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 780`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 781`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 782`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 783`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (1 nodes): `data.ts`
+- **Thin community `Community 784`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 785`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (1 nodes): `constants.ts`
+- **Thin community `Community 786`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 787`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 788`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 789`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 790`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (1 nodes): `data.ts`
+- **Thin community `Community 791`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 792`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (1 nodes): `CartItems.tsx`
+- **Thin community `Community 793`** (1 nodes): `CartItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (1 nodes): `CashierAuthDialog.tsx`
+- **Thin community `Community 794`** (1 nodes): `CashierAuthDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 795`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 796`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (1 nodes): `SearchResultsSection.tsx`
+- **Thin community `Community 797`** (1 nodes): `SearchResultsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (1 nodes): `ExpenseReportView.tsx`
+- **Thin community `Community 798`** (1 nodes): `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 799`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (1 nodes): `TransactionView.tsx`
+- **Thin community `Community 800`** (1 nodes): `TransactionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (1 nodes): `types.ts`
+- **Thin community `Community 801`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 802`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 803`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 804`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (1 nodes): `ProductDetailView.tsx`
+- **Thin community `Community 805`** (1 nodes): `ProductDetailView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (1 nodes): `ProductStatus.tsx`
+- **Thin community `Community 806`** (1 nodes): `ProductStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (1 nodes): `CategoryListView.tsx`
+- **Thin community `Community 807`** (1 nodes): `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 808`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (1 nodes): `Products.tsx`
+- **Thin community `Community 809`** (1 nodes): `Products.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 810`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 811`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 812`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 813`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 814`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 815`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 816`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 817`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 818`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (1 nodes): `data.ts`
+- **Thin community `Community 819`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 820`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (1 nodes): `PromoCodePreview.tsx`
+- **Thin community `Community 821`** (1 nodes): `PromoCodePreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 822`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 823`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 824`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (1 nodes): `columns.tsx`
+- **Thin community `Community 825`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 826`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 827`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 828`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 829`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 830`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (1 nodes): `columns.tsx`
+- **Thin community `Community 831`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (1 nodes): `constants.ts`
+- **Thin community `Community 832`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 833`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 834`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 835`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (1 nodes): `data.ts`
+- **Thin community `Community 836`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (1 nodes): `types.ts`
+- **Thin community `Community 837`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 838`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 839`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 840`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 841`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 842`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (1 nodes): `index.tsx`
+- **Thin community `Community 843`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 844`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 845`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (1 nodes): `button.tsx`
+- **Thin community `Community 846`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 847`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (1 nodes): `calendar.tsx`
+- **Thin community `Community 848`** (1 nodes): `calendar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (1 nodes): `card.tsx`
+- **Thin community `Community 849`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 850`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 851`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (1 nodes): `command.tsx`
+- **Thin community `Community 852`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 853`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 854`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 855`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (1 nodes): `form.tsx`
+- **Thin community `Community 856`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (1 nodes): `icons.tsx`
+- **Thin community `Community 857`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 858`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (1 nodes): `input.tsx`
+- **Thin community `Community 859`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 860`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (1 nodes): `popover.tsx`
+- **Thin community `Community 861`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 862`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 863`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (1 nodes): `select.tsx`
+- **Thin community `Community 864`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (1 nodes): `separator.tsx`
+- **Thin community `Community 865`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 866`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (1 nodes): `switch.tsx`
+- **Thin community `Community 867`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (1 nodes): `table.tsx`
+- **Thin community `Community 868`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 869`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 870`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 871`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 872`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 873`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 874`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 875`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (1 nodes): `columns.tsx`
+- **Thin community `Community 876`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (1 nodes): `constants.ts`
+- **Thin community `Community 877`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 878`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 879`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 880`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (1 nodes): `data.ts`
+- **Thin community `Community 881`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 882`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 883`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (1 nodes): `columns.tsx`
+- **Thin community `Community 884`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 885`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 886`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 887`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 888`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 889`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 890`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 891`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 892`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 893`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (1 nodes): `UserBehaviorInsights.tsx`
+- **Thin community `Community 894`** (1 nodes): `UserBehaviorInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (1 nodes): `index.ts`
+- **Thin community `Community 895`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (1 nodes): `config.ts`
+- **Thin community `Community 896`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 897`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 898`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 899`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (1 nodes): `aws.ts`
+- **Thin community `Community 900`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (1 nodes): `constants.ts`
+- **Thin community `Community 901`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (1 nodes): `countries.ts`
+- **Thin community `Community 902`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (1 nodes): `ghana.ts`
+- **Thin community `Community 903`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 904`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (1 nodes): `constants.ts`
+- **Thin community `Community 905`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 906`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (1 nodes): `category.ts`
+- **Thin community `Community 907`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (1 nodes): `product.ts`
+- **Thin community `Community 908`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (1 nodes): `store.ts`
+- **Thin community `Community 909`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 910`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (1 nodes): `user.ts`
+- **Thin community `Community 911`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 912`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 913`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 914`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (1 nodes): `__root.tsx`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (1 nodes): `index.tsx`
+- **Thin community `Community 915`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 916`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 917`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 918`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 919`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 920`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 921`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 922`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (1 nodes): `index.tsx`
+- **Thin community `Community 923`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 924`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 925`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 926`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (1 nodes): `home.tsx`
+- **Thin community `Community 927`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 928`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 929`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 930`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (1 nodes): `index.tsx`
+- **Thin community `Community 931`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 932`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 933`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 934`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `index.tsx`
+- **Thin community `Community 935`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 936`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 937`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 938`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 939`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 940`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 941`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `expense.index.tsx`
+- **Thin community `Community 942`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `index.tsx`
+- **Thin community `Community 943`** (1 nodes): `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 944`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 945`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 946`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 947`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `edit.tsx`
+- **Thin community `Community 948`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `index.tsx`
+- **Thin community `Community 949`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 950`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `new.tsx`
+- **Thin community `Community 951`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `index.tsx`
+- **Thin community `Community 952`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `new.tsx`
+- **Thin community `Community 953`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 954`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 955`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `index.tsx`
+- **Thin community `Community 956`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `new.tsx`
+- **Thin community `Community 957`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `index.tsx`
+- **Thin community `Community 958`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 959`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 960`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `index.tsx`
+- **Thin community `Community 961`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 962`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `_layout.index.tsx`
+- **Thin community `Community 963`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 964`** (1 nodes): `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 965`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `posStore.ts`
+- **Thin community `Community 966`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `setup.ts`
+- **Thin community `Community 967`** (1 nodes): `posStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `usePrint.test.ts`
+- **Thin community `Community 968`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 969`** (1 nodes): `usePrint.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `types.ts`
+- **Thin community `Community 970`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 971`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 972`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 973`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `global.d.ts`
+- **Thin community `Community 974`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 975`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `types.ts`
+- **Thin community `Community 976`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 977`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `client.tsx`
+- **Thin community `Community 978`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 979`** (1 nodes): `client.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 980`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 981`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 982`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 983`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `schema.ts`
+- **Thin community `Community 984`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 985`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 986`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 987`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 988`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 989`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 990`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 991`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 992`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 993`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `types.ts`
+- **Thin community `Community 994`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 995`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 996`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 997`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 998`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 999`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `constants.ts`
+- **Thin community `Community 1000`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1001`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `About.tsx`
+- **Thin community `Community 1002`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1003`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1004`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1005`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1006`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1007`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1008`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1009`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1010`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `types.ts`
+- **Thin community `Community 1011`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1012`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1013`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1014`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1015`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1016`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1017`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1018`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1019`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1020`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `button.tsx`
+- **Thin community `Community 1021`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `card.tsx`
+- **Thin community `Community 1022`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1023`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `command.tsx`
+- **Thin community `Community 1024`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1025`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1026`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1027`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `form.tsx`
+- **Thin community `Community 1028`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1029`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1030`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1031`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1032`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `input.tsx`
+- **Thin community `Community 1033`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `label.tsx`
+- **Thin community `Community 1034`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1035`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1036`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1037`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `index.ts`
+- **Thin community `Community 1038`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `types.ts`
+- **Thin community `Community 1039`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1040`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1041`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1042`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1043`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `select.tsx`
+- **Thin community `Community 1044`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1045`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1046`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `table.tsx`
+- **Thin community `Community 1047`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1048`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1049`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1050`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1051`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1052`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `config.ts`
+- **Thin community `Community 1053`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1054`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1055`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1056`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `constants.ts`
+- **Thin community `Community 1057`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `countries.ts`
+- **Thin community `Community 1058`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1059`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1060`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1061`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1062`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `index.ts`
+- **Thin community `Community 1063`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `store.ts`
+- **Thin community `Community 1064`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `bag.ts`
+- **Thin community `Community 1065`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1066`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `category.ts`
+- **Thin community `Community 1067`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `organization.ts`
+- **Thin community `Community 1068`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `product.ts`
+- **Thin community `Community 1069`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `store.ts`
+- **Thin community `Community 1070`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1071`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `user.ts`
+- **Thin community `Community 1072`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `states.ts`
+- **Thin community `Community 1073`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1074`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1075`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1076`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1077`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1078`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1079`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `index.tsx`
+- **Thin community `Community 1080`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1081`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `index.tsx`
+- **Thin community `Community 1082`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1083`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1084`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `index.tsx`
+- **Thin community `Community 1085`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1086`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1087`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1088`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `index.tsx`
+- **Thin community `Community 1089`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1090`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `ssr.tsx`
+- **Thin community `Community 1091`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1092`** (1 nodes): `ssr.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1093`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1094`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `index.js`
+- **Thin community `Community 1095`** (1 nodes): `vitest.setup.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1096`** (1 nodes): `index.js`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1097`** (1 nodes): `harness-behavior-scenarios.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -9,7 +9,7 @@
       "source_file": "packages/athena-webapp/convex/_generated/api.d.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_generated_api_d_ts",
-      "community": 556
+      "community": 557
     },
     {
       "label": "api.js",
@@ -17,7 +17,7 @@
       "source_file": "packages/athena-webapp/convex/_generated/api.js",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_generated_api_js",
-      "community": 557
+      "community": 558
     },
     {
       "label": "dataModel.d.ts",
@@ -25,7 +25,7 @@
       "source_file": "packages/athena-webapp/convex/_generated/dataModel.d.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_generated_datamodel_d_ts",
-      "community": 558
+      "community": 559
     },
     {
       "label": "server.d.ts",
@@ -33,7 +33,7 @@
       "source_file": "packages/athena-webapp/convex/_generated/server.d.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_generated_server_d_ts",
-      "community": 559
+      "community": 560
     },
     {
       "label": "server.js",
@@ -41,7 +41,7 @@
       "source_file": "packages/athena-webapp/convex/_generated/server.js",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_generated_server_js",
-      "community": 560
+      "community": 561
     },
     {
       "label": "app.ts",
@@ -49,7 +49,7 @@
       "source_file": "packages/athena-webapp/convex/app.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_app_ts",
-      "community": 561
+      "community": 562
     },
     {
       "label": "auth.config.js",
@@ -57,7 +57,7 @@
       "source_file": "packages/athena-webapp/convex/auth.config.js",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_auth_config_js",
-      "community": 562
+      "community": 563
     },
     {
       "label": "auth.ts",
@@ -65,7 +65,7 @@
       "source_file": "packages/athena-webapp/convex/auth.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_auth_ts",
-      "community": 563
+      "community": 564
     },
     {
       "label": "index.ts",
@@ -73,7 +73,7 @@
       "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_cache_index_ts",
-      "community": 50
+      "community": 51
     },
     {
       "label": "ValkeyClient",
@@ -81,7 +81,7 @@
       "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L4",
       "id": "index_valkeyclient",
-      "community": 50
+      "community": 51
     },
     {
       "label": ".constructor()",
@@ -89,7 +89,7 @@
       "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L11",
       "id": "index_valkeyclient_constructor",
-      "community": 50
+      "community": 51
     },
     {
       "label": ".get()",
@@ -97,7 +97,7 @@
       "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L20",
       "id": "index_valkeyclient_get",
-      "community": 50
+      "community": 51
     },
     {
       "label": ".set()",
@@ -105,7 +105,7 @@
       "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L48",
       "id": "index_valkeyclient_set",
-      "community": 50
+      "community": 51
     },
     {
       "label": ".invalidate()",
@@ -113,7 +113,7 @@
       "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L75",
       "id": "index_valkeyclient_invalidate",
-      "community": 50
+      "community": 51
     },
     {
       "label": "r2.ts",
@@ -121,7 +121,7 @@
       "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_cloudflare_r2_ts",
-      "community": 76
+      "community": 77
     },
     {
       "label": "uploadFileToR2()",
@@ -129,7 +129,7 @@
       "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
       "source_location": "L21",
       "id": "r2_uploadfiletor2",
-      "community": 76
+      "community": 77
     },
     {
       "label": "deleteFileInR2()",
@@ -137,7 +137,7 @@
       "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
       "source_location": "L40",
       "id": "r2_deletefileinr2",
-      "community": 76
+      "community": 77
     },
     {
       "label": "deleteDirectoryInR2()",
@@ -145,7 +145,7 @@
       "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
       "source_location": "L62",
       "id": "r2_deletedirectoryinr2",
-      "community": 76
+      "community": 77
     },
     {
       "label": "listItemsInR2Directory()",
@@ -153,7 +153,7 @@
       "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
       "source_location": "L106",
       "id": "r2_listitemsinr2directory",
-      "community": 76
+      "community": 77
     },
     {
       "label": "stream.ts",
@@ -161,7 +161,7 @@
       "source_file": "packages/athena-webapp/convex/cloudflare/stream.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_cloudflare_stream_ts",
-      "community": 260
+      "community": 261
     },
     {
       "label": "getCloudflareConfig()",
@@ -169,7 +169,7 @@
       "source_file": "packages/athena-webapp/convex/cloudflare/stream.ts",
       "source_location": "L8",
       "id": "stream_getcloudflareconfig",
-      "community": 260
+      "community": 261
     },
     {
       "label": "countries.ts",
@@ -177,7 +177,7 @@
       "source_file": "packages/athena-webapp/convex/constants/countries.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_constants_countries_ts",
-      "community": 564
+      "community": 565
     },
     {
       "label": "email.ts",
@@ -185,7 +185,7 @@
       "source_file": "packages/athena-webapp/convex/constants/email.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_constants_email_ts",
-      "community": 565
+      "community": 566
     },
     {
       "label": "ghana.ts",
@@ -193,7 +193,7 @@
       "source_file": "packages/athena-webapp/convex/constants/ghana.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_constants_ghana_ts",
-      "community": 566
+      "community": 567
     },
     {
       "label": "payment.ts",
@@ -201,7 +201,7 @@
       "source_file": "packages/athena-webapp/convex/constants/payment.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_constants_payment_ts",
-      "community": 567
+      "community": 568
     },
     {
       "label": "crons.ts",
@@ -209,7 +209,7 @@
       "source_file": "packages/athena-webapp/convex/crons.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_crons_ts",
-      "community": 568
+      "community": 569
     },
     {
       "label": "DiscountCode.tsx",
@@ -217,7 +217,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_emails_discountcode_tsx",
-      "community": 155
+      "community": 157
     },
     {
       "label": "ProductCard()",
@@ -225,7 +225,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
       "source_location": "L33",
       "id": "discountcode_productcard",
-      "community": 155
+      "community": 157
     },
     {
       "label": "chunkProducts()",
@@ -233,7 +233,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
       "source_location": "L98",
       "id": "discountcode_chunkproducts",
-      "community": 155
+      "community": 157
     },
     {
       "label": "DiscountReminder.tsx",
@@ -241,7 +241,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_emails_discountreminder_tsx",
-      "community": 156
+      "community": 158
     },
     {
       "label": "ProductCard()",
@@ -249,7 +249,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
       "source_location": "L31",
       "id": "discountreminder_productcard",
-      "community": 156
+      "community": 158
     },
     {
       "label": "chunkProducts()",
@@ -257,7 +257,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
       "source_location": "L85",
       "id": "discountreminder_chunkproducts",
-      "community": 156
+      "community": 158
     },
     {
       "label": "FeedbackRequest.tsx",
@@ -265,7 +265,7 @@
       "source_file": "packages/athena-webapp/convex/emails/FeedbackRequest.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_emails_feedbackrequest_tsx",
-      "community": 569
+      "community": 570
     },
     {
       "label": "NewOrderAdmin.tsx",
@@ -273,7 +273,7 @@
       "source_file": "packages/athena-webapp/convex/emails/NewOrderAdmin.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_emails_neworderadmin_tsx",
-      "community": 570
+      "community": 571
     },
     {
       "label": "OrderEmail.tsx",
@@ -281,7 +281,7 @@
       "source_file": "packages/athena-webapp/convex/emails/OrderEmail.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_emails_orderemail_tsx",
-      "community": 571
+      "community": 572
     },
     {
       "label": "PosReceiptEmail.tsx",
@@ -289,7 +289,7 @@
       "source_file": "packages/athena-webapp/convex/emails/PosReceiptEmail.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_emails_posreceiptemail_tsx",
-      "community": 572
+      "community": 573
     },
     {
       "label": "VerificationCode.tsx",
@@ -297,7 +297,7 @@
       "source_file": "packages/athena-webapp/convex/emails/VerificationCode.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_emails_verificationcode_tsx",
-      "community": 261
+      "community": 262
     },
     {
       "label": "VerificationCode()",
@@ -305,7 +305,7 @@
       "source_file": "packages/athena-webapp/convex/emails/VerificationCode.tsx",
       "source_location": "L18",
       "id": "verificationcode_verificationcode",
-      "community": 261
+      "community": 262
     },
     {
       "label": "env.ts",
@@ -313,7 +313,7 @@
       "source_file": "packages/athena-webapp/convex/env.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_env_ts",
-      "community": 573
+      "community": 574
     },
     {
       "label": "analytics.ts",
@@ -321,7 +321,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/analytics.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_analytics_ts",
-      "community": 574
+      "community": 575
     },
     {
       "label": "auth.ts",
@@ -329,7 +329,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/auth.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_auth_ts",
-      "community": 575
+      "community": 576
     },
     {
       "label": "bannerMessage.ts",
@@ -337,7 +337,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/bannerMessage.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_bannermessage_ts",
-      "community": 576
+      "community": 577
     },
     {
       "label": "categories.ts",
@@ -345,7 +345,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/categories.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_categories_ts",
-      "community": 577
+      "community": 578
     },
     {
       "label": "colors.ts",
@@ -353,7 +353,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/colors.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_colors_ts",
-      "community": 578
+      "community": 579
     },
     {
       "label": "index.ts",
@@ -361,7 +361,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/index.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_index_ts",
-      "community": 579
+      "community": 580
     },
     {
       "label": "organizations.ts",
@@ -369,7 +369,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/organizations.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_organizations_ts",
-      "community": 580
+      "community": 581
     },
     {
       "label": "products.ts",
@@ -377,7 +377,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/products.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_products_ts",
-      "community": 581
+      "community": 582
     },
     {
       "label": "stores.ts",
@@ -385,7 +385,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/stores.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_stores_ts",
-      "community": 582
+      "community": 583
     },
     {
       "label": "subcategories.ts",
@@ -393,7 +393,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/subcategories.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_subcategories_ts",
-      "community": 583
+      "community": 584
     },
     {
       "label": "index.ts",
@@ -401,7 +401,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/index.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_payments_routes_index_ts",
-      "community": 584
+      "community": 585
     },
     {
       "label": "mtnMomo.ts",
@@ -409,7 +409,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/mtnMomo.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_payments_routes_mtnmomo_ts",
-      "community": 262
+      "community": 263
     },
     {
       "label": "handleCollectionNotification()",
@@ -417,7 +417,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/mtnMomo.ts",
       "source_location": "L10",
       "id": "mtnmomo_handlecollectionnotification",
-      "community": 262
+      "community": 263
     },
     {
       "label": "bag.ts",
@@ -425,7 +425,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/bag.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_bag_ts",
-      "community": 585
+      "community": 586
     },
     {
       "label": "checkout.ts",
@@ -433,7 +433,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/checkout.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_checkout_ts",
-      "community": 113
+      "community": 114
     },
     {
       "label": "hasValidCanonicalBagItem()",
@@ -441,7 +441,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/checkout.ts",
       "source_location": "L84",
       "id": "checkout_hasvalidcanonicalbagitem",
-      "community": 113
+      "community": 114
     },
     {
       "label": "hasValidSessionItems()",
@@ -449,7 +449,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/checkout.ts",
       "source_location": "L95",
       "id": "checkout_hasvalidsessionitems",
-      "community": 113
+      "community": 114
     },
     {
       "label": "hasAllVisibileSessionItems()",
@@ -457,7 +457,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/checkout.ts",
       "source_location": "L109",
       "id": "checkout_hasallvisibilesessionitems",
-      "community": 113
+      "community": 114
     },
     {
       "label": "guest.ts",
@@ -465,7 +465,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/guest.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_guest_ts",
-      "community": 586
+      "community": 587
     },
     {
       "label": "index.ts",
@@ -473,7 +473,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/index.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_index_ts",
-      "community": 587
+      "community": 588
     },
     {
       "label": "me.ts",
@@ -481,7 +481,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/me.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_me_ts",
-      "community": 588
+      "community": 589
     },
     {
       "label": "offers.ts",
@@ -489,7 +489,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/offers.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_offers_ts",
-      "community": 589
+      "community": 590
     },
     {
       "label": "onlineOrder.ts",
@@ -497,7 +497,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/onlineOrder.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_onlineorder_ts",
-      "community": 590
+      "community": 591
     },
     {
       "label": "paystack.ts",
@@ -505,7 +505,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/paystack.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_paystack_ts",
-      "community": 591
+      "community": 592
     },
     {
       "label": "reviews.ts",
@@ -513,7 +513,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/reviews.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_reviews_ts",
-      "community": 592
+      "community": 593
     },
     {
       "label": "rewards.ts",
@@ -521,7 +521,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/rewards.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_rewards_ts",
-      "community": 593
+      "community": 594
     },
     {
       "label": "savedBag.ts",
@@ -529,7 +529,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/savedBag.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_savedbag_ts",
-      "community": 594
+      "community": 595
     },
     {
       "label": "security.test.ts",
@@ -537,7 +537,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_test_ts",
-      "community": 595
+      "community": 596
     },
     {
       "label": "security.ts",
@@ -545,7 +545,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_ts",
-      "community": 51
+      "community": 52
     },
     {
       "label": "hasValidPositiveQuantity()",
@@ -553,7 +553,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
       "source_location": "L27",
       "id": "security_hasvalidpositivequantity",
-      "community": 51
+      "community": 52
     },
     {
       "label": "isAuthorizedResourceOwner()",
@@ -561,7 +561,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
       "source_location": "L31",
       "id": "security_isauthorizedresourceowner",
-      "community": 51
+      "community": 52
     },
     {
       "label": "buildCanonicalCheckoutProducts()",
@@ -569,7 +569,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
       "source_location": "L42",
       "id": "security_buildcanonicalcheckoutproducts",
-      "community": 51
+      "community": 52
     },
     {
       "label": "isAmountTampered()",
@@ -577,7 +577,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
       "source_location": "L65",
       "id": "security_isamounttampered",
-      "community": 51
+      "community": 52
     },
     {
       "label": "isDuplicateChargeSuccess()",
@@ -585,7 +585,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
       "source_location": "L76",
       "id": "security_isduplicatechargesuccess",
-      "community": 51
+      "community": 52
     },
     {
       "label": "storefront.ts",
@@ -593,7 +593,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/storefront.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_storefront_ts",
-      "community": 596
+      "community": 597
     },
     {
       "label": "upsells.ts",
@@ -601,7 +601,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/upsells.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_upsells_ts",
-      "community": 597
+      "community": 598
     },
     {
       "label": "user.ts",
@@ -609,7 +609,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/user.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_user_ts",
-      "community": 598
+      "community": 599
     },
     {
       "label": "userOffers.ts",
@@ -617,7 +617,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/userOffers.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_useroffers_ts",
-      "community": 599
+      "community": 600
     },
     {
       "label": "routerComposition.test.ts",
@@ -625,7 +625,7 @@
       "source_file": "packages/athena-webapp/convex/http/routerComposition.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_routercomposition_test_ts",
-      "community": 263
+      "community": 264
     },
     {
       "label": "readProjectFile()",
@@ -633,7 +633,7 @@
       "source_file": "packages/athena-webapp/convex/http/routerComposition.test.ts",
       "source_location": "L6",
       "id": "routercomposition_test_readprojectfile",
-      "community": 263
+      "community": 264
     },
     {
       "label": "utils.ts",
@@ -641,7 +641,7 @@
       "source_file": "packages/athena-webapp/convex/http/utils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_utils_ts",
-      "community": 157
+      "community": 159
     },
     {
       "label": "getStoreDataFromRequest()",
@@ -649,7 +649,7 @@
       "source_file": "packages/athena-webapp/convex/http/utils.ts",
       "source_location": "L5",
       "id": "utils_getstoredatafromrequest",
-      "community": 157
+      "community": 159
     },
     {
       "label": "getStorefrontUserFromRequest()",
@@ -657,7 +657,7 @@
       "source_file": "packages/athena-webapp/convex/http/utils.ts",
       "source_location": "L12",
       "id": "utils_getstorefrontuserfromrequest",
-      "community": 157
+      "community": 159
     },
     {
       "label": "http.ts",
@@ -665,7 +665,7 @@
       "source_file": "packages/athena-webapp/convex/http.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_ts",
-      "community": 600
+      "community": 601
     },
     {
       "label": "athenaUser.ts",
@@ -673,7 +673,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/athenaUser.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_athenauser_ts",
-      "community": 601
+      "community": 602
     },
     {
       "label": "auth.ts",
@@ -681,7 +681,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/auth.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_auth_ts",
-      "community": 602
+      "community": 603
     },
     {
       "label": "bannerMessage.ts",
@@ -689,7 +689,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/bannerMessage.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_bannermessage_ts",
-      "community": 603
+      "community": 604
     },
     {
       "label": "bestSeller.ts",
@@ -697,7 +697,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/bestSeller.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_bestseller_ts",
-      "community": 604
+      "community": 605
     },
     {
       "label": "cashier.ts",
@@ -705,7 +705,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/cashier.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_cashier_ts",
-      "community": 264
+      "community": 265
     },
     {
       "label": "authenticateHandler()",
@@ -713,7 +713,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/cashier.ts",
       "source_location": "L239",
       "id": "cashier_authenticatehandler",
-      "community": 264
+      "community": 265
     },
     {
       "label": "categories.ts",
@@ -721,7 +721,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/categories.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_categories_ts",
-      "community": 605
+      "community": 606
     },
     {
       "label": "colors.ts",
@@ -729,7 +729,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/colors.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_colors_ts",
-      "community": 606
+      "community": 607
     },
     {
       "label": "complimentaryProduct.ts",
@@ -737,7 +737,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/complimentaryProduct.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_complimentaryproduct_ts",
-      "community": 607
+      "community": 608
     },
     {
       "label": "expenseSessionItems.ts",
@@ -745,7 +745,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessionItems.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_expensesessionitems_ts",
-      "community": 608
+      "community": 609
     },
     {
       "label": "expenseSessions.ts",
@@ -753,7 +753,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_expensesessions_ts",
-      "community": 114
+      "community": 115
     },
     {
       "label": "buildNextExpenseSessionNumber()",
@@ -761,7 +761,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
       "source_location": "L33",
       "id": "expensesessions_buildnextexpensesessionnumber",
-      "community": 114
+      "community": 115
     },
     {
       "label": "loadExpenseSessionItems()",
@@ -769,7 +769,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
       "source_location": "L41",
       "id": "expensesessions_loadexpensesessionitems",
-      "community": 114
+      "community": 115
     },
     {
       "label": "listExpenseSessionsByStatusBefore()",
@@ -777,7 +777,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
       "source_location": "L66",
       "id": "expensesessions_listexpensesessionsbystatusbefore",
-      "community": 114
+      "community": 115
     },
     {
       "label": "expenseTransactions.ts",
@@ -785,7 +785,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_expensetransactions_ts",
-      "community": 609
+      "community": 610
     },
     {
       "label": "featuredItem.ts",
@@ -793,7 +793,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/featuredItem.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_featureditem_ts",
-      "community": 610
+      "community": 611
     },
     {
       "label": "expenseSessionExpiration.ts",
@@ -801,7 +801,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionExpiration.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionexpiration_ts",
-      "community": 115
+      "community": 116
     },
     {
       "label": "calculateExpenseSessionExpiration()",
@@ -809,7 +809,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionExpiration.ts",
       "source_location": "L21",
       "id": "expensesessionexpiration_calculateexpensesessionexpiration",
-      "community": 115
+      "community": 116
     },
     {
       "label": "getExpenseSessionExpiryDuration()",
@@ -817,7 +817,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionExpiration.ts",
       "source_location": "L35",
       "id": "expensesessionexpiration_getexpensesessionexpiryduration",
-      "community": 115
+      "community": 116
     },
     {
       "label": "getExpenseSessionExpiryDurationMinutes()",
@@ -825,7 +825,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionExpiration.ts",
       "source_location": "L45",
       "id": "expensesessionexpiration_getexpensesessionexpirydurationminutes",
-      "community": 115
+      "community": 116
     },
     {
       "label": "expenseSessionValidation.ts",
@@ -833,7 +833,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionvalidation_ts",
-      "community": 77
+      "community": 78
     },
     {
       "label": "validateExpenseSessionExists()",
@@ -841,7 +841,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
       "source_location": "L19",
       "id": "expensesessionvalidation_validateexpensesessionexists",
-      "community": 77
+      "community": 78
     },
     {
       "label": "validateExpenseSessionActive()",
@@ -849,7 +849,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
       "source_location": "L39",
       "id": "expensesessionvalidation_validateexpensesessionactive",
-      "community": 77
+      "community": 78
     },
     {
       "label": "validateExpenseSessionModifiable()",
@@ -857,7 +857,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
       "source_location": "L92",
       "id": "expensesessionvalidation_validateexpensesessionmodifiable",
-      "community": 77
+      "community": 78
     },
     {
       "label": "validateExpenseItemBelongsToSession()",
@@ -865,7 +865,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
       "source_location": "L135",
       "id": "expensesessionvalidation_validateexpenseitembelongstosession",
-      "community": 77
+      "community": 78
     },
     {
       "label": "inventoryHolds.ts",
@@ -1009,7 +1009,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_helpers_sessionexpiration_ts",
-      "community": 116
+      "community": 117
     },
     {
       "label": "calculateSessionExpiration()",
@@ -1017,7 +1017,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
       "source_location": "L21",
       "id": "sessionexpiration_calculatesessionexpiration",
-      "community": 116
+      "community": 117
     },
     {
       "label": "getSessionExpiryDuration()",
@@ -1025,7 +1025,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
       "source_location": "L35",
       "id": "sessionexpiration_getsessionexpiryduration",
-      "community": 116
+      "community": 117
     },
     {
       "label": "getSessionExpiryDurationMinutes()",
@@ -1033,7 +1033,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
       "source_location": "L45",
       "id": "sessionexpiration_getsessionexpirydurationminutes",
-      "community": 116
+      "community": 117
     },
     {
       "label": "sessionValidation.ts",
@@ -1121,7 +1121,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/inviteCode.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_invitecode_ts",
-      "community": 611
+      "community": 612
     },
     {
       "label": "organizationMembers.ts",
@@ -1129,7 +1129,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/organizationMembers.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_organizationmembers_ts",
-      "community": 612
+      "community": 613
     },
     {
       "label": "organizations.ts",
@@ -1137,7 +1137,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/organizations.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_organizations_ts",
-      "community": 613
+      "community": 614
     },
     {
       "label": "pos.ts",
@@ -1225,7 +1225,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posCustomers.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_poscustomers_ts",
-      "community": 614
+      "community": 615
     },
     {
       "label": "posQueryCleanup.test.ts",
@@ -1233,7 +1233,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posQueryCleanup.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_posquerycleanup_test_ts",
-      "community": 265
+      "community": 266
     },
     {
       "label": "readProjectFile()",
@@ -1241,7 +1241,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posQueryCleanup.test.ts",
       "source_location": "L8",
       "id": "posquerycleanup_test_readprojectfile",
-      "community": 265
+      "community": 266
     },
     {
       "label": "posSessionItems.ts",
@@ -1249,7 +1249,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posSessionItems.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_possessionitems_ts",
-      "community": 615
+      "community": 616
     },
     {
       "label": "posSessions.ts",
@@ -1257,7 +1257,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_possessions_ts",
-      "community": 78
+      "community": 79
     },
     {
       "label": "buildNextSessionNumber()",
@@ -1265,7 +1265,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
       "source_location": "L34",
       "id": "possessions_buildnextsessionnumber",
-      "community": 78
+      "community": 79
     },
     {
       "label": "loadPosSessionItems()",
@@ -1273,7 +1273,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
       "source_location": "L45",
       "id": "possessions_loadpossessionitems",
-      "community": 78
+      "community": 79
     },
     {
       "label": "listPosSessionsByStatusBefore()",
@@ -1281,7 +1281,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
       "source_location": "L67",
       "id": "possessions_listpossessionsbystatusbefore",
-      "community": 78
+      "community": 79
     },
     {
       "label": "listPosSessionsForStoreStatus()",
@@ -1289,7 +1289,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
       "source_location": "L93",
       "id": "possessions_listpossessionsforstorestatus",
-      "community": 78
+      "community": 79
     },
     {
       "label": "posTerminal.ts",
@@ -1297,7 +1297,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posTerminal.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_posterminal_ts",
-      "community": 616
+      "community": 617
     },
     {
       "label": "productSku.ts",
@@ -1305,7 +1305,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/productSku.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_productsku_ts",
-      "community": 617
+      "community": 618
     },
     {
       "label": "productUtil.ts",
@@ -1313,7 +1313,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/productUtil.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_productutil_ts",
-      "community": 618
+      "community": 619
     },
     {
       "label": "products.ts",
@@ -1321,7 +1321,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/products.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_products_ts",
-      "community": 79
+      "community": 80
     },
     {
       "label": "generateSKU()",
@@ -1329,7 +1329,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/products.ts",
       "source_location": "L18",
       "id": "products_generatesku",
-      "community": 79
+      "community": 80
     },
     {
       "label": "generateBarcode()",
@@ -1337,7 +1337,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/products.ts",
       "source_location": "L42",
       "id": "products_generatebarcode",
-      "community": 79
+      "community": 80
     },
     {
       "label": "calculateTotalInventoryCount()",
@@ -1345,7 +1345,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/products.ts",
       "source_location": "L65",
       "id": "products_calculatetotalinventorycount",
-      "community": 79
+      "community": 80
     },
     {
       "label": "calculateTotalAvailableCount()",
@@ -1353,7 +1353,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/products.ts",
       "source_location": "L70",
       "id": "products_calculatetotalavailablecount",
-      "community": 79
+      "community": 80
     },
     {
       "label": "promoCode.ts",
@@ -1361,7 +1361,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/promoCode.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_promocode_ts",
-      "community": 619
+      "community": 620
     },
     {
       "label": "sessionQueryIndexes.test.ts",
@@ -1369,7 +1369,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/sessionQueryIndexes.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_sessionqueryindexes_test_ts",
-      "community": 266
+      "community": 267
     },
     {
       "label": "readProjectFile()",
@@ -1377,7 +1377,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/sessionQueryIndexes.test.ts",
       "source_location": "L6",
       "id": "sessionqueryindexes_test_readprojectfile",
-      "community": 266
+      "community": 267
     },
     {
       "label": "stockValidation.ts",
@@ -1385,7 +1385,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/stockValidation.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_stockvalidation_ts",
-      "community": 620
+      "community": 621
     },
     {
       "label": "storeConfigV2.test.ts",
@@ -1393,7 +1393,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_storeconfigv2_test_ts",
-      "community": 621
+      "community": 622
     },
     {
       "label": "storeConfigV2.ts",
@@ -1625,7 +1625,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/stores.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_stores_ts",
-      "community": 267
+      "community": 268
     },
     {
       "label": "toV2OnlyConfig()",
@@ -1633,7 +1633,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/stores.ts",
       "source_location": "L27",
       "id": "stores_tov2onlyconfig",
-      "community": 267
+      "community": 268
     },
     {
       "label": "subcategories.ts",
@@ -1641,7 +1641,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/subcategories.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_subcategories_ts",
-      "community": 622
+      "community": 623
     },
     {
       "label": "utils.ts",
@@ -1689,7 +1689,7 @@
       "source_file": "packages/athena-webapp/convex/lib/currency.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_lib_currency_test_ts",
-      "community": 623
+      "community": 624
     },
     {
       "label": "currency.ts",
@@ -1697,7 +1697,7 @@
       "source_file": "packages/athena-webapp/convex/lib/currency.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_lib_currency_ts",
-      "community": 117
+      "community": 118
     },
     {
       "label": "toPesewas()",
@@ -1705,7 +1705,7 @@
       "source_file": "packages/storefront-webapp/src/lib/currency.ts",
       "source_location": "L1",
       "id": "currency_topesewas",
-      "community": 117
+      "community": 118
     },
     {
       "label": "toDisplayAmount()",
@@ -1713,7 +1713,7 @@
       "source_file": "packages/storefront-webapp/src/lib/currency.ts",
       "source_location": "L5",
       "id": "currency_todisplayamount",
-      "community": 117
+      "community": 118
     },
     {
       "label": "callLlmProvider.ts",
@@ -1721,7 +1721,7 @@
       "source_file": "packages/athena-webapp/convex/llm/callLlmProvider.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_llm_callllmprovider_ts",
-      "community": 268
+      "community": 269
     },
     {
       "label": "callLlmProvider()",
@@ -1729,7 +1729,7 @@
       "source_file": "packages/athena-webapp/convex/llm/callLlmProvider.ts",
       "source_location": "L4",
       "id": "callllmprovider_callllmprovider",
-      "community": 268
+      "community": 269
     },
     {
       "label": "anthropic.ts",
@@ -1737,7 +1737,7 @@
       "source_file": "packages/athena-webapp/convex/llm/providers/anthropic.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_llm_providers_anthropic_ts",
-      "community": 269
+      "community": 270
     },
     {
       "label": "callAnthropic()",
@@ -1745,7 +1745,7 @@
       "source_file": "packages/athena-webapp/convex/llm/providers/anthropic.ts",
       "source_location": "L3",
       "id": "anthropic_callanthropic",
-      "community": 269
+      "community": 270
     },
     {
       "label": "openai.ts",
@@ -1753,7 +1753,7 @@
       "source_file": "packages/athena-webapp/convex/llm/providers/openai.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_llm_providers_openai_ts",
-      "community": 270
+      "community": 271
     },
     {
       "label": "callOpenAi()",
@@ -1761,7 +1761,7 @@
       "source_file": "packages/athena-webapp/convex/llm/providers/openai.ts",
       "source_location": "L3",
       "id": "openai_callopenai",
-      "community": 270
+      "community": 271
     },
     {
       "label": "storeInsights.ts",
@@ -1769,7 +1769,7 @@
       "source_file": "packages/athena-webapp/convex/llm/storeInsights.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_llm_storeinsights_ts",
-      "community": 624
+      "community": 625
     },
     {
       "label": "userInsights.ts",
@@ -1777,7 +1777,7 @@
       "source_file": "packages/athena-webapp/convex/llm/userInsights.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_llm_userinsights_ts",
-      "community": 625
+      "community": 626
     },
     {
       "label": "analyticsUtils.ts",
@@ -1785,7 +1785,7 @@
       "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_llm_utils_analyticsutils_ts",
-      "community": 158
+      "community": 160
     },
     {
       "label": "calculateDeviceDistribution()",
@@ -1793,7 +1793,7 @@
       "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
       "source_location": "L11",
       "id": "analyticsutils_calculatedevicedistribution",
-      "community": 158
+      "community": 160
     },
     {
       "label": "calculateActivityTrend()",
@@ -1801,7 +1801,7 @@
       "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
       "source_location": "L43",
       "id": "analyticsutils_calculateactivitytrend",
-      "community": 158
+      "community": 160
     },
     {
       "label": "index.tsx",
@@ -1865,7 +1865,7 @@
       "source_file": "packages/athena-webapp/convex/migrations/migrateAmountsToPesewas.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_migrations_migrateamountstopesewas_ts",
-      "community": 626
+      "community": 627
     },
     {
       "label": "client.test.ts",
@@ -1873,7 +1873,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_mtn_client_test_ts",
-      "community": 627
+      "community": 628
     },
     {
       "label": "client.ts",
@@ -1937,7 +1937,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_mtn_collections_ts",
-      "community": 118
+      "community": 119
     },
     {
       "label": "getCachedTokenRecord()",
@@ -1945,7 +1945,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
       "source_location": "L26",
       "id": "collections_getcachedtokenrecord",
-      "community": 118
+      "community": 119
     },
     {
       "label": "resolveConfigForStore()",
@@ -1953,7 +1953,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
       "source_location": "L33",
       "id": "collections_resolveconfigforstore",
-      "community": 118
+      "community": 119
     },
     {
       "label": "resolveAccessTokenForStore()",
@@ -1961,7 +1961,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
       "source_location": "L79",
       "id": "collections_resolveaccesstokenforstore",
-      "community": 118
+      "community": 119
     },
     {
       "label": "config.test.ts",
@@ -1969,7 +1969,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_mtn_config_test_ts",
-      "community": 628
+      "community": 629
     },
     {
       "label": "config.ts",
@@ -2041,7 +2041,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/foundation.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_mtn_foundation_test_ts",
-      "community": 271
+      "community": 272
     },
     {
       "label": "readProjectFile()",
@@ -2049,7 +2049,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/foundation.test.ts",
       "source_location": "L6",
       "id": "foundation_test_readprojectfile",
-      "community": 271
+      "community": 272
     },
     {
       "label": "normalize.test.ts",
@@ -2057,7 +2057,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/normalize.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_mtn_normalize_test_ts",
-      "community": 629
+      "community": 630
     },
     {
       "label": "normalize.ts",
@@ -2065,7 +2065,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_mtn_normalize_ts",
-      "community": 119
+      "community": 120
     },
     {
       "label": "maskMtnPartyId()",
@@ -2073,7 +2073,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
       "source_location": "L10",
       "id": "normalize_maskmtnpartyid",
-      "community": 119
+      "community": 120
     },
     {
       "label": "normalizeCollectionsTransaction()",
@@ -2081,7 +2081,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
       "source_location": "L18",
       "id": "normalize_normalizecollectionstransaction",
-      "community": 119
+      "community": 120
     },
     {
       "label": "parseCollectionsNotificationRequest()",
@@ -2089,7 +2089,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
       "source_location": "L52",
       "id": "normalize_parsecollectionsnotificationrequest",
-      "community": 119
+      "community": 120
     },
     {
       "label": "types.ts",
@@ -2097,7 +2097,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/types.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_mtn_types_ts",
-      "community": 630
+      "community": 631
     },
     {
       "label": "ResendOTP.ts",
@@ -2105,7 +2105,7 @@
       "source_file": "packages/athena-webapp/convex/otp/ResendOTP.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_otp_resendotp_ts",
-      "community": 631
+      "community": 632
     },
     {
       "label": "VerificationCodeEmail.tsx",
@@ -2113,7 +2113,7 @@
       "source_file": "packages/athena-webapp/convex/otp/VerificationCodeEmail.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_otp_verificationcodeemail_tsx",
-      "community": 272
+      "community": 273
     },
     {
       "label": "VerificationCodeEmail()",
@@ -2121,7 +2121,7 @@
       "source_file": "packages/athena-webapp/convex/otp/VerificationCodeEmail.tsx",
       "source_location": "L11",
       "id": "verificationcodeemail_verificationcodeemail",
-      "community": 272
+      "community": 273
     },
     {
       "label": "index.ts",
@@ -2129,7 +2129,7 @@
       "source_file": "packages/athena-webapp/convex/paystack/index.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_paystack_index_ts",
-      "community": 159
+      "community": 161
     },
     {
       "label": "listTransactions()",
@@ -2137,7 +2137,7 @@
       "source_file": "packages/athena-webapp/convex/paystack/index.ts",
       "source_location": "L7",
       "id": "index_listtransactions",
-      "community": 159
+      "community": 161
     },
     {
       "label": "verifyTransaction()",
@@ -2145,7 +2145,7 @@
       "source_file": "packages/athena-webapp/convex/paystack/index.ts",
       "source_location": "L109",
       "id": "index_verifytransaction",
-      "community": 159
+      "community": 161
     },
     {
       "label": "schema.ts",
@@ -2153,7 +2153,7 @@
       "source_file": "packages/athena-webapp/convex/schema.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schema_ts",
-      "community": 632
+      "community": 633
     },
     {
       "label": "appVerificationCode.ts",
@@ -2161,7 +2161,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/appVerificationCode.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_inventory_appverificationcode_ts",
-      "community": 633
+      "community": 634
     },
     {
       "label": "athenaUser.ts",
@@ -2169,7 +2169,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/athenaUser.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_inventory_athenauser_ts",
-      "community": 634
+      "community": 635
     },
     {
       "label": "bannerMessage.ts",
@@ -2177,7 +2177,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/bannerMessage.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_inventory_bannermessage_ts",
-      "community": 635
+      "community": 636
     },
     {
       "label": "bestSeller.ts",
@@ -2185,7 +2185,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/bestSeller.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_inventory_bestseller_ts",
-      "community": 636
+      "community": 637
     },
     {
       "label": "cashier.ts",
@@ -2193,7 +2193,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/cashier.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_inventory_cashier_ts",
-      "community": 637
+      "community": 638
     },
     {
       "label": "category.ts",
@@ -2201,7 +2201,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/category.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_inventory_category_ts",
-      "community": 638
+      "community": 639
     },
     {
       "label": "color.ts",
@@ -2209,7 +2209,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/color.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_inventory_color_ts",
-      "community": 639
+      "community": 640
     },
     {
       "label": "complimentaryProduct.ts",
@@ -2217,7 +2217,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/complimentaryProduct.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_inventory_complimentaryproduct_ts",
-      "community": 640
+      "community": 641
     },
     {
       "label": "featuredItem.ts",
@@ -2225,7 +2225,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/featuredItem.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_inventory_featureditem_ts",
-      "community": 641
+      "community": 642
     },
     {
       "label": "index.ts",
@@ -2233,7 +2233,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/index.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_inventory_index_ts",
-      "community": 642
+      "community": 643
     },
     {
       "label": "inviteCode.ts",
@@ -2241,7 +2241,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/inviteCode.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_inventory_invitecode_ts",
-      "community": 643
+      "community": 644
     },
     {
       "label": "organization.ts",
@@ -2249,7 +2249,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/organization.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_inventory_organization_ts",
-      "community": 644
+      "community": 645
     },
     {
       "label": "organizationMember.ts",
@@ -2257,7 +2257,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/organizationMember.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_inventory_organizationmember_ts",
-      "community": 645
+      "community": 646
     },
     {
       "label": "product.ts",
@@ -2265,7 +2265,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/product.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_inventory_product_ts",
-      "community": 646
+      "community": 647
     },
     {
       "label": "promoCode.ts",
@@ -2273,7 +2273,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/promoCode.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_inventory_promocode_ts",
-      "community": 647
+      "community": 648
     },
     {
       "label": "redeemedPromoCode.ts",
@@ -2281,7 +2281,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/redeemedPromoCode.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_inventory_redeemedpromocode_ts",
-      "community": 648
+      "community": 649
     },
     {
       "label": "store.ts",
@@ -2289,7 +2289,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/store.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_inventory_store_ts",
-      "community": 649
+      "community": 650
     },
     {
       "label": "subcategory.ts",
@@ -2297,7 +2297,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/subcategory.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_inventory_subcategory_ts",
-      "community": 650
+      "community": 651
     },
     {
       "label": "mtnCollections.ts",
@@ -2305,7 +2305,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/payments/mtnCollections.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_payments_mtncollections_ts",
-      "community": 651
+      "community": 652
     },
     {
       "label": "customer.ts",
@@ -2313,7 +2313,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/pos/customer.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_pos_customer_ts",
-      "community": 652
+      "community": 653
     },
     {
       "label": "expenseSession.ts",
@@ -2321,7 +2321,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/pos/expenseSession.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesession_ts",
-      "community": 653
+      "community": 654
     },
     {
       "label": "expenseSessionItem.ts",
@@ -2329,7 +2329,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/pos/expenseSessionItem.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesessionitem_ts",
-      "community": 654
+      "community": 655
     },
     {
       "label": "expenseTransaction.ts",
@@ -2337,7 +2337,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/pos/expenseTransaction.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransaction_ts",
-      "community": 655
+      "community": 656
     },
     {
       "label": "expenseTransactionItem.ts",
@@ -2345,7 +2345,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/pos/expenseTransactionItem.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransactionitem_ts",
-      "community": 656
+      "community": 657
     },
     {
       "label": "index.ts",
@@ -2353,7 +2353,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/pos/index.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_pos_index_ts",
-      "community": 657
+      "community": 658
     },
     {
       "label": "posSession.ts",
@@ -2361,7 +2361,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/pos/posSession.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_pos_possession_ts",
-      "community": 658
+      "community": 659
     },
     {
       "label": "posSessionItem.ts",
@@ -2369,7 +2369,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/pos/posSessionItem.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_pos_possessionitem_ts",
-      "community": 659
+      "community": 660
     },
     {
       "label": "posTerminal.ts",
@@ -2377,7 +2377,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/pos/posTerminal.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_pos_posterminal_ts",
-      "community": 660
+      "community": 661
     },
     {
       "label": "posTransaction.ts",
@@ -2385,7 +2385,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/pos/posTransaction.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_pos_postransaction_ts",
-      "community": 661
+      "community": 662
     },
     {
       "label": "posTransactionItem.ts",
@@ -2393,7 +2393,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/pos/posTransactionItem.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_pos_postransactionitem_ts",
-      "community": 662
+      "community": 663
     },
     {
       "label": "analytics.ts",
@@ -2401,7 +2401,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/analytics.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_storefront_analytics_ts",
-      "community": 663
+      "community": 664
     },
     {
       "label": "bag.ts",
@@ -2409,7 +2409,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/bag.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_storefront_bag_ts",
-      "community": 664
+      "community": 665
     },
     {
       "label": "bagItem.ts",
@@ -2417,7 +2417,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/bagItem.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_storefront_bagitem_ts",
-      "community": 665
+      "community": 666
     },
     {
       "label": "checkoutSession.ts",
@@ -2425,7 +2425,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/checkoutSession.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsession_ts",
-      "community": 666
+      "community": 667
     },
     {
       "label": "checkoutSessionItem.ts",
@@ -2433,7 +2433,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/checkoutSessionItem.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsessionitem_ts",
-      "community": 667
+      "community": 668
     },
     {
       "label": "customer.ts",
@@ -2441,7 +2441,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/customer.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_storefront_customer_ts",
-      "community": 668
+      "community": 669
     },
     {
       "label": "guest.ts",
@@ -2449,7 +2449,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/guest.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_storefront_guest_ts",
-      "community": 669
+      "community": 670
     },
     {
       "label": "index.ts",
@@ -2457,7 +2457,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/index.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_storefront_index_ts",
-      "community": 670
+      "community": 671
     },
     {
       "label": "offer.ts",
@@ -2465,7 +2465,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/offer.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_storefront_offer_ts",
-      "community": 671
+      "community": 672
     },
     {
       "label": "onlineOrder.ts",
@@ -2473,7 +2473,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/onlineOrder/onlineOrder.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorder_ts",
-      "community": 672
+      "community": 673
     },
     {
       "label": "onlineOrderItem.ts",
@@ -2481,7 +2481,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/onlineOrder/onlineOrderItem.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorderitem_ts",
-      "community": 673
+      "community": 674
     },
     {
       "label": "review.ts",
@@ -2489,7 +2489,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/review.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_storefront_review_ts",
-      "community": 674
+      "community": 675
     },
     {
       "label": "rewards.ts",
@@ -2497,7 +2497,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/rewards.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_storefront_rewards_ts",
-      "community": 675
+      "community": 676
     },
     {
       "label": "savedBag.ts",
@@ -2505,7 +2505,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/savedBag.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbag_ts",
-      "community": 676
+      "community": 677
     },
     {
       "label": "savedBagItem.ts",
@@ -2513,7 +2513,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/savedBagItem.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbagitem_ts",
-      "community": 677
+      "community": 678
     },
     {
       "label": "storeFrontSession.ts",
@@ -2521,7 +2521,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontSession.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontsession_ts",
-      "community": 678
+      "community": 679
     },
     {
       "label": "storeFrontUser.ts",
@@ -2529,7 +2529,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontUser.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontuser_ts",
-      "community": 679
+      "community": 680
     },
     {
       "label": "storeFrontVerificationCode.ts",
@@ -2537,7 +2537,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontVerificationCode.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontverificationcode_ts",
-      "community": 680
+      "community": 681
     },
     {
       "label": "supportTicket.ts",
@@ -2545,7 +2545,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/supportTicket.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_storefront_supportticket_ts",
-      "community": 681
+      "community": 682
     },
     {
       "label": "index.tsx",
@@ -2561,7 +2561,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_services_orderemailservice_ts",
-      "community": 52
+      "community": 53
     },
     {
       "label": "shouldSendToAdmins()",
@@ -2569,7 +2569,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L42",
       "id": "orderemailservice_shouldsendtoadmins",
-      "community": 52
+      "community": 53
     },
     {
       "label": "buildOrderStatusMessage()",
@@ -2577,7 +2577,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L49",
       "id": "orderemailservice_buildorderstatusmessage",
-      "community": 52
+      "community": 53
     },
     {
       "label": "buildPickupDetails()",
@@ -2585,7 +2585,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L77",
       "id": "orderemailservice_buildpickupdetails",
-      "community": 52
+      "community": 53
     },
     {
       "label": "sendPODOrderEmails()",
@@ -2593,7 +2593,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L96",
       "id": "orderemailservice_sendpodorderemails",
-      "community": 52
+      "community": 53
     },
     {
       "label": "sendPaymentVerificationEmails()",
@@ -2601,7 +2601,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L217",
       "id": "orderemailservice_sendpaymentverificationemails",
-      "community": 52
+      "community": 53
     },
     {
       "label": "paystackService.ts",
@@ -2609,7 +2609,7 @@
       "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_services_paystackservice_ts",
-      "community": 80
+      "community": 81
     },
     {
       "label": "getPaystackHeaders()",
@@ -2617,7 +2617,7 @@
       "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
       "source_location": "L11",
       "id": "paystackservice_getpaystackheaders",
-      "community": 80
+      "community": 81
     },
     {
       "label": "initializeTransaction()",
@@ -2625,7 +2625,7 @@
       "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
       "source_location": "L21",
       "id": "paystackservice_initializetransaction",
-      "community": 80
+      "community": 81
     },
     {
       "label": "verifyTransaction()",
@@ -2633,7 +2633,7 @@
       "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
       "source_location": "L65",
       "id": "paystackservice_verifytransaction",
-      "community": 80
+      "community": 81
     },
     {
       "label": "initiateRefund()",
@@ -2641,7 +2641,7 @@
       "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
       "source_location": "L87",
       "id": "paystackservice_initiaterefund",
-      "community": 80
+      "community": 81
     },
     {
       "label": "analytics.ts",
@@ -2649,7 +2649,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_analytics_ts",
-      "community": 53
+      "community": 54
     },
     {
       "label": "extractPromoCodeId()",
@@ -2657,7 +2657,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L18",
       "id": "analytics_extractpromocodeid",
-      "community": 53
+      "community": 54
     },
     {
       "label": "getAnalyticsByStoreQuery()",
@@ -2665,7 +2665,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L28",
       "id": "analytics_getanalyticsbystorequery",
-      "community": 53
+      "community": 54
     },
     {
       "label": "getCompletedOrdersQuery()",
@@ -2673,7 +2673,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L59",
       "id": "analytics_getcompletedordersquery",
-      "community": 53
+      "community": 54
     },
     {
       "label": "getAnalyticsByStoreAndActionQuery()",
@@ -2681,7 +2681,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L97",
       "id": "analytics_getanalyticsbystoreandactionquery",
-      "community": 53
+      "community": 54
     },
     {
       "label": "getSkuMapForProducts()",
@@ -2689,7 +2689,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L132",
       "id": "analytics_getskumapforproducts",
-      "community": 53
+      "community": 54
     },
     {
       "label": "auth.ts",
@@ -2697,7 +2697,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/auth.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_auth_ts",
-      "community": 273
+      "community": 274
     },
     {
       "label": "getStoreFrontActorById()",
@@ -2705,7 +2705,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/auth.ts",
       "source_location": "L15",
       "id": "auth_getstorefrontactorbyid",
-      "community": 273
+      "community": 274
     },
     {
       "label": "bag.ts",
@@ -2713,7 +2713,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/bag.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_bag_ts",
-      "community": 682
+      "community": 683
     },
     {
       "label": "bagItem.ts",
@@ -2721,7 +2721,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/bagItem.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_bagitem_ts",
-      "community": 683
+      "community": 684
     },
     {
       "label": "checkoutSession.ts",
@@ -2873,7 +2873,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_commercequeryindexes_test_ts",
-      "community": 120
+      "community": 121
     },
     {
       "label": "getTableIndexes()",
@@ -2881,7 +2881,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
       "source_location": "L12",
       "id": "commercequeryindexes_test_gettableindexes",
-      "community": 120
+      "community": 121
     },
     {
       "label": "expectIndex()",
@@ -2889,7 +2889,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
       "source_location": "L19",
       "id": "commercequeryindexes_test_expectindex",
-      "community": 120
+      "community": 121
     },
     {
       "label": "getSource()",
@@ -2897,7 +2897,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
       "source_location": "L26",
       "id": "commercequeryindexes_test_getsource",
-      "community": 120
+      "community": 121
     },
     {
       "label": "customer.ts",
@@ -2905,7 +2905,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customer.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_customer_ts",
-      "community": 684
+      "community": 685
     },
     {
       "label": "customerBehaviorTimeline.ts",
@@ -2913,7 +2913,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_ts",
-      "community": 81
+      "community": 82
     },
     {
       "label": "getTimeFilterForRange()",
@@ -2921,7 +2921,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
       "source_location": "L11",
       "id": "customerbehaviortimeline_gettimefilterforrange",
-      "community": 81
+      "community": 82
     },
     {
       "label": "getCustomerAnalyticsQuery()",
@@ -2929,7 +2929,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
       "source_location": "L26",
       "id": "customerbehaviortimeline_getcustomeranalyticsquery",
-      "community": 81
+      "community": 82
     },
     {
       "label": "getTimelineUserData()",
@@ -2937,7 +2937,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
       "source_location": "L42",
       "id": "customerbehaviortimeline_gettimelineuserdata",
-      "community": 81
+      "community": 82
     },
     {
       "label": "getProductInfoMaps()",
@@ -2945,7 +2945,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
       "source_location": "L66",
       "id": "customerbehaviortimeline_getproductinfomaps",
-      "community": 81
+      "community": 82
     },
     {
       "label": "customerObservabilityTimeline.test.ts",
@@ -2953,7 +2953,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimeline.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_customerobservabilitytimeline_test_ts",
-      "community": 274
+      "community": 275
     },
     {
       "label": "createAnalyticsEvent()",
@@ -2961,7 +2961,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimeline.test.ts",
       "source_location": "L17",
       "id": "customerobservabilitytimeline_test_createanalyticsevent",
-      "community": 274
+      "community": 275
     },
     {
       "label": "customerObservabilityTimelineData.ts",
@@ -2969,7 +2969,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_customerobservabilitytimelinedata_ts",
-      "community": 82
+      "community": 83
     },
     {
       "label": "getNonEmptyString()",
@@ -2977,7 +2977,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L64",
       "id": "customerobservabilitytimelinedata_getnonemptystring",
-      "community": 82
+      "community": 83
     },
     {
       "label": "isFailureStatus()",
@@ -2985,7 +2985,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L68",
       "id": "customerobservabilitytimelinedata_isfailurestatus",
-      "community": 82
+      "community": 83
     },
     {
       "label": "normalizeEvent()",
@@ -2993,7 +2993,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L72",
       "id": "customerobservabilitytimelinedata_normalizeevent",
-      "community": 82
+      "community": 83
     },
     {
       "label": "buildCustomerObservabilityTimeline()",
@@ -3001,7 +3001,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L118",
       "id": "customerobservabilitytimelinedata_buildcustomerobservabilitytimeline",
-      "community": 82
+      "community": 83
     },
     {
       "label": "guest.ts",
@@ -3009,7 +3009,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/guest.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_guest_ts",
-      "community": 685
+      "community": 686
     },
     {
       "label": "helperOrchestration.test.ts",
@@ -3017,7 +3017,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helperOrchestration.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_helperorchestration_test_ts",
-      "community": 275
+      "community": 276
     },
     {
       "label": "readProjectFile()",
@@ -3025,7 +3025,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helperOrchestration.test.ts",
       "source_location": "L6",
       "id": "helperorchestration_test_readprojectfile",
-      "community": 275
+      "community": 276
     },
     {
       "label": "bag.ts",
@@ -3033,7 +3033,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/bag.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_helpers_bag_ts",
-      "community": 160
+      "community": 162
     },
     {
       "label": "listBagItems()",
@@ -3041,7 +3041,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/bag.ts",
       "source_location": "L7",
       "id": "bag_listbagitems",
-      "community": 160
+      "community": 162
     },
     {
       "label": "loadBagWithItems()",
@@ -3049,7 +3049,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/bag.ts",
       "source_location": "L14",
       "id": "bag_loadbagwithitems",
-      "community": 160
+      "community": 162
     },
     {
       "label": "onlineOrder.ts",
@@ -3057,7 +3057,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_helpers_onlineorder_ts",
-      "community": 54
+      "community": 55
     },
     {
       "label": "generateOrderNumber()",
@@ -3065,7 +3065,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
       "source_location": "L8",
       "id": "onlineorder_generateordernumber",
-      "community": 54
+      "community": 55
     },
     {
       "label": "findOrderByExternalReference()",
@@ -3073,7 +3073,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
       "source_location": "L15",
       "id": "onlineorder_findorderbyexternalreference",
-      "community": 54
+      "community": 55
     },
     {
       "label": "clearBagItems()",
@@ -3081,7 +3081,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
       "source_location": "L27",
       "id": "onlineorder_clearbagitems",
-      "community": 54
+      "community": 55
     },
     {
       "label": "returnOrderItemsToStock()",
@@ -3089,7 +3089,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
       "source_location": "L39",
       "id": "onlineorder_returnorderitemstostock",
-      "community": 54
+      "community": 55
     },
     {
       "label": "createOrderFromCheckoutSession()",
@@ -3097,7 +3097,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
       "source_location": "L75",
       "id": "onlineorder_createorderfromcheckoutsession",
-      "community": 54
+      "community": 55
     },
     {
       "label": "orderUpdateEmails.ts",
@@ -3217,7 +3217,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_offers_ts",
-      "community": 83
+      "community": 84
     },
     {
       "label": "isDuplicate()",
@@ -3225,7 +3225,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
       "source_location": "L36",
       "id": "offers_isduplicate",
-      "community": 83
+      "community": 84
     },
     {
       "label": "updateStoreFrontActorEmail()",
@@ -3233,7 +3233,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
       "source_location": "L59",
       "id": "offers_updatestorefrontactoremail",
-      "community": 83
+      "community": 84
     },
     {
       "label": "createOffer()",
@@ -3241,7 +3241,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
       "source_location": "L88",
       "id": "offers_createoffer",
-      "community": 83
+      "community": 84
     },
     {
       "label": "getUpsellProducts()",
@@ -3249,7 +3249,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
       "source_location": "L685",
       "id": "offers_getupsellproducts",
-      "community": 83
+      "community": 84
     },
     {
       "label": "onlineOrder.ts",
@@ -3257,7 +3257,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_onlineorder_ts",
-      "community": 276
+      "community": 277
     },
     {
       "label": "listOrderItems()",
@@ -3265,7 +3265,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
       "source_location": "L27",
       "id": "onlineorder_listorderitems",
-      "community": 276
+      "community": 277
     },
     {
       "label": "onlineOrderItem.ts",
@@ -3273,7 +3273,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderItem.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_onlineorderitem_ts",
-      "community": 277
+      "community": 278
     },
     {
       "label": "updateOnlineOrderItem()",
@@ -3281,7 +3281,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderItem.ts",
       "source_location": "L21",
       "id": "onlineorderitem_updateonlineorderitem",
-      "community": 277
+      "community": 278
     },
     {
       "label": "onlineOrderUtilFns.ts",
@@ -3289,7 +3289,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderUtilFns.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_onlineorderutilfns_ts",
-      "community": 686
+      "community": 687
     },
     {
       "label": "payment.ts",
@@ -3297,7 +3297,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/payment.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_payment_ts",
-      "community": 687
+      "community": 688
     },
     {
       "label": "paystackActions.ts",
@@ -3305,7 +3305,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/paystackActions.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_paystackactions_ts",
-      "community": 688
+      "community": 689
     },
     {
       "label": "reviews.ts",
@@ -3313,7 +3313,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/reviews.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_reviews_ts",
-      "community": 278
+      "community": 279
     },
     {
       "label": "getStoreFrontActorById()",
@@ -3321,7 +3321,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/reviews.ts",
       "source_location": "L17",
       "id": "reviews_getstorefrontactorbyid",
-      "community": 278
+      "community": 279
     },
     {
       "label": "rewards.ts",
@@ -3329,7 +3329,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/rewards.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_rewards_ts",
-      "community": 689
+      "community": 690
     },
     {
       "label": "savedBag.ts",
@@ -3337,7 +3337,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/savedBag.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_savedbag_ts",
-      "community": 279
+      "community": 280
     },
     {
       "label": "listSavedBagItems()",
@@ -3345,7 +3345,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/savedBag.ts",
       "source_location": "L14",
       "id": "savedbag_listsavedbagitems",
-      "community": 279
+      "community": 280
     },
     {
       "label": "savedBagItem.ts",
@@ -3353,7 +3353,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/savedBagItem.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_savedbagitem_ts",
-      "community": 690
+      "community": 691
     },
     {
       "label": "storefrontObservabilityReport.test.ts",
@@ -3361,7 +3361,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_test_ts",
-      "community": 280
+      "community": 281
     },
     {
       "label": "createAnalyticsEvent()",
@@ -3369,7 +3369,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.test.ts",
       "source_location": "L7",
       "id": "storefrontobservabilityreport_test_createanalyticsevent",
-      "community": 280
+      "community": 281
     },
     {
       "label": "storefrontObservabilityReport.ts",
@@ -3377,7 +3377,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_ts",
-      "community": 121
+      "community": 122
     },
     {
       "label": "getNonEmptyString()",
@@ -3385,7 +3385,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
       "source_location": "L59",
       "id": "storefrontobservabilityreport_getnonemptystring",
-      "community": 121
+      "community": 122
     },
     {
       "label": "normalizeStorefrontObservabilityEvent()",
@@ -3393,7 +3393,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
       "source_location": "L63",
       "id": "storefrontobservabilityreport_normalizestorefrontobservabilityevent",
-      "community": 121
+      "community": 122
     },
     {
       "label": "buildStorefrontObservabilityReport()",
@@ -3401,7 +3401,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
       "source_location": "L95",
       "id": "storefrontobservabilityreport_buildstorefrontobservabilityreport",
-      "community": 121
+      "community": 122
     },
     {
       "label": "supportTicket.ts",
@@ -3409,7 +3409,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/supportTicket.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_supportticket_ts",
-      "community": 691
+      "community": 692
     },
     {
       "label": "timeQueryRefactors.test.ts",
@@ -3417,7 +3417,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/timeQueryRefactors.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_timequeryrefactors_test_ts",
-      "community": 281
+      "community": 282
     },
     {
       "label": "readSource()",
@@ -3425,7 +3425,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/timeQueryRefactors.test.ts",
       "source_location": "L5",
       "id": "timequeryrefactors_test_readsource",
-      "community": 281
+      "community": 282
     },
     {
       "label": "user.ts",
@@ -3433,7 +3433,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/user.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_user_ts",
-      "community": 282
+      "community": 283
     },
     {
       "label": "getStoreFrontActorById()",
@@ -3441,7 +3441,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/user.ts",
       "source_location": "L15",
       "id": "user_getstorefrontactorbyid",
-      "community": 282
+      "community": 283
     },
     {
       "label": "userOffers.ts",
@@ -3449,7 +3449,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/userOffers.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_useroffers_ts",
-      "community": 283
+      "community": 284
     },
     {
       "label": "determineOfferEligibility()",
@@ -3457,7 +3457,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/userOffers.ts",
       "source_location": "L30",
       "id": "useroffers_determineoffereligibility",
-      "community": 283
+      "community": 284
     },
     {
       "label": "users.ts",
@@ -3465,7 +3465,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/users.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_users_ts",
-      "community": 692
+      "community": 693
     },
     {
       "label": "payment.ts",
@@ -3473,7 +3473,7 @@
       "source_file": "packages/athena-webapp/convex/types/payment.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_types_payment_ts",
-      "community": 693
+      "community": 694
     },
     {
       "label": "utils.ts",
@@ -3545,7 +3545,7 @@
       "source_file": "packages/athena-webapp/eslint.config.js",
       "source_location": "L1",
       "id": "packages_athena_webapp_eslint_config_js",
-      "community": 694
+      "community": 695
     },
     {
       "label": "index.ts",
@@ -3553,7 +3553,7 @@
       "source_file": "packages/athena-webapp/index.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_index_ts",
-      "community": 695
+      "community": 696
     },
     {
       "label": "postcss.config.js",
@@ -3561,7 +3561,7 @@
       "source_file": "packages/athena-webapp/postcss.config.js",
       "source_location": "L1",
       "id": "packages_athena_webapp_postcss_config_js",
-      "community": 696
+      "community": 697
     },
     {
       "label": "GenericComboBox.tsx",
@@ -3569,7 +3569,7 @@
       "source_file": "packages/athena-webapp/src/components/GenericComboBox.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_genericcombobox_tsx",
-      "community": 697
+      "community": 698
     },
     {
       "label": "Navbar.tsx",
@@ -3577,7 +3577,7 @@
       "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_navbar_tsx",
-      "community": 84
+      "community": 85
     },
     {
       "label": "SettingsHeader()",
@@ -3585,7 +3585,7 @@
       "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
       "source_location": "L20",
       "id": "navbar_settingsheader",
-      "community": 84
+      "community": 85
     },
     {
       "label": "AppHeader()",
@@ -3593,7 +3593,7 @@
       "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
       "source_location": "L61",
       "id": "navbar_appheader",
-      "community": 84
+      "community": 85
     },
     {
       "label": "Header()",
@@ -3601,7 +3601,7 @@
       "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
       "source_location": "L75",
       "id": "navbar_header",
-      "community": 84
+      "community": 85
     },
     {
       "label": "Navbar()",
@@ -3609,7 +3609,7 @@
       "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
       "source_location": "L116",
       "id": "navbar_navbar",
-      "community": 84
+      "community": 85
     },
     {
       "label": "OrganizationView.tsx",
@@ -3617,7 +3617,7 @@
       "source_file": "packages/athena-webapp/src/components/OrganizationView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organizationview_tsx",
-      "community": 284
+      "community": 285
     },
     {
       "label": "Navigation()",
@@ -3625,7 +3625,7 @@
       "source_file": "packages/athena-webapp/src/components/OrganizationView.tsx",
       "source_location": "L7",
       "id": "organizationview_navigation",
-      "community": 284
+      "community": 285
     },
     {
       "label": "OrganizationsView.tsx",
@@ -3633,7 +3633,7 @@
       "source_file": "packages/athena-webapp/src/components/OrganizationsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organizationsview_tsx",
-      "community": 285
+      "community": 286
     },
     {
       "label": "Navigation()",
@@ -3641,7 +3641,7 @@
       "source_file": "packages/athena-webapp/src/components/OrganizationsView.tsx",
       "source_location": "L12",
       "id": "organizationsview_navigation",
-      "community": 285
+      "community": 286
     },
     {
       "label": "PermissionGate.tsx",
@@ -3649,7 +3649,7 @@
       "source_file": "packages/athena-webapp/src/components/PermissionGate.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_permissiongate_tsx",
-      "community": 286
+      "community": 287
     },
     {
       "label": "PermissionGate()",
@@ -3657,7 +3657,7 @@
       "source_file": "packages/athena-webapp/src/components/PermissionGate.tsx",
       "source_location": "L11",
       "id": "permissiongate_permissiongate",
-      "community": 286
+      "community": 287
     },
     {
       "label": "ProtectedRoute.tsx",
@@ -3665,7 +3665,7 @@
       "source_file": "packages/athena-webapp/src/components/ProtectedRoute.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_protectedroute_tsx",
-      "community": 287
+      "community": 288
     },
     {
       "label": "ProtectedRoute()",
@@ -3673,7 +3673,7 @@
       "source_file": "packages/athena-webapp/src/components/ProtectedRoute.tsx",
       "source_location": "L11",
       "id": "protectedroute_protectedroute",
-      "community": 287
+      "community": 288
     },
     {
       "label": "SettingsView.tsx",
@@ -3681,7 +3681,7 @@
       "source_file": "packages/athena-webapp/src/components/SettingsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_settingsview_tsx",
-      "community": 288
+      "community": 289
     },
     {
       "label": "SettingsView()",
@@ -3689,7 +3689,7 @@
       "source_file": "packages/athena-webapp/src/components/SettingsView.tsx",
       "source_location": "L3",
       "id": "settingsview_settingsview",
-      "community": 288
+      "community": 289
     },
     {
       "label": "StoreAccordion.tsx",
@@ -3697,7 +3697,7 @@
       "source_file": "packages/athena-webapp/src/components/StoreAccordion.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_storeaccordion_tsx",
-      "community": 698
+      "community": 699
     },
     {
       "label": "StoreActions.tsx",
@@ -3705,7 +3705,7 @@
       "source_file": "packages/athena-webapp/src/components/StoreActions.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_storeactions_tsx",
-      "community": 289
+      "community": 290
     },
     {
       "label": "StoreActions()",
@@ -3713,7 +3713,7 @@
       "source_file": "packages/athena-webapp/src/components/StoreActions.tsx",
       "source_location": "L12",
       "id": "storeactions_storeactions",
-      "community": 289
+      "community": 290
     },
     {
       "label": "StoreDropdown.tsx",
@@ -3721,7 +3721,7 @@
       "source_file": "packages/athena-webapp/src/components/StoreDropdown.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_storedropdown_tsx",
-      "community": 290
+      "community": 291
     },
     {
       "label": "StoreDropdown()",
@@ -3729,7 +3729,7 @@
       "source_file": "packages/athena-webapp/src/components/StoreDropdown.tsx",
       "source_location": "L42",
       "id": "storedropdown_storedropdown",
-      "community": 290
+      "community": 291
     },
     {
       "label": "StoreView.tsx",
@@ -3737,7 +3737,7 @@
       "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_storeview_tsx",
-      "community": 291
+      "community": 292
     },
     {
       "label": "Navigation()",
@@ -3745,7 +3745,7 @@
       "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
       "source_location": "L13",
       "id": "storeview_navigation",
-      "community": 291
+      "community": 292
     },
     {
       "label": "StoresAccordion.tsx",
@@ -3753,7 +3753,7 @@
       "source_file": "packages/athena-webapp/src/components/StoresAccordion.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_storesaccordion_tsx",
-      "community": 699
+      "community": 700
     },
     {
       "label": "StoresDropdown.tsx",
@@ -3761,7 +3761,7 @@
       "source_file": "packages/athena-webapp/src/components/StoresDropdown.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_storesdropdown_tsx",
-      "community": 292
+      "community": 293
     },
     {
       "label": "StoresDropdown()",
@@ -3769,7 +3769,7 @@
       "source_file": "packages/athena-webapp/src/components/StoresDropdown.tsx",
       "source_location": "L42",
       "id": "storesdropdown_storesdropdown",
-      "community": 292
+      "community": 293
     },
     {
       "label": "ThemeToggle.tsx",
@@ -3777,7 +3777,7 @@
       "source_file": "packages/athena-webapp/src/components/ThemeToggle.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_themetoggle_tsx",
-      "community": 700
+      "community": 701
     },
     {
       "label": "View.tsx",
@@ -3785,7 +3785,7 @@
       "source_file": "packages/athena-webapp/src/components/View.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_view_tsx",
-      "community": 161
+      "community": 163
     },
     {
       "label": "View()",
@@ -3793,7 +3793,7 @@
       "source_file": "packages/storefront-webapp/src/components/View.tsx",
       "source_location": "L4",
       "id": "view_view",
-      "community": 161
+      "community": 163
     },
     {
       "label": "AttributesManager.tsx",
@@ -3801,7 +3801,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_attributesmanager_tsx",
-      "community": 122
+      "community": 123
     },
     {
       "label": "Sidebar()",
@@ -3809,7 +3809,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
       "source_location": "L26",
       "id": "attributesmanager_sidebar",
-      "community": 122
+      "community": 123
     },
     {
       "label": "ColorManager()",
@@ -3817,7 +3817,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
       "source_location": "L45",
       "id": "attributesmanager_colormanager",
-      "community": 122
+      "community": 123
     },
     {
       "label": "AttributesManager()",
@@ -3825,7 +3825,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
       "source_location": "L228",
       "id": "attributesmanager_attributesmanager",
-      "community": 122
+      "community": 123
     },
     {
       "label": "AttributesTable.tsx",
@@ -3833,7 +3833,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_attributestable_tsx",
-      "community": 123
+      "community": 124
     },
     {
       "label": "handleChange()",
@@ -3841,7 +3841,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
       "source_location": "L32",
       "id": "attributestable_handlechange",
-      "community": 123
+      "community": 124
     },
     {
       "label": "getProductAttribute()",
@@ -3849,7 +3849,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
       "source_location": "L55",
       "id": "attributestable_getproductattribute",
-      "community": 123
+      "community": 124
     },
     {
       "label": "onSubmit()",
@@ -3857,7 +3857,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
       "source_location": "L210",
       "id": "attributestable_onsubmit",
-      "community": 123
+      "community": 124
     },
     {
       "label": "BarcodeQRViewer.tsx",
@@ -3865,7 +3865,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/BarcodeQRViewer.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_barcodeqrviewer_tsx",
-      "community": 293
+      "community": 294
     },
     {
       "label": "handlePrint()",
@@ -3873,7 +3873,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/BarcodeQRViewer.tsx",
       "source_location": "L31",
       "id": "barcodeqrviewer_handleprint",
-      "community": 293
+      "community": 294
     },
     {
       "label": "CategorySubcategoryManager.tsx",
@@ -3881,7 +3881,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_categorysubcategorymanager_tsx",
-      "community": 124
+      "community": 125
     },
     {
       "label": "Sidebar()",
@@ -3889,7 +3889,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
       "source_location": "L26",
       "id": "categorysubcategorymanager_sidebar",
-      "community": 124
+      "community": 125
     },
     {
       "label": "CategoryManager()",
@@ -3897,7 +3897,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
       "source_location": "L51",
       "id": "categorysubcategorymanager_categorymanager",
-      "community": 124
+      "community": 125
     },
     {
       "label": "SubcategoryManager()",
@@ -3905,7 +3905,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
       "source_location": "L290",
       "id": "categorysubcategorymanager_subcategorymanager",
-      "community": 124
+      "community": 125
     },
     {
       "label": "DefaultAttributesToggleGroup.tsx",
@@ -3913,7 +3913,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/DefaultAttributesToggleGroup.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_defaultattributestogglegroup_tsx",
-      "community": 701
+      "community": 702
     },
     {
       "label": "ProcessingFees.tsx",
@@ -3921,7 +3921,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProcessingFees.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_processingfees_tsx",
-      "community": 294
+      "community": 295
     },
     {
       "label": "ProcessingFeesView()",
@@ -3929,7 +3929,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProcessingFees.tsx",
       "source_location": "L10",
       "id": "processingfees_processingfeesview",
-      "community": 294
+      "community": 295
     },
     {
       "label": "ProductAttributes.tsx",
@@ -3937,7 +3937,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAttributes.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_productattributes_tsx",
-      "community": 295
+      "community": 296
     },
     {
       "label": "isAllowedAttribute()",
@@ -3945,7 +3945,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAttributes.tsx",
       "source_location": "L14",
       "id": "productattributes_isallowedattribute",
-      "community": 295
+      "community": 296
     },
     {
       "label": "ProductAttributesView.tsx",
@@ -3953,7 +3953,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAttributesView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_productattributesview_tsx",
-      "community": 702
+      "community": 703
     },
     {
       "label": "ProductAvailability.tsx",
@@ -3961,7 +3961,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_productavailability_tsx",
-      "community": 162
+      "community": 164
     },
     {
       "label": "ProductAvailabilityView()",
@@ -3969,7 +3969,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
       "source_location": "L5",
       "id": "productavailability_productavailabilityview",
-      "community": 162
+      "community": 164
     },
     {
       "label": "ProductAvailability()",
@@ -3977,7 +3977,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
       "source_location": "L18",
       "id": "productavailability_productavailability",
-      "community": 162
+      "community": 164
     },
     {
       "label": "ProductAvailabilityToggleGroup.tsx",
@@ -3985,7 +3985,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailabilityToggleGroup.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_productavailabilitytogglegroup_tsx",
-      "community": 296
+      "community": 297
     },
     {
       "label": "ProductAvailabilityToggleGroup()",
@@ -3993,7 +3993,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailabilityToggleGroup.tsx",
       "source_location": "L5",
       "id": "productavailabilitytogglegroup_productavailabilitytogglegroup",
-      "community": 296
+      "community": 297
     },
     {
       "label": "ProductCategorization.tsx",
@@ -4001,7 +4001,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_productcategorization_tsx",
-      "community": 85
+      "community": 86
     },
     {
       "label": "handleClose()",
@@ -4009,7 +4009,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
       "source_location": "L203",
       "id": "productcategorization_handleclose",
-      "community": 85
+      "community": 86
     },
     {
       "label": "setInitialSelectedOption()",
@@ -4017,7 +4017,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
       "source_location": "L230",
       "id": "productcategorization_setinitialselectedoption",
-      "community": 85
+      "community": 86
     },
     {
       "label": "handleProductVisibility()",
@@ -4025,7 +4025,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
       "source_location": "L243",
       "id": "productcategorization_handleproductvisibility",
-      "community": 85
+      "community": 86
     },
     {
       "label": "getProductName()",
@@ -4033,7 +4033,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
       "source_location": "L286",
       "id": "productcategorization_getproductname",
-      "community": 85
+      "community": 86
     },
     {
       "label": "ProductDetails.tsx",
@@ -4041,7 +4041,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductDetails.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_productdetails_tsx",
-      "community": 297
+      "community": 298
     },
     {
       "label": "handleNameChange()",
@@ -4049,7 +4049,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductDetails.tsx",
       "source_location": "L10",
       "id": "productdetails_handlenamechange",
-      "community": 297
+      "community": 298
     },
     {
       "label": "ProductImages.tsx",
@@ -4057,7 +4057,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductImages.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_productimages_tsx",
-      "community": 298
+      "community": 299
     },
     {
       "label": "Header()",
@@ -4065,7 +4065,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductImages.tsx",
       "source_location": "L15",
       "id": "productimages_header",
-      "community": 298
+      "community": 299
     },
     {
       "label": "ProductPage.tsx",
@@ -4073,7 +4073,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductPage.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_productpage_tsx",
-      "community": 299
+      "community": 300
     },
     {
       "label": "ProductPage()",
@@ -4081,7 +4081,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductPage.tsx",
       "source_location": "L13",
       "id": "productpage_productpage",
-      "community": 299
+      "community": 300
     },
     {
       "label": "ProductStock.tsx",
@@ -4321,7 +4321,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_sheetprovider_tsx",
-      "community": 163
+      "community": 165
     },
     {
       "label": "useSheet()",
@@ -4329,7 +4329,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
       "source_location": "L11",
       "id": "sheetprovider_usesheet",
-      "community": 163
+      "community": 165
     },
     {
       "label": "SheetProvider()",
@@ -4337,7 +4337,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
       "source_location": "L19",
       "id": "sheetprovider_sheetprovider",
-      "community": 163
+      "community": 165
     },
     {
       "label": "WigType.tsx",
@@ -4345,7 +4345,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_wigtype_tsx",
-      "community": 164
+      "community": 166
     },
     {
       "label": "WigTypeView()",
@@ -4353,7 +4353,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
       "source_location": "L8",
       "id": "wigtype_wigtypeview",
-      "community": 164
+      "community": 166
     },
     {
       "label": "WigType()",
@@ -4361,7 +4361,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
       "source_location": "L21",
       "id": "wigtype_wigtype",
-      "community": 164
+      "community": 166
     },
     {
       "label": "CopyImagesProvider.tsx",
@@ -4369,7 +4369,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesprovider_tsx",
-      "community": 165
+      "community": 167
     },
     {
       "label": "useCopyImages()",
@@ -4377,7 +4377,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
       "source_location": "L13",
       "id": "copyimagesprovider_usecopyimages",
-      "community": 165
+      "community": 167
     },
     {
       "label": "CopyImagesProvider()",
@@ -4385,7 +4385,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
       "source_location": "L21",
       "id": "copyimagesprovider_copyimagesprovider",
-      "community": 165
+      "community": 167
     },
     {
       "label": "CopyImagesView.tsx",
@@ -4393,7 +4393,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesview_tsx",
-      "community": 300
+      "community": 301
     },
     {
       "label": "setIsUpdatingSku()",
@@ -4401,7 +4401,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesView.tsx",
       "source_location": "L116",
       "id": "copyimagesview_setisupdatingsku",
-      "community": 300
+      "community": 301
     },
     {
       "label": "constants.ts",
@@ -4409,7 +4409,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/constants.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_constants_ts",
-      "community": 703
+      "community": 704
     },
     {
       "label": "data-table-column-header.tsx",
@@ -4433,7 +4433,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-faceted-filter.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_faceted_filter_tsx",
-      "community": 704
+      "community": 705
     },
     {
       "label": "data-table-pagination.tsx",
@@ -4441,7 +4441,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_pagination_tsx",
-      "community": 705
+      "community": 706
     },
     {
       "label": "data-table-toolbar-provider.tsx",
@@ -4473,7 +4473,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_tsx",
-      "community": 55
+      "community": 56
     },
     {
       "label": "DataTableToolbar()",
@@ -4481,7 +4481,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
       "source_location": "L23",
       "id": "data_table_toolbar_datatabletoolbar",
-      "community": 55
+      "community": 56
     },
     {
       "label": "data-table-view-options.tsx",
@@ -4505,7 +4505,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_tsx",
-      "community": 706
+      "community": 707
     },
     {
       "label": "product-variant-columns.tsx",
@@ -4513,7 +4513,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_product_variant_columns_tsx",
-      "community": 301
+      "community": 302
     },
     {
       "label": "setSourceVariant()",
@@ -4521,7 +4521,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
       "source_location": "L47",
       "id": "product_variant_columns_setsourcevariant",
-      "community": 301
+      "community": 302
     },
     {
       "label": "types.ts",
@@ -4529,7 +4529,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/types.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_types_ts",
-      "community": 707
+      "community": 708
     },
     {
       "label": "ActivityTimeline.tsx",
@@ -4537,7 +4537,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/ActivityTimeline.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_activitytimeline_tsx",
-      "community": 302
+      "community": 303
     },
     {
       "label": "capitalizeFirstLetter()",
@@ -4545,7 +4545,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/ActivityTimeline.tsx",
       "source_location": "L151",
       "id": "activitytimeline_capitalizefirstletter",
-      "community": 302
+      "community": 303
     },
     {
       "label": "AnalyticsCombinedUsers.tsx",
@@ -4553,7 +4553,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analyticscombinedusers_tsx",
-      "community": 166
+      "community": 168
     },
     {
       "label": "processAnalyticsToUsers()",
@@ -4561,7 +4561,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
       "source_location": "L10",
       "id": "analyticscombinedusers_processanalyticstousers",
-      "community": 166
+      "community": 168
     },
     {
       "label": "AnalyticsCombinedUsers()",
@@ -4569,7 +4569,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
       "source_location": "L100",
       "id": "analyticscombinedusers_analyticscombinedusers",
-      "community": 166
+      "community": 168
     },
     {
       "label": "AnalyticsItems.tsx",
@@ -4577,7 +4577,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsItems.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analyticsitems_tsx",
-      "community": 303
+      "community": 304
     },
     {
       "label": "AnalyticsItems()",
@@ -4585,7 +4585,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsItems.tsx",
       "source_location": "L6",
       "id": "analyticsitems_analyticsitems",
-      "community": 303
+      "community": 304
     },
     {
       "label": "AnalyticsProducts.tsx",
@@ -4593,7 +4593,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsProducts.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analyticsproducts_tsx",
-      "community": 304
+      "community": 305
     },
     {
       "label": "AnalyticsProducts()",
@@ -4601,7 +4601,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsProducts.tsx",
       "source_location": "L19",
       "id": "analyticsproducts_analyticsproducts",
-      "community": 304
+      "community": 305
     },
     {
       "label": "AnalyticsTopUsers.tsx",
@@ -4609,7 +4609,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsTopUsers.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analyticstopusers_tsx",
-      "community": 167
+      "community": 169
     },
     {
       "label": "processAnalyticsToUsers()",
@@ -4617,7 +4617,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsTopUsers.tsx",
       "source_location": "L10",
       "id": "analyticstopusers_processanalyticstousers",
-      "community": 167
+      "community": 169
     },
     {
       "label": "AnalyticsTopUsers()",
@@ -4625,7 +4625,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsTopUsers.tsx",
       "source_location": "L100",
       "id": "analyticstopusers_analyticstopusers",
-      "community": 167
+      "community": 169
     },
     {
       "label": "AnalyticsUsers.tsx",
@@ -4633,7 +4633,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsUsers.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analyticsusers_tsx",
-      "community": 305
+      "community": 306
     },
     {
       "label": "AnalyticsUsers()",
@@ -4641,7 +4641,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsUsers.tsx",
       "source_location": "L7",
       "id": "analyticsusers_analyticsusers",
-      "community": 305
+      "community": 306
     },
     {
       "label": "AnalyticsView.tsx",
@@ -4649,7 +4649,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analyticsview_tsx",
-      "community": 125
+      "community": 126
     },
     {
       "label": "StoreVisitors()",
@@ -4657,7 +4657,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
       "source_location": "L14",
       "id": "analyticsview_storevisitors",
-      "community": 125
+      "community": 126
     },
     {
       "label": "ActiveCheckoutSessions()",
@@ -4665,7 +4665,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
       "source_location": "L44",
       "id": "analyticsview_activecheckoutsessions",
-      "community": 125
+      "community": 126
     },
     {
       "label": "AnalyticsView()",
@@ -4673,7 +4673,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
       "source_location": "L84",
       "id": "analyticsview_analyticsview",
-      "community": 125
+      "community": 126
     },
     {
       "label": "ConversionFunnelChart.tsx",
@@ -4681,7 +4681,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/ConversionFunnelChart.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_conversionfunnelchart_tsx",
-      "community": 708
+      "community": 709
     },
     {
       "label": "EnhancedAnalyticsView.tsx",
@@ -4689,7 +4689,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/EnhancedAnalyticsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_enhancedanalyticsview_tsx",
-      "community": 306
+      "community": 307
     },
     {
       "label": "getDateRangeMilliseconds()",
@@ -4697,7 +4697,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/EnhancedAnalyticsView.tsx",
       "source_location": "L42",
       "id": "enhancedanalyticsview_getdaterangemilliseconds",
-      "community": 306
+      "community": 307
     },
     {
       "label": "RevenueChart.tsx",
@@ -4705,7 +4705,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/RevenueChart.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_revenuechart_tsx",
-      "community": 709
+      "community": 710
     },
     {
       "label": "StoreInsights.tsx",
@@ -4713,7 +4713,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/StoreInsights.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_storeinsights_tsx",
-      "community": 307
+      "community": 308
     },
     {
       "label": "getTrendIcon()",
@@ -4721,7 +4721,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/StoreInsights.tsx",
       "source_location": "L66",
       "id": "storeinsights_gettrendicon",
-      "community": 307
+      "community": 308
     },
     {
       "label": "StorefrontObservabilityPanel.tsx",
@@ -4729,7 +4729,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_storefrontobservabilitypanel_tsx",
-      "community": 168
+      "community": 170
     },
     {
       "label": "formatLabel()",
@@ -4737,7 +4737,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
       "source_location": "L15",
       "id": "storefrontobservabilitypanel_formatlabel",
-      "community": 168
+      "community": 170
     },
     {
       "label": "SummaryCard()",
@@ -4745,7 +4745,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
       "source_location": "L19",
       "id": "storefrontobservabilitypanel_summarycard",
-      "community": 168
+      "community": 170
     },
     {
       "label": "VisitorChart.tsx",
@@ -4753,7 +4753,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/VisitorChart.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_visitorchart_tsx",
-      "community": 308
+      "community": 309
     },
     {
       "label": "formatHour()",
@@ -4761,7 +4761,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/VisitorChart.tsx",
       "source_location": "L18",
       "id": "visitorchart_formathour",
-      "community": 308
+      "community": 309
     },
     {
       "label": "analytics-columns.tsx",
@@ -4769,7 +4769,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/analytics-columns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_analytics_columns_tsx",
-      "community": 710
+      "community": 711
     },
     {
       "label": "data-table-column-header.tsx",
@@ -4777,7 +4777,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_column_header_tsx",
-      "community": 711
+      "community": 712
     },
     {
       "label": "data-table-faceted-filter.tsx",
@@ -4785,7 +4785,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-faceted-filter.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_faceted_filter_tsx",
-      "community": 712
+      "community": 713
     },
     {
       "label": "data-table-pagination.tsx",
@@ -4793,7 +4793,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_pagination_tsx",
-      "community": 713
+      "community": 714
     },
     {
       "label": "data-table-row-actions.tsx",
@@ -4817,7 +4817,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-toolbar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_toolbar_tsx",
-      "community": 714
+      "community": 715
     },
     {
       "label": "data-table-view-options.tsx",
@@ -4833,7 +4833,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_tsx",
-      "community": 715
+      "community": 716
     },
     {
       "label": "selectable-data-provider.tsx",
@@ -4841,7 +4841,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/selectable-data-provider.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
-      "community": 56
+      "community": 57
     },
     {
       "label": "SelectedProductsProvider()",
@@ -4849,7 +4849,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
       "source_location": "L16",
       "id": "selectable_data_provider_selectedproductsprovider",
-      "community": 56
+      "community": 57
     },
     {
       "label": "useSelectedProducts()",
@@ -4857,7 +4857,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
       "source_location": "L37",
       "id": "selectable_data_provider_useselectedproducts",
-      "community": 56
+      "community": 57
     },
     {
       "label": "columns.tsx",
@@ -4865,7 +4865,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/columns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_columns_tsx",
-      "community": 716
+      "community": 717
     },
     {
       "label": "data-table-column-header.tsx",
@@ -4881,7 +4881,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-faceted-filter.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_faceted_filter_tsx",
-      "community": 717
+      "community": 718
     },
     {
       "label": "data-table-pagination.tsx",
@@ -4889,7 +4889,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_pagination_tsx",
-      "community": 718
+      "community": 719
     },
     {
       "label": "data-table-row-actions.tsx",
@@ -4905,7 +4905,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-toolbar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_toolbar_tsx",
-      "community": 719
+      "community": 720
     },
     {
       "label": "data-table-view-options.tsx",
@@ -4921,7 +4921,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_tsx",
-      "community": 720
+      "community": 721
     },
     {
       "label": "columns.tsx",
@@ -4929,7 +4929,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/columns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_columns_tsx",
-      "community": 721
+      "community": 722
     },
     {
       "label": "data-table-column-header.tsx",
@@ -4945,7 +4945,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_pagination_tsx",
-      "community": 722
+      "community": 723
     },
     {
       "label": "data-table.tsx",
@@ -4953,7 +4953,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/data-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_tsx",
-      "community": 723
+      "community": 724
     },
     {
       "label": "chart.tsx",
@@ -4961,7 +4961,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/chart.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_chart_tsx",
-      "community": 724
+      "community": 725
     },
     {
       "label": "columns.tsx",
@@ -4969,7 +4969,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/columns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_columns_tsx",
-      "community": 725
+      "community": 726
     },
     {
       "label": "data-table-column-header.tsx",
@@ -4985,7 +4985,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_pagination_tsx",
-      "community": 726
+      "community": 727
     },
     {
       "label": "data-table.tsx",
@@ -4993,7 +4993,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/data-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_tsx",
-      "community": 727
+      "community": 728
     },
     {
       "label": "columns.tsx",
@@ -5001,7 +5001,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/table/columns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_table_columns_tsx",
-      "community": 728
+      "community": 729
     },
     {
       "label": "constants.ts",
@@ -5009,7 +5009,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/table/constants.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_table_constants_ts",
-      "community": 729
+      "community": 730
     },
     {
       "label": "data-table-column-header.tsx",
@@ -5025,7 +5025,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-faceted-filter.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_faceted_filter_tsx",
-      "community": 730
+      "community": 731
     },
     {
       "label": "data-table-pagination.tsx",
@@ -5033,7 +5033,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_pagination_tsx",
-      "community": 731
+      "community": 732
     },
     {
       "label": "data-table-toolbar-provider.tsx",
@@ -5049,7 +5049,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_tsx",
-      "community": 55
+      "community": 56
     },
     {
       "label": "data-table-view-options.tsx",
@@ -5065,7 +5065,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/table/data-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_tsx",
-      "community": 732
+      "community": 733
     },
     {
       "label": "data.ts",
@@ -5073,7 +5073,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/table/data.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_table_data_ts",
-      "community": 733
+      "community": 734
     },
     {
       "label": "columns.tsx",
@@ -5081,7 +5081,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/users-table/columns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_users_table_columns_tsx",
-      "community": 734
+      "community": 735
     },
     {
       "label": "data-table-column-header.tsx",
@@ -5097,7 +5097,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/users-table/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_pagination_tsx",
-      "community": 735
+      "community": 736
     },
     {
       "label": "data-table.tsx",
@@ -5105,7 +5105,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/users-table/data-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_tsx",
-      "community": 736
+      "community": 737
     },
     {
       "label": "utils.ts",
@@ -5113,7 +5113,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_utils_ts",
-      "community": 126
+      "community": 127
     },
     {
       "label": "groupAnalytics()",
@@ -5121,7 +5121,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
       "source_location": "L3",
       "id": "utils_groupanalytics",
-      "community": 126
+      "community": 127
     },
     {
       "label": "countGroupedAnalytics()",
@@ -5129,7 +5129,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
       "source_location": "L52",
       "id": "utils_countgroupedanalytics",
-      "community": 126
+      "community": 127
     },
     {
       "label": "groupProductViewsByDay()",
@@ -5137,7 +5137,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
       "source_location": "L90",
       "id": "utils_groupproductviewsbyday",
-      "community": 126
+      "community": 127
     },
     {
       "label": "LogItems.tsx",
@@ -5145,7 +5145,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/LogItems.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_app_logs_logitems_tsx",
-      "community": 309
+      "community": 310
     },
     {
       "label": "LogItems()",
@@ -5153,7 +5153,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/LogItems.tsx",
       "source_location": "L6",
       "id": "logitems_logitems",
-      "community": 309
+      "community": 310
     },
     {
       "label": "LogView.tsx",
@@ -5161,7 +5161,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/LogView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_app_logs_logview_tsx",
-      "community": 310
+      "community": 311
     },
     {
       "label": "Header()",
@@ -5169,7 +5169,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/LogView.tsx",
       "source_location": "L10",
       "id": "logview_header",
-      "community": 310
+      "community": 311
     },
     {
       "label": "LogsView.tsx",
@@ -5177,7 +5177,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_app_logs_logsview_tsx",
-      "community": 311
+      "community": 312
     },
     {
       "label": "Navigation()",
@@ -5185,7 +5185,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
       "source_location": "L27",
       "id": "logsview_navigation",
-      "community": 311
+      "community": 312
     },
     {
       "label": "columns.tsx",
@@ -5193,7 +5193,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/columns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_columns_tsx",
-      "community": 737
+      "community": 738
     },
     {
       "label": "data-table-column-header.tsx",
@@ -5201,7 +5201,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_column_header_tsx",
-      "community": 738
+      "community": 739
     },
     {
       "label": "data-table-faceted-filter.tsx",
@@ -5209,7 +5209,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-faceted-filter.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_faceted_filter_tsx",
-      "community": 739
+      "community": 740
     },
     {
       "label": "data-table-pagination.tsx",
@@ -5217,7 +5217,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_pagination_tsx",
-      "community": 740
+      "community": 741
     },
     {
       "label": "data-table-row-actions.tsx",
@@ -5233,7 +5233,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-toolbar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_toolbar_tsx",
-      "community": 741
+      "community": 742
     },
     {
       "label": "data-table-view-options.tsx",
@@ -5249,7 +5249,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_tsx",
-      "community": 742
+      "community": 743
     },
     {
       "label": "log-items-provider.tsx",
@@ -5257,7 +5257,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_log_items_provider_tsx",
-      "community": 169
+      "community": 171
     },
     {
       "label": "LogItemsProvider()",
@@ -5265,7 +5265,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
       "source_location": "L15",
       "id": "log_items_provider_logitemsprovider",
-      "community": 169
+      "community": 171
     },
     {
       "label": "useLogItems()",
@@ -5273,7 +5273,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
       "source_location": "L39",
       "id": "log_items_provider_uselogitems",
-      "community": 169
+      "community": 171
     },
     {
       "label": "useLoadLogItems.ts",
@@ -5281,7 +5281,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/hooks/useLoadLogItems.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_app_logs_hooks_useloadlogitems_ts",
-      "community": 312
+      "community": 313
     },
     {
       "label": "useLoadLogItems()",
@@ -5289,7 +5289,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/hooks/useLoadLogItems.ts",
       "source_location": "L12",
       "id": "useloadlogitems_useloadlogitems",
-      "community": 312
+      "community": 313
     },
     {
       "label": "app-sidebar.tsx",
@@ -5297,7 +5297,7 @@
       "source_file": "packages/athena-webapp/src/components/app-sidebar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_app_sidebar_tsx",
-      "community": 743
+      "community": 744
     },
     {
       "label": "assetsColumns.tsx",
@@ -5305,7 +5305,7 @@
       "source_file": "packages/athena-webapp/src/components/assets/assets-table/assetsColumns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_assets_assets_table_assetscolumns_tsx",
-      "community": 744
+      "community": 745
     },
     {
       "label": "constants.ts",
@@ -5313,7 +5313,7 @@
       "source_file": "packages/athena-webapp/src/components/assets/assets-table/constants.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_assets_assets_table_constants_ts",
-      "community": 745
+      "community": 746
     },
     {
       "label": "data-table-column-header.tsx",
@@ -5329,7 +5329,7 @@
       "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-faceted-filter.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_faceted_filter_tsx",
-      "community": 746
+      "community": 747
     },
     {
       "label": "data-table-pagination.tsx",
@@ -5337,7 +5337,7 @@
       "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_pagination_tsx",
-      "community": 747
+      "community": 748
     },
     {
       "label": "data-table-toolbar-provider.tsx",
@@ -5361,7 +5361,7 @@
       "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_tsx",
-      "community": 748
+      "community": 749
     },
     {
       "label": "data.ts",
@@ -5369,7 +5369,7 @@
       "source_file": "packages/athena-webapp/src/components/assets/assets-table/data.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_ts",
-      "community": 749
+      "community": 750
     },
     {
       "label": "index.tsx",
@@ -5377,7 +5377,7 @@
       "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_assets_index_tsx",
-      "community": 86
+      "community": 87
     },
     {
       "label": "Header()",
@@ -5385,7 +5385,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
       "source_location": "L42",
       "id": "index_header",
-      "community": 86
+      "community": 87
     },
     {
       "label": "FeesView()",
@@ -5393,7 +5393,7 @@
       "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
       "source_location": "L29",
       "id": "index_feesview",
-      "community": 86
+      "community": 87
     },
     {
       "label": "Auth.tsx",
@@ -5401,7 +5401,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Auth.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_auth_auth_tsx",
-      "community": 313
+      "community": 314
     },
     {
       "label": "Auth()",
@@ -5409,7 +5409,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Auth.tsx",
       "source_location": "L3",
       "id": "auth_auth",
-      "community": 313
+      "community": 314
     },
     {
       "label": "DefaultCatchBoundary.tsx",
@@ -5417,7 +5417,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/DefaultCatchBoundary.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_tsx",
-      "community": 750
+      "community": 751
     },
     {
       "label": "InputOTP.tsx",
@@ -5425,7 +5425,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
-      "community": 170
+      "community": 172
     },
     {
       "label": "handlePinChange()",
@@ -5433,7 +5433,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
       "source_location": "L48",
       "id": "inputotp_handlepinchange",
-      "community": 170
+      "community": 172
     },
     {
       "label": "onSubmit()",
@@ -5441,7 +5441,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
       "source_location": "L56",
       "id": "inputotp_onsubmit",
-      "community": 170
+      "community": 172
     },
     {
       "label": "LoginForm.tsx",
@@ -5449,7 +5449,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Login/LoginForm.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_auth_login_loginform_tsx",
-      "community": 751
+      "community": 752
     },
     {
       "label": "index.tsx",
@@ -5457,7 +5457,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Login/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_auth_login_index_tsx",
-      "community": 314
+      "community": 315
     },
     {
       "label": "Login()",
@@ -5465,7 +5465,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Login/index.tsx",
       "source_location": "L5",
       "id": "index_login",
-      "community": 314
+      "community": 315
     },
     {
       "label": "columns.tsx",
@@ -5473,7 +5473,7 @@
       "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/columns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_columns_tsx",
-      "community": 752
+      "community": 753
     },
     {
       "label": "data-table-column-header.tsx",
@@ -5481,7 +5481,7 @@
       "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_column_header_tsx",
-      "community": 753
+      "community": 754
     },
     {
       "label": "data-table-faceted-filter.tsx",
@@ -5489,7 +5489,7 @@
       "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-faceted-filter.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_faceted_filter_tsx",
-      "community": 754
+      "community": 755
     },
     {
       "label": "data-table-pagination.tsx",
@@ -5497,7 +5497,7 @@
       "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_pagination_tsx",
-      "community": 755
+      "community": 756
     },
     {
       "label": "data-table-row-actions.tsx",
@@ -5513,7 +5513,7 @@
       "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-toolbar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_toolbar_tsx",
-      "community": 756
+      "community": 757
     },
     {
       "label": "data-table-view-options.tsx",
@@ -5529,7 +5529,7 @@
       "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_tsx",
-      "community": 757
+      "community": 758
     },
     {
       "label": "selectable-data-provider.tsx",
@@ -5537,7 +5537,7 @@
       "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/selectable-data-provider.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
-      "community": 56
+      "community": 57
     },
     {
       "label": "columns.tsx",
@@ -5545,7 +5545,7 @@
       "source_file": "packages/athena-webapp/src/components/base/table/columns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_base_table_columns_tsx",
-      "community": 758
+      "community": 759
     },
     {
       "label": "constants.ts",
@@ -5553,7 +5553,7 @@
       "source_file": "packages/athena-webapp/src/components/base/table/constants.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_base_table_constants_ts",
-      "community": 759
+      "community": 760
     },
     {
       "label": "data-table-column-header.tsx",
@@ -5569,7 +5569,7 @@
       "source_file": "packages/athena-webapp/src/components/base/table/data-table-faceted-filter.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_base_table_data_table_faceted_filter_tsx",
-      "community": 760
+      "community": 761
     },
     {
       "label": "data-table-pagination.tsx",
@@ -5577,7 +5577,7 @@
       "source_file": "packages/athena-webapp/src/components/base/table/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_base_table_data_table_pagination_tsx",
-      "community": 761
+      "community": 762
     },
     {
       "label": "data-table-toolbar-provider.tsx",
@@ -5593,7 +5593,7 @@
       "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_tsx",
-      "community": 55
+      "community": 56
     },
     {
       "label": "data-table-view-options.tsx",
@@ -5609,7 +5609,7 @@
       "source_file": "packages/athena-webapp/src/components/base/table/data-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_base_table_data_table_tsx",
-      "community": 762
+      "community": 763
     },
     {
       "label": "BulkOperationsFilters.tsx",
@@ -5617,7 +5617,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsFilters.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationsfilters_tsx",
-      "community": 315
+      "community": 316
     },
     {
       "label": "handleLoadProducts()",
@@ -5625,7 +5625,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsFilters.tsx",
       "source_location": "L49",
       "id": "bulkoperationsfilters_handleloadproducts",
-      "community": 315
+      "community": 316
     },
     {
       "label": "BulkOperationsPage.tsx",
@@ -5633,7 +5633,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPage.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspage_tsx",
-      "community": 763
+      "community": 764
     },
     {
       "label": "BulkOperationsPreview.test.tsx",
@@ -5641,7 +5641,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.test.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_test_tsx",
-      "community": 316
+      "community": 317
     },
     {
       "label": "makeRow()",
@@ -5649,7 +5649,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.test.tsx",
       "source_location": "L23",
       "id": "bulkoperationspreview_test_makerow",
-      "community": 316
+      "community": 317
     },
     {
       "label": "BulkOperationsPreview.tsx",
@@ -5657,7 +5657,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_tsx",
-      "community": 317
+      "community": 318
     },
     {
       "label": "formatPrice()",
@@ -5665,7 +5665,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.tsx",
       "source_location": "L50",
       "id": "bulkoperationspreview_formatprice",
-      "community": 317
+      "community": 318
     },
     {
       "label": "CashierManagement.tsx",
@@ -5673,7 +5673,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_cashiers_cashiermanagement_tsx",
-      "community": 57
+      "community": 58
     },
     {
       "label": "normalizeNameSegment()",
@@ -5681,7 +5681,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L42",
       "id": "cashiermanagement_normalizenamesegment",
-      "community": 57
+      "community": 58
     },
     {
       "label": "buildUsername()",
@@ -5689,7 +5689,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L50",
       "id": "cashiermanagement_buildusername",
-      "community": 57
+      "community": 58
     },
     {
       "label": "handleSubmit()",
@@ -5697,7 +5697,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L109",
       "id": "cashiermanagement_handlesubmit",
-      "community": 57
+      "community": 58
     },
     {
       "label": "handlePinKeyDown()",
@@ -5705,7 +5705,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L169",
       "id": "cashiermanagement_handlepinkeydown",
-      "community": 57
+      "community": 58
     },
     {
       "label": "handleDelete()",
@@ -5713,7 +5713,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L320",
       "id": "cashiermanagement_handledelete",
-      "community": 57
+      "community": 58
     },
     {
       "label": "index.tsx",
@@ -5721,7 +5721,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_cashiers_index_tsx",
-      "community": 764
+      "community": 765
     },
     {
       "label": "CheckoutSessionsTable.tsx",
@@ -5729,7 +5729,7 @@
       "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSessionsTable.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsessionstable_tsx",
-      "community": 318
+      "community": 319
     },
     {
       "label": "CheckoutSessionsTable()",
@@ -5737,7 +5737,7 @@
       "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSessionsTable.tsx",
       "source_location": "L13",
       "id": "checkoutsessionstable_checkoutsessionstable",
-      "community": 318
+      "community": 319
     },
     {
       "label": "CheckoutSesssionsView.tsx",
@@ -5745,7 +5745,7 @@
       "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSesssionsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsesssionsview_tsx",
-      "community": 319
+      "community": 320
     },
     {
       "label": "Navigation()",
@@ -5753,7 +5753,7 @@
       "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSesssionsView.tsx",
       "source_location": "L11",
       "id": "checkoutsesssionsview_navigation",
-      "community": 319
+      "community": 320
     },
     {
       "label": "columns.tsx",
@@ -5761,7 +5761,7 @@
       "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/columns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_columns_tsx",
-      "community": 765
+      "community": 766
     },
     {
       "label": "data-table-column-header.tsx",
@@ -5777,7 +5777,7 @@
       "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_pagination_tsx",
-      "community": 766
+      "community": 767
     },
     {
       "label": "data-table.tsx",
@@ -5785,7 +5785,7 @@
       "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/data-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_tsx",
-      "community": 767
+      "community": 768
     },
     {
       "label": "FadeIn.tsx",
@@ -5793,7 +5793,7 @@
       "source_file": "packages/athena-webapp/src/components/common/FadeIn.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_common_fadein_tsx",
-      "community": 171
+      "community": 173
     },
     {
       "label": "FadeIn()",
@@ -5801,7 +5801,7 @@
       "source_file": "packages/storefront-webapp/src/components/common/FadeIn.tsx",
       "source_location": "L3",
       "id": "fadein_fadein",
-      "community": 171
+      "community": 173
     },
     {
       "label": "PageHeader.tsx",
@@ -5809,7 +5809,7 @@
       "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
-      "community": 320
+      "community": 321
     },
     {
       "label": "PageHeader()",
@@ -5817,7 +5817,7 @@
       "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
       "source_location": "L7",
       "id": "pageheader_pageheader",
-      "community": 320
+      "community": 321
     },
     {
       "label": "Dashboard.tsx",
@@ -5825,7 +5825,7 @@
       "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
-      "community": 87
+      "community": 88
     },
     {
       "label": "getPeriodRange()",
@@ -5833,7 +5833,7 @@
       "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
       "source_location": "L20",
       "id": "dashboard_getperiodrange",
-      "community": 87
+      "community": 88
     },
     {
       "label": "LoadingSection()",
@@ -5841,7 +5841,7 @@
       "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
       "source_location": "L50",
       "id": "dashboard_loadingsection",
-      "community": 87
+      "community": 88
     },
     {
       "label": "renderSalesSection()",
@@ -5849,7 +5849,7 @@
       "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
       "source_location": "L322",
       "id": "dashboard_rendersalessection",
-      "community": 87
+      "community": 88
     },
     {
       "label": "renderProductsSection()",
@@ -5857,7 +5857,7 @@
       "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
       "source_location": "L342",
       "id": "dashboard_renderproductssection",
-      "community": 87
+      "community": 88
     },
     {
       "label": "MetricCard.tsx",
@@ -5865,7 +5865,7 @@
       "source_file": "packages/athena-webapp/src/components/dashboard/MetricCard.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_dashboard_metriccard_tsx",
-      "community": 768
+      "community": 769
     },
     {
       "label": "ExpenseCompletion.tsx",
@@ -5873,7 +5873,7 @@
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseCompletion.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_expense_expensecompletion_tsx",
-      "community": 769
+      "community": 770
     },
     {
       "label": "ExpenseView.tsx",
@@ -5953,7 +5953,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_bannermessageeditor_tsx",
-      "community": 58
+      "community": 59
     },
     {
       "label": "handleSave()",
@@ -5961,7 +5961,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L46",
       "id": "bannermessageeditor_handlesave",
-      "community": 58
+      "community": 59
     },
     {
       "label": "handleClear()",
@@ -5969,7 +5969,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L66",
       "id": "bannermessageeditor_handleclear",
-      "community": 58
+      "community": 59
     },
     {
       "label": "handleActiveToggle()",
@@ -5977,7 +5977,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L91",
       "id": "bannermessageeditor_handleactivetoggle",
-      "community": 58
+      "community": 59
     },
     {
       "label": "handleCountdownChange()",
@@ -5985,7 +5985,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L113",
       "id": "bannermessageeditor_handlecountdownchange",
-      "community": 58
+      "community": 59
     },
     {
       "label": "getCountdownStatus()",
@@ -5993,7 +5993,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L123",
       "id": "bannermessageeditor_getcountdownstatus",
-      "community": 58
+      "community": 59
     },
     {
       "label": "BestSellers.tsx",
@@ -6001,7 +6001,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_bestsellers_tsx",
-      "community": 172
+      "community": 174
     },
     {
       "label": "handleRemoveBestSeller()",
@@ -6009,7 +6009,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
       "source_location": "L53",
       "id": "bestsellers_handleremovebestseller",
-      "community": 172
+      "community": 174
     },
     {
       "label": "onDragEnd()",
@@ -6017,7 +6017,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
       "source_location": "L65",
       "id": "bestsellers_ondragend",
-      "community": 172
+      "community": 174
     },
     {
       "label": "BestSellersDialog.tsx",
@@ -6025,7 +6025,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BestSellersDialog.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_bestsellersdialog_tsx",
-      "community": 321
+      "community": 322
     },
     {
       "label": "handleAddBestSeller()",
@@ -6033,7 +6033,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BestSellersDialog.tsx",
       "source_location": "L29",
       "id": "bestsellersdialog_handleaddbestseller",
-      "community": 321
+      "community": 322
     },
     {
       "label": "FeaturedSection.tsx",
@@ -6041,7 +6041,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_featuredsection_tsx",
-      "community": 173
+      "community": 175
     },
     {
       "label": "handleHighlightedItem()",
@@ -6049,7 +6049,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
       "source_location": "L47",
       "id": "featuredsection_handlehighlighteditem",
-      "community": 173
+      "community": 175
     },
     {
       "label": "onDragEnd()",
@@ -6057,7 +6057,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
       "source_location": "L53",
       "id": "featuredsection_ondragend",
-      "community": 173
+      "community": 175
     },
     {
       "label": "FeaturedSectionDialog.tsx",
@@ -6065,7 +6065,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSectionDialog.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_featuredsectiondialog_tsx",
-      "community": 322
+      "community": 323
     },
     {
       "label": "handleAddFeaturedItem()",
@@ -6073,7 +6073,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSectionDialog.tsx",
       "source_location": "L37",
       "id": "featuredsectiondialog_handleaddfeatureditem",
-      "community": 322
+      "community": 323
     },
     {
       "label": "HeroHeaderImageUploader.tsx",
@@ -6161,7 +6161,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
-      "community": 88
+      "community": 89
     },
     {
       "label": "handleImageUpdate()",
@@ -6169,7 +6169,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
       "source_location": "L57",
       "id": "herosectiontabs_handleimageupdate",
-      "community": 88
+      "community": 89
     },
     {
       "label": "handleDisplayTypeChange()",
@@ -6177,7 +6177,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
       "source_location": "L61",
       "id": "herosectiontabs_handledisplaytypechange",
-      "community": 88
+      "community": 89
     },
     {
       "label": "handleOverlayToggle()",
@@ -6185,7 +6185,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
       "source_location": "L98",
       "id": "herosectiontabs_handleoverlaytoggle",
-      "community": 88
+      "community": 89
     },
     {
       "label": "handleTextToggle()",
@@ -6193,7 +6193,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
       "source_location": "L134",
       "id": "herosectiontabs_handletexttoggle",
-      "community": 88
+      "community": 89
     },
     {
       "label": "Home.tsx",
@@ -6201,7 +6201,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/Home.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_home_tsx",
-      "community": 323
+      "community": 324
     },
     {
       "label": "Navigation()",
@@ -6209,7 +6209,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/Home.tsx",
       "source_location": "L25",
       "id": "home_navigation",
-      "community": 323
+      "community": 324
     },
     {
       "label": "LandingPageReelVersion.tsx",
@@ -6217,7 +6217,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/LandingPageReelVersion.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_landingpagereelversion_tsx",
-      "community": 324
+      "community": 325
     },
     {
       "label": "handleUpdateConfig()",
@@ -6225,7 +6225,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/LandingPageReelVersion.tsx",
       "source_location": "L83",
       "id": "landingpagereelversion_handleupdateconfig",
-      "community": 324
+      "community": 325
     },
     {
       "label": "MaintenanceMessageEditor.tsx",
@@ -6233,7 +6233,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_maintenancemessageeditor_tsx",
-      "community": 127
+      "community": 128
     },
     {
       "label": "handleSave()",
@@ -6241,7 +6241,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
       "source_location": "L52",
       "id": "maintenancemessageeditor_handlesave",
-      "community": 127
+      "community": 128
     },
     {
       "label": "handleCountdownChange()",
@@ -6249,7 +6249,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
       "source_location": "L76",
       "id": "maintenancemessageeditor_handlecountdownchange",
-      "community": 127
+      "community": 128
     },
     {
       "label": "getCountdownStatus()",
@@ -6257,7 +6257,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
       "source_location": "L86",
       "id": "maintenancemessageeditor_getcountdownstatus",
-      "community": 127
+      "community": 128
     },
     {
       "label": "ReelUploader.tsx",
@@ -6265,7 +6265,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
-      "community": 89
+      "community": 90
     },
     {
       "label": "formatFileSize()",
@@ -6273,7 +6273,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
       "source_location": "L38",
       "id": "reeluploader_formatfilesize",
-      "community": 89
+      "community": 90
     },
     {
       "label": "validateFile()",
@@ -6281,7 +6281,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
       "source_location": "L43",
       "id": "reeluploader_validatefile",
-      "community": 89
+      "community": 90
     },
     {
       "label": "handleFileSelect()",
@@ -6289,7 +6289,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
       "source_location": "L64",
       "id": "reeluploader_handlefileselect",
-      "community": 89
+      "community": 90
     },
     {
       "label": "handleUpload()",
@@ -6297,7 +6297,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
       "source_location": "L135",
       "id": "reeluploader_handleupload",
-      "community": 89
+      "community": 90
     },
     {
       "label": "ShopLook.tsx",
@@ -6305,7 +6305,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_shoplook_tsx",
-      "community": 128
+      "community": 129
     },
     {
       "label": "handleHighlightedItem()",
@@ -6313,7 +6313,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
       "source_location": "L67",
       "id": "shoplook_handlehighlighteditem",
-      "community": 128
+      "community": 129
     },
     {
       "label": "onDragEnd()",
@@ -6321,7 +6321,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
       "source_location": "L73",
       "id": "shoplook_ondragend",
-      "community": 128
+      "community": 129
     },
     {
       "label": "handleImageUpdate()",
@@ -6329,7 +6329,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
       "source_location": "L90",
       "id": "shoplook_handleimageupdate",
-      "community": 128
+      "community": 129
     },
     {
       "label": "ShopLookDialog.tsx",
@@ -6337,7 +6337,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ShopLookDialog.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_shoplookdialog_tsx",
-      "community": 325
+      "community": 326
     },
     {
       "label": "handleAddFeaturedItem()",
@@ -6345,7 +6345,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ShopLookDialog.tsx",
       "source_location": "L35",
       "id": "shoplookdialog_handleaddfeatureditem",
-      "community": 325
+      "community": 326
     },
     {
       "label": "ShopLookImageUploader.tsx",
@@ -6353,7 +6353,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_shoplookimageuploader_tsx",
-      "community": 326
+      "community": 327
     },
     {
       "label": "ShopLookImageUploader()",
@@ -6361,7 +6361,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
       "source_location": "L28",
       "id": "shoplookimageuploader_shoplookimageuploader",
-      "community": 326
+      "community": 327
     },
     {
       "label": "VideoPlayer.tsx",
@@ -6369,7 +6369,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/VideoPlayer.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_videoplayer_tsx",
-      "community": 174
+      "community": 176
     },
     {
       "label": "VideoPlayer()",
@@ -6377,7 +6377,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
       "source_location": "L9",
       "id": "videoplayer_videoplayer",
-      "community": 174
+      "community": 176
     },
     {
       "label": "index.tsx",
@@ -6385,7 +6385,7 @@
       "source_file": "packages/athena-webapp/src/components/join-team/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_join_team_index_tsx",
-      "community": 327
+      "community": 328
     },
     {
       "label": "JoinTeam()",
@@ -6393,7 +6393,7 @@
       "source_file": "packages/athena-webapp/src/components/join-team/index.tsx",
       "source_location": "L11",
       "id": "index_jointeam",
-      "community": 327
+      "community": 328
     },
     {
       "label": "ActivityView.tsx",
@@ -6401,7 +6401,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
-      "community": 90
+      "community": 91
     },
     {
       "label": "isRefundAction()",
@@ -6409,7 +6409,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
       "source_location": "L50",
       "id": "activityview_isrefundaction",
-      "community": 90
+      "community": 91
     },
     {
       "label": "isTransitionAction()",
@@ -6417,7 +6417,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
       "source_location": "L53",
       "id": "activityview_istransitionaction",
-      "community": 90
+      "community": 91
     },
     {
       "label": "isCreatedAction()",
@@ -6425,7 +6425,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
       "source_location": "L58",
       "id": "activityview_iscreatedaction",
-      "community": 90
+      "community": 91
     },
     {
       "label": "isFeedbackRequestAction()",
@@ -6433,7 +6433,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
       "source_location": "L63",
       "id": "activityview_isfeedbackrequestaction",
-      "community": 90
+      "community": 91
     },
     {
       "label": "CustomerDetailsView.tsx",
@@ -6441,7 +6441,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/CustomerDetailsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_customerdetailsview_tsx",
-      "community": 328
+      "community": 329
     },
     {
       "label": "CustomerDetailsView()",
@@ -6449,7 +6449,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/CustomerDetailsView.tsx",
       "source_location": "L13",
       "id": "customerdetailsview_customerdetailsview",
-      "community": 328
+      "community": 329
     },
     {
       "label": "EmailStatusView.tsx",
@@ -6457,7 +6457,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/EmailStatusView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_emailstatusview_tsx",
-      "community": 329
+      "community": 330
     },
     {
       "label": "handleSendOrderEmail()",
@@ -6465,7 +6465,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/EmailStatusView.tsx",
       "source_location": "L41",
       "id": "emailstatusview_handlesendorderemail",
-      "community": 329
+      "community": 330
     },
     {
       "label": "OrderDetailsView.tsx",
@@ -6473,7 +6473,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
-      "community": 91
+      "community": 92
     },
     {
       "label": "VerifiedBadge()",
@@ -6481,7 +6481,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
       "source_location": "L41",
       "id": "orderdetailsview_verifiedbadge",
-      "community": 91
+      "community": 92
     },
     {
       "label": "fetchTransactions()",
@@ -6489,7 +6489,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
       "source_location": "L136",
       "id": "orderdetailsview_fetchtransactions",
-      "community": 91
+      "community": 92
     },
     {
       "label": "handleMarkAsVerified()",
@@ -6497,7 +6497,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
       "source_location": "L173",
       "id": "orderdetailsview_handlemarkasverified",
-      "community": 91
+      "community": 92
     },
     {
       "label": "handleMarkPaymentCollected()",
@@ -6505,7 +6505,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
       "source_location": "L187",
       "id": "orderdetailsview_handlemarkpaymentcollected",
-      "community": 91
+      "community": 92
     },
     {
       "label": "OrderItemsView.tsx",
@@ -6513,7 +6513,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
-      "community": 92
+      "community": 93
     },
     {
       "label": "handleUpdateOrderItem()",
@@ -6521,7 +6521,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
       "source_location": "L47",
       "id": "orderitemsview_handleupdateorderitem",
-      "community": 92
+      "community": 93
     },
     {
       "label": "handleReturnItemToStock()",
@@ -6529,7 +6529,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
       "source_location": "L61",
       "id": "orderitemsview_handlereturnitemtostock",
-      "community": 92
+      "community": 93
     },
     {
       "label": "handleRequestFeedback()",
@@ -6537,7 +6537,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
       "source_location": "L77",
       "id": "orderitemsview_handlerequestfeedback",
-      "community": 92
+      "community": 93
     },
     {
       "label": "handleRestockAll()",
@@ -6545,7 +6545,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
       "source_location": "L295",
       "id": "orderitemsview_handlerestockall",
-      "community": 92
+      "community": 93
     },
     {
       "label": "OrderMetricsPanel.tsx",
@@ -6553,7 +6553,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_ordermetricspanel_tsx",
-      "community": 330
+      "community": 331
     },
     {
       "label": "handleTimeRangeChange()",
@@ -6561,7 +6561,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
       "source_location": "L33",
       "id": "ordermetricspanel_handletimerangechange",
-      "community": 330
+      "community": 331
     },
     {
       "label": "OrderStatus.tsx",
@@ -6569,7 +6569,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderStatus.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_tsx",
-      "community": 770
+      "community": 771
     },
     {
       "label": "OrderSummary.tsx",
@@ -6577,7 +6577,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderSummary.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_ordersummary_tsx",
-      "community": 771
+      "community": 772
     },
     {
       "label": "OrderView.tsx",
@@ -6585,7 +6585,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_orderview_tsx",
-      "community": 175
+      "community": 177
     },
     {
       "label": "handleRefundOrder()",
@@ -6593,7 +6593,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderView.tsx",
       "source_location": "L67",
       "id": "orderview_handlerefundorder",
-      "community": 175
+      "community": 177
     },
     {
       "label": "handleVerifyPayment()",
@@ -6601,7 +6601,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderView.tsx",
       "source_location": "L423",
       "id": "orderview_handleverifypayment",
-      "community": 175
+      "community": 177
     },
     {
       "label": "Orders.tsx",
@@ -6609,7 +6609,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/Orders.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_orders_tsx",
-      "community": 772
+      "community": 773
     },
     {
       "label": "OrdersView.tsx",
@@ -6617,7 +6617,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_ordersview_tsx",
-      "community": 331
+      "community": 332
     },
     {
       "label": "getTimeFilter()",
@@ -6625,7 +6625,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
       "source_location": "L35",
       "id": "ordersview_gettimefilter",
-      "community": 331
+      "community": 332
     },
     {
       "label": "PickupDetailsView.tsx",
@@ -6633,7 +6633,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/PickupDetailsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_pickupdetailsview_tsx",
-      "community": 176
+      "community": 178
     },
     {
       "label": "PickupDetailsView()",
@@ -6641,7 +6641,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/PickupDetailsView.tsx",
       "source_location": "L9",
       "id": "pickupdetailsview_pickupdetailsview",
-      "community": 176
+      "community": 178
     },
     {
       "label": "DeliveryDetails()",
@@ -6649,7 +6649,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/PickupDetailsView.tsx",
       "source_location": "L67",
       "id": "pickupdetailsview_deliverydetails",
-      "community": 176
+      "community": 178
     },
     {
       "label": "RefundsView.tsx",
@@ -6657,7 +6657,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/RefundsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_refundsview_tsx",
-      "community": 332
+      "community": 333
     },
     {
       "label": "handleRefundOrder()",
@@ -6665,7 +6665,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/RefundsView.tsx",
       "source_location": "L79",
       "id": "refundsview_handlerefundorder",
-      "community": 332
+      "community": 333
     },
     {
       "label": "useGetActiveOnlineOrder.ts",
@@ -6673,7 +6673,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/hooks/useGetActiveOnlineOrder.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_hooks_usegetactiveonlineorder_ts",
-      "community": 333
+      "community": 334
     },
     {
       "label": "useGetActiveOnlineOrder()",
@@ -6681,7 +6681,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/hooks/useGetActiveOnlineOrder.ts",
       "source_location": "L6",
       "id": "usegetactiveonlineorder_usegetactiveonlineorder",
-      "community": 333
+      "community": 334
     },
     {
       "label": "constants.ts",
@@ -6689,7 +6689,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/constants.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_constants_ts",
-      "community": 773
+      "community": 774
     },
     {
       "label": "data-table-column-header.tsx",
@@ -6705,7 +6705,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-faceted-filter.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_faceted_filter_tsx",
-      "community": 774
+      "community": 775
     },
     {
       "label": "data-table-pagination.tsx",
@@ -6713,7 +6713,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_pagination_tsx",
-      "community": 775
+      "community": 776
     },
     {
       "label": "data-table-toolbar-provider.tsx",
@@ -6729,7 +6729,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_tsx",
-      "community": 334
+      "community": 335
     },
     {
       "label": "handleClearFilters()",
@@ -6737,7 +6737,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar.tsx",
       "source_location": "L34",
       "id": "data_table_toolbar_handleclearfilters",
-      "community": 334
+      "community": 335
     },
     {
       "label": "data-table-view-options.tsx",
@@ -6753,7 +6753,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_tsx",
-      "community": 776
+      "community": 777
     },
     {
       "label": "data.ts",
@@ -6761,7 +6761,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_ts",
-      "community": 777
+      "community": 778
     },
     {
       "label": "orderColumns.tsx",
@@ -6769,7 +6769,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/orderColumns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_ordercolumns_tsx",
-      "community": 335
+      "community": 336
     },
     {
       "label": "if()",
@@ -6777,7 +6777,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/orderColumns.tsx",
       "source_location": "L89",
       "id": "ordercolumns_if",
-      "community": 335
+      "community": 336
     },
     {
       "label": "refundUtils.ts",
@@ -6881,7 +6881,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
-      "community": 86
+      "community": 87
     },
     {
       "label": "onSubmit()",
@@ -6889,7 +6889,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
       "source_location": "L105",
       "id": "index_onsubmit",
-      "community": 86
+      "community": 87
     },
     {
       "label": "constants.ts",
@@ -6897,7 +6897,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/constants.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_constants_ts",
-      "community": 778
+      "community": 779
     },
     {
       "label": "data-table-column-header.tsx",
@@ -6913,7 +6913,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-faceted-filter.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_faceted_filter_tsx",
-      "community": 779
+      "community": 780
     },
     {
       "label": "data-table-pagination.tsx",
@@ -6921,7 +6921,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_pagination_tsx",
-      "community": 780
+      "community": 781
     },
     {
       "label": "data-table-toolbar-provider.tsx",
@@ -6937,7 +6937,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_tsx",
-      "community": 781
+      "community": 782
     },
     {
       "label": "data-table-view-options.tsx",
@@ -6953,7 +6953,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_tsx",
-      "community": 782
+      "community": 783
     },
     {
       "label": "data.ts",
@@ -6961,7 +6961,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_ts",
-      "community": 783
+      "community": 784
     },
     {
       "label": "inviteColumns.tsx",
@@ -6969,7 +6969,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/inviteColumns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_invitecolumns_tsx",
-      "community": 784
+      "community": 785
     },
     {
       "label": "constants.ts",
@@ -6977,7 +6977,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/constants.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_constants_ts",
-      "community": 785
+      "community": 786
     },
     {
       "label": "data-table-column-header.tsx",
@@ -6993,7 +6993,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-faceted-filter.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_faceted_filter_tsx",
-      "community": 786
+      "community": 787
     },
     {
       "label": "data-table-pagination.tsx",
@@ -7001,7 +7001,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_pagination_tsx",
-      "community": 787
+      "community": 788
     },
     {
       "label": "data-table-toolbar-provider.tsx",
@@ -7017,7 +7017,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_tsx",
-      "community": 788
+      "community": 789
     },
     {
       "label": "data-table-view-options.tsx",
@@ -7033,7 +7033,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_tsx",
-      "community": 789
+      "community": 790
     },
     {
       "label": "data.ts",
@@ -7041,7 +7041,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_ts",
-      "community": 790
+      "community": 791
     },
     {
       "label": "membersColumns.tsx",
@@ -7049,7 +7049,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/membersColumns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_memberscolumns_tsx",
-      "community": 791
+      "community": 792
     },
     {
       "label": "organization-switcher.tsx",
@@ -7057,7 +7057,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-switcher.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_switcher_tsx",
-      "community": 177
+      "community": 179
     },
     {
       "label": "onOrganizationSelect()",
@@ -7065,7 +7065,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-switcher.tsx",
       "source_location": "L94",
       "id": "organization_switcher_onorganizationselect",
-      "community": 177
+      "community": 179
     },
     {
       "label": "handleSignOut()",
@@ -7073,7 +7073,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-switcher.tsx",
       "source_location": "L99",
       "id": "organization_switcher_handlesignout",
-      "community": 177
+      "community": 179
     },
     {
       "label": "CartItems.tsx",
@@ -7081,7 +7081,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CartItems.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_cartitems_tsx",
-      "community": 792
+      "community": 793
     },
     {
       "label": "CashierAuthDialog.tsx",
@@ -7089,7 +7089,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_tsx",
-      "community": 793
+      "community": 794
     },
     {
       "label": "CashierView.tsx",
@@ -7097,7 +7097,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CashierView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_cashierview_tsx",
-      "community": 336
+      "community": 337
     },
     {
       "label": "handleSignOut()",
@@ -7105,7 +7105,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CashierView.tsx",
       "source_location": "L63",
       "id": "cashierview_handlesignout",
-      "community": 336
+      "community": 337
     },
     {
       "label": "CustomerInfoPanel.tsx",
@@ -7169,7 +7169,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/DebugProducts.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_debugproducts_tsx",
-      "community": 337
+      "community": 338
     },
     {
       "label": "DebugProducts()",
@@ -7177,7 +7177,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/DebugProducts.tsx",
       "source_location": "L5",
       "id": "debugproducts_debugproducts",
-      "community": 337
+      "community": 338
     },
     {
       "label": "NewTransactionView.tsx",
@@ -7185,7 +7185,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
-      "community": 129
+      "community": 130
     },
     {
       "label": "Navigation()",
@@ -7193,7 +7193,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
       "source_location": "L22",
       "id": "newtransactionview_navigation",
-      "community": 129
+      "community": 130
     },
     {
       "label": "handleStartTransaction()",
@@ -7201,7 +7201,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
       "source_location": "L68",
       "id": "newtransactionview_handlestarttransaction",
-      "community": 129
+      "community": 130
     },
     {
       "label": "handleQuickStart()",
@@ -7209,7 +7209,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
       "source_location": "L91",
       "id": "newtransactionview_handlequickstart",
-      "community": 129
+      "community": 130
     },
     {
       "label": "NoResultsMessage.tsx",
@@ -7217,7 +7217,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/NoResultsMessage.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_noresultsmessage_tsx",
-      "community": 338
+      "community": 339
     },
     {
       "label": "NoResultsMessage()",
@@ -7225,7 +7225,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/NoResultsMessage.tsx",
       "source_location": "L7",
       "id": "noresultsmessage_noresultsmessage",
-      "community": 338
+      "community": 339
     },
     {
       "label": "OrderSummary.tsx",
@@ -7233,7 +7233,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
-      "community": 130
+      "community": 131
     },
     {
       "label": "handleCompleteTransaction()",
@@ -7241,7 +7241,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
       "source_location": "L128",
       "id": "ordersummary_handlecompletetransaction",
-      "community": 130
+      "community": 131
     },
     {
       "label": "handleSelectedPaymentMethod()",
@@ -7249,7 +7249,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
       "source_location": "L150",
       "id": "ordersummary_handleselectedpaymentmethod",
-      "community": 130
+      "community": 131
     },
     {
       "label": "handleNewTransaction()",
@@ -7257,7 +7257,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
       "source_location": "L162",
       "id": "ordersummary_handlenewtransaction",
-      "community": 130
+      "community": 131
     },
     {
       "label": "POSRegisterView.tsx",
@@ -7329,7 +7329,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_paymentview_tsx",
-      "community": 93
+      "community": 94
     },
     {
       "label": "handleAddPayment()",
@@ -7337,7 +7337,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
       "source_location": "L178",
       "id": "paymentview_handleaddpayment",
-      "community": 93
+      "community": 94
     },
     {
       "label": "handleClearAll()",
@@ -7345,7 +7345,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
       "source_location": "L219",
       "id": "paymentview_handleclearall",
-      "community": 93
+      "community": 94
     },
     {
       "label": "handleAmountChange()",
@@ -7353,7 +7353,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
       "source_location": "L224",
       "id": "paymentview_handleamountchange",
-      "community": 93
+      "community": 94
     },
     {
       "label": "handleAmountBlur()",
@@ -7361,7 +7361,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
       "source_location": "L253",
       "id": "paymentview_handleamountblur",
-      "community": 93
+      "community": 94
     },
     {
       "label": "PaymentsAddedList.tsx",
@@ -7369,7 +7369,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_tsx",
-      "community": 59
+      "community": 60
     },
     {
       "label": "getPaymentMethodLabel()",
@@ -7377,7 +7377,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L18",
       "id": "paymentsaddedlist_getpaymentmethodlabel",
-      "community": 59
+      "community": 60
     },
     {
       "label": "handleStartEdit()",
@@ -7385,7 +7385,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L57",
       "id": "paymentsaddedlist_handlestartedit",
-      "community": 59
+      "community": 60
     },
     {
       "label": "handleSaveEdit()",
@@ -7393,7 +7393,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L62",
       "id": "paymentsaddedlist_handlesaveedit",
-      "community": 59
+      "community": 60
     },
     {
       "label": "handleCancelEdit()",
@@ -7401,7 +7401,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L93",
       "id": "paymentsaddedlist_handlecanceledit",
-      "community": 59
+      "community": 60
     },
     {
       "label": "handleRemovePayment()",
@@ -7409,7 +7409,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L98",
       "id": "paymentsaddedlist_handleremovepayment",
-      "community": 59
+      "community": 60
     },
     {
       "label": "PinInput.tsx",
@@ -7417,7 +7417,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_pininput_tsx",
-      "community": 339
+      "community": 340
     },
     {
       "label": "PinInput()",
@@ -7425,7 +7425,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
       "source_location": "L13",
       "id": "pininput_pininput",
-      "community": 339
+      "community": 340
     },
     {
       "label": "PointOfSaleView.tsx",
@@ -7433,7 +7433,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
-      "community": 340
+      "community": 341
     },
     {
       "label": "Navigation()",
@@ -7441,7 +7441,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
       "source_location": "L34",
       "id": "pointofsaleview_navigation",
-      "community": 340
+      "community": 341
     },
     {
       "label": "PrintInstructions.tsx",
@@ -7449,7 +7449,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_printinstructions_tsx",
-      "community": 341
+      "community": 342
     },
     {
       "label": "PrintInstructions()",
@@ -7457,7 +7457,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
       "source_location": "L3",
       "id": "printinstructions_printinstructions",
-      "community": 341
+      "community": 342
     },
     {
       "label": "ProductCard.tsx",
@@ -7465,7 +7465,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/ProductCard.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_productcard_tsx",
-      "community": 342
+      "community": 343
     },
     {
       "label": "ProductCard()",
@@ -7473,7 +7473,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/ProductCard.tsx",
       "source_location": "L14",
       "id": "productcard_productcard",
-      "community": 342
+      "community": 343
     },
     {
       "label": "ProductEntry.tsx",
@@ -7481,7 +7481,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_productentry_tsx",
-      "community": 343
+      "community": 344
     },
     {
       "label": "handleClearSearch()",
@@ -7489,7 +7489,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
       "source_location": "L86",
       "id": "productentry_handleclearsearch",
-      "community": 343
+      "community": 344
     },
     {
       "label": "ProductLookup.tsx",
@@ -7497,7 +7497,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/ProductLookup.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_productlookup_tsx",
-      "community": 794
+      "community": 795
     },
     {
       "label": "QuickActionsBar.tsx",
@@ -7505,7 +7505,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/QuickActionsBar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_quickactionsbar_tsx",
-      "community": 344
+      "community": 345
     },
     {
       "label": "QuickActionsBar()",
@@ -7513,7 +7513,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/QuickActionsBar.tsx",
       "source_location": "L11",
       "id": "quickactionsbar_quickactionsbar",
-      "community": 344
+      "community": 345
     },
     {
       "label": "RegisterActions.tsx",
@@ -7521,7 +7521,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/RegisterActions.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_registeractions_tsx",
-      "community": 795
+      "community": 796
     },
     {
       "label": "SearchResultsSection.tsx",
@@ -7529,7 +7529,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SearchResultsSection.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_searchresultssection_tsx",
-      "community": 796
+      "community": 797
     },
     {
       "label": "SessionDemo.tsx",
@@ -7537,7 +7537,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionDemo.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_sessiondemo_tsx",
-      "community": 345
+      "community": 346
     },
     {
       "label": "SessionDemo()",
@@ -7545,7 +7545,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionDemo.tsx",
       "source_location": "L15",
       "id": "sessiondemo_sessiondemo",
-      "community": 345
+      "community": 346
     },
     {
       "label": "SessionManager.tsx",
@@ -7553,7 +7553,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_sessionmanager_tsx",
-      "community": 94
+      "community": 95
     },
     {
       "label": "onHoldConfirm()",
@@ -7561,7 +7561,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
       "source_location": "L72",
       "id": "sessionmanager_onholdconfirm",
-      "community": 94
+      "community": 95
     },
     {
       "label": "onResumeSession()",
@@ -7569,7 +7569,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
       "source_location": "L77",
       "id": "sessionmanager_onresumesession",
-      "community": 94
+      "community": 95
     },
     {
       "label": "onVoidConfirm()",
@@ -7577,7 +7577,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
       "source_location": "L90",
       "id": "sessionmanager_onvoidconfirm",
-      "community": 94
+      "community": 95
     },
     {
       "label": "onNewSessionClick()",
@@ -7585,7 +7585,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
       "source_location": "L96",
       "id": "sessionmanager_onnewsessionclick",
-      "community": 94
+      "community": 95
     },
     {
       "label": "TotalsDisplay.tsx",
@@ -7593,7 +7593,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_tsx",
-      "community": 346
+      "community": 347
     },
     {
       "label": "TotalsDisplay()",
@@ -7601,7 +7601,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.tsx",
       "source_location": "L12",
       "id": "totalsdisplay_totalsdisplay",
-      "community": 346
+      "community": 347
     },
     {
       "label": "ExpenseReportView.tsx",
@@ -7609,7 +7609,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportview_tsx",
-      "community": 797
+      "community": 798
     },
     {
       "label": "ExpenseReportsView.tsx",
@@ -7617,7 +7617,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_tsx",
-      "community": 347
+      "community": 348
     },
     {
       "label": "isToday()",
@@ -7625,7 +7625,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
       "source_location": "L17",
       "id": "expensereportsview_istoday",
-      "community": 347
+      "community": 348
     },
     {
       "label": "expenseReportColumns.tsx",
@@ -7633,7 +7633,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/expense-reports/expenseReportColumns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportcolumns_tsx",
-      "community": 798
+      "community": 799
     },
     {
       "label": "hooks.ts",
@@ -7641,7 +7641,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/hooks.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_hooks_ts",
-      "community": 348
+      "community": 349
     },
     {
       "label": "usePOSCashier()",
@@ -7649,7 +7649,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/hooks.ts",
       "source_location": "L5",
       "id": "hooks_useposcashier",
-      "community": 348
+      "community": 349
     },
     {
       "label": "HeldSessionsList.tsx",
@@ -7657,7 +7657,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_tsx",
-      "community": 178
+      "community": 180
     },
     {
       "label": "hasExpired()",
@@ -7665,7 +7665,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx",
       "source_location": "L54",
       "id": "heldsessionslist_hasexpired",
-      "community": 178
+      "community": 180
     },
     {
       "label": "getSessionCartItemsCount()",
@@ -7673,7 +7673,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx",
       "source_location": "L58",
       "id": "heldsessionslist_getsessioncartitemscount",
-      "community": 178
+      "community": 180
     },
     {
       "label": "HoldSessionDialog.tsx",
@@ -7681,7 +7681,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/HoldSessionDialog.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_session_holdsessiondialog_tsx",
-      "community": 349
+      "community": 350
     },
     {
       "label": "HoldSessionDialog()",
@@ -7689,7 +7689,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/HoldSessionDialog.tsx",
       "source_location": "L19",
       "id": "holdsessiondialog_holdsessiondialog",
-      "community": 349
+      "community": 350
     },
     {
       "label": "VoidSessionDialog.tsx",
@@ -7697,7 +7697,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/VoidSessionDialog.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_session_voidsessiondialog_tsx",
-      "community": 350
+      "community": 351
     },
     {
       "label": "VoidSessionDialog()",
@@ -7705,7 +7705,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/VoidSessionDialog.tsx",
       "source_location": "L19",
       "id": "voidsessiondialog_voidsessiondialog",
-      "community": 350
+      "community": 351
     },
     {
       "label": "POSSettingsView.tsx",
@@ -7713,7 +7713,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_tsx",
-      "community": 131
+      "community": 132
     },
     {
       "label": "loadFingerprint()",
@@ -7721,7 +7721,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
       "source_location": "L166",
       "id": "possettingsview_loadfingerprint",
-      "community": 131
+      "community": 132
     },
     {
       "label": "handleRegisterTerminal()",
@@ -7729,7 +7729,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
       "source_location": "L247",
       "id": "possettingsview_handleregisterterminal",
-      "community": 131
+      "community": 132
     },
     {
       "label": "handleUpdateExistingTerminal()",
@@ -7737,7 +7737,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
       "source_location": "L284",
       "id": "possettingsview_handleupdateexistingterminal",
-      "community": 131
+      "community": 132
     },
     {
       "label": "TransactionView.tsx",
@@ -7745,7 +7745,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
-      "community": 799
+      "community": 800
     },
     {
       "label": "TransactionsView.tsx",
@@ -7753,7 +7753,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
-      "community": 179
+      "community": 181
     },
     {
       "label": "formatPaymentMethod()",
@@ -7761,7 +7761,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
       "source_location": "L19",
       "id": "transactionsview_formatpaymentmethod",
-      "community": 179
+      "community": 181
     },
     {
       "label": "isToday()",
@@ -7769,7 +7769,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
       "source_location": "L25",
       "id": "transactionsview_istoday",
-      "community": 179
+      "community": 181
     },
     {
       "label": "transactionColumns.tsx",
@@ -7777,7 +7777,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_tsx",
-      "community": 351
+      "community": 352
     },
     {
       "label": "getPaymentMethodIcon()",
@@ -7785,7 +7785,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
       "source_location": "L22",
       "id": "transactioncolumns_getpaymentmethodicon",
-      "community": 351
+      "community": 352
     },
     {
       "label": "types.ts",
@@ -7793,7 +7793,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/types.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_types_ts",
-      "community": 800
+      "community": 801
     },
     {
       "label": "AnalyticsInsights.tsx",
@@ -7801,7 +7801,7 @@
       "source_file": "packages/athena-webapp/src/components/product/AnalyticsInsights.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_product_analyticsinsights_tsx",
-      "community": 801
+      "community": 802
     },
     {
       "label": "AttributesView.tsx",
@@ -7809,7 +7809,7 @@
       "source_file": "packages/athena-webapp/src/components/product/AttributesView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_product_attributesview_tsx",
-      "community": 802
+      "community": 803
     },
     {
       "label": "BarcodeView.tsx",
@@ -7817,7 +7817,7 @@
       "source_file": "packages/athena-webapp/src/components/product/BarcodeView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_product_barcodeview_tsx",
-      "community": 352
+      "community": 353
     },
     {
       "label": "BarcodeView()",
@@ -7825,7 +7825,7 @@
       "source_file": "packages/athena-webapp/src/components/product/BarcodeView.tsx",
       "source_location": "L14",
       "id": "barcodeview_barcodeview",
-      "community": 352
+      "community": 353
     },
     {
       "label": "CategorizationView.tsx",
@@ -7833,7 +7833,7 @@
       "source_file": "packages/athena-webapp/src/components/product/CategorizationView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_product_categorizationview_tsx",
-      "community": 353
+      "community": 354
     },
     {
       "label": "CategorizationView()",
@@ -7841,7 +7841,7 @@
       "source_file": "packages/athena-webapp/src/components/product/CategorizationView.tsx",
       "source_location": "L6",
       "id": "categorizationview_categorizationview",
-      "community": 353
+      "community": 354
     },
     {
       "label": "DetailsView.tsx",
@@ -7849,7 +7849,7 @@
       "source_file": "packages/athena-webapp/src/components/product/DetailsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_product_detailsview_tsx",
-      "community": 803
+      "community": 804
     },
     {
       "label": "ImagesView.tsx",
@@ -7857,7 +7857,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ImagesView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_product_imagesview_tsx",
-      "community": 354
+      "community": 355
     },
     {
       "label": "handleKeyDown()",
@@ -7865,7 +7865,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ImagesView.tsx",
       "source_location": "L36",
       "id": "imagesview_handlekeydown",
-      "community": 354
+      "community": 355
     },
     {
       "label": "ProductDetailView.tsx",
@@ -7873,7 +7873,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ProductDetailView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_product_productdetailview_tsx",
-      "community": 804
+      "community": 805
     },
     {
       "label": "ProductStatus.tsx",
@@ -7881,7 +7881,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ProductStatus.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_product_productstatus_tsx",
-      "community": 805
+      "community": 806
     },
     {
       "label": "ProductStock.tsx",
@@ -7889,7 +7889,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_product_productstock_tsx",
-      "community": 132
+      "community": 133
     },
     {
       "label": "ProductStockStatus()",
@@ -7897,7 +7897,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
       "source_location": "L4",
       "id": "productstock_productstockstatus",
-      "community": 132
+      "community": 133
     },
     {
       "label": "OutOfStockStatus()",
@@ -7905,7 +7905,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
       "source_location": "L38",
       "id": "productstock_outofstockstatus",
-      "community": 132
+      "community": 133
     },
     {
       "label": "LowStockStatus()",
@@ -7913,7 +7913,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
       "source_location": "L47",
       "id": "productstock_lowstockstatus",
-      "community": 132
+      "community": 133
     },
     {
       "label": "SKUSelector.tsx",
@@ -7921,7 +7921,7 @@
       "source_file": "packages/athena-webapp/src/components/product/SKUSelector.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_product_skuselector_tsx",
-      "community": 355
+      "community": 356
     },
     {
       "label": "SKUSelector()",
@@ -7929,7 +7929,7 @@
       "source_file": "packages/athena-webapp/src/components/product/SKUSelector.tsx",
       "source_location": "L10",
       "id": "skuselector_skuselector",
-      "community": 355
+      "community": 356
     },
     {
       "label": "product-actions.tsx",
@@ -7937,7 +7937,7 @@
       "source_file": "packages/athena-webapp/src/components/product-actions.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_product_actions_tsx",
-      "community": 356
+      "community": 357
     },
     {
       "label": "useDeleteProduct()",
@@ -7945,7 +7945,7 @@
       "source_file": "packages/athena-webapp/src/components/product-actions.tsx",
       "source_location": "L6",
       "id": "product_actions_usedeleteproduct",
-      "community": 356
+      "community": 357
     },
     {
       "label": "CategoryListView.tsx",
@@ -7953,7 +7953,7 @@
       "source_file": "packages/athena-webapp/src/components/products/CategoryListView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_categorylistview_tsx",
-      "community": 806
+      "community": 807
     },
     {
       "label": "ProductSubcategoryToggleGroup.tsx",
@@ -7961,7 +7961,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductSubcategoryToggleGroup.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_productsubcategorytogglegroup_tsx",
-      "community": 807
+      "community": 808
     },
     {
       "label": "Products.tsx",
@@ -7969,7 +7969,7 @@
       "source_file": "packages/athena-webapp/src/components/products/Products.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_products_tsx",
-      "community": 808
+      "community": 809
     },
     {
       "label": "ProductsListView.tsx",
@@ -7977,7 +7977,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsListView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_productslistview_tsx",
-      "community": 180
+      "community": 182
     },
     {
       "label": "ProductActionsToggleGroup()",
@@ -7985,7 +7985,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsListView.tsx",
       "source_location": "L20",
       "id": "productslistview_productactionstogglegroup",
-      "community": 180
+      "community": 182
     },
     {
       "label": "handleClearCache()",
@@ -7993,7 +7993,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsListView.tsx",
       "source_location": "L65",
       "id": "productslistview_handleclearcache",
-      "community": 180
+      "community": 182
     },
     {
       "label": "ProductsTableContext.tsx",
@@ -8001,7 +8001,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsTableContext.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_productstablecontext_tsx",
-      "community": 181
+      "community": 183
     },
     {
       "label": "ProductsTableProvider()",
@@ -8009,7 +8009,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsTableContext.tsx",
       "source_location": "L16",
       "id": "productstablecontext_productstableprovider",
-      "community": 181
+      "community": 183
     },
     {
       "label": "useProductsTableState()",
@@ -8017,7 +8017,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsTableContext.tsx",
       "source_location": "L60",
       "id": "productstablecontext_useproductstablestate",
-      "community": 181
+      "community": 183
     },
     {
       "label": "ProductsView.tsx",
@@ -8025,7 +8025,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_productsview_tsx",
-      "community": 357
+      "community": 358
     },
     {
       "label": "ProductsView()",
@@ -8033,7 +8033,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsView.tsx",
       "source_location": "L5",
       "id": "productsview_productsview",
-      "community": 357
+      "community": 358
     },
     {
       "label": "StoreProducts.tsx",
@@ -8041,7 +8041,7 @@
       "source_file": "packages/athena-webapp/src/components/products/StoreProducts.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_storeproducts_tsx",
-      "community": 809
+      "community": 810
     },
     {
       "label": "StoreProductsView.tsx",
@@ -8049,7 +8049,7 @@
       "source_file": "packages/athena-webapp/src/components/products/StoreProductsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_storeproductsview_tsx",
-      "community": 182
+      "community": 184
     },
     {
       "label": "ProductActionsToggleGroup()",
@@ -8057,7 +8057,7 @@
       "source_file": "packages/athena-webapp/src/components/products/StoreProductsView.tsx",
       "source_location": "L19",
       "id": "storeproductsview_productactionstogglegroup",
-      "community": 182
+      "community": 184
     },
     {
       "label": "Navigation()",
@@ -8065,7 +8065,7 @@
       "source_file": "packages/athena-webapp/src/components/products/StoreProductsView.tsx",
       "source_location": "L45",
       "id": "storeproductsview_navigation",
-      "community": 182
+      "community": 184
     },
     {
       "label": "UnresolvedProducts.tsx",
@@ -8073,7 +8073,7 @@
       "source_file": "packages/athena-webapp/src/components/products/UnresolvedProducts.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_unresolvedproducts_tsx",
-      "community": 810
+      "community": 811
     },
     {
       "label": "AddComplimentaryProduct.tsx",
@@ -8081,7 +8081,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/AddComplimentaryProduct.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_complimentary_addcomplimentaryproduct_tsx",
-      "community": 183
+      "community": 185
     },
     {
       "label": "handleAddComplimentaryProducts()",
@@ -8089,7 +8089,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/AddComplimentaryProduct.tsx",
       "source_location": "L40",
       "id": "addcomplimentaryproduct_handleaddcomplimentaryproducts",
-      "community": 183
+      "community": 185
     },
     {
       "label": "AddComplimentaryProduct()",
@@ -8097,7 +8097,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/AddComplimentaryProduct.tsx",
       "source_location": "L128",
       "id": "addcomplimentaryproduct_addcomplimentaryproduct",
-      "community": 183
+      "community": 185
     },
     {
       "label": "ComplimentaryProducts.tsx",
@@ -8105,7 +8105,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProducts.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproducts_tsx",
-      "community": 811
+      "community": 812
     },
     {
       "label": "ComplimentaryProductsView.tsx",
@@ -8113,7 +8113,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
-      "community": 133
+      "community": 134
     },
     {
       "label": "Navigation()",
@@ -8121,7 +8121,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
       "source_location": "L6",
       "id": "complimentaryproductsview_navigation",
-      "community": 133
+      "community": 134
     },
     {
       "label": "Body()",
@@ -8129,7 +8129,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
       "source_location": "L16",
       "id": "complimentaryproductsview_body",
-      "community": 133
+      "community": 134
     },
     {
       "label": "ComplimentaryProductsView()",
@@ -8137,7 +8137,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
       "source_location": "L35",
       "id": "complimentaryproductsview_complimentaryproductsview",
-      "community": 133
+      "community": 134
     },
     {
       "label": "complimentaryProductsColumn.tsx",
@@ -8145,7 +8145,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/complimentaryProductsColumn.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductscolumn_tsx",
-      "community": 812
+      "community": 813
     },
     {
       "label": "add-product-command.tsx",
@@ -8153,7 +8153,7 @@
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/add-product-command.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_products_table_components_add_product_command_tsx",
-      "community": 358
+      "community": 359
     },
     {
       "label": "AddProductCommand()",
@@ -8161,7 +8161,7 @@
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/add-product-command.tsx",
       "source_location": "L17",
       "id": "add_product_command_addproductcommand",
-      "community": 358
+      "community": 359
     },
     {
       "label": "data-table-column-header.tsx",
@@ -8169,7 +8169,7 @@
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_column_header_tsx",
-      "community": 813
+      "community": 814
     },
     {
       "label": "data-table-faceted-filter.tsx",
@@ -8177,7 +8177,7 @@
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-faceted-filter.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_faceted_filter_tsx",
-      "community": 814
+      "community": 815
     },
     {
       "label": "data-table-pagination.tsx",
@@ -8185,7 +8185,7 @@
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_pagination_tsx",
-      "community": 815
+      "community": 816
     },
     {
       "label": "data-table-row-actions.tsx",
@@ -8201,7 +8201,7 @@
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-toolbar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_toolbar_tsx",
-      "community": 816
+      "community": 817
     },
     {
       "label": "data-table-view-options.tsx",
@@ -8217,7 +8217,7 @@
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_tsx",
-      "community": 817
+      "community": 818
     },
     {
       "label": "data.ts",
@@ -8225,7 +8225,7 @@
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/data.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_ts",
-      "community": 818
+      "community": 819
     },
     {
       "label": "productColumns.tsx",
@@ -8233,7 +8233,7 @@
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/productColumns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_products_table_components_productcolumns_tsx",
-      "community": 819
+      "community": 820
     },
     {
       "label": "Products.tsx",
@@ -8241,7 +8241,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/Products.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_products_tsx",
-      "community": 359
+      "community": 360
     },
     {
       "label": "Products()",
@@ -8249,7 +8249,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/Products.tsx",
       "source_location": "L4",
       "id": "products_products",
-      "community": 359
+      "community": 360
     },
     {
       "label": "PromoCodeForm.tsx",
@@ -8257,7 +8257,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeForm.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeform_tsx",
-      "community": 360
+      "community": 361
     },
     {
       "label": "toggleDiscountType()",
@@ -8265,7 +8265,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeForm.tsx",
       "source_location": "L84",
       "id": "promocodeform_togglediscounttype",
-      "community": 360
+      "community": 361
     },
     {
       "label": "PromoCodeHeader.tsx",
@@ -8273,7 +8273,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_tsx",
-      "community": 361
+      "community": 362
     },
     {
       "label": "handleDeletePromoCode()",
@@ -8281,7 +8281,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
       "source_location": "L22",
       "id": "promocodeheader_handledeletepromocode",
-      "community": 361
+      "community": 362
     },
     {
       "label": "PromoCodePreview.tsx",
@@ -8289,7 +8289,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodePreview.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodepreview_tsx",
-      "community": 820
+      "community": 821
     },
     {
       "label": "PromoCodeView.tsx",
@@ -8297,7 +8297,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeview_tsx",
-      "community": 95
+      "community": 96
     },
     {
       "label": "handleAddPromoCode()",
@@ -8305,7 +8305,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
       "source_location": "L146",
       "id": "promocodeview_handleaddpromocode",
-      "community": 95
+      "community": 96
     },
     {
       "label": "handleUpdatePromoCode()",
@@ -8313,7 +8313,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
       "source_location": "L213",
       "id": "promocodeview_handleupdatepromocode",
-      "community": 95
+      "community": 96
     },
     {
       "label": "updateHomepageDiscountCode()",
@@ -8321,7 +8321,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
       "source_location": "L299",
       "id": "promocodeview_updatehomepagediscountcode",
-      "community": 95
+      "community": 96
     },
     {
       "label": "updateLeaveAReviewDiscountCode()",
@@ -8329,7 +8329,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
       "source_location": "L351",
       "id": "promocodeview_updateleaveareviewdiscountcode",
-      "community": 95
+      "community": 96
     },
     {
       "label": "PromoCodes.tsx",
@@ -8337,7 +8337,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodes.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodes_tsx",
-      "community": 821
+      "community": 822
     },
     {
       "label": "PromoCodesView.tsx",
@@ -8345,7 +8345,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodesView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodesview_tsx",
-      "community": 362
+      "community": 363
     },
     {
       "label": "PromoCodesView()",
@@ -8353,7 +8353,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodesView.tsx",
       "source_location": "L9",
       "id": "promocodesview_promocodesview",
-      "community": 362
+      "community": 363
     },
     {
       "label": "SelectableCategories.tsx",
@@ -8361,7 +8361,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/SelectableCategories.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_selectablecategories_tsx",
-      "community": 363
+      "community": 364
     },
     {
       "label": "toggle()",
@@ -8369,7 +8369,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/SelectableCategories.tsx",
       "source_location": "L23",
       "id": "selectablecategories_toggle",
-      "community": 363
+      "community": 364
     },
     {
       "label": "DiscountTypeToggleGroup.tsx",
@@ -8377,7 +8377,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/DiscountTypeToggleGroup.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_discounttypetogglegroup_tsx",
-      "community": 364
+      "community": 365
     },
     {
       "label": "DiscountTypeToggleGroup()",
@@ -8385,7 +8385,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/DiscountTypeToggleGroup.tsx",
       "source_location": "L5",
       "id": "discounttypetogglegroup_discounttypetogglegroup",
-      "community": 364
+      "community": 365
     },
     {
       "label": "PromoCodeSpanToggleGroup.tsx",
@@ -8393,7 +8393,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/PromoCodeSpanToggleGroup.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_promocodespantogglegroup_tsx",
-      "community": 365
+      "community": 366
     },
     {
       "label": "PromoCodeSpanToggleGroup()",
@@ -8401,7 +8401,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/PromoCodeSpanToggleGroup.tsx",
       "source_location": "L4",
       "id": "promocodespantogglegroup_promocodespantogglegroup",
-      "community": 365
+      "community": 366
     },
     {
       "label": "PromoCodeAnalytics.tsx",
@@ -8409,7 +8409,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/analytics/PromoCodeAnalytics.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_analytics_promocodeanalytics_tsx",
-      "community": 822
+      "community": 823
     },
     {
       "label": "CapturedEmails.tsx",
@@ -8417,7 +8417,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/captured/CapturedEmails.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_capturedemails_tsx",
-      "community": 366
+      "community": 367
     },
     {
       "label": "CapturedEmails()",
@@ -8425,7 +8425,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/captured/CapturedEmails.tsx",
       "source_location": "L13",
       "id": "capturedemails_capturedemails",
-      "community": 366
+      "community": 367
     },
     {
       "label": "captured-emails-columns.tsx",
@@ -8433,7 +8433,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/captured/captured-emails-columns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_captured_emails_columns_tsx",
-      "community": 823
+      "community": 824
     },
     {
       "label": "color-picker.tsx",
@@ -8441,7 +8441,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_color_picker_tsx",
-      "community": 184
+      "community": 186
     },
     {
       "label": "handleInputChange()",
@@ -8449,7 +8449,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
       "source_location": "L20",
       "id": "color_picker_handleinputchange",
-      "community": 184
+      "community": 186
     },
     {
       "label": "handleBlur()",
@@ -8457,7 +8457,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
       "source_location": "L24",
       "id": "color_picker_handleblur",
-      "community": 184
+      "community": 186
     },
     {
       "label": "promo-code-modal.tsx",
@@ -8465,7 +8465,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/promo-code-modal.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_promo_code_modal_tsx",
-      "community": 367
+      "community": 368
     },
     {
       "label": "PromoCodeModal()",
@@ -8473,7 +8473,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/promo-code-modal.tsx",
       "source_location": "L29",
       "id": "promo_code_modal_promocodemodal",
-      "community": 367
+      "community": 368
     },
     {
       "label": "welcome-offer-modal.tsx",
@@ -8545,7 +8545,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/columns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_columns_tsx",
-      "community": 824
+      "community": 825
     },
     {
       "label": "data-table-column-header.tsx",
@@ -8553,7 +8553,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_column_header_tsx",
-      "community": 825
+      "community": 826
     },
     {
       "label": "data-table-faceted-filter.tsx",
@@ -8561,7 +8561,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-faceted-filter.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_faceted_filter_tsx",
-      "community": 826
+      "community": 827
     },
     {
       "label": "data-table-pagination.tsx",
@@ -8569,7 +8569,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_pagination_tsx",
-      "community": 827
+      "community": 828
     },
     {
       "label": "data-table-row-actions.tsx",
@@ -8585,7 +8585,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-toolbar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_toolbar_tsx",
-      "community": 828
+      "community": 829
     },
     {
       "label": "data-table-view-options.tsx",
@@ -8601,7 +8601,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_tsx",
-      "community": 829
+      "community": 830
     },
     {
       "label": "selectable-data-provider.tsx",
@@ -8609,7 +8609,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/selectable-data-provider.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
-      "community": 56
+      "community": 57
     },
     {
       "label": "columns.tsx",
@@ -8617,7 +8617,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/table/columns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_table_columns_tsx",
-      "community": 830
+      "community": 831
     },
     {
       "label": "constants.ts",
@@ -8625,7 +8625,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/table/constants.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_table_constants_ts",
-      "community": 831
+      "community": 832
     },
     {
       "label": "data-table-column-header.tsx",
@@ -8641,7 +8641,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-faceted-filter.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_faceted_filter_tsx",
-      "community": 832
+      "community": 833
     },
     {
       "label": "data-table-pagination.tsx",
@@ -8649,7 +8649,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_pagination_tsx",
-      "community": 833
+      "community": 834
     },
     {
       "label": "data-table-toolbar-provider.tsx",
@@ -8665,7 +8665,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_tsx",
-      "community": 55
+      "community": 56
     },
     {
       "label": "data-table-view-options.tsx",
@@ -8681,7 +8681,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_tsx",
-      "community": 834
+      "community": 835
     },
     {
       "label": "data.ts",
@@ -8689,7 +8689,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/table/data.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_ts",
-      "community": 835
+      "community": 836
     },
     {
       "label": "types.ts",
@@ -8697,7 +8697,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/types.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_types_ts",
-      "community": 836
+      "community": 837
     },
     {
       "label": "welcome-offer-card.tsx",
@@ -8705,7 +8705,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/welcome-offer-card.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_welcome_offer_card_tsx",
-      "community": 837
+      "community": 838
     },
     {
       "label": "currency-provider.tsx",
@@ -8713,7 +8713,7 @@
       "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_providers_currency_provider_tsx",
-      "community": 185
+      "community": 187
     },
     {
       "label": "useStoreCurrency()",
@@ -8721,7 +8721,7 @@
       "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
       "source_location": "L17",
       "id": "currency_provider_usestorecurrency",
-      "community": 185
+      "community": 187
     },
     {
       "label": "CurrencyProvider()",
@@ -8729,7 +8729,7 @@
       "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
       "source_location": "L25",
       "id": "currency_provider_currencyprovider",
-      "community": 185
+      "community": 187
     },
     {
       "label": "RatingStars.tsx",
@@ -8737,7 +8737,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/RatingStars.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_reviews_ratingstars_tsx",
-      "community": 838
+      "community": 839
     },
     {
       "label": "ReviewActions.tsx",
@@ -8745,7 +8745,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewActions.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_reviews_reviewactions_tsx",
-      "community": 368
+      "community": 369
     },
     {
       "label": "ReviewActions()",
@@ -8753,7 +8753,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewActions.tsx",
       "source_location": "L20",
       "id": "reviewactions_reviewactions",
-      "community": 368
+      "community": 369
     },
     {
       "label": "ReviewCard.tsx",
@@ -8761,7 +8761,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewCard.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_reviews_reviewcard_tsx",
-      "community": 839
+      "community": 840
     },
     {
       "label": "ReviewMetadata.tsx",
@@ -8769,7 +8769,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewMetadata.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_reviews_reviewmetadata_tsx",
-      "community": 840
+      "community": 841
     },
     {
       "label": "ReviewsView.tsx",
@@ -8777,7 +8777,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_reviews_reviewsview_tsx",
-      "community": 60
+      "community": 61
     },
     {
       "label": "Header()",
@@ -8785,7 +8785,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L13",
       "id": "reviewsview_header",
-      "community": 60
+      "community": 61
     },
     {
       "label": "handleApprove()",
@@ -8793,7 +8793,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L42",
       "id": "reviewsview_handleapprove",
-      "community": 60
+      "community": 61
     },
     {
       "label": "handleReject()",
@@ -8801,7 +8801,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L58",
       "id": "reviewsview_handlereject",
-      "community": 60
+      "community": 61
     },
     {
       "label": "handlePublish()",
@@ -8809,7 +8809,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L74",
       "id": "reviewsview_handlepublish",
-      "community": 60
+      "community": 61
     },
     {
       "label": "handleUnpublish()",
@@ -8817,7 +8817,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L90",
       "id": "reviewsview_handleunpublish",
-      "community": 60
+      "community": 61
     },
     {
       "label": "empty-state.tsx",
@@ -8825,7 +8825,7 @@
       "source_file": "packages/athena-webapp/src/components/states/empty/empty-state.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_states_empty_empty_state_tsx",
-      "community": 369
+      "community": 370
     },
     {
       "label": "onClick()",
@@ -8833,7 +8833,7 @@
       "source_file": "packages/athena-webapp/src/components/states/empty/empty-state.tsx",
       "source_location": "L29",
       "id": "empty_state_onclick",
-      "community": 369
+      "community": 370
     },
     {
       "label": "SingleLineError.tsx",
@@ -8841,7 +8841,7 @@
       "source_file": "packages/athena-webapp/src/components/states/error/SingleLineError.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_states_error_singlelineerror_tsx",
-      "community": 186
+      "community": 188
     },
     {
       "label": "SingleLineError()",
@@ -8849,7 +8849,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/error/SingleLineError.tsx",
       "source_location": "L3",
       "id": "singlelineerror_singlelineerror",
-      "community": 186
+      "community": 188
     },
     {
       "label": "index.tsx",
@@ -8857,7 +8857,7 @@
       "source_file": "packages/athena-webapp/src/components/states/error/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_states_error_index_tsx",
-      "community": 187
+      "community": 189
     },
     {
       "label": "ErrorPage()",
@@ -8865,7 +8865,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/error/index.tsx",
       "source_location": "L9",
       "id": "index_errorpage",
-      "community": 187
+      "community": 189
     },
     {
       "label": "app-skeleton.tsx",
@@ -8873,7 +8873,7 @@
       "source_file": "packages/athena-webapp/src/components/states/loading/app-skeleton.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_states_loading_app_skeleton_tsx",
-      "community": 188
+      "community": 190
     },
     {
       "label": "AppSkeleton()",
@@ -8881,7 +8881,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/app-skeleton.tsx",
       "source_location": "L3",
       "id": "app_skeleton_appskeleton",
-      "community": 188
+      "community": 190
     },
     {
       "label": "dashboard-skeleton.tsx",
@@ -8889,7 +8889,7 @@
       "source_file": "packages/athena-webapp/src/components/states/loading/dashboard-skeleton.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_states_loading_dashboard_skeleton_tsx",
-      "community": 189
+      "community": 191
     },
     {
       "label": "DashboardSkeleton()",
@@ -8897,7 +8897,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/dashboard-skeleton.tsx",
       "source_location": "L3",
       "id": "dashboard_skeleton_dashboardskeleton",
-      "community": 189
+      "community": 191
     },
     {
       "label": "table-skeleton.tsx",
@@ -8905,7 +8905,7 @@
       "source_file": "packages/athena-webapp/src/components/states/loading/table-skeleton.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_states_loading_table_skeleton_tsx",
-      "community": 190
+      "community": 192
     },
     {
       "label": "TableSkeleton()",
@@ -8913,7 +8913,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/table-skeleton.tsx",
       "source_location": "L3",
       "id": "table_skeleton_tableskeleton",
-      "community": 190
+      "community": 192
     },
     {
       "label": "transactions-skeleton.tsx",
@@ -8921,7 +8921,7 @@
       "source_file": "packages/athena-webapp/src/components/states/loading/transactions-skeleton.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_states_loading_transactions_skeleton_tsx",
-      "community": 191
+      "community": 193
     },
     {
       "label": "TransactionsSkeleton()",
@@ -8929,7 +8929,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/transactions-skeleton.tsx",
       "source_location": "L3",
       "id": "transactions_skeleton_transactionsskeleton",
-      "community": 191
+      "community": 193
     },
     {
       "label": "NoPermission.tsx",
@@ -8937,7 +8937,7 @@
       "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermission.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermission_tsx",
-      "community": 370
+      "community": 371
     },
     {
       "label": "NoPermission()",
@@ -8945,7 +8945,7 @@
       "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermission.tsx",
       "source_location": "L3",
       "id": "nopermission_nopermission",
-      "community": 370
+      "community": 371
     },
     {
       "label": "NoPermissionView.tsx",
@@ -8953,7 +8953,7 @@
       "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermissionView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermissionview_tsx",
-      "community": 371
+      "community": 372
     },
     {
       "label": "NoPermissionView()",
@@ -8961,7 +8961,7 @@
       "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermissionView.tsx",
       "source_location": "L4",
       "id": "nopermissionview_nopermissionview",
-      "community": 371
+      "community": 372
     },
     {
       "label": "NotFound.tsx",
@@ -8969,7 +8969,7 @@
       "source_file": "packages/athena-webapp/src/components/states/not-found/NotFound.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_states_not_found_notfound_tsx",
-      "community": 192
+      "community": 194
     },
     {
       "label": "NotFound()",
@@ -8977,7 +8977,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/not-found/NotFound.tsx",
       "source_location": "L4",
       "id": "notfound_notfound",
-      "community": 192
+      "community": 194
     },
     {
       "label": "NotFoundView.tsx",
@@ -8985,7 +8985,7 @@
       "source_file": "packages/athena-webapp/src/components/states/not-found/NotFoundView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_states_not_found_notfoundview_tsx",
-      "community": 372
+      "community": 373
     },
     {
       "label": "NotFoundView()",
@@ -8993,7 +8993,7 @@
       "source_file": "packages/athena-webapp/src/components/states/not-found/NotFoundView.tsx",
       "source_location": "L4",
       "id": "notfoundview_notfoundview",
-      "community": 372
+      "community": 373
     },
     {
       "label": "ContactView.tsx",
@@ -9001,7 +9001,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/ContactView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_store_configuration_components_contactview_tsx",
-      "community": 373
+      "community": 374
     },
     {
       "label": "ContactView()",
@@ -9009,7 +9009,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/ContactView.tsx",
       "source_location": "L9",
       "id": "contactview_contactview",
-      "community": 373
+      "community": 374
     },
     {
       "label": "FeesView.tsx",
@@ -9017,7 +9017,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FeesView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_store_configuration_components_feesview_tsx",
-      "community": 193
+      "community": 195
     },
     {
       "label": "handleUpdateFees()",
@@ -9025,7 +9025,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FeesView.tsx",
       "source_location": "L36",
       "id": "feesview_handleupdatefees",
-      "community": 193
+      "community": 195
     },
     {
       "label": "handleToggleAllFees()",
@@ -9033,7 +9033,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FeesView.tsx",
       "source_location": "L104",
       "id": "feesview_handletoggleallfees",
-      "community": 193
+      "community": 195
     },
     {
       "label": "FulfillmentView.tsx",
@@ -9113,7 +9113,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_store_configuration_components_header_tsx",
-      "community": 374
+      "community": 375
     },
     {
       "label": "Header()",
@@ -9121,7 +9121,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
       "source_location": "L1",
       "id": "header_header",
-      "community": 374
+      "community": 375
     },
     {
       "label": "MaintenanceView.tsx",
@@ -9129,7 +9129,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_tsx",
-      "community": 375
+      "community": 376
     },
     {
       "label": "MaintenanceView()",
@@ -9137,7 +9137,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.tsx",
       "source_location": "L13",
       "id": "maintenanceview_maintenanceview",
-      "community": 375
+      "community": 376
     },
     {
       "label": "MtnMomoView.test.tsx",
@@ -9145,7 +9145,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.test.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_test_tsx",
-      "community": 841
+      "community": 842
     },
     {
       "label": "MtnMomoView.tsx",
@@ -9265,7 +9265,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/TaxView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_store_configuration_components_taxview_tsx",
-      "community": 376
+      "community": 377
     },
     {
       "label": "handleUpdateTaxSettings()",
@@ -9273,7 +9273,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/TaxView.tsx",
       "source_location": "L25",
       "id": "taxview_handleupdatetaxsettings",
-      "community": 376
+      "community": 377
     },
     {
       "label": "useStoreConfigUpdate.ts",
@@ -9281,7 +9281,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/hooks/useStoreConfigUpdate.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_ts",
-      "community": 377
+      "community": 378
     },
     {
       "label": "useStoreConfigUpdate()",
@@ -9289,7 +9289,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/hooks/useStoreConfigUpdate.ts",
       "source_location": "L19",
       "id": "usestoreconfigupdate_usestoreconfigupdate",
-      "community": 377
+      "community": 378
     },
     {
       "label": "index.tsx",
@@ -9297,7 +9297,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_store_configuration_index_tsx",
-      "community": 842
+      "community": 843
     },
     {
       "label": "store-switcher.tsx",
@@ -9305,7 +9305,7 @@
       "source_file": "packages/athena-webapp/src/components/store-switcher.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_store_switcher_tsx",
-      "community": 378
+      "community": 379
     },
     {
       "label": "onStoreSelect()",
@@ -9313,7 +9313,7 @@
       "source_file": "packages/athena-webapp/src/components/store-switcher.tsx",
       "source_location": "L63",
       "id": "store_switcher_onstoreselect",
-      "community": 378
+      "community": 379
     },
     {
       "label": "accordion.tsx",
@@ -9321,7 +9321,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/accordion.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_accordion_tsx",
-      "community": 843
+      "community": 844
     },
     {
       "label": "app-context-menu.tsx",
@@ -9329,7 +9329,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/app-context-menu.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_app_context_menu_tsx",
-      "community": 194
+      "community": 196
     },
     {
       "label": "AppContextMenu()",
@@ -9337,7 +9337,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/app-context-menu.tsx",
       "source_location": "L20",
       "id": "app_context_menu_appcontextmenu",
-      "community": 194
+      "community": 196
     },
     {
       "label": "badge.tsx",
@@ -9345,7 +9345,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/badge.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_badge_tsx",
-      "community": 195
+      "community": 197
     },
     {
       "label": "Badge()",
@@ -9353,7 +9353,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/badge.tsx",
       "source_location": "L30",
       "id": "badge_badge",
-      "community": 195
+      "community": 197
     },
     {
       "label": "button.test.tsx",
@@ -9361,7 +9361,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/button.test.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_button_test_tsx",
-      "community": 844
+      "community": 845
     },
     {
       "label": "button.tsx",
@@ -9369,7 +9369,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/button.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_button_tsx",
-      "community": 845
+      "community": 846
     },
     {
       "label": "calendar.test.tsx",
@@ -9377,7 +9377,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/calendar.test.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_calendar_test_tsx",
-      "community": 846
+      "community": 847
     },
     {
       "label": "calendar.tsx",
@@ -9385,7 +9385,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/calendar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_calendar_tsx",
-      "community": 847
+      "community": 848
     },
     {
       "label": "card.tsx",
@@ -9393,7 +9393,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/card.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_card_tsx",
-      "community": 848
+      "community": 849
     },
     {
       "label": "chart.tsx",
@@ -9401,7 +9401,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/chart.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_chart_tsx",
-      "community": 379
+      "community": 380
     },
     {
       "label": "useChart()",
@@ -9409,7 +9409,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/chart.tsx",
       "source_location": "L25",
       "id": "chart_usechart",
-      "community": 379
+      "community": 380
     },
     {
       "label": "checkbox.tsx",
@@ -9417,7 +9417,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/checkbox.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_checkbox_tsx",
-      "community": 849
+      "community": 850
     },
     {
       "label": "collapsible.tsx",
@@ -9425,7 +9425,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/collapsible.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_collapsible_tsx",
-      "community": 850
+      "community": 851
     },
     {
       "label": "command.tsx",
@@ -9433,7 +9433,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/command.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_command_tsx",
-      "community": 851
+      "community": 852
     },
     {
       "label": "context-menu.tsx",
@@ -9441,7 +9441,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/context-menu.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_context_menu_tsx",
-      "community": 852
+      "community": 853
     },
     {
       "label": "copy-button.tsx",
@@ -9449,7 +9449,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/copy-button.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_copy_button_tsx",
-      "community": 380
+      "community": 381
     },
     {
       "label": "handleCopy()",
@@ -9457,7 +9457,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/copy-button.tsx",
       "source_location": "L15",
       "id": "copy_button_handlecopy",
-      "community": 380
+      "community": 381
     },
     {
       "label": "copy-wrapper.tsx",
@@ -9465,7 +9465,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/copy-wrapper.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_copy_wrapper_tsx",
-      "community": 381
+      "community": 382
     },
     {
       "label": "handleCopy()",
@@ -9473,7 +9473,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/copy-wrapper.tsx",
       "source_location": "L21",
       "id": "copy_wrapper_handlecopy",
-      "community": 381
+      "community": 382
     },
     {
       "label": "date-time-picker.tsx",
@@ -9481,7 +9481,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/date-time-picker.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
-      "community": 382
+      "community": 383
     },
     {
       "label": "DateTimePicker()",
@@ -9489,7 +9489,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/date-time-picker.tsx",
       "source_location": "L21",
       "id": "date_time_picker_datetimepicker",
-      "community": 382
+      "community": 383
     },
     {
       "label": "dialog.tsx",
@@ -9497,7 +9497,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/dialog.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_dialog_tsx",
-      "community": 853
+      "community": 854
     },
     {
       "label": "dropdown-menu.tsx",
@@ -9505,7 +9505,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/dropdown-menu.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_dropdown_menu_tsx",
-      "community": 854
+      "community": 855
     },
     {
       "label": "form.tsx",
@@ -9513,7 +9513,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/form.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_form_tsx",
-      "community": 855
+      "community": 856
     },
     {
       "label": "icons.tsx",
@@ -9521,7 +9521,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/icons.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_icons_tsx",
-      "community": 856
+      "community": 857
     },
     {
       "label": "image-uploader.tsx",
@@ -9529,7 +9529,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "community": 61
+      "community": 62
     },
     {
       "label": "onDrop()",
@@ -9537,7 +9537,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L20",
       "id": "image_uploader_ondrop",
-      "community": 61
+      "community": 62
     },
     {
       "label": "removeImage()",
@@ -9545,7 +9545,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L31",
       "id": "image_uploader_removeimage",
-      "community": 61
+      "community": 62
     },
     {
       "label": "unmarkForDeletion()",
@@ -9553,7 +9553,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L46",
       "id": "image_uploader_unmarkfordeletion",
-      "community": 61
+      "community": 62
     },
     {
       "label": "onDragEnd()",
@@ -9561,7 +9561,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L100",
       "id": "image_uploader_ondragend",
-      "community": 61
+      "community": 62
     },
     {
       "label": "input-otp.tsx",
@@ -9569,7 +9569,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/input-otp.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_input_otp_tsx",
-      "community": 857
+      "community": 858
     },
     {
       "label": "input.tsx",
@@ -9577,7 +9577,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/input.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_input_tsx",
-      "community": 858
+      "community": 859
     },
     {
       "label": "label.tsx",
@@ -9585,7 +9585,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/label.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_label_tsx",
-      "community": 383
+      "community": 384
     },
     {
       "label": "Label()",
@@ -9593,7 +9593,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/label.tsx",
       "source_location": "L6",
       "id": "label_label",
-      "community": 383
+      "community": 384
     },
     {
       "label": "loading-button.tsx",
@@ -9601,7 +9601,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/loading-button.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_loading_button_tsx",
-      "community": 196
+      "community": 198
     },
     {
       "label": "LoadingButton()",
@@ -9609,7 +9609,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/loading-button.tsx",
       "source_location": "L9",
       "id": "loading_button_loadingbutton",
-      "community": 196
+      "community": 198
     },
     {
       "label": "modal.tsx",
@@ -9617,7 +9617,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modal.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_modal_tsx",
-      "community": 197
+      "community": 199
     },
     {
       "label": "onChange()",
@@ -9625,7 +9625,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modal.tsx",
       "source_location": "L38",
       "id": "modal_onchange",
-      "community": 197
+      "community": 199
     },
     {
       "label": "action-modal.tsx",
@@ -9633,7 +9633,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/action-modal.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_modals_action_modal_tsx",
-      "community": 859
+      "community": 860
     },
     {
       "label": "alert-modal.tsx",
@@ -9641,7 +9641,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/alert-modal.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_modals_alert_modal_tsx",
-      "community": 198
+      "community": 200
     },
     {
       "label": "AlertModal()",
@@ -9649,7 +9649,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/alert-modal.tsx",
       "source_location": "L20",
       "id": "alert_modal_alertmodal",
-      "community": 198
+      "community": 200
     },
     {
       "label": "custom-modal-example.tsx",
@@ -9657,7 +9657,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_example_tsx",
-      "community": 96
+      "community": 97
     },
     {
       "label": "BasicModalExample()",
@@ -9665,7 +9665,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
       "source_location": "L7",
       "id": "custom_modal_example_basicmodalexample",
-      "community": 96
+      "community": 97
     },
     {
       "label": "CustomPositionModalExample()",
@@ -9673,7 +9673,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
       "source_location": "L44",
       "id": "custom_modal_example_custompositionmodalexample",
-      "community": 96
+      "community": 97
     },
     {
       "label": "CustomCloseButtonExample()",
@@ -9681,7 +9681,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
       "source_location": "L69",
       "id": "custom_modal_example_customclosebuttonexample",
-      "community": 96
+      "community": 97
     },
     {
       "label": "FullScreenModalExample()",
@@ -9689,7 +9689,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
       "source_location": "L103",
       "id": "custom_modal_example_fullscreenmodalexample",
-      "community": 96
+      "community": 97
     },
     {
       "label": "custom-modal.tsx",
@@ -9697,7 +9697,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_tsx",
-      "community": 384
+      "community": 385
     },
     {
       "label": "CustomModal()",
@@ -9705,7 +9705,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
       "source_location": "L25",
       "id": "custom_modal_custommodal",
-      "community": 384
+      "community": 385
     },
     {
       "label": "organization-modal.tsx",
@@ -9713,7 +9713,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/organization-modal.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_modals_organization_modal_tsx",
-      "community": 385
+      "community": 386
     },
     {
       "label": "onSubmit()",
@@ -9721,7 +9721,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/organization-modal.tsx",
       "source_location": "L49",
       "id": "organization_modal_onsubmit",
-      "community": 385
+      "community": 386
     },
     {
       "label": "overlay-modal.tsx",
@@ -9729,7 +9729,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/overlay-modal.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_modals_overlay_modal_tsx",
-      "community": 199
+      "community": 201
     },
     {
       "label": "OverlayModal()",
@@ -9737,7 +9737,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/overlay-modal.tsx",
       "source_location": "L12",
       "id": "overlay_modal_overlaymodal",
-      "community": 199
+      "community": 201
     },
     {
       "label": "store-modal.tsx",
@@ -9745,7 +9745,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/store-modal.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_modals_store_modal_tsx",
-      "community": 386
+      "community": 387
     },
     {
       "label": "onSubmit()",
@@ -9753,7 +9753,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/store-modal.tsx",
       "source_location": "L63",
       "id": "store_modal_onsubmit",
-      "community": 386
+      "community": 387
     },
     {
       "label": "welcome-back-modal-example.tsx",
@@ -9761,7 +9761,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal-example.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_example_tsx",
-      "community": 387
+      "community": 388
     },
     {
       "label": "WelcomeBackModalExample()",
@@ -9769,7 +9769,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal-example.tsx",
       "source_location": "L5",
       "id": "welcome_back_modal_example_welcomebackmodalexample",
-      "community": 387
+      "community": 388
     },
     {
       "label": "welcome-back-modal.tsx",
@@ -9777,7 +9777,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_tsx",
-      "community": 388
+      "community": 389
     },
     {
       "label": "WelcomeBackModal()",
@@ -9785,7 +9785,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal.tsx",
       "source_location": "L12",
       "id": "welcome_back_modal_welcomebackmodal",
-      "community": 388
+      "community": 389
     },
     {
       "label": "popover.tsx",
@@ -9793,7 +9793,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/popover.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_popover_tsx",
-      "community": 860
+      "community": 861
     },
     {
       "label": "radio-group.tsx",
@@ -9801,7 +9801,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/radio-group.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_radio_group_tsx",
-      "community": 861
+      "community": 862
     },
     {
       "label": "scroll-area.tsx",
@@ -9809,7 +9809,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/scroll-area.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
-      "community": 862
+      "community": 863
     },
     {
       "label": "select-native.tsx",
@@ -9817,7 +9817,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/select-native.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_select_native_tsx",
-      "community": 389
+      "community": 390
     },
     {
       "label": "cn()",
@@ -9825,7 +9825,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/select-native.tsx",
       "source_location": "L15",
       "id": "select_native_cn",
-      "community": 389
+      "community": 390
     },
     {
       "label": "select.tsx",
@@ -9833,7 +9833,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/select.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_select_tsx",
-      "community": 863
+      "community": 864
     },
     {
       "label": "separator.tsx",
@@ -9841,7 +9841,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/separator.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_separator_tsx",
-      "community": 864
+      "community": 865
     },
     {
       "label": "sheet.tsx",
@@ -9849,7 +9849,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sheet.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_sheet_tsx",
-      "community": 865
+      "community": 866
     },
     {
       "label": "sidebar.tsx",
@@ -9857,7 +9857,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
-      "community": 62
+      "community": 63
     },
     {
       "label": "useSidebar()",
@@ -9865,7 +9865,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L45",
       "id": "sidebar_usesidebar",
-      "community": 62
+      "community": 63
     },
     {
       "label": "handleKeyDown()",
@@ -9873,7 +9873,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L105",
       "id": "sidebar_handlekeydown",
-      "community": 62
+      "community": 63
     },
     {
       "label": "cn()",
@@ -9881,7 +9881,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L147",
       "id": "sidebar_cn",
-      "community": 62
+      "community": 63
     },
     {
       "label": "handleOnHover()",
@@ -9889,7 +9889,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L224",
       "id": "sidebar_handleonhover",
-      "community": 62
+      "community": 63
     },
     {
       "label": "handleOnMouseLeave()",
@@ -9897,7 +9897,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L228",
       "id": "sidebar_handleonmouseleave",
-      "community": 62
+      "community": 63
     },
     {
       "label": "skeleton.tsx",
@@ -9905,7 +9905,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/skeleton.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_skeleton_tsx",
-      "community": 200
+      "community": 202
     },
     {
       "label": "Skeleton()",
@@ -9913,7 +9913,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/skeleton.tsx",
       "source_location": "L3",
       "id": "skeleton_skeleton",
-      "community": 200
+      "community": 202
     },
     {
       "label": "sonner.tsx",
@@ -9921,7 +9921,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sonner.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_sonner_tsx",
-      "community": 201
+      "community": 203
     },
     {
       "label": "Toaster()",
@@ -9929,7 +9929,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/sonner.tsx",
       "source_location": "L6",
       "id": "sonner_toaster",
-      "community": 201
+      "community": 203
     },
     {
       "label": "spinner.tsx",
@@ -9937,7 +9937,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/spinner.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_spinner_tsx",
-      "community": 202
+      "community": 204
     },
     {
       "label": "Spinner()",
@@ -9945,7 +9945,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/spinner.tsx",
       "source_location": "L3",
       "id": "spinner_spinner",
-      "community": 202
+      "community": 204
     },
     {
       "label": "switch.tsx",
@@ -9953,7 +9953,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/switch.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_switch_tsx",
-      "community": 866
+      "community": 867
     },
     {
       "label": "table.tsx",
@@ -9961,7 +9961,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_table_tsx",
-      "community": 867
+      "community": 868
     },
     {
       "label": "tabs.tsx",
@@ -9969,7 +9969,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/tabs.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_tabs_tsx",
-      "community": 868
+      "community": 869
     },
     {
       "label": "textarea.tsx",
@@ -9977,7 +9977,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/textarea.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_textarea_tsx",
-      "community": 869
+      "community": 870
     },
     {
       "label": "timeline-item.tsx",
@@ -9985,7 +9985,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/timeline-item.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_timeline_item_tsx",
-      "community": 390
+      "community": 391
     },
     {
       "label": "TimelineItem()",
@@ -9993,7 +9993,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/timeline-item.tsx",
       "source_location": "L3",
       "id": "timeline_item_timelineitem",
-      "community": 390
+      "community": 391
     },
     {
       "label": "toggle-group.tsx",
@@ -10001,7 +10001,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/toggle-group.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_toggle_group_tsx",
-      "community": 870
+      "community": 871
     },
     {
       "label": "toggle.tsx",
@@ -10009,7 +10009,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/toggle.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_toggle_tsx",
-      "community": 871
+      "community": 872
     },
     {
       "label": "tooltip.tsx",
@@ -10017,7 +10017,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/tooltip.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
-      "community": 872
+      "community": 873
     },
     {
       "label": "webp-image.tsx",
@@ -10025,7 +10025,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/webp-image.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_webp_image_tsx",
-      "community": 391
+      "community": 392
     },
     {
       "label": "WebpImage()",
@@ -10033,7 +10033,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/webp-image.tsx",
       "source_location": "L1",
       "id": "webp_image_webpimage",
-      "community": 391
+      "community": 392
     },
     {
       "label": "upload-button.tsx",
@@ -10041,7 +10041,7 @@
       "source_file": "packages/athena-webapp/src/components/upload-button.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_upload_button_tsx",
-      "community": 873
+      "community": 874
     },
     {
       "label": "BagItems.tsx",
@@ -10049,7 +10049,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/BagItems.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_bagitems_tsx",
-      "community": 392
+      "community": 393
     },
     {
       "label": "BagItems()",
@@ -10057,7 +10057,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/BagItems.tsx",
       "source_location": "L5",
       "id": "bagitems_bagitems",
-      "community": 392
+      "community": 393
     },
     {
       "label": "BagItemsView.tsx",
@@ -10065,7 +10065,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/BagItemsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_bagitemsview_tsx",
-      "community": 393
+      "community": 394
     },
     {
       "label": "BagItemsView()",
@@ -10073,7 +10073,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/BagItemsView.tsx",
       "source_location": "L11",
       "id": "bagitemsview_bagitemsview",
-      "community": 393
+      "community": 394
     },
     {
       "label": "BagView.tsx",
@@ -10081,7 +10081,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/BagView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_bagview_tsx",
-      "community": 874
+      "community": 875
     },
     {
       "label": "Bags.tsx",
@@ -10089,7 +10089,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_bags_tsx",
-      "community": 394
+      "community": 395
     },
     {
       "label": "Bags()",
@@ -10097,7 +10097,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
       "source_location": "L4",
       "id": "bags_bags",
-      "community": 394
+      "community": 395
     },
     {
       "label": "columns.tsx",
@@ -10105,7 +10105,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/columns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_table_columns_tsx",
-      "community": 875
+      "community": 876
     },
     {
       "label": "constants.ts",
@@ -10113,7 +10113,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/constants.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
-      "community": 876
+      "community": 877
     },
     {
       "label": "data-table-column-header.tsx",
@@ -10129,7 +10129,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-faceted-filter.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_faceted_filter_tsx",
-      "community": 877
+      "community": 878
     },
     {
       "label": "data-table-pagination.tsx",
@@ -10137,7 +10137,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_pagination_tsx",
-      "community": 878
+      "community": 879
     },
     {
       "label": "data-table-toolbar-provider.tsx",
@@ -10153,7 +10153,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_tsx",
-      "community": 55
+      "community": 56
     },
     {
       "label": "data-table-view-options.tsx",
@@ -10169,7 +10169,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_tsx",
-      "community": 879
+      "community": 880
     },
     {
       "label": "data.ts",
@@ -10177,7 +10177,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_ts",
-      "community": 880
+      "community": 881
     },
     {
       "label": "bag-columns.tsx",
@@ -10185,7 +10185,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bag-columns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bag_columns_tsx",
-      "community": 881
+      "community": 882
     },
     {
       "label": "bags-table.tsx",
@@ -10193,7 +10193,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bags-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
-      "community": 882
+      "community": 883
     },
     {
       "label": "columns.tsx",
@@ -10201,7 +10201,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/columns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_columns_tsx",
-      "community": 883
+      "community": 884
     },
     {
       "label": "data-table-column-header.tsx",
@@ -10209,7 +10209,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_column_header_tsx",
-      "community": 884
+      "community": 885
     },
     {
       "label": "data-table-faceted-filter.tsx",
@@ -10217,7 +10217,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-faceted-filter.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_faceted_filter_tsx",
-      "community": 885
+      "community": 886
     },
     {
       "label": "data-table-pagination.tsx",
@@ -10225,7 +10225,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_pagination_tsx",
-      "community": 886
+      "community": 887
     },
     {
       "label": "data-table-row-actions.tsx",
@@ -10241,7 +10241,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-toolbar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
-      "community": 887
+      "community": 888
     },
     {
       "label": "data-table-view-options.tsx",
@@ -10257,7 +10257,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_tsx",
-      "community": 888
+      "community": 889
     },
     {
       "label": "selectable-data-provider.tsx",
@@ -10265,7 +10265,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
-      "community": 56
+      "community": 57
     },
     {
       "label": "ActivitySummaryCards.tsx",
@@ -10273,7 +10273,7 @@
       "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_activitysummarycards_tsx",
-      "community": 203
+      "community": 205
     },
     {
       "label": "SummaryCard()",
@@ -10281,7 +10281,7 @@
       "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
       "source_location": "L19",
       "id": "activitysummarycards_summarycard",
-      "community": 203
+      "community": 205
     },
     {
       "label": "ActivitySummaryCards()",
@@ -10289,7 +10289,7 @@
       "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
       "source_location": "L44",
       "id": "activitysummarycards_activitysummarycards",
-      "community": 203
+      "community": 205
     },
     {
       "label": "CustomerBehaviorTimeline.tsx",
@@ -10297,7 +10297,7 @@
       "source_file": "packages/athena-webapp/src/components/users/CustomerBehaviorTimeline.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_customerbehaviortimeline_tsx",
-      "community": 395
+      "community": 396
     },
     {
       "label": "String()",
@@ -10305,7 +10305,7 @@
       "source_file": "packages/athena-webapp/src/components/users/CustomerBehaviorTimeline.tsx",
       "source_location": "L110",
       "id": "customerbehaviortimeline_string",
-      "community": 395
+      "community": 396
     },
     {
       "label": "LinkedAccounts.tsx",
@@ -10313,7 +10313,7 @@
       "source_file": "packages/athena-webapp/src/components/users/LinkedAccounts.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_linkedaccounts_tsx",
-      "community": 889
+      "community": 890
     },
     {
       "label": "TimelineEventCard.test.tsx",
@@ -10321,7 +10321,7 @@
       "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.test.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_test_tsx",
-      "community": 890
+      "community": 891
     },
     {
       "label": "TimelineEventCard.tsx",
@@ -10329,7 +10329,7 @@
       "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_tsx",
-      "community": 204
+      "community": 206
     },
     {
       "label": "formatObservabilityLabel()",
@@ -10337,7 +10337,7 @@
       "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
       "source_location": "L139",
       "id": "timelineeventcard_formatobservabilitylabel",
-      "community": 204
+      "community": 206
     },
     {
       "label": "loadMore()",
@@ -10345,7 +10345,7 @@
       "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
       "source_location": "L175",
       "id": "timelineeventcard_loadmore",
-      "community": 204
+      "community": 206
     },
     {
       "label": "UserActivity.tsx",
@@ -10353,7 +10353,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_useractivity_tsx",
-      "community": 205
+      "community": 207
     },
     {
       "label": "ActivityHeader()",
@@ -10361,7 +10361,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
       "source_location": "L22",
       "id": "useractivity_activityheader",
-      "community": 205
+      "community": 207
     },
     {
       "label": "UserActivity()",
@@ -10369,7 +10369,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
       "source_location": "L45",
       "id": "useractivity_useractivity",
-      "community": 205
+      "community": 207
     },
     {
       "label": "UserAnalyticsName.tsx",
@@ -10377,7 +10377,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserAnalyticsName.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_useranalyticsname_tsx",
-      "community": 396
+      "community": 397
     },
     {
       "label": "UserAnalyticsName()",
@@ -10385,7 +10385,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserAnalyticsName.tsx",
       "source_location": "L13",
       "id": "useranalyticsname_useranalyticsname",
-      "community": 396
+      "community": 397
     },
     {
       "label": "UserBag.tsx",
@@ -10393,7 +10393,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserBag.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_userbag_tsx",
-      "community": 397
+      "community": 398
     },
     {
       "label": "UserBag()",
@@ -10401,7 +10401,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserBag.tsx",
       "source_location": "L7",
       "id": "userbag_userbag",
-      "community": 397
+      "community": 398
     },
     {
       "label": "UserCheckoutSession.tsx",
@@ -10409,7 +10409,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserCheckoutSession.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_usercheckoutsession_tsx",
-      "community": 891
+      "community": 892
     },
     {
       "label": "UserInsightsSection.tsx",
@@ -10417,7 +10417,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserInsightsSection.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_userinsightssection_tsx",
-      "community": 892
+      "community": 893
     },
     {
       "label": "UserOnlineOrders.tsx",
@@ -10425,7 +10425,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserOnlineOrders.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_useronlineorders_tsx",
-      "community": 398
+      "community": 399
     },
     {
       "label": "UserOnlineOrders()",
@@ -10433,7 +10433,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserOnlineOrders.tsx",
       "source_location": "L11",
       "id": "useronlineorders_useronlineorders",
-      "community": 398
+      "community": 399
     },
     {
       "label": "UserStatus.tsx",
@@ -10441,7 +10441,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserStatus.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_userstatus_tsx",
-      "community": 399
+      "community": 400
     },
     {
       "label": "UserStatus()",
@@ -10449,7 +10449,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserStatus.tsx",
       "source_location": "L7",
       "id": "userstatus_userstatus",
-      "community": 399
+      "community": 400
     },
     {
       "label": "UserView.tsx",
@@ -10457,7 +10457,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_userview_tsx",
-      "community": 400
+      "community": 401
     },
     {
       "label": "UserActions()",
@@ -10465,7 +10465,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserView.tsx",
       "source_location": "L45",
       "id": "userview_useractions",
-      "community": 400
+      "community": 401
     },
     {
       "label": "CustomerJourneyStage.tsx",
@@ -10473,7 +10473,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/CustomerJourneyStage.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_customerjourneystage_tsx",
-      "community": 401
+      "community": 402
     },
     {
       "label": "CustomerJourneyStageCard()",
@@ -10481,7 +10481,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/CustomerJourneyStage.tsx",
       "source_location": "L13",
       "id": "customerjourneystage_customerjourneystagecard",
-      "community": 401
+      "community": 402
     },
     {
       "label": "EngagementMetrics.tsx",
@@ -10489,7 +10489,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_engagementmetrics_tsx",
-      "community": 134
+      "community": 135
     },
     {
       "label": "formatLastActivity()",
@@ -10497,7 +10497,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
       "source_location": "L75",
       "id": "engagementmetrics_formatlastactivity",
-      "community": 134
+      "community": 135
     },
     {
       "label": "getDeviceIcon()",
@@ -10505,7 +10505,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
       "source_location": "L82",
       "id": "engagementmetrics_getdeviceicon",
-      "community": 134
+      "community": 135
     },
     {
       "label": "getDeviceLabel()",
@@ -10513,7 +10513,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
       "source_location": "L93",
       "id": "engagementmetrics_getdevicelabel",
-      "community": 134
+      "community": 135
     },
     {
       "label": "RiskIndicators.tsx",
@@ -10521,7 +10521,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
-      "community": 135
+      "community": 136
     },
     {
       "label": "getRiskIcon()",
@@ -10529,7 +10529,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
       "source_location": "L15",
       "id": "riskindicators_getriskicon",
-      "community": 135
+      "community": 136
     },
     {
       "label": "getRiskStyles()",
@@ -10537,7 +10537,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
       "source_location": "L28",
       "id": "riskindicators_getriskstyles",
-      "community": 135
+      "community": 136
     },
     {
       "label": "RiskIndicators()",
@@ -10545,7 +10545,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
       "source_location": "L54",
       "id": "riskindicators_riskindicators",
-      "community": 135
+      "community": 136
     },
     {
       "label": "UserBehaviorInsights.tsx",
@@ -10553,7 +10553,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/UserBehaviorInsights.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_userbehaviorinsights_tsx",
-      "community": 893
+      "community": 894
     },
     {
       "label": "index.ts",
@@ -10561,7 +10561,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/index.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_index_ts",
-      "community": 894
+      "community": 895
     },
     {
       "label": "config.ts",
@@ -10569,7 +10569,7 @@
       "source_file": "packages/athena-webapp/src/config.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_config_ts",
-      "community": 895
+      "community": 896
     },
     {
       "label": "OnlineOrderContext.tsx",
@@ -10577,7 +10577,7 @@
       "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_contexts_onlineordercontext_tsx",
-      "community": 206
+      "community": 208
     },
     {
       "label": "OnlineOrderProvider()",
@@ -10585,7 +10585,7 @@
       "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
       "source_location": "L24",
       "id": "onlineordercontext_onlineorderprovider",
-      "community": 206
+      "community": 208
     },
     {
       "label": "useOnlineOrder()",
@@ -10593,7 +10593,7 @@
       "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
       "source_location": "L38",
       "id": "onlineordercontext_useonlineorder",
-      "community": 206
+      "community": 208
     },
     {
       "label": "PermissionsContext.tsx",
@@ -10601,7 +10601,7 @@
       "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_contexts_permissionscontext_tsx",
-      "community": 207
+      "community": 209
     },
     {
       "label": "PermissionsProvider()",
@@ -10609,7 +10609,7 @@
       "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
       "source_location": "L23",
       "id": "permissionscontext_permissionsprovider",
-      "community": 207
+      "community": 209
     },
     {
       "label": "usePermissionsContext()",
@@ -10617,7 +10617,7 @@
       "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
       "source_location": "L51",
       "id": "permissionscontext_usepermissionscontext",
-      "community": 207
+      "community": 209
     },
     {
       "label": "ProductContext.tsx",
@@ -10625,7 +10625,7 @@
       "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_contexts_productcontext_tsx",
-      "community": 208
+      "community": 210
     },
     {
       "label": "ProductProvider()",
@@ -10633,7 +10633,7 @@
       "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
       "source_location": "L54",
       "id": "productcontext_productprovider",
-      "community": 208
+      "community": 210
     },
     {
       "label": "useProduct()",
@@ -10641,7 +10641,7 @@
       "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
       "source_location": "L282",
       "id": "productcontext_useproduct",
-      "community": 208
+      "community": 210
     },
     {
       "label": "ThemeContext.tsx",
@@ -10649,7 +10649,7 @@
       "source_file": "packages/athena-webapp/src/contexts/ThemeContext.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_contexts_themecontext_tsx",
-      "community": 896
+      "community": 897
     },
     {
       "label": "UserContext.tsx",
@@ -10657,7 +10657,7 @@
       "source_file": "packages/athena-webapp/src/contexts/UserContext.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_contexts_usercontext_tsx",
-      "community": 209
+      "community": 211
     },
     {
       "label": "UserProvider()",
@@ -10665,7 +10665,7 @@
       "source_file": "packages/athena-webapp/src/contexts/UserContext.tsx",
       "source_location": "L12",
       "id": "usercontext_userprovider",
-      "community": 209
+      "community": 211
     },
     {
       "label": "useUserContext()",
@@ -10673,7 +10673,7 @@
       "source_file": "packages/athena-webapp/src/contexts/UserContext.tsx",
       "source_location": "L37",
       "id": "usercontext_useusercontext",
-      "community": 209
+      "community": 211
     },
     {
       "label": "use-image-upload.ts",
@@ -10681,7 +10681,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-image-upload.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_use_image_upload_ts",
-      "community": 402
+      "community": 403
     },
     {
       "label": "useImageUpload()",
@@ -10689,7 +10689,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-image-upload.ts",
       "source_location": "L7",
       "id": "use_image_upload_useimageupload",
-      "community": 402
+      "community": 403
     },
     {
       "label": "use-mobile.tsx",
@@ -10697,7 +10697,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_use_mobile_tsx",
-      "community": 403
+      "community": 404
     },
     {
       "label": "useIsMobile()",
@@ -10705,7 +10705,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
       "source_location": "L5",
       "id": "use_mobile_useismobile",
-      "community": 403
+      "community": 404
     },
     {
       "label": "use-navigate-back.ts",
@@ -10713,7 +10713,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_use_navigate_back_ts",
-      "community": 404
+      "community": 405
     },
     {
       "label": "useNavigateBack()",
@@ -10721,7 +10721,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
       "source_location": "L5",
       "id": "use_navigate_back_usenavigateback",
-      "community": 404
+      "community": 405
     },
     {
       "label": "use-navigation-keyboard-shortcuts.ts",
@@ -10729,7 +10729,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-navigation-keyboard-shortcuts.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_use_navigation_keyboard_shortcuts_ts",
-      "community": 405
+      "community": 406
     },
     {
       "label": "useNavigationKeyboardShortcuts()",
@@ -10737,7 +10737,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-navigation-keyboard-shortcuts.ts",
       "source_location": "L7",
       "id": "use_navigation_keyboard_shortcuts_usenavigationkeyboardshortcuts",
-      "community": 405
+      "community": 406
     },
     {
       "label": "use-pagination-persistence.ts",
@@ -10745,7 +10745,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-pagination-persistence.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_use_pagination_persistence_ts",
-      "community": 406
+      "community": 407
     },
     {
       "label": "usePaginationPersistence()",
@@ -10753,7 +10753,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-pagination-persistence.ts",
       "source_location": "L9",
       "id": "use_pagination_persistence_usepaginationpersistence",
-      "community": 406
+      "community": 407
     },
     {
       "label": "use-store-modal.tsx",
@@ -10761,7 +10761,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-store-modal.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_use_store_modal_tsx",
-      "community": 897
+      "community": 898
     },
     {
       "label": "use-table-keyboard-pagination.ts",
@@ -10769,7 +10769,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-table-keyboard-pagination.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_use_table_keyboard_pagination_ts",
-      "community": 407
+      "community": 408
     },
     {
       "label": "useTableKeyboardPagination()",
@@ -10777,7 +10777,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-table-keyboard-pagination.ts",
       "source_location": "L6",
       "id": "use_table_keyboard_pagination_usetablekeyboardpagination",
-      "community": 407
+      "community": 408
     },
     {
       "label": "useAuth.ts",
@@ -10785,7 +10785,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useAuth.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_useauth_ts",
-      "community": 210
+      "community": 212
     },
     {
       "label": "useAuth()",
@@ -10793,7 +10793,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useAuth.ts",
       "source_location": "L4",
       "id": "useauth_useauth",
-      "community": 210
+      "community": 212
     },
     {
       "label": "useBulkOperations.test.ts",
@@ -10801,7 +10801,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usebulkoperations_test_ts",
-      "community": 408
+      "community": 409
     },
     {
       "label": "makeSku()",
@@ -10809,7 +10809,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.test.ts",
       "source_location": "L168",
       "id": "usebulkoperations_test_makesku",
-      "community": 408
+      "community": 409
     },
     {
       "label": "useBulkOperations.ts",
@@ -10817,7 +10817,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
-      "community": 63
+      "community": 64
     },
     {
       "label": "applyOperation()",
@@ -10825,7 +10825,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L56",
       "id": "usebulkoperations_applyoperation",
-      "community": 63
+      "community": 64
     },
     {
       "label": "calculatePriceWithFee()",
@@ -10833,7 +10833,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L87",
       "id": "usebulkoperations_calculatepricewithfee",
-      "community": 63
+      "community": 64
     },
     {
       "label": "computePreview()",
@@ -10841,7 +10841,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L101",
       "id": "usebulkoperations_computepreview",
-      "community": 63
+      "community": 64
     },
     {
       "label": "validateOperationValue()",
@@ -10849,7 +10849,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L139",
       "id": "usebulkoperations_validateoperationvalue",
-      "community": 63
+      "community": 64
     },
     {
       "label": "useBulkOperations()",
@@ -10857,7 +10857,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L158",
       "id": "usebulkoperations_usebulkoperations",
-      "community": 63
+      "community": 64
     },
     {
       "label": "useCartOperations.ts",
@@ -10865,7 +10865,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useCartOperations.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usecartoperations_ts",
-      "community": 409
+      "community": 410
     },
     {
       "label": "useCartOperations()",
@@ -10873,7 +10873,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useCartOperations.ts",
       "source_location": "L23",
       "id": "usecartoperations_usecartoperations",
-      "community": 409
+      "community": 410
     },
     {
       "label": "useCopyText.ts",
@@ -10881,7 +10881,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useCopyText.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usecopytext_ts",
-      "community": 410
+      "community": 411
     },
     {
       "label": "useCopyText()",
@@ -10889,7 +10889,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useCopyText.ts",
       "source_location": "L1",
       "id": "usecopytext_usecopytext",
-      "community": 410
+      "community": 411
     },
     {
       "label": "useCreateComplimentaryProduct.ts",
@@ -10897,7 +10897,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useCreateComplimentaryProduct.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usecreatecomplimentaryproduct_ts",
-      "community": 411
+      "community": 412
     },
     {
       "label": "useCreateComplimentaryProduct()",
@@ -10905,7 +10905,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useCreateComplimentaryProduct.ts",
       "source_location": "L6",
       "id": "usecreatecomplimentaryproduct_usecreatecomplimentaryproduct",
-      "community": 411
+      "community": 412
     },
     {
       "label": "useCustomerOperations.ts",
@@ -10913,7 +10913,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useCustomerOperations.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usecustomeroperations_ts",
-      "community": 412
+      "community": 413
     },
     {
       "label": "useCustomerOperations()",
@@ -10921,7 +10921,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useCustomerOperations.ts",
       "source_location": "L21",
       "id": "usecustomeroperations_usecustomeroperations",
-      "community": 412
+      "community": 413
     },
     {
       "label": "useDebounce.ts",
@@ -10929,7 +10929,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useDebounce.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usedebounce_ts",
-      "community": 413
+      "community": 414
     },
     {
       "label": "useDebounce()",
@@ -10937,7 +10937,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useDebounce.ts",
       "source_location": "L12",
       "id": "usedebounce_usedebounce",
-      "community": 413
+      "community": 414
     },
     {
       "label": "useExpenseOperations.ts",
@@ -10945,7 +10945,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
-      "community": 414
+      "community": 415
     },
     {
       "label": "useExpenseOperations()",
@@ -10953,7 +10953,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
       "source_location": "L23",
       "id": "useexpenseoperations_useexpenseoperations",
-      "community": 414
+      "community": 415
     },
     {
       "label": "useExpenseSessions.ts",
@@ -10961,7 +10961,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
-      "community": 64
+      "community": 65
     },
     {
       "label": "useExpenseStoreSessions()",
@@ -10969,7 +10969,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L7",
       "id": "useexpensesessions_useexpensestoresessions",
-      "community": 64
+      "community": 65
     },
     {
       "label": "useExpenseSession()",
@@ -10977,7 +10977,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L23",
       "id": "useexpensesessions_useexpensesession",
-      "community": 64
+      "community": 65
     },
     {
       "label": "useExpenseActiveSession()",
@@ -10985,7 +10985,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L33",
       "id": "useexpensesessions_useexpenseactivesession",
-      "community": 64
+      "community": 65
     },
     {
       "label": "useExpenseSessionCreate()",
@@ -10993,7 +10993,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L48",
       "id": "useexpensesessions_useexpensesessioncreate",
-      "community": 64
+      "community": 65
     },
     {
       "label": "useExpenseSessionUpdate()",
@@ -11001,7 +11001,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L85",
       "id": "useexpensesessions_useexpensesessionupdate",
-      "community": 64
+      "community": 65
     },
     {
       "label": "useGetActiveProduct.ts",
@@ -11009,7 +11009,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usegetactiveproduct_ts",
-      "community": 415
+      "community": 416
     },
     {
       "label": "useGetActiveProduct()",
@@ -11017,7 +11017,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
       "source_location": "L6",
       "id": "usegetactiveproduct_usegetactiveproduct",
-      "community": 415
+      "community": 416
     },
     {
       "label": "useGetActiveStore.ts",
@@ -11025,7 +11025,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetActiveStore.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usegetactivestore_ts",
-      "community": 211
+      "community": 213
     },
     {
       "label": "useGetActiveStore()",
@@ -11033,7 +11033,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetActiveStore.ts",
       "source_location": "L9",
       "id": "usegetactivestore_usegetactivestore",
-      "community": 211
+      "community": 213
     },
     {
       "label": "useGetStores()",
@@ -11041,7 +11041,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetActiveStore.ts",
       "source_location": "L50",
       "id": "usegetactivestore_usegetstores",
-      "community": 211
+      "community": 213
     },
     {
       "label": "useGetAuthedUser.ts",
@@ -11049,7 +11049,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetAuthedUser.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usegetautheduser_ts",
-      "community": 416
+      "community": 417
     },
     {
       "label": "useGetAuthedUser()",
@@ -11057,7 +11057,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetAuthedUser.ts",
       "source_location": "L4",
       "id": "usegetautheduser_usegetautheduser",
-      "community": 416
+      "community": 417
     },
     {
       "label": "useGetCategories.ts",
@@ -11065,7 +11065,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetCategories.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usegetcategories_ts",
-      "community": 417
+      "community": 418
     },
     {
       "label": "useGetCategories()",
@@ -11073,7 +11073,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetCategories.ts",
       "source_location": "L5",
       "id": "usegetcategories_usegetcategories",
-      "community": 417
+      "community": 418
     },
     {
       "label": "useGetComplimentaryProducts.ts",
@@ -11081,7 +11081,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetComplimentaryProducts.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usegetcomplimentaryproducts_ts",
-      "community": 418
+      "community": 419
     },
     {
       "label": "useGetComplimentaryProducts()",
@@ -11089,7 +11089,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetComplimentaryProducts.ts",
       "source_location": "L5",
       "id": "usegetcomplimentaryproducts_usegetcomplimentaryproducts",
-      "community": 418
+      "community": 419
     },
     {
       "label": "useGetCurrencyFormatter.ts",
@@ -11097,7 +11097,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetCurrencyFormatter.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usegetcurrencyformatter_ts",
-      "community": 419
+      "community": 420
     },
     {
       "label": "useGetCurrencyFormatter()",
@@ -11105,7 +11105,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetCurrencyFormatter.ts",
       "source_location": "L4",
       "id": "usegetcurrencyformatter_usegetcurrencyformatter",
-      "community": 419
+      "community": 420
     },
     {
       "label": "useGetOrganizations.ts",
@@ -11113,7 +11113,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usegetorganizations_ts",
-      "community": 212
+      "community": 214
     },
     {
       "label": "useGetActiveOrganization()",
@@ -11121,7 +11121,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
       "source_location": "L6",
       "id": "usegetorganizations_usegetactiveorganization",
-      "community": 212
+      "community": 214
     },
     {
       "label": "useGetOrganizations()",
@@ -11129,7 +11129,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
       "source_location": "L31",
       "id": "usegetorganizations_usegetorganizations",
-      "community": 212
+      "community": 214
     },
     {
       "label": "useGetProducts.ts",
@@ -11137,7 +11137,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usegetproducts_ts",
-      "community": 213
+      "community": 215
     },
     {
       "label": "useGetProducts()",
@@ -11145,7 +11145,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
       "source_location": "L5",
       "id": "usegetproducts_usegetproducts",
-      "community": 213
+      "community": 215
     },
     {
       "label": "useGetUnresolvedProducts()",
@@ -11153,7 +11153,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
       "source_location": "L31",
       "id": "usegetproducts_usegetunresolvedproducts",
-      "community": 213
+      "community": 215
     },
     {
       "label": "useGetSubcategories.ts",
@@ -11161,7 +11161,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetSubcategories.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usegetsubcategories_ts",
-      "community": 420
+      "community": 421
     },
     {
       "label": "useGetSubcategories()",
@@ -11169,7 +11169,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetSubcategories.ts",
       "source_location": "L5",
       "id": "usegetsubcategories_usegetsubcategories",
-      "community": 420
+      "community": 421
     },
     {
       "label": "useGetTerminal.ts",
@@ -11177,7 +11177,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetTerminal.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usegetterminal_ts",
-      "community": 421
+      "community": 422
     },
     {
       "label": "useGetTerminal()",
@@ -11185,7 +11185,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetTerminal.ts",
       "source_location": "L6",
       "id": "usegetterminal_usegetterminal",
-      "community": 421
+      "community": 422
     },
     {
       "label": "useNewOrderNotification.ts",
@@ -11193,7 +11193,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useNewOrderNotification.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usenewordernotification_ts",
-      "community": 422
+      "community": 423
     },
     {
       "label": "useNewOrderNotification()",
@@ -11201,7 +11201,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useNewOrderNotification.ts",
       "source_location": "L8",
       "id": "usenewordernotification_usenewordernotification",
-      "community": 422
+      "community": 423
     },
     {
       "label": "useOrganizationModal.tsx",
@@ -11209,7 +11209,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useOrganizationModal.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
-      "community": 898
+      "community": 899
     },
     {
       "label": "usePOSCustomers.ts",
@@ -11217,7 +11217,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_useposcustomers_ts",
-      "community": 65
+      "community": 66
     },
     {
       "label": "usePOSCustomerSearch()",
@@ -11225,7 +11225,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L7",
       "id": "useposcustomers_useposcustomersearch",
-      "community": 65
+      "community": 66
     },
     {
       "label": "usePOSCustomer()",
@@ -11233,7 +11233,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L18",
       "id": "useposcustomers_useposcustomer",
-      "community": 65
+      "community": 66
     },
     {
       "label": "usePOSCustomerCreate()",
@@ -11241,7 +11241,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L26",
       "id": "useposcustomers_useposcustomercreate",
-      "community": 65
+      "community": 66
     },
     {
       "label": "usePOSCustomerUpdate()",
@@ -11249,7 +11249,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L57",
       "id": "useposcustomers_useposcustomerupdate",
-      "community": 65
+      "community": 66
     },
     {
       "label": "usePOSCustomerTransactions()",
@@ -11257,7 +11257,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L90",
       "id": "useposcustomers_useposcustomertransactions",
-      "community": 65
+      "community": 66
     },
     {
       "label": "usePOSOperations.ts",
@@ -11265,7 +11265,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSOperations.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_useposoperations_ts",
-      "community": 214
+      "community": 216
     },
     {
       "label": "usePOSOperations()",
@@ -11273,7 +11273,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSOperations.ts",
       "source_location": "L30",
       "id": "useposoperations_useposoperations",
-      "community": 214
+      "community": 216
     },
     {
       "label": "usePOSState()",
@@ -11281,7 +11281,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSOperations.ts",
       "source_location": "L580",
       "id": "useposoperations_useposstate",
-      "community": 214
+      "community": 216
     },
     {
       "label": "usePOSProducts.ts",
@@ -11289,7 +11289,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
-      "community": 97
+      "community": 98
     },
     {
       "label": "usePOSProductSearch()",
@@ -11297,7 +11297,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L10",
       "id": "useposproducts_useposproductsearch",
-      "community": 97
+      "community": 98
     },
     {
       "label": "usePOSBarcodeSearch()",
@@ -11305,7 +11305,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L30",
       "id": "useposproducts_useposbarcodesearch",
-      "community": 97
+      "community": 98
     },
     {
       "label": "usePOSProductIdSearch()",
@@ -11313,7 +11313,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L41",
       "id": "useposproducts_useposproductidsearch",
-      "community": 97
+      "community": 98
     },
     {
       "label": "usePOSTransactionComplete()",
@@ -11321,7 +11321,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L100",
       "id": "useposproducts_usepostransactioncomplete",
-      "community": 97
+      "community": 98
     },
     {
       "label": "usePOSSessions.ts",
@@ -11417,7 +11417,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePermissions.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usepermissions_ts",
-      "community": 423
+      "community": 424
     },
     {
       "label": "usePermissions()",
@@ -11425,7 +11425,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePermissions.ts",
       "source_location": "L12",
       "id": "usepermissions_usepermissions",
-      "community": 423
+      "community": 424
     },
     {
       "label": "usePrint.ts",
@@ -11433,7 +11433,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_useprint_ts",
-      "community": 424
+      "community": 425
     },
     {
       "label": "usePrint()",
@@ -11441,7 +11441,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
       "source_location": "L3",
       "id": "useprint_useprint",
-      "community": 424
+      "community": 425
     },
     {
       "label": "useProductSearchResults.ts",
@@ -11449,7 +11449,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_useproductsearchresults_ts",
-      "community": 425
+      "community": 426
     },
     {
       "label": "useProductSearchResults()",
@@ -11457,7 +11457,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
       "source_location": "L26",
       "id": "useproductsearchresults_useproductsearchresults",
-      "community": 425
+      "community": 426
     },
     {
       "label": "useProductWithNoImagesNotification.tsx",
@@ -11465,7 +11465,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useProductWithNoImagesNotification.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_useproductwithnoimagesnotification_tsx",
-      "community": 426
+      "community": 427
     },
     {
       "label": "useProductWithNoImagesNotification()",
@@ -11473,7 +11473,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useProductWithNoImagesNotification.tsx",
       "source_location": "L7",
       "id": "useproductwithnoimagesnotification_useproductwithnoimagesnotification",
-      "community": 426
+      "community": 427
     },
     {
       "label": "useSessionManagement.ts",
@@ -11481,7 +11481,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSessionManagement.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usesessionmanagement_ts",
-      "community": 427
+      "community": 428
     },
     {
       "label": "useSessionManagement()",
@@ -11489,7 +11489,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSessionManagement.ts",
       "source_location": "L17",
       "id": "usesessionmanagement_usesessionmanagement",
-      "community": 427
+      "community": 428
     },
     {
       "label": "useSessionManagementExpense.ts",
@@ -11497,7 +11497,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSessionManagementExpense.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usesessionmanagementexpense_ts",
-      "community": 428
+      "community": 429
     },
     {
       "label": "useSessionManagementExpense()",
@@ -11505,7 +11505,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSessionManagementExpense.ts",
       "source_location": "L17",
       "id": "usesessionmanagementexpense_usesessionmanagementexpense",
-      "community": 428
+      "community": 429
     },
     {
       "label": "useSessionManagerOperations.ts",
@@ -11513,7 +11513,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSessionManagerOperations.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usesessionmanageroperations_ts",
-      "community": 429
+      "community": 430
     },
     {
       "label": "useSessionManagerOperations()",
@@ -11521,7 +11521,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSessionManagerOperations.ts",
       "source_location": "L16",
       "id": "usesessionmanageroperations_usesessionmanageroperations",
-      "community": 429
+      "community": 430
     },
     {
       "label": "useSkusReservedInCheckout.ts",
@@ -11529,7 +11529,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSkusReservedInCheckout.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_useskusreservedincheckout_ts",
-      "community": 430
+      "community": 431
     },
     {
       "label": "useSkusReservedInCheckout()",
@@ -11537,7 +11537,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSkusReservedInCheckout.ts",
       "source_location": "L12",
       "id": "useskusreservedincheckout_useskusreservedincheckout",
-      "community": 430
+      "community": 431
     },
     {
       "label": "useSkusReservedInPosSession.ts",
@@ -11545,7 +11545,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSkusReservedInPosSession.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_useskusreservedinpossession_ts",
-      "community": 431
+      "community": 432
     },
     {
       "label": "useSkusReservedInPosSession()",
@@ -11553,7 +11553,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSkusReservedInPosSession.ts",
       "source_location": "L12",
       "id": "useskusreservedinpossession_useskusreservedinpossession",
-      "community": 431
+      "community": 432
     },
     {
       "label": "useToggleComplimentaryProductActive.ts",
@@ -11561,7 +11561,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useToggleComplimentaryProductActive.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usetogglecomplimentaryproductactive_ts",
-      "community": 432
+      "community": 433
     },
     {
       "label": "useToggleComplimentaryProductActive()",
@@ -11569,7 +11569,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useToggleComplimentaryProductActive.ts",
       "source_location": "L5",
       "id": "usetogglecomplimentaryproductactive_usetogglecomplimentaryproductactive",
-      "community": 432
+      "community": 433
     },
     {
       "label": "aws.ts",
@@ -11577,7 +11577,7 @@
       "source_file": "packages/athena-webapp/src/lib/aws.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_aws_ts",
-      "community": 899
+      "community": 900
     },
     {
       "label": "behaviorUtils.ts",
@@ -11585,7 +11585,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
-      "community": 66
+      "community": 67
     },
     {
       "label": "getCustomerJourneyStage()",
@@ -11593,7 +11593,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L36",
       "id": "behaviorutils_getcustomerjourneystage",
-      "community": 66
+      "community": 67
     },
     {
       "label": "calculateRiskIndicators()",
@@ -11601,7 +11601,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L71",
       "id": "behaviorutils_calculateriskindicators",
-      "community": 66
+      "community": 67
     },
     {
       "label": "calculateEngagementMetrics()",
@@ -11609,7 +11609,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L173",
       "id": "behaviorutils_calculateengagementmetrics",
-      "community": 66
+      "community": 67
     },
     {
       "label": "getActivityPriority()",
@@ -11617,7 +11617,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L251",
       "id": "behaviorutils_getactivitypriority",
-      "community": 66
+      "community": 67
     },
     {
       "label": "getJourneyStageInfo()",
@@ -11625,7 +11625,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L277",
       "id": "behaviorutils_getjourneystageinfo",
-      "community": 66
+      "community": 67
     },
     {
       "label": "browserFingerprint.ts",
@@ -11633,7 +11633,7 @@
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_browserfingerprint_ts",
-      "community": 98
+      "community": 99
     },
     {
       "label": "bufferToHex()",
@@ -11641,7 +11641,7 @@
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
       "source_location": "L18",
       "id": "browserfingerprint_buffertohex",
-      "community": 98
+      "community": 99
     },
     {
       "label": "collectBrowserInfo()",
@@ -11649,7 +11649,7 @@
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
       "source_location": "L23",
       "id": "browserfingerprint_collectbrowserinfo",
-      "community": 98
+      "community": 99
     },
     {
       "label": "hashFingerprintSource()",
@@ -11657,7 +11657,7 @@
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
       "source_location": "L45",
       "id": "browserfingerprint_hashfingerprintsource",
-      "community": 98
+      "community": 99
     },
     {
       "label": "generateBrowserFingerprint()",
@@ -11665,7 +11665,7 @@
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
       "source_location": "L65",
       "id": "browserfingerprint_generatebrowserfingerprint",
-      "community": 98
+      "community": 99
     },
     {
       "label": "constants.ts",
@@ -11673,7 +11673,7 @@
       "source_file": "packages/athena-webapp/src/lib/constants.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_constants_ts",
-      "community": 900
+      "community": 901
     },
     {
       "label": "countries.ts",
@@ -11681,7 +11681,7 @@
       "source_file": "packages/athena-webapp/src/lib/countries.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_countries_ts",
-      "community": 901
+      "community": 902
     },
     {
       "label": "customerObservabilityTimeline.ts",
@@ -11689,7 +11689,7 @@
       "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_customerobservabilitytimeline_ts",
-      "community": 136
+      "community": 137
     },
     {
       "label": "formatObservabilityLabel()",
@@ -11697,7 +11697,7 @@
       "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
       "source_location": "L59",
       "id": "customerobservabilitytimeline_formatobservabilitylabel",
-      "community": 136
+      "community": 137
     },
     {
       "label": "getObservabilityStatusStyles()",
@@ -11705,7 +11705,7 @@
       "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
       "source_location": "L67",
       "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
-      "community": 136
+      "community": 137
     },
     {
       "label": "getDeviceIcon()",
@@ -11713,7 +11713,7 @@
       "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
       "source_location": "L114",
       "id": "customerobservabilitytimeline_getdeviceicon",
-      "community": 136
+      "community": 137
     },
     {
       "label": "ghana.ts",
@@ -11721,7 +11721,7 @@
       "source_file": "packages/athena-webapp/src/lib/ghana.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_ghana_ts",
-      "community": 902
+      "community": 903
     },
     {
       "label": "ghanaRegions.ts",
@@ -11729,7 +11729,7 @@
       "source_file": "packages/athena-webapp/src/lib/ghanaRegions.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_ghanaregions_ts",
-      "community": 903
+      "community": 904
     },
     {
       "label": "imageUtils.test.ts",
@@ -11737,7 +11737,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_imageutils_test_ts",
-      "community": 99
+      "community": 100
     },
     {
       "label": "constructor()",
@@ -11745,7 +11745,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
       "source_location": "L74",
       "id": "imageutils_test_constructor",
-      "community": 99
+      "community": 100
     },
     {
       "label": "arrayBuffer()",
@@ -11753,7 +11753,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
       "source_location": "L78",
       "id": "imageutils_test_arraybuffer",
-      "community": 99
+      "community": 100
     },
     {
       "label": "MockImage",
@@ -11761,7 +11761,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
       "source_location": "L103",
       "id": "imageutils_test_mockimage",
-      "community": 99
+      "community": 100
     },
     {
       "label": ".src()",
@@ -11769,7 +11769,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
       "source_location": "L109",
       "id": "imageutils_test_mockimage_src",
-      "community": 99
+      "community": 100
     },
     {
       "label": "imageUtils.ts",
@@ -11777,7 +11777,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_imageutils_ts",
-      "community": 100
+      "community": 101
     },
     {
       "label": "getUploadImagesData()",
@@ -11785,7 +11785,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
       "source_location": "L4",
       "id": "imageutils_getuploadimagesdata",
-      "community": 100
+      "community": 101
     },
     {
       "label": "convertImagesToWebp()",
@@ -11793,7 +11793,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
       "source_location": "L26",
       "id": "imageutils_convertimagestowebp",
-      "community": 100
+      "community": 101
     },
     {
       "label": "convertToJpg()",
@@ -11801,7 +11801,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
       "source_location": "L38",
       "id": "imageutils_converttojpg",
-      "community": 100
+      "community": 101
     },
     {
       "label": "convertImagesToJpg()",
@@ -11809,7 +11809,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
       "source_location": "L75",
       "id": "imageutils_convertimagestojpg",
-      "community": 100
+      "community": 101
     },
     {
       "label": "logger.ts",
@@ -11889,7 +11889,7 @@
       "source_file": "packages/athena-webapp/src/lib/maintenanceUtils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_maintenanceutils_ts",
-      "community": 215
+      "community": 217
     },
     {
       "label": "isInMaintenanceMode()",
@@ -11897,7 +11897,7 @@
       "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.ts",
       "source_location": "L7",
       "id": "maintenanceutils_isinmaintenancemode",
-      "community": 215
+      "community": 217
     },
     {
       "label": "navigationUtils.ts",
@@ -11905,7 +11905,7 @@
       "source_file": "packages/athena-webapp/src/lib/navigationUtils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_navigationutils_ts",
-      "community": 433
+      "community": 434
     },
     {
       "label": "getOrigin()",
@@ -11913,7 +11913,7 @@
       "source_file": "packages/athena-webapp/src/lib/navigationUtils.ts",
       "source_location": "L1",
       "id": "navigationutils_getorigin",
-      "community": 433
+      "community": 434
     },
     {
       "label": "barcodeUtils.ts",
@@ -11921,7 +11921,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_pos_barcodeutils_ts",
-      "community": 137
+      "community": 138
     },
     {
       "label": "isValidConvexId()",
@@ -11929,7 +11929,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
       "source_location": "L16",
       "id": "barcodeutils_isvalidconvexid",
-      "community": 137
+      "community": 138
     },
     {
       "label": "extractBarcodeFromInput()",
@@ -11937,7 +11937,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
       "source_location": "L51",
       "id": "barcodeutils_extractbarcodefrominput",
-      "community": 137
+      "community": 138
     },
     {
       "label": "isUrlOrBarcode()",
@@ -11945,7 +11945,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
       "source_location": "L92",
       "id": "barcodeutils_isurlorbarcode",
-      "community": 137
+      "community": 138
     },
     {
       "label": "calculations.ts",
@@ -11953,7 +11953,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/calculations.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_pos_calculations_ts",
-      "community": 434
+      "community": 435
     },
     {
       "label": "calculateCartTotals()",
@@ -11961,7 +11961,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/calculations.ts",
       "source_location": "L10",
       "id": "calculations_calculatecarttotals",
-      "community": 434
+      "community": 435
     },
     {
       "label": "constants.ts",
@@ -11969,7 +11969,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/constants.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_pos_constants_ts",
-      "community": 904
+      "community": 905
     },
     {
       "label": "calculationService.ts",
@@ -12033,7 +12033,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
-      "community": 67
+      "community": 68
     },
     {
       "label": "handlePOSOperation()",
@@ -12041,7 +12041,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L171",
       "id": "toastservice_handleposoperation",
-      "community": 67
+      "community": 68
     },
     {
       "label": "showValidationError()",
@@ -12049,7 +12049,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L293",
       "id": "toastservice_showvalidationerror",
-      "community": 67
+      "community": 68
     },
     {
       "label": "showInventoryError()",
@@ -12057,7 +12057,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L302",
       "id": "toastservice_showinventoryerror",
-      "community": 67
+      "community": 68
     },
     {
       "label": "showSessionExpiredError()",
@@ -12065,7 +12065,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L312",
       "id": "toastservice_showsessionexpirederror",
-      "community": 67
+      "community": 68
     },
     {
       "label": "showNoActiveSessionError()",
@@ -12073,7 +12073,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L319",
       "id": "toastservice_shownoactivesessionerror",
-      "community": 67
+      "community": 68
     },
     {
       "label": "transactionUtils.ts",
@@ -12081,7 +12081,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_pos_transactionutils_ts",
-      "community": 101
+      "community": 102
     },
     {
       "label": "generateTransactionNumber()",
@@ -12089,7 +12089,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
       "source_location": "L14",
       "id": "transactionutils_generatetransactionnumber",
-      "community": 101
+      "community": 102
     },
     {
       "label": "formatCurrency()",
@@ -12097,7 +12097,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
       "source_location": "L29",
       "id": "transactionutils_formatcurrency",
-      "community": 101
+      "community": 102
     },
     {
       "label": "calculateChange()",
@@ -12105,7 +12105,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
       "source_location": "L42",
       "id": "transactionutils_calculatechange",
-      "community": 101
+      "community": 102
     },
     {
       "label": "formatTimestamp()",
@@ -12113,7 +12113,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
       "source_location": "L49",
       "id": "transactionutils_formattimestamp",
-      "community": 101
+      "community": 102
     },
     {
       "label": "validation.ts",
@@ -12225,7 +12225,7 @@
       "source_file": "packages/athena-webapp/src/lib/productUtils.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_productutils_test_ts",
-      "community": 905
+      "community": 906
     },
     {
       "label": "productUtils.ts",
@@ -12233,7 +12233,7 @@
       "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "community": 49
+      "community": 47
     },
     {
       "label": "getProductName()",
@@ -12241,7 +12241,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L18",
       "id": "productutils_getproductname",
-      "community": 49
+      "community": 47
     },
     {
       "label": "sortProduct()",
@@ -12249,7 +12249,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L66",
       "id": "productutils_sortproduct",
-      "community": 49
+      "community": 47
     },
     {
       "label": "category.ts",
@@ -12257,7 +12257,7 @@
       "source_file": "packages/athena-webapp/src/lib/schemas/category.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_schemas_category_ts",
-      "community": 906
+      "community": 907
     },
     {
       "label": "product.ts",
@@ -12265,7 +12265,7 @@
       "source_file": "packages/athena-webapp/src/lib/schemas/product.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_schemas_product_ts",
-      "community": 907
+      "community": 908
     },
     {
       "label": "store.ts",
@@ -12273,7 +12273,7 @@
       "source_file": "packages/athena-webapp/src/lib/schemas/store.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_schemas_store_ts",
-      "community": 908
+      "community": 909
     },
     {
       "label": "subcategory.ts",
@@ -12281,7 +12281,7 @@
       "source_file": "packages/athena-webapp/src/lib/schemas/subcategory.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_schemas_subcategory_ts",
-      "community": 909
+      "community": 910
     },
     {
       "label": "user.ts",
@@ -12289,7 +12289,7 @@
       "source_file": "packages/athena-webapp/src/lib/schemas/user.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_schemas_user_ts",
-      "community": 910
+      "community": 911
     },
     {
       "label": "pinHash.ts",
@@ -12297,7 +12297,7 @@
       "source_file": "packages/athena-webapp/src/lib/security/pinHash.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_security_pinhash_ts",
-      "community": 435
+      "community": 436
     },
     {
       "label": "hashPin()",
@@ -12305,7 +12305,7 @@
       "source_file": "packages/athena-webapp/src/lib/security/pinHash.ts",
       "source_location": "L12",
       "id": "pinhash_hashpin",
-      "community": 435
+      "community": 436
     },
     {
       "label": "storeConfig.test.ts",
@@ -12313,7 +12313,7 @@
       "source_file": "packages/athena-webapp/src/lib/storeConfig.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_storeconfig_test_ts",
-      "community": 911
+      "community": 912
     },
     {
       "label": "storeConfig.ts",
@@ -12457,7 +12457,7 @@
       "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_timelineutils_ts",
-      "community": 102
+      "community": 103
     },
     {
       "label": "enrichTimelineEvent()",
@@ -12465,7 +12465,7 @@
       "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
       "source_location": "L184",
       "id": "timelineutils_enrichtimelineevent",
-      "community": 102
+      "community": 103
     },
     {
       "label": "enrichTimelineEvents()",
@@ -12473,7 +12473,7 @@
       "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
       "source_location": "L200",
       "id": "timelineutils_enrichtimelineevents",
-      "community": 102
+      "community": 103
     },
     {
       "label": "groupEventsByTimeframe()",
@@ -12481,7 +12481,7 @@
       "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
       "source_location": "L206",
       "id": "timelineutils_groupeventsbytimeframe",
-      "community": 102
+      "community": 103
     },
     {
       "label": "getTimeRangeLabel()",
@@ -12489,7 +12489,7 @@
       "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
       "source_location": "L244",
       "id": "timelineutils_gettimerangelabel",
-      "community": 102
+      "community": 103
     },
     {
       "label": "utils.test.ts",
@@ -12497,7 +12497,7 @@
       "source_file": "packages/athena-webapp/src/lib/utils.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_utils_test_ts",
-      "community": 912
+      "community": 913
     },
     {
       "label": "utils.ts",
@@ -12577,7 +12577,7 @@
       "source_file": "packages/athena-webapp/src/main.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_main_tsx",
-      "community": 216
+      "community": 218
     },
     {
       "label": "App()",
@@ -12585,7 +12585,7 @@
       "source_file": "packages/storefront-webapp/src/main.tsx",
       "source_location": "L38",
       "id": "main_app",
-      "community": 216
+      "community": 218
     },
     {
       "label": "routeTree.gen.ts",
@@ -12593,7 +12593,7 @@
       "source_file": "packages/athena-webapp/src/routeTree.gen.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routetree_gen_ts",
-      "community": 913
+      "community": 914
     },
     {
       "label": "__root.tsx",
@@ -12601,7 +12601,7 @@
       "source_file": "packages/athena-webapp/src/routes/__root.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_root_tsx",
-      "community": 914
+      "community": 915
     },
     {
       "label": "index.tsx",
@@ -12609,7 +12609,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_index_tsx",
-      "community": 915
+      "community": 916
     },
     {
       "label": "index.tsx",
@@ -12617,7 +12617,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_index_tsx",
-      "community": 916
+      "community": 917
     },
     {
       "label": "index.tsx",
@@ -12625,7 +12625,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/organization/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
-      "community": 917
+      "community": 918
     },
     {
       "label": "$storeUrlSlug.tsx",
@@ -12633,7 +12633,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/stores/$storeUrlSlug.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_stores_storeurlslug_tsx",
-      "community": 918
+      "community": 919
     },
     {
       "label": "analytics.tsx",
@@ -12641,7 +12641,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/analytics.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_analytics_tsx",
-      "community": 919
+      "community": 920
     },
     {
       "label": "assets.index.tsx",
@@ -12649,7 +12649,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/assets.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_assets_index_tsx",
-      "community": 920
+      "community": 921
     },
     {
       "label": "bags.$bagId.tsx",
@@ -12657,7 +12657,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.$bagId.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_bagid_tsx",
-      "community": 921
+      "community": 922
     },
     {
       "label": "bags.index.tsx",
@@ -12665,7 +12665,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_index_tsx",
-      "community": 922
+      "community": 923
     },
     {
       "label": "index.tsx",
@@ -12673,7 +12673,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bulk-operations/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bulk_operations_index_tsx",
-      "community": 923
+      "community": 924
     },
     {
       "label": "checkout-sessions.index.tsx",
@@ -12681,7 +12681,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/checkout-sessions.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_checkout_sessions_index_tsx",
-      "community": 924
+      "community": 925
     },
     {
       "label": "configuration.index.tsx",
@@ -12689,7 +12689,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/configuration.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_configuration_index_tsx",
-      "community": 925
+      "community": 926
     },
     {
       "label": "dashboard.index.tsx",
@@ -12697,7 +12697,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/dashboard.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
-      "community": 926
+      "community": 927
     },
     {
       "label": "home.tsx",
@@ -12705,7 +12705,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/home.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
-      "community": 927
+      "community": 928
     },
     {
       "label": "index.tsx",
@@ -12713,7 +12713,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_index_tsx",
-      "community": 436
+      "community": 437
     },
     {
       "label": "StoreRootRedirect()",
@@ -12721,7 +12721,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/index.tsx",
       "source_location": "L13",
       "id": "index_storerootredirect",
-      "community": 436
+      "community": 437
     },
     {
       "label": "logs.$logId.tsx",
@@ -12729,7 +12729,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.$logId.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_logid_tsx",
-      "community": 928
+      "community": 929
     },
     {
       "label": "logs.index.tsx",
@@ -12737,7 +12737,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_index_tsx",
-      "community": 929
+      "community": 930
     },
     {
       "label": "members.index.tsx",
@@ -12745,7 +12745,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/members.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_members_index_tsx",
-      "community": 930
+      "community": 931
     },
     {
       "label": "index.tsx",
@@ -12753,7 +12753,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/$orderSlug/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_orderslug_index_tsx",
-      "community": 931
+      "community": 932
     },
     {
       "label": "all.index.tsx",
@@ -12761,7 +12761,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/all.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_all_index_tsx",
-      "community": 932
+      "community": 933
     },
     {
       "label": "cancelled.index.tsx",
@@ -12769,7 +12769,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/cancelled.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_cancelled_index_tsx",
-      "community": 933
+      "community": 934
     },
     {
       "label": "completed.index.tsx",
@@ -12777,7 +12777,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/completed.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
-      "community": 934
+      "community": 935
     },
     {
       "label": "index.tsx",
@@ -12785,7 +12785,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_index_tsx",
-      "community": 935
+      "community": 936
     },
     {
       "label": "open.index.tsx",
@@ -12793,7 +12793,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/open.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
-      "community": 936
+      "community": 937
     },
     {
       "label": "out-for-delivery.index.tsx",
@@ -12801,7 +12801,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/out-for-delivery.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_out_for_delivery_index_tsx",
-      "community": 937
+      "community": 938
     },
     {
       "label": "ready.index.tsx",
@@ -12809,7 +12809,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/ready.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
-      "community": 938
+      "community": 939
     },
     {
       "label": "refunded.index.tsx",
@@ -12817,7 +12817,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/refunded.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
-      "community": 939
+      "community": 940
     },
     {
       "label": "$reportId.tsx",
@@ -12825,7 +12825,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports/$reportId.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
-      "community": 940
+      "community": 941
     },
     {
       "label": "expense-reports.index.tsx",
@@ -12833,7 +12833,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
-      "community": 941
+      "community": 942
     },
     {
       "label": "expense.index.tsx",
@@ -12841,7 +12841,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_index_tsx",
-      "community": 942
+      "community": 943
     },
     {
       "label": "index.tsx",
@@ -12849,7 +12849,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_index_tsx",
-      "community": 943
+      "community": 944
     },
     {
       "label": "register.index.tsx",
@@ -12857,7 +12857,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/register.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
-      "community": 944
+      "community": 945
     },
     {
       "label": "settings.index.tsx",
@@ -12865,7 +12865,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/settings.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_settings_index_tsx",
-      "community": 945
+      "community": 946
     },
     {
       "label": "$transactionId.tsx",
@@ -12873,7 +12873,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
-      "community": 946
+      "community": 947
     },
     {
       "label": "transactions.index.tsx",
@@ -12881,7 +12881,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
-      "community": 947
+      "community": 948
     },
     {
       "label": "edit.tsx",
@@ -12889,7 +12889,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/edit.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_edit_tsx",
-      "community": 948
+      "community": 949
     },
     {
       "label": "index.tsx",
@@ -12897,7 +12897,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_index_tsx",
-      "community": 949
+      "community": 950
     },
     {
       "label": "index.tsx",
@@ -12905,7 +12905,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_index_tsx",
-      "community": 950
+      "community": 951
     },
     {
       "label": "new.tsx",
@@ -12913,7 +12913,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/new.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_new_tsx",
-      "community": 951
+      "community": 952
     },
     {
       "label": "index.tsx",
@@ -12921,7 +12921,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_index_tsx",
-      "community": 952
+      "community": 953
     },
     {
       "label": "new.tsx",
@@ -12929,7 +12929,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/new.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_new_tsx",
-      "community": 953
+      "community": 954
     },
     {
       "label": "unresolved.tsx",
@@ -12937,7 +12937,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/unresolved.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_unresolved_tsx",
-      "community": 954
+      "community": 955
     },
     {
       "label": "$promoCodeSlug.tsx",
@@ -12945,7 +12945,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/$promoCodeSlug.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
-      "community": 955
+      "community": 956
     },
     {
       "label": "index.tsx",
@@ -12953,7 +12953,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
-      "community": 956
+      "community": 957
     },
     {
       "label": "new.tsx",
@@ -12961,7 +12961,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/new.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
-      "community": 957
+      "community": 958
     },
     {
       "label": "index.tsx",
@@ -12969,7 +12969,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_index_tsx",
-      "community": 958
+      "community": 959
     },
     {
       "label": "new.index.tsx",
@@ -12977,7 +12977,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/new.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_new_index_tsx",
-      "community": 959
+      "community": 960
     },
     {
       "label": "published.index.tsx",
@@ -12985,7 +12985,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/published.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_published_index_tsx",
-      "community": 437
+      "community": 438
     },
     {
       "label": "RouteComponent()",
@@ -12993,7 +12993,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/published.index.tsx",
       "source_location": "L9",
       "id": "published_index_routecomponent",
-      "community": 437
+      "community": 438
     },
     {
       "label": "users.$userId.tsx",
@@ -13001,7 +13001,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/users.$userId.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_users_userid_tsx",
-      "community": 960
+      "community": 961
     },
     {
       "label": "index.tsx",
@@ -13009,7 +13009,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_index_tsx",
-      "community": 961
+      "community": 962
     },
     {
       "label": "_authed.tsx",
@@ -13017,7 +13017,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_tsx",
-      "community": 217
+      "community": 219
     },
     {
       "label": "AuthedComponent()",
@@ -13025,7 +13025,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed.tsx",
       "source_location": "L18",
       "id": "authed_authedcomponent",
-      "community": 217
+      "community": 219
     },
     {
       "label": "Layout()",
@@ -13033,7 +13033,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed.tsx",
       "source_location": "L38",
       "id": "authed_layout",
-      "community": 217
+      "community": 219
     },
     {
       "label": "index.tsx",
@@ -13041,7 +13041,7 @@
       "source_file": "packages/athena-webapp/src/routes/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_index_tsx",
-      "community": 438
+      "community": 439
     },
     {
       "label": "Index()",
@@ -13049,7 +13049,7 @@
       "source_file": "packages/athena-webapp/src/routes/index.tsx",
       "source_location": "L13",
       "id": "index_index",
-      "community": 438
+      "community": 439
     },
     {
       "label": "join-team.index.tsx",
@@ -13057,7 +13057,7 @@
       "source_file": "packages/athena-webapp/src/routes/join-team.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_join_team_index_tsx",
-      "community": 962
+      "community": 963
     },
     {
       "label": "_layout.index.tsx",
@@ -13065,7 +13065,7 @@
       "source_file": "packages/athena-webapp/src/routes/login/_layout.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_login_layout_index_tsx",
-      "community": 963
+      "community": 964
     },
     {
       "label": "_layout.tsx",
@@ -13073,7 +13073,7 @@
       "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_login_layout_tsx",
-      "community": 439
+      "community": 440
     },
     {
       "label": "LoginLayout()",
@@ -13081,7 +13081,7 @@
       "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
       "source_location": "L36",
       "id": "layout_loginlayout",
-      "community": 439
+      "community": 440
     },
     {
       "label": "OrganizationSettingsView.tsx",
@@ -13089,7 +13089,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
-      "community": 68
+      "community": 69
     },
     {
       "label": "OrganizationSettings()",
@@ -13097,7 +13097,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L24",
       "id": "organizationsettingsview_organizationsettings",
-      "community": 68
+      "community": 69
     },
     {
       "label": "saveStoreChanges()",
@@ -13105,7 +13105,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L71",
       "id": "organizationsettingsview_savestorechanges",
-      "community": 68
+      "community": 69
     },
     {
       "label": "onSubmit()",
@@ -13113,7 +13113,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L105",
       "id": "organizationsettingsview_onsubmit",
-      "community": 68
+      "community": 69
     },
     {
       "label": "handleDeleteStore()",
@@ -13121,7 +13121,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L156",
       "id": "organizationsettingsview_handledeletestore",
-      "community": 68
+      "community": 69
     },
     {
       "label": "Navigation()",
@@ -13129,7 +13129,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L198",
       "id": "organizationsettingsview_navigation",
-      "community": 68
+      "community": 69
     },
     {
       "label": "OrganizationsSettingsAccordion.tsx",
@@ -13137,7 +13137,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationsSettingsAccordion.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationssettingsaccordion_tsx",
-      "community": 440
+      "community": 441
     },
     {
       "label": "OrganizationSettingsAccordion()",
@@ -13145,7 +13145,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationsSettingsAccordion.tsx",
       "source_location": "L13",
       "id": "organizationssettingsaccordion_organizationsettingsaccordion",
-      "community": 440
+      "community": 441
     },
     {
       "label": "StoreSettingsView.tsx",
@@ -13153,7 +13153,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
-      "community": 69
+      "community": 70
     },
     {
       "label": "StoreSettings()",
@@ -13161,7 +13161,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L28",
       "id": "storesettingsview_storesettings",
-      "community": 69
+      "community": 70
     },
     {
       "label": "saveStoreChanges()",
@@ -13169,7 +13169,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L82",
       "id": "storesettingsview_savestorechanges",
-      "community": 69
+      "community": 70
     },
     {
       "label": "onSubmit()",
@@ -13177,7 +13177,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L116",
       "id": "storesettingsview_onsubmit",
-      "community": 69
+      "community": 70
     },
     {
       "label": "handleDeleteStore()",
@@ -13185,7 +13185,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L167",
       "id": "storesettingsview_handledeletestore",
-      "community": 69
+      "community": 70
     },
     {
       "label": "handleDeleteAllProductsInStore()",
@@ -13193,7 +13193,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L232",
       "id": "storesettingsview_handledeleteallproductsinstore",
-      "community": 69
+      "community": 70
     },
     {
       "label": "StoresSettingsAccordion.tsx",
@@ -13201,7 +13201,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoresSettingsAccordion.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_settings_store_storessettingsaccordion_tsx",
-      "community": 964
+      "community": 965
     },
     {
       "label": "expenseStore.ts",
@@ -13209,7 +13209,7 @@
       "source_file": "packages/athena-webapp/src/stores/expenseStore.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_stores_expensestore_ts",
-      "community": 965
+      "community": 966
     },
     {
       "label": "posStore.ts",
@@ -13217,7 +13217,7 @@
       "source_file": "packages/athena-webapp/src/stores/posStore.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_stores_posstore_ts",
-      "community": 966
+      "community": 967
     },
     {
       "label": "setup.ts",
@@ -13225,7 +13225,7 @@
       "source_file": "packages/athena-webapp/src/test/setup.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_test_setup_ts",
-      "community": 967
+      "community": 968
     },
     {
       "label": "backend.test.ts",
@@ -13321,7 +13321,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/inventoryValidationLogic.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_tests_pos_inventoryvalidationlogic_test_ts",
-      "community": 218
+      "community": 220
     },
     {
       "label": "validateInventoryForTransaction()",
@@ -13329,7 +13329,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/inventoryValidationLogic.test.ts",
       "source_location": "L20",
       "id": "inventoryvalidationlogic_test_validateinventoryfortransaction",
-      "community": 218
+      "community": 220
     },
     {
       "label": "mockGetSku()",
@@ -13337,7 +13337,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/inventoryValidationLogic.test.ts",
       "source_location": "L66",
       "id": "inventoryvalidationlogic_test_mockgetsku",
-      "community": 218
+      "community": 220
     },
     {
       "label": "simple.test.ts",
@@ -13425,7 +13425,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/usePrint.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_tests_pos_useprint_test_ts",
-      "community": 968
+      "community": 969
     },
     {
       "label": "formatNumber.ts",
@@ -13433,7 +13433,7 @@
       "source_file": "packages/athena-webapp/src/utils/formatNumber.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_utils_formatnumber_ts",
-      "community": 441
+      "community": 442
     },
     {
       "label": "formatNumber()",
@@ -13441,7 +13441,7 @@
       "source_file": "packages/athena-webapp/src/utils/formatNumber.ts",
       "source_location": "L1",
       "id": "formatnumber_formatnumber",
-      "community": 441
+      "community": 442
     },
     {
       "label": "index.ts",
@@ -13449,7 +13449,7 @@
       "source_file": "packages/athena-webapp/src/utils/index.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_utils_index_ts",
-      "community": 219
+      "community": 221
     },
     {
       "label": "hashPassword()",
@@ -13457,7 +13457,7 @@
       "source_file": "packages/storefront-webapp/src/utils/index.ts",
       "source_location": "L1",
       "id": "index_hashpassword",
-      "community": 219
+      "community": 221
     },
     {
       "label": "session.ts",
@@ -13465,7 +13465,7 @@
       "source_file": "packages/athena-webapp/src/utils/session.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_utils_session_ts",
-      "community": 220
+      "community": 222
     },
     {
       "label": "useAppSession()",
@@ -13473,7 +13473,7 @@
       "source_file": "packages/storefront-webapp/src/utils/session.ts",
       "source_location": "L8",
       "id": "session_useappsession",
-      "community": 220
+      "community": 222
     },
     {
       "label": "versionChecker.ts",
@@ -13481,7 +13481,7 @@
       "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_utils_versionchecker_ts",
-      "community": 221
+      "community": 223
     },
     {
       "label": "createVersionChecker()",
@@ -13489,7 +13489,7 @@
       "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
       "source_location": "L16",
       "id": "versionchecker_createversionchecker",
-      "community": 221
+      "community": 223
     },
     {
       "label": "tailwind.config.js",
@@ -13497,7 +13497,7 @@
       "source_file": "packages/athena-webapp/tailwind.config.js",
       "source_location": "L1",
       "id": "packages_athena_webapp_tailwind_config_js",
-      "community": 969
+      "community": 970
     },
     {
       "label": "types.ts",
@@ -13505,7 +13505,7 @@
       "source_file": "packages/athena-webapp/types.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_types_ts",
-      "community": 970
+      "community": 971
     },
     {
       "label": "vite.config.ts",
@@ -13513,7 +13513,7 @@
       "source_file": "packages/athena-webapp/vite.config.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_vite_config_ts",
-      "community": 222
+      "community": 224
     },
     {
       "label": "manualChunks()",
@@ -13521,7 +13521,7 @@
       "source_file": "packages/storefront-webapp/vite.config.ts",
       "source_location": "L19",
       "id": "vite_config_manualchunks",
-      "community": 222
+      "community": 224
     },
     {
       "label": "vitest.config.ts",
@@ -13529,7 +13529,7 @@
       "source_file": "packages/athena-webapp/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_vitest_config_ts",
-      "community": 971
+      "community": 972
     },
     {
       "label": "vitest.setup.ts",
@@ -13537,7 +13537,7 @@
       "source_file": "packages/athena-webapp/vitest.setup.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_vitest_setup_ts",
-      "community": 972
+      "community": 973
     },
     {
       "label": "eslint.config.js",
@@ -13545,7 +13545,7 @@
       "source_file": "packages/storefront-webapp/eslint.config.js",
       "source_location": "L1",
       "id": "packages_storefront_webapp_eslint_config_js",
-      "community": 973
+      "community": 974
     },
     {
       "label": "global.d.ts",
@@ -13553,7 +13553,7 @@
       "source_file": "packages/storefront-webapp/global.d.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_global_d_ts",
-      "community": 974
+      "community": 975
     },
     {
       "label": "playwright.config.ts",
@@ -13561,7 +13561,7 @@
       "source_file": "packages/storefront-webapp/playwright.config.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_playwright_config_ts",
-      "community": 975
+      "community": 976
     },
     {
       "label": "analytics.ts",
@@ -13569,7 +13569,7 @@
       "source_file": "packages/storefront-webapp/src/api/analytics.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_analytics_ts",
-      "community": 103
+      "community": 104
     },
     {
       "label": "postAnalytics()",
@@ -13577,7 +13577,7 @@
       "source_file": "packages/storefront-webapp/src/api/analytics.ts",
       "source_location": "L3",
       "id": "analytics_postanalytics",
-      "community": 103
+      "community": 104
     },
     {
       "label": "updateAnalyticsOwner()",
@@ -13585,7 +13585,7 @@
       "source_file": "packages/storefront-webapp/src/api/analytics.ts",
       "source_location": "L32",
       "id": "analytics_updateanalyticsowner",
-      "community": 103
+      "community": 104
     },
     {
       "label": "logout()",
@@ -13593,7 +13593,7 @@
       "source_file": "packages/storefront-webapp/src/api/analytics.ts",
       "source_location": "L60",
       "id": "analytics_logout",
-      "community": 103
+      "community": 104
     },
     {
       "label": "getProductViewCount()",
@@ -13601,7 +13601,7 @@
       "source_file": "packages/storefront-webapp/src/api/analytics.ts",
       "source_location": "L78",
       "id": "analytics_getproductviewcount",
-      "community": 103
+      "community": 104
     },
     {
       "label": "auth.ts",
@@ -13609,7 +13609,7 @@
       "source_file": "packages/storefront-webapp/src/api/auth.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_auth_ts",
-      "community": 223
+      "community": 225
     },
     {
       "label": "verifyUserAccount()",
@@ -13617,7 +13617,7 @@
       "source_file": "packages/storefront-webapp/src/api/auth.ts",
       "source_location": "L3",
       "id": "auth_verifyuseraccount",
-      "community": 223
+      "community": 225
     },
     {
       "label": "logout()",
@@ -13625,7 +13625,7 @@
       "source_file": "packages/storefront-webapp/src/api/auth.ts",
       "source_location": "L32",
       "id": "auth_logout",
-      "community": 223
+      "community": 225
     },
     {
       "label": "bag.ts",
@@ -13697,7 +13697,7 @@
       "source_file": "packages/storefront-webapp/src/api/bannerMessage.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_bannermessage_ts",
-      "community": 442
+      "community": 443
     },
     {
       "label": "getBannerMessage()",
@@ -13705,7 +13705,7 @@
       "source_file": "packages/storefront-webapp/src/api/bannerMessage.ts",
       "source_location": "L4",
       "id": "bannermessage_getbannermessage",
-      "community": 442
+      "community": 443
     },
     {
       "label": "category.ts",
@@ -13713,7 +13713,7 @@
       "source_file": "packages/storefront-webapp/src/api/category.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_category_ts",
-      "community": 104
+      "community": 105
     },
     {
       "label": "getBaseUrl()",
@@ -13721,7 +13721,7 @@
       "source_file": "packages/storefront-webapp/src/api/category.ts",
       "source_location": "L9",
       "id": "category_getbaseurl",
-      "community": 104
+      "community": 105
     },
     {
       "label": "getAllCategories()",
@@ -13729,7 +13729,7 @@
       "source_file": "packages/storefront-webapp/src/api/category.ts",
       "source_location": "L11",
       "id": "category_getallcategories",
-      "community": 104
+      "community": 105
     },
     {
       "label": "getAllCategoriesWithSubcategories()",
@@ -13737,7 +13737,7 @@
       "source_file": "packages/storefront-webapp/src/api/category.ts",
       "source_location": "L25",
       "id": "category_getallcategorieswithsubcategories",
-      "community": 104
+      "community": 105
     },
     {
       "label": "getCategory()",
@@ -13745,7 +13745,7 @@
       "source_file": "packages/storefront-webapp/src/api/category.ts",
       "source_location": "L39",
       "id": "category_getcategory",
-      "community": 104
+      "community": 105
     },
     {
       "label": "checkoutSession.test.ts",
@@ -13753,7 +13753,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.test.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_checkoutsession_test_ts",
-      "community": 443
+      "community": 444
     },
     {
       "label": "jsonResponse()",
@@ -13761,7 +13761,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.test.ts",
       "source_location": "L27",
       "id": "checkoutsession_test_jsonresponse",
-      "community": 443
+      "community": 444
     },
     {
       "label": "checkoutSession.ts",
@@ -13897,7 +13897,7 @@
       "source_file": "packages/storefront-webapp/src/api/color.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_color_ts",
-      "community": 224
+      "community": 226
     },
     {
       "label": "getBaseUrl()",
@@ -13905,7 +13905,7 @@
       "source_file": "packages/storefront-webapp/src/api/color.ts",
       "source_location": "L5",
       "id": "color_getbaseurl",
-      "community": 224
+      "community": 226
     },
     {
       "label": "getAllColors()",
@@ -13913,7 +13913,7 @@
       "source_file": "packages/storefront-webapp/src/api/color.ts",
       "source_location": "L7",
       "id": "color_getallcolors",
-      "community": 224
+      "community": 226
     },
     {
       "label": "guest.ts",
@@ -13921,7 +13921,7 @@
       "source_file": "packages/storefront-webapp/src/api/guest.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_guest_ts",
-      "community": 444
+      "community": 445
     },
     {
       "label": "updateGuest()",
@@ -13929,7 +13929,7 @@
       "source_file": "packages/storefront-webapp/src/api/guest.ts",
       "source_location": "L4",
       "id": "guest_updateguest",
-      "community": 444
+      "community": 445
     },
     {
       "label": "offers.ts",
@@ -13937,7 +13937,7 @@
       "source_file": "packages/storefront-webapp/src/api/offers.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_offers_ts",
-      "community": 138
+      "community": 139
     },
     {
       "label": "getBaseUrl()",
@@ -13945,7 +13945,7 @@
       "source_file": "packages/storefront-webapp/src/api/offers.ts",
       "source_location": "L13",
       "id": "offers_getbaseurl",
-      "community": 138
+      "community": 139
     },
     {
       "label": "submitOffer()",
@@ -13953,7 +13953,7 @@
       "source_file": "packages/storefront-webapp/src/api/offers.ts",
       "source_location": "L21",
       "id": "offers_submitoffer",
-      "community": 138
+      "community": 139
     },
     {
       "label": "getUserRedeemedOffers()",
@@ -13961,7 +13961,7 @@
       "source_file": "packages/storefront-webapp/src/api/offers.ts",
       "source_location": "L46",
       "id": "offers_getuserredeemedoffers",
-      "community": 138
+      "community": 139
     },
     {
       "label": "onlineOrder.ts",
@@ -13969,7 +13969,7 @@
       "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_onlineorder_ts",
-      "community": 105
+      "community": 106
     },
     {
       "label": "getBaseUrl()",
@@ -13977,7 +13977,7 @@
       "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
       "source_location": "L4",
       "id": "onlineorder_getbaseurl",
-      "community": 105
+      "community": 106
     },
     {
       "label": "getOrders()",
@@ -13985,7 +13985,7 @@
       "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
       "source_location": "L6",
       "id": "onlineorder_getorders",
-      "community": 105
+      "community": 106
     },
     {
       "label": "getOrder()",
@@ -13993,7 +13993,7 @@
       "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
       "source_location": "L24",
       "id": "onlineorder_getorder",
-      "community": 105
+      "community": 106
     },
     {
       "label": "updateOrdersOwner()",
@@ -14001,7 +14001,7 @@
       "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
       "source_location": "L42",
       "id": "onlineorder_updateordersowner",
-      "community": 105
+      "community": 106
     },
     {
       "label": "organization.ts",
@@ -14009,7 +14009,7 @@
       "source_file": "packages/storefront-webapp/src/api/organization.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_organization_ts",
-      "community": 225
+      "community": 227
     },
     {
       "label": "getAllOrganizations()",
@@ -14017,7 +14017,7 @@
       "source_file": "packages/storefront-webapp/src/api/organization.ts",
       "source_location": "L6",
       "id": "organization_getallorganizations",
-      "community": 225
+      "community": 227
     },
     {
       "label": "getOrganization()",
@@ -14025,7 +14025,7 @@
       "source_file": "packages/storefront-webapp/src/api/organization.ts",
       "source_location": "L18",
       "id": "organization_getorganization",
-      "community": 225
+      "community": 227
     },
     {
       "label": "product.ts",
@@ -14097,7 +14097,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_promocodes_ts",
-      "community": 70
+      "community": 71
     },
     {
       "label": "getBaseUrl()",
@@ -14105,7 +14105,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L4",
       "id": "promocodes_getbaseurl",
-      "community": 70
+      "community": 71
     },
     {
       "label": "redeemPromoCode()",
@@ -14113,7 +14113,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L6",
       "id": "promocodes_redeempromocode",
-      "community": 70
+      "community": 71
     },
     {
       "label": "getPromoCodes()",
@@ -14121,7 +14121,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L34",
       "id": "promocodes_getpromocodes",
-      "community": 70
+      "community": 71
     },
     {
       "label": "getPromoCodeItems()",
@@ -14129,7 +14129,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L49",
       "id": "promocodes_getpromocodeitems",
-      "community": 70
+      "community": 71
     },
     {
       "label": "getRedeemedPromoCodes()",
@@ -14137,7 +14137,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L74",
       "id": "promocodes_getredeemedpromocodes",
-      "community": 70
+      "community": 71
     },
     {
       "label": "reviews.ts",
@@ -14329,7 +14329,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_savedbag_ts",
-      "community": 47
+      "community": 48
     },
     {
       "label": "getBaseUrl()",
@@ -14337,7 +14337,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L8",
       "id": "savedbag_getbaseurl",
-      "community": 47
+      "community": 48
     },
     {
       "label": "getActiveSavedBag()",
@@ -14345,7 +14345,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L10",
       "id": "savedbag_getactivesavedbag",
-      "community": 47
+      "community": 48
     },
     {
       "label": "addItemToSavedBag()",
@@ -14353,7 +14353,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L25",
       "id": "savedbag_additemtosavedbag",
-      "community": 47
+      "community": 48
     },
     {
       "label": "updateSavedBagItem()",
@@ -14361,7 +14361,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L61",
       "id": "savedbag_updatesavedbagitem",
-      "community": 47
+      "community": 48
     },
     {
       "label": "removeItemFromSavedBag()",
@@ -14369,7 +14369,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L91",
       "id": "savedbag_removeitemfromsavedbag",
-      "community": 47
+      "community": 48
     },
     {
       "label": "updateSavedBagOwner()",
@@ -14377,7 +14377,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L109",
       "id": "savedbag_updatesavedbagowner",
-      "community": 47
+      "community": 48
     },
     {
       "label": "storeFrontUser.ts",
@@ -14385,7 +14385,7 @@
       "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_storefrontuser_ts",
-      "community": 106
+      "community": 107
     },
     {
       "label": "getBaseUrl()",
@@ -14393,7 +14393,7 @@
       "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
       "source_location": "L5",
       "id": "storefrontuser_getbaseurl",
-      "community": 106
+      "community": 107
     },
     {
       "label": "getGuest()",
@@ -14401,7 +14401,7 @@
       "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
       "source_location": "L7",
       "id": "storefrontuser_getguest",
-      "community": 106
+      "community": 107
     },
     {
       "label": "getActiveUser()",
@@ -14409,7 +14409,7 @@
       "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
       "source_location": "L28",
       "id": "storefrontuser_getactiveuser",
-      "community": 106
+      "community": 107
     },
     {
       "label": "updateUser()",
@@ -14417,7 +14417,7 @@
       "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
       "source_location": "L46",
       "id": "storefrontuser_updateuser",
-      "community": 106
+      "community": 107
     },
     {
       "label": "storefront.ts",
@@ -14425,7 +14425,7 @@
       "source_file": "packages/storefront-webapp/src/api/storefront.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_storefront_ts",
-      "community": 445
+      "community": 446
     },
     {
       "label": "getStore()",
@@ -14433,7 +14433,7 @@
       "source_file": "packages/storefront-webapp/src/api/storefront.ts",
       "source_location": "L5",
       "id": "storefront_getstore",
-      "community": 445
+      "community": 446
     },
     {
       "label": "stores.ts",
@@ -14441,7 +14441,7 @@
       "source_file": "packages/storefront-webapp/src/api/stores.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_stores_ts",
-      "community": 139
+      "community": 140
     },
     {
       "label": "getBaseUrl()",
@@ -14449,7 +14449,7 @@
       "source_file": "packages/storefront-webapp/src/api/stores.ts",
       "source_location": "L5",
       "id": "stores_getbaseurl",
-      "community": 139
+      "community": 140
     },
     {
       "label": "getAllStores()",
@@ -14457,7 +14457,7 @@
       "source_file": "packages/storefront-webapp/src/api/stores.ts",
       "source_location": "L8",
       "id": "stores_getallstores",
-      "community": 139
+      "community": 140
     },
     {
       "label": "getStore()",
@@ -14465,7 +14465,7 @@
       "source_file": "packages/storefront-webapp/src/api/stores.ts",
       "source_location": "L20",
       "id": "stores_getstore",
-      "community": 139
+      "community": 140
     },
     {
       "label": "subcategory.ts",
@@ -14473,7 +14473,7 @@
       "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_subcategory_ts",
-      "community": 140
+      "community": 141
     },
     {
       "label": "getBaseUrl()",
@@ -14481,7 +14481,7 @@
       "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
       "source_location": "L9",
       "id": "subcategory_getbaseurl",
-      "community": 140
+      "community": 141
     },
     {
       "label": "getAllSubcategories()",
@@ -14489,7 +14489,7 @@
       "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
       "source_location": "L11",
       "id": "subcategory_getallsubcategories",
-      "community": 140
+      "community": 141
     },
     {
       "label": "getSubategory()",
@@ -14497,7 +14497,7 @@
       "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
       "source_location": "L25",
       "id": "subcategory_getsubategory",
-      "community": 140
+      "community": 141
     },
     {
       "label": "types.ts",
@@ -14505,7 +14505,7 @@
       "source_file": "packages/storefront-webapp/src/api/types.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_types_ts",
-      "community": 976
+      "community": 977
     },
     {
       "label": "upsells.ts",
@@ -14513,7 +14513,7 @@
       "source_file": "packages/storefront-webapp/src/api/upsells.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_upsells_ts",
-      "community": 226
+      "community": 228
     },
     {
       "label": "getBaseUrl()",
@@ -14521,7 +14521,7 @@
       "source_file": "packages/storefront-webapp/src/api/upsells.ts",
       "source_location": "L3",
       "id": "upsells_getbaseurl",
-      "community": 226
+      "community": 228
     },
     {
       "label": "getLastViewedProduct()",
@@ -14529,7 +14529,7 @@
       "source_file": "packages/storefront-webapp/src/api/upsells.ts",
       "source_location": "L5",
       "id": "upsells_getlastviewedproduct",
-      "community": 226
+      "community": 228
     },
     {
       "label": "userOffers.ts",
@@ -14537,7 +14537,7 @@
       "source_file": "packages/storefront-webapp/src/api/userOffers.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_useroffers_ts",
-      "community": 227
+      "community": 229
     },
     {
       "label": "getBaseUrl()",
@@ -14545,7 +14545,7 @@
       "source_file": "packages/storefront-webapp/src/api/userOffers.ts",
       "source_location": "L18",
       "id": "useroffers_getbaseurl",
-      "community": 227
+      "community": 229
     },
     {
       "label": "getUserOffersEligibility()",
@@ -14553,7 +14553,7 @@
       "source_file": "packages/storefront-webapp/src/api/userOffers.ts",
       "source_location": "L23",
       "id": "useroffers_getuserofferseligibility",
-      "community": 227
+      "community": 229
     },
     {
       "label": "HeartIconFilled.tsx",
@@ -14561,7 +14561,7 @@
       "source_file": "packages/storefront-webapp/src/assets/icons/HeartIconFilled.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_assets_icons_hearticonfilled_tsx",
-      "community": 977
+      "community": 978
     },
     {
       "label": "client.tsx",
@@ -14569,7 +14569,7 @@
       "source_file": "packages/storefront-webapp/src/client.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_client_tsx",
-      "community": 978
+      "community": 979
     },
     {
       "label": "DefaultCatchBoundary.tsx",
@@ -14577,7 +14577,7 @@
       "source_file": "packages/storefront-webapp/src/components/DefaultCatchBoundary.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_defaultcatchboundary_tsx",
-      "community": 979
+      "community": 980
     },
     {
       "label": "EntityPage.tsx",
@@ -14585,7 +14585,7 @@
       "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_entitypage_tsx",
-      "community": 446
+      "community": 447
     },
     {
       "label": "EntityPage()",
@@ -14593,7 +14593,7 @@
       "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
       "source_location": "L10",
       "id": "entitypage_entitypage",
-      "community": 446
+      "community": 447
     },
     {
       "label": "HomePage.tsx",
@@ -14601,7 +14601,7 @@
       "source_file": "packages/storefront-webapp/src/components/HomePage.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_homepage_tsx",
-      "community": 141
+      "community": 142
     },
     {
       "label": "handleScroll()",
@@ -14609,7 +14609,7 @@
       "source_file": "packages/storefront-webapp/src/components/HomePage.tsx",
       "source_location": "L106",
       "id": "homepage_handlescroll",
-      "community": 141
+      "community": 142
     },
     {
       "label": "handleClickOnDiscountCode()",
@@ -14617,7 +14617,7 @@
       "source_file": "packages/storefront-webapp/src/components/HomePage.tsx",
       "source_location": "L155",
       "id": "homepage_handleclickondiscountcode",
-      "community": 141
+      "community": 142
     },
     {
       "label": "handleClickOnLeaveReviewButton()",
@@ -14625,7 +14625,7 @@
       "source_file": "packages/storefront-webapp/src/components/HomePage.tsx",
       "source_location": "L167",
       "id": "homepage_handleclickonleavereviewbutton",
-      "community": 141
+      "community": 142
     },
     {
       "label": "ProductActionBar.tsx",
@@ -14633,7 +14633,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_productactionbar_tsx",
-      "community": 142
+      "community": 143
     },
     {
       "label": "checkScroll()",
@@ -14641,7 +14641,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
       "source_location": "L50",
       "id": "productactionbar_checkscroll",
-      "community": 142
+      "community": 143
     },
     {
       "label": "handleDismiss()",
@@ -14649,7 +14649,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
       "source_location": "L74",
       "id": "productactionbar_handledismiss",
-      "community": 142
+      "community": 143
     },
     {
       "label": "handleAction()",
@@ -14657,7 +14657,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
       "source_location": "L92",
       "id": "productactionbar_handleaction",
-      "community": 142
+      "community": 143
     },
     {
       "label": "ProductCard.tsx",
@@ -14665,7 +14665,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductCard.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_productcard_tsx",
-      "community": 980
+      "community": 981
     },
     {
       "label": "ProductReminderBar.tsx",
@@ -14673,7 +14673,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_productreminderbar_tsx",
-      "community": 143
+      "community": 144
     },
     {
       "label": "checkScroll()",
@@ -14681,7 +14681,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
       "source_location": "L62",
       "id": "productreminderbar_checkscroll",
-      "community": 143
+      "community": 144
     },
     {
       "label": "handleAddToBag()",
@@ -14689,7 +14689,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
       "source_location": "L109",
       "id": "productreminderbar_handleaddtobag",
-      "community": 143
+      "community": 144
     },
     {
       "label": "handleDismiss()",
@@ -14697,7 +14697,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
       "source_location": "L177",
       "id": "productreminderbar_handledismiss",
-      "community": 143
+      "community": 144
     },
     {
       "label": "ProductsPage.tsx",
@@ -14705,7 +14705,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductsPage.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_productspage_tsx",
-      "community": 447
+      "community": 448
     },
     {
       "label": "ProductCardLoadingSkeleton()",
@@ -14713,7 +14713,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductsPage.tsx",
       "source_location": "L10",
       "id": "productspage_productcardloadingskeleton",
-      "community": 447
+      "community": 448
     },
     {
       "label": "Upsell.tsx",
@@ -14721,7 +14721,7 @@
       "source_file": "packages/storefront-webapp/src/components/Upsell.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_upsell_tsx",
-      "community": 981
+      "community": 982
     },
     {
       "label": "View.tsx",
@@ -14729,7 +14729,7 @@
       "source_file": "packages/storefront-webapp/src/components/View.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_view_tsx",
-      "community": 161
+      "community": 163
     },
     {
       "label": "Auth.tsx",
@@ -14737,7 +14737,7 @@
       "source_file": "packages/storefront-webapp/src/components/auth/Auth.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_auth_auth_tsx",
-      "community": 448
+      "community": 449
     },
     {
       "label": "AuthComponent()",
@@ -14745,7 +14745,7 @@
       "source_file": "packages/storefront-webapp/src/components/auth/Auth.tsx",
       "source_location": "L4",
       "id": "auth_authcomponent",
-      "community": 448
+      "community": 449
     },
     {
       "label": "BagSummary.tsx",
@@ -14753,7 +14753,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BagSummary.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_bagsummary_tsx",
-      "community": 449
+      "community": 450
     },
     {
       "label": "toBagSummaryItems()",
@@ -14761,7 +14761,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BagSummary.tsx",
       "source_location": "L39",
       "id": "bagsummary_tobagsummaryitems",
-      "community": 449
+      "community": 450
     },
     {
       "label": "BillingDetails.tsx",
@@ -14769,7 +14769,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
-      "community": 71
+      "community": 72
     },
     {
       "label": "EnteredBillingAddressDetails()",
@@ -14777,7 +14777,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L102",
       "id": "billingdetails_enteredbillingaddressdetails",
-      "community": 71
+      "community": 72
     },
     {
       "label": "onSubmit()",
@@ -14785,7 +14785,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L150",
       "id": "billingdetails_onsubmit",
-      "community": 71
+      "community": 72
     },
     {
       "label": "toggleSameAsDelivery()",
@@ -14793,7 +14793,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L155",
       "id": "billingdetails_togglesameasdelivery",
-      "community": 71
+      "community": 72
     },
     {
       "label": "clearForm()",
@@ -14801,7 +14801,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L173",
       "id": "billingdetails_clearform",
-      "community": 71
+      "community": 72
     },
     {
       "label": "handleUseBillingAddressOnFile()",
@@ -14809,7 +14809,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L201",
       "id": "billingdetails_handleusebillingaddressonfile",
-      "community": 71
+      "community": 72
     },
     {
       "label": "BillingDetailsSection.tsx",
@@ -14817,7 +14817,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetailssection_tsx",
-      "community": 144
+      "community": 145
     },
     {
       "label": "clearForm()",
@@ -14825,7 +14825,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
       "source_location": "L18",
       "id": "billingdetailssection_clearform",
-      "community": 144
+      "community": 145
     },
     {
       "label": "handleUseBillingAddressOnFile()",
@@ -14833,7 +14833,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
       "source_location": "L52",
       "id": "billingdetailssection_handleusebillingaddressonfile",
-      "community": 144
+      "community": 145
     },
     {
       "label": "toggleSameAsDelivery()",
@@ -14841,7 +14841,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
       "source_location": "L68",
       "id": "billingdetailssection_togglesameasdelivery",
-      "community": 144
+      "community": 145
     },
     {
       "label": "Checkout.tsx",
@@ -14849,7 +14849,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/Checkout.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_tsx",
-      "community": 982
+      "community": 983
     },
     {
       "label": "CheckoutForm.tsx",
@@ -14857,7 +14857,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/CheckoutForm.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutform_tsx",
-      "community": 450
+      "community": 451
     },
     {
       "label": "CheckoutForm()",
@@ -14865,7 +14865,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/CheckoutForm.tsx",
       "source_location": "L18",
       "id": "checkoutform_checkoutform",
-      "community": 450
+      "community": 451
     },
     {
       "label": "CheckoutProvider.tsx",
@@ -14873,7 +14873,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/CheckoutProvider.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutprovider_tsx",
-      "community": 451
+      "community": 452
     },
     {
       "label": "CheckoutProvider()",
@@ -14881,7 +14881,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/CheckoutProvider.tsx",
       "source_location": "L71",
       "id": "checkoutprovider_checkoutprovider",
-      "community": 451
+      "community": 452
     },
     {
       "label": "CustomerDetails.tsx",
@@ -14889,7 +14889,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/CustomerDetails.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_customerdetails_tsx",
-      "community": 228
+      "community": 230
     },
     {
       "label": "EnteredCustomerDetails()",
@@ -14897,7 +14897,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/CustomerDetails.tsx",
       "source_location": "L22",
       "id": "customerdetails_enteredcustomerdetails",
-      "community": 228
+      "community": 230
     },
     {
       "label": "onSubmit()",
@@ -14905,7 +14905,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/CustomerDetails.tsx",
       "source_location": "L55",
       "id": "customerdetails_onsubmit",
-      "community": 228
+      "community": 230
     },
     {
       "label": "CustomerInfoSection.tsx",
@@ -14913,7 +14913,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/CustomerInfoSection.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_customerinfosection_tsx",
-      "community": 983
+      "community": 984
     },
     {
       "label": "DeliveryOptionsSelector.tsx",
@@ -14921,7 +14921,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliveryoptionsselector_tsx",
-      "community": 229
+      "community": 231
     },
     {
       "label": "StoreSelector()",
@@ -14929,7 +14929,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
       "source_location": "L11",
       "id": "deliveryoptionsselector_storeselector",
-      "community": 229
+      "community": 231
     },
     {
       "label": "handleChange()",
@@ -14937,7 +14937,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
       "source_location": "L77",
       "id": "deliveryoptionsselector_handlechange",
-      "community": 229
+      "community": 231
     },
     {
       "label": "DeliverySection.tsx",
@@ -14945,7 +14945,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliverysection_tsx",
-      "community": 230
+      "community": 232
     },
     {
       "label": "DeliveryDetails()",
@@ -14953,7 +14953,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
       "source_location": "L11",
       "id": "deliverysection_deliverydetails",
-      "community": 230
+      "community": 232
     },
     {
       "label": "DeliveryOptions()",
@@ -14961,7 +14961,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
       "source_location": "L22",
       "id": "deliverysection_deliveryoptions",
-      "community": 230
+      "community": 232
     },
     {
       "label": "PickupOptions.tsx",
@@ -14969,7 +14969,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/PickupOptions.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_pickupoptions_tsx",
-      "community": 452
+      "community": 453
     },
     {
       "label": "isWithinRestrictionTime()",
@@ -14977,7 +14977,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/PickupOptions.tsx",
       "source_location": "L12",
       "id": "pickupoptions_iswithinrestrictiontime",
-      "community": 452
+      "community": 453
     },
     {
       "label": "schema.ts",
@@ -14985,7 +14985,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/schema.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_schema_ts",
-      "community": 984
+      "community": 985
     },
     {
       "label": "DeliveryDetailsSection.tsx",
@@ -14993,7 +14993,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetailsSection.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetailssection_tsx",
-      "community": 985
+      "community": 986
     },
     {
       "label": "EnteredBillingAddressDetails.tsx",
@@ -15001,7 +15001,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/EnteredBillingAddressDetails.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_enteredbillingaddressdetails_tsx",
-      "community": 453
+      "community": 454
     },
     {
       "label": "EnteredBillingAddressDetails()",
@@ -15009,7 +15009,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/EnteredBillingAddressDetails.tsx",
       "source_location": "L6",
       "id": "enteredbillingaddressdetails_enteredbillingaddressdetails",
-      "community": 453
+      "community": 454
     },
     {
       "label": "MobileBagSummary.tsx",
@@ -15017,7 +15017,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_mobilebagsummary_tsx",
-      "community": 231
+      "community": 233
     },
     {
       "label": "handleRedeemPromoCode()",
@@ -15025,7 +15025,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
       "source_location": "L89",
       "id": "mobilebagsummary_handleredeempromocode",
-      "community": 231
+      "community": 233
     },
     {
       "label": "handleKeyDown()",
@@ -15033,7 +15033,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
       "source_location": "L110",
       "id": "mobilebagsummary_handlekeydown",
-      "community": 231
+      "community": 233
     },
     {
       "label": "OrderSummary.tsx",
@@ -15041,7 +15041,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/OrderSummary.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_ordersummary_tsx",
-      "community": 454
+      "community": 455
     },
     {
       "label": "OrderSummary()",
@@ -15049,7 +15049,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/OrderSummary.tsx",
       "source_location": "L18",
       "id": "ordersummary_ordersummary",
-      "community": 454
+      "community": 455
     },
     {
       "label": "index.tsx",
@@ -15057,7 +15057,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/index.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_index_tsx",
-      "community": 455
+      "community": 456
     },
     {
       "label": "PickupDetails()",
@@ -15065,7 +15065,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/index.tsx",
       "source_location": "L10",
       "id": "index_pickupdetails",
-      "community": 455
+      "community": 456
     },
     {
       "label": "PaymentMethodSection.tsx",
@@ -15073,7 +15073,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/PaymentMethodSection.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_paymentmethodsection_tsx",
-      "community": 456
+      "community": 457
     },
     {
       "label": "PaymentMethodSection()",
@@ -15081,7 +15081,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/PaymentMethodSection.tsx",
       "source_location": "L8",
       "id": "paymentmethodsection_paymentmethodsection",
-      "community": 456
+      "community": 457
     },
     {
       "label": "PaymentSection.tsx",
@@ -15089,7 +15089,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/PaymentSection.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_paymentsection_tsx",
-      "community": 457
+      "community": 458
     },
     {
       "label": "PaymentSection()",
@@ -15097,7 +15097,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/PaymentSection.tsx",
       "source_location": "L27",
       "id": "paymentsection_paymentsection",
-      "community": 457
+      "community": 458
     },
     {
       "label": "checkoutStorage.test.ts",
@@ -15105,7 +15105,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.test.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_test_ts",
-      "community": 986
+      "community": 987
     },
     {
       "label": "checkoutStorage.ts",
@@ -15113,7 +15113,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_ts",
-      "community": 232
+      "community": 234
     },
     {
       "label": "loadCheckoutState()",
@@ -15121,7 +15121,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
       "source_location": "L4",
       "id": "checkoutstorage_loadcheckoutstate",
-      "community": 232
+      "community": 234
     },
     {
       "label": "saveCheckoutState()",
@@ -15129,7 +15129,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
       "source_location": "L24",
       "id": "checkoutstorage_savecheckoutstate",
-      "community": 232
+      "community": 234
     },
     {
       "label": "deliveryFees.test.ts",
@@ -15137,7 +15137,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.test.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_test_ts",
-      "community": 987
+      "community": 988
     },
     {
       "label": "deliveryFees.ts",
@@ -15145,7 +15145,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_ts",
-      "community": 458
+      "community": 459
     },
     {
       "label": "calculateDeliveryFee()",
@@ -15153,7 +15153,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.ts",
       "source_location": "L40",
       "id": "deliveryfees_calculatedeliveryfee",
-      "community": 458
+      "community": 459
     },
     {
       "label": "deriveCheckoutState.test.ts",
@@ -15161,7 +15161,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.test.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_test_ts",
-      "community": 988
+      "community": 989
     },
     {
       "label": "deriveCheckoutState.ts",
@@ -15169,7 +15169,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_ts",
-      "community": 459
+      "community": 460
     },
     {
       "label": "deriveCheckoutState()",
@@ -15177,7 +15177,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
       "source_location": "L3",
       "id": "derivecheckoutstate_derivecheckoutstate",
-      "community": 459
+      "community": 460
     },
     {
       "label": "billingDetailsSchema.ts",
@@ -15185,7 +15185,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/billingDetailsSchema.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_billingdetailsschema_ts",
-      "community": 989
+      "community": 990
     },
     {
       "label": "checkoutFormSchema.ts",
@@ -15193,7 +15193,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutFormSchema.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutformschema_ts",
-      "community": 990
+      "community": 991
     },
     {
       "label": "checkoutSchemas.test.ts",
@@ -15201,7 +15201,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutSchemas.test.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutschemas_test_ts",
-      "community": 460
+      "community": 461
     },
     {
       "label": "getIssueMap()",
@@ -15209,7 +15209,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutSchemas.test.ts",
       "source_location": "L8",
       "id": "checkoutschemas_test_getissuemap",
-      "community": 460
+      "community": 461
     },
     {
       "label": "customerDetailsSchema.ts",
@@ -15217,7 +15217,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/customerDetailsSchema.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_customerdetailsschema_ts",
-      "community": 991
+      "community": 992
     },
     {
       "label": "deliveryDetailsSchema.ts",
@@ -15225,7 +15225,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/deliveryDetailsSchema.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_deliverydetailsschema_ts",
-      "community": 992
+      "community": 993
     },
     {
       "label": "webOrderSchema.test.ts",
@@ -15233,7 +15233,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.test.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_test_ts",
-      "community": 461
+      "community": 462
     },
     {
       "label": "getIssueMap()",
@@ -15241,7 +15241,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.test.ts",
       "source_location": "L12",
       "id": "weborderschema_test_getissuemap",
-      "community": 461
+      "community": 462
     },
     {
       "label": "webOrderSchema.ts",
@@ -15249,7 +15249,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_ts",
-      "community": 993
+      "community": 994
     },
     {
       "label": "types.ts",
@@ -15257,7 +15257,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/types.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_types_ts",
-      "community": 994
+      "community": 995
     },
     {
       "label": "utils.test.ts",
@@ -15265,7 +15265,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.test.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_utils_test_ts",
-      "community": 995
+      "community": 996
     },
     {
       "label": "utils.ts",
@@ -15289,7 +15289,7 @@
       "source_file": "packages/storefront-webapp/src/components/common/FadeIn.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_common_fadein_tsx",
-      "community": 171
+      "community": 173
     },
     {
       "label": "CustomerDetailsForm.tsx",
@@ -15297,7 +15297,7 @@
       "source_file": "packages/storefront-webapp/src/components/common/forms/CustomerDetailsForm.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_common_forms_customerdetailsform_tsx",
-      "community": 462
+      "community": 463
     },
     {
       "label": "onSubmit()",
@@ -15305,7 +15305,7 @@
       "source_file": "packages/storefront-webapp/src/components/common/forms/CustomerDetailsForm.tsx",
       "source_location": "L77",
       "id": "customerdetailsform_onsubmit",
-      "community": 462
+      "community": 463
     },
     {
       "label": "DeliveryDetailsForm.tsx",
@@ -15313,7 +15313,7 @@
       "source_file": "packages/storefront-webapp/src/components/common/forms/DeliveryDetailsForm.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_common_forms_deliverydetailsform_tsx",
-      "community": 463
+      "community": 464
     },
     {
       "label": "onSubmit()",
@@ -15321,7 +15321,7 @@
       "source_file": "packages/storefront-webapp/src/components/common/forms/DeliveryDetailsForm.tsx",
       "source_location": "L161",
       "id": "deliverydetailsform_onsubmit",
-      "community": 463
+      "community": 464
     },
     {
       "label": "hooks.ts",
@@ -15329,7 +15329,7 @@
       "source_file": "packages/storefront-webapp/src/components/common/hooks.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_common_hooks_ts",
-      "community": 464
+      "community": 465
     },
     {
       "label": "useCountdown()",
@@ -15337,7 +15337,7 @@
       "source_file": "packages/storefront-webapp/src/components/common/hooks.ts",
       "source_location": "L3",
       "id": "hooks_usecountdown",
-      "community": 464
+      "community": 465
     },
     {
       "label": "TrustSignals.tsx",
@@ -15345,7 +15345,7 @@
       "source_file": "packages/storefront-webapp/src/components/communication/TrustSignals.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_communication_trustsignals_tsx",
-      "community": 465
+      "community": 466
     },
     {
       "label": "TrustSignals()",
@@ -15353,7 +15353,7 @@
       "source_file": "packages/storefront-webapp/src/components/communication/TrustSignals.tsx",
       "source_location": "L4",
       "id": "trustsignals_trustsignals",
-      "community": 465
+      "community": 466
     },
     {
       "label": "ProductFilter.tsx",
@@ -15361,7 +15361,7 @@
       "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_filter_productfilter_tsx",
-      "community": 466
+      "community": 467
     },
     {
       "label": "ProductFilter()",
@@ -15369,7 +15369,7 @@
       "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
       "source_location": "L14",
       "id": "productfilter_productfilter",
-      "community": 466
+      "community": 467
     },
     {
       "label": "ProductFilterBar.tsx",
@@ -15377,7 +15377,7 @@
       "source_file": "packages/storefront-webapp/src/components/filter/ProductFilterBar.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_filter_productfilterbar_tsx",
-      "community": 996
+      "community": 997
     },
     {
       "label": "Filter.tsx",
@@ -15385,7 +15385,7 @@
       "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_footer_filter_tsx",
-      "community": 467
+      "community": 468
     },
     {
       "label": "handleCheckboxChange()",
@@ -15393,7 +15393,7 @@
       "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
       "source_location": "L27",
       "id": "filter_handlecheckboxchange",
-      "community": 467
+      "community": 468
     },
     {
       "label": "Footer.tsx",
@@ -15401,7 +15401,7 @@
       "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_footer_footer_tsx",
-      "community": 468
+      "community": 469
     },
     {
       "label": "LinkGroup()",
@@ -15409,7 +15409,7 @@
       "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
       "source_location": "L13",
       "id": "footer_linkgroup",
-      "community": 468
+      "community": 469
     },
     {
       "label": "BestSellersSection.tsx",
@@ -15417,7 +15417,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_tsx",
-      "community": 469
+      "community": 470
     },
     {
       "label": "BestSellersSection()",
@@ -15425,7 +15425,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.tsx",
       "source_location": "L17",
       "id": "bestsellerssection_bestsellerssection",
-      "community": 469
+      "community": 470
     },
     {
       "label": "FeaturedProductsSection.tsx",
@@ -15433,7 +15433,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_home_featuredproductssection_tsx",
-      "community": 233
+      "community": 235
     },
     {
       "label": "FeaturedProductsSection()",
@@ -15441,7 +15441,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
       "source_location": "L20",
       "id": "featuredproductssection_featuredproductssection",
-      "community": 233
+      "community": 235
     },
     {
       "label": "FeaturedSection()",
@@ -15449,7 +15449,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
       "source_location": "L46",
       "id": "featuredproductssection_featuredsection",
-      "community": 233
+      "community": 235
     },
     {
       "label": "HomeHero.tsx",
@@ -15457,7 +15457,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/HomeHero.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_home_homehero_tsx",
-      "community": 997
+      "community": 998
     },
     {
       "label": "HomeHeroSection.tsx",
@@ -15465,7 +15465,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/HomeHeroSection.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_home_homeherosection_tsx",
-      "community": 998
+      "community": 999
     },
     {
       "label": "PromoAlert.tsx",
@@ -15473,7 +15473,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_home_promoalert_tsx",
-      "community": 234
+      "community": 236
     },
     {
       "label": "getPromoAlertCopy()",
@@ -15481,7 +15481,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
       "source_location": "L20",
       "id": "promoalert_getpromoalertcopy",
-      "community": 234
+      "community": 236
     },
     {
       "label": "PromoAlert()",
@@ -15489,7 +15489,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
       "source_location": "L59",
       "id": "promoalert_promoalert",
-      "community": 234
+      "community": 236
     },
     {
       "label": "RewardsAlert.tsx",
@@ -15497,7 +15497,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_home_rewardsalert_tsx",
-      "community": 235
+      "community": 237
     },
     {
       "label": "onRewardsAlertClose()",
@@ -15505,7 +15505,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
       "source_location": "L20",
       "id": "rewardsalert_onrewardsalertclose",
-      "community": 235
+      "community": 237
     },
     {
       "label": "handleShopNow()",
@@ -15513,7 +15513,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
       "source_location": "L25",
       "id": "rewardsalert_handleshopnow",
-      "community": 235
+      "community": 237
     },
     {
       "label": "VideoPlayer.tsx",
@@ -15521,7 +15521,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_home_videoplayer_tsx",
-      "community": 174
+      "community": 176
     },
     {
       "label": "hooks.ts",
@@ -15529,7 +15529,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
-      "community": 145
+      "community": 146
     },
     {
       "label": "useGetStoreSubcategories()",
@@ -15537,7 +15537,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
       "source_location": "L10",
       "id": "hooks_usegetstoresubcategories",
-      "community": 145
+      "community": 146
     },
     {
       "label": "useGetStoreCategories()",
@@ -15545,7 +15545,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
       "source_location": "L21",
       "id": "hooks_usegetstorecategories",
-      "community": 145
+      "community": 146
     },
     {
       "label": "useGetShopSearchParams()",
@@ -15553,7 +15553,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
       "source_location": "L55",
       "id": "hooks_usegetshopsearchparams",
-      "community": 145
+      "community": 146
     },
     {
       "label": "BagMenu.tsx",
@@ -15561,7 +15561,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/BagMenu.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_navigation_bar_bagmenu_tsx",
-      "community": 470
+      "community": 471
     },
     {
       "label": "handleOnLinkClick()",
@@ -15569,7 +15569,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/BagMenu.tsx",
       "source_location": "L47",
       "id": "bagmenu_handleonlinkclick",
-      "community": 470
+      "community": 471
     },
     {
       "label": "MobileBagMenu.tsx",
@@ -15577,7 +15577,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileBagMenu.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilebagmenu_tsx",
-      "community": 471
+      "community": 472
     },
     {
       "label": "MobileBagMenu()",
@@ -15585,7 +15585,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileBagMenu.tsx",
       "source_location": "L7",
       "id": "mobilebagmenu_mobilebagmenu",
-      "community": 471
+      "community": 472
     },
     {
       "label": "MobileMenu.tsx",
@@ -15593,7 +15593,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileMenu.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilemenu_tsx",
-      "community": 999
+      "community": 1000
     },
     {
       "label": "NavigationBar.tsx",
@@ -15601,7 +15601,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/NavigationBar.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navigationbar_tsx",
-      "community": 472
+      "community": 473
     },
     {
       "label": "StoreCategoriesSubmenu()",
@@ -15609,7 +15609,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/NavigationBar.tsx",
       "source_location": "L62",
       "id": "navigationbar_storecategoriessubmenu",
-      "community": 472
+      "community": 473
     },
     {
       "label": "SiteBanner.tsx",
@@ -15617,7 +15617,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/SiteBanner.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_navigation_bar_sitebanner_tsx",
-      "community": 473
+      "community": 474
     },
     {
       "label": "SiteBanner()",
@@ -15625,7 +15625,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/SiteBanner.tsx",
       "source_location": "L17",
       "id": "sitebanner_sitebanner",
-      "community": 473
+      "community": 474
     },
     {
       "label": "constants.ts",
@@ -15633,7 +15633,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/constants.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_navigation_bar_constants_ts",
-      "community": 1000
+      "community": 1001
     },
     {
       "label": "navBarConstants.ts",
@@ -15641,7 +15641,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarConstants.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navbarconstants_ts",
-      "community": 1001
+      "community": 1002
     },
     {
       "label": "navBarStyles.ts",
@@ -15737,7 +15737,7 @@
       "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_notification_notificationpill_tsx",
-      "community": 474
+      "community": 475
     },
     {
       "label": "NotificationPill()",
@@ -15745,7 +15745,7 @@
       "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
       "source_location": "L1",
       "id": "notificationpill_notificationpill",
-      "community": 474
+      "community": 475
     },
     {
       "label": "About.tsx",
@@ -15753,7 +15753,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/About.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_page_about_tsx",
-      "community": 1002
+      "community": 1003
     },
     {
       "label": "AboutProduct.tsx",
@@ -15761,7 +15761,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/AboutProduct.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_page_aboutproduct_tsx",
-      "community": 1003
+      "community": 1004
     },
     {
       "label": "DimensionBar.tsx",
@@ -15769,7 +15769,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_page_dimensionbar_tsx",
-      "community": 475
+      "community": 476
     },
     {
       "label": "mapValueToLabelIndex()",
@@ -15777,7 +15777,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
       "source_location": "L12",
       "id": "dimensionbar_mapvaluetolabelindex",
-      "community": 475
+      "community": 476
     },
     {
       "label": "DiscountBadge.tsx",
@@ -15785,7 +15785,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/DiscountBadge.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_page_discountbadge_tsx",
-      "community": 476
+      "community": 477
     },
     {
       "label": "DiscountBadge()",
@@ -15793,7 +15793,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/DiscountBadge.tsx",
       "source_location": "L7",
       "id": "discountbadge_discountbadge",
-      "community": 476
+      "community": 477
     },
     {
       "label": "GalleryViewer.tsx",
@@ -15801,7 +15801,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/GalleryViewer.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_page_galleryviewer_tsx",
-      "community": 477
+      "community": 478
     },
     {
       "label": "handleClickOnPreview()",
@@ -15809,7 +15809,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/GalleryViewer.tsx",
       "source_location": "L45",
       "id": "galleryviewer_handleclickonpreview",
-      "community": 477
+      "community": 478
     },
     {
       "label": "InventoryLevelBadge.tsx",
@@ -15817,7 +15817,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_page_inventorylevelbadge_tsx",
-      "community": 107
+      "community": 108
     },
     {
       "label": "SoldOutBadge()",
@@ -15825,7 +15825,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
       "source_location": "L3",
       "id": "inventorylevelbadge_soldoutbadge",
-      "community": 107
+      "community": 108
     },
     {
       "label": "LowStockBadge()",
@@ -15833,7 +15833,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
       "source_location": "L14",
       "id": "inventorylevelbadge_lowstockbadge",
-      "community": 107
+      "community": 108
     },
     {
       "label": "SellingFastBadge()",
@@ -15841,7 +15841,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
       "source_location": "L22",
       "id": "inventorylevelbadge_sellingfastbadge",
-      "community": 107
+      "community": 108
     },
     {
       "label": "SellingFastSignal()",
@@ -15849,7 +15849,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
       "source_location": "L30",
       "id": "inventorylevelbadge_sellingfastsignal",
-      "community": 107
+      "community": 108
     },
     {
       "label": "OnSaleProduct.tsx",
@@ -15857,7 +15857,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/OnSaleProduct.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_page_onsaleproduct_tsx",
-      "community": 478
+      "community": 479
     },
     {
       "label": "OnsaleProduct()",
@@ -15865,7 +15865,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/OnSaleProduct.tsx",
       "source_location": "L5",
       "id": "onsaleproduct_onsaleproduct",
-      "community": 478
+      "community": 479
     },
     {
       "label": "ProductActions.tsx",
@@ -15873,7 +15873,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_tsx",
-      "community": 479
+      "community": 480
     },
     {
       "label": "ProductActions()",
@@ -15881,7 +15881,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.tsx",
       "source_location": "L17",
       "id": "productactions_productactions",
-      "community": 479
+      "community": 480
     },
     {
       "label": "ProductAttribute.tsx",
@@ -15889,7 +15889,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
-      "community": 236
+      "community": 238
     },
     {
       "label": "findSize()",
@@ -15897,7 +15897,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
       "source_location": "L61",
       "id": "productattribute_findsize",
-      "community": 236
+      "community": 238
     },
     {
       "label": "handleClick()",
@@ -15905,7 +15905,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
       "source_location": "L65",
       "id": "productattribute_handleclick",
-      "community": 236
+      "community": 238
     },
     {
       "label": "ProductAttributes.tsx",
@@ -15913,7 +15913,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttributes.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_page_productattributes_tsx",
-      "community": 480
+      "community": 481
     },
     {
       "label": "ProductAttributes()",
@@ -15921,7 +15921,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttributes.tsx",
       "source_location": "L3",
       "id": "productattributes_productattributes",
-      "community": 480
+      "community": 481
     },
     {
       "label": "ProductDetails.tsx",
@@ -15929,7 +15929,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_page_productdetails_tsx",
-      "community": 146
+      "community": 147
     },
     {
       "label": "PickupDetails()",
@@ -15937,7 +15937,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
       "source_location": "L13",
       "id": "productdetails_pickupdetails",
-      "community": 146
+      "community": 147
     },
     {
       "label": "BagProduct()",
@@ -15945,7 +15945,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
       "source_location": "L43",
       "id": "productdetails_bagproduct",
-      "community": 146
+      "community": 147
     },
     {
       "label": "ShippingPolicy()",
@@ -15953,7 +15953,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
       "source_location": "L88",
       "id": "productdetails_shippingpolicy",
-      "community": 146
+      "community": 147
     },
     {
       "label": "ProductInfo.tsx",
@@ -15961,7 +15961,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductInfo.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_page_productinfo_tsx",
-      "community": 1004
+      "community": 1005
     },
     {
       "label": "ProductPage.tsx",
@@ -15969,7 +15969,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductPage.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_page_productpage_tsx",
-      "community": 481
+      "community": 482
     },
     {
       "label": "showShippingPolicy()",
@@ -15977,7 +15977,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductPage.tsx",
       "source_location": "L78",
       "id": "productpage_showshippingpolicy",
-      "community": 481
+      "community": 482
     },
     {
       "label": "ProductReview.tsx",
@@ -15985,7 +15985,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductReview.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_page_productreview_tsx",
-      "community": 482
+      "community": 483
     },
     {
       "label": "handleHelpful()",
@@ -15993,7 +15993,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductReview.tsx",
       "source_location": "L87",
       "id": "productreview_handlehelpful",
-      "community": 482
+      "community": 483
     },
     {
       "label": "ProductReviews.tsx",
@@ -16001,7 +16001,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductReviews.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_page_productreviews_tsx",
-      "community": 1005
+      "community": 1006
     },
     {
       "label": "ProductsNavigationBar.tsx",
@@ -16009,7 +16009,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductsNavigationBar.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_page_productsnavigationbar_tsx",
-      "community": 1006
+      "community": 1007
     },
     {
       "label": "ReviewSummary.tsx",
@@ -16017,7 +16017,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_page_reviewsummary_tsx",
-      "community": 483
+      "community": 484
     },
     {
       "label": "ReviewSummary()",
@@ -16025,7 +16025,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
       "source_location": "L8",
       "id": "reviewsummary_reviewsummary",
-      "community": 483
+      "community": 484
     },
     {
       "label": "ErrorMessage.tsx",
@@ -16033,7 +16033,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ErrorMessage.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_reviews_errormessage_tsx",
-      "community": 1007
+      "community": 1008
     },
     {
       "label": "ExistingReviewMessage.tsx",
@@ -16041,7 +16041,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ExistingReviewMessage.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_reviews_existingreviewmessage_tsx",
-      "community": 1008
+      "community": 1009
     },
     {
       "label": "OrderItem.tsx",
@@ -16049,7 +16049,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_tsx",
-      "community": 484
+      "community": 485
     },
     {
       "label": "OrderItem()",
@@ -16057,7 +16057,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
       "source_location": "L12",
       "id": "orderitem_orderitem",
-      "community": 484
+      "community": 485
     },
     {
       "label": "RatingSelector.tsx",
@@ -16065,7 +16065,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/RatingSelector.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_reviews_ratingselector_tsx",
-      "community": 485
+      "community": 486
     },
     {
       "label": "RatingSelector()",
@@ -16073,7 +16073,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/RatingSelector.tsx",
       "source_location": "L18",
       "id": "ratingselector_ratingselector",
-      "community": 485
+      "community": 486
     },
     {
       "label": "ReviewEditor.tsx",
@@ -16081,7 +16081,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_reviews_revieweditor_tsx",
-      "community": 237
+      "community": 239
     },
     {
       "label": "handleFormDataChange()",
@@ -16089,7 +16089,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
       "source_location": "L150",
       "id": "revieweditor_handleformdatachange",
-      "community": 237
+      "community": 239
     },
     {
       "label": "handleSubmit()",
@@ -16097,7 +16097,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
       "source_location": "L157",
       "id": "revieweditor_handlesubmit",
-      "community": 237
+      "community": 239
     },
     {
       "label": "ReviewForm.tsx",
@@ -16105,7 +16105,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewForm.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_reviews_reviewform_tsx",
-      "community": 1009
+      "community": 1010
     },
     {
       "label": "SuccessMessage.tsx",
@@ -16113,7 +16113,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/SuccessMessage.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_reviews_successmessage_tsx",
-      "community": 1010
+      "community": 1011
     },
     {
       "label": "types.ts",
@@ -16121,7 +16121,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/types.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_reviews_types_ts",
-      "community": 1011
+      "community": 1012
     },
     {
       "label": "GuestRewardsPrompt.tsx",
@@ -16129,7 +16129,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/GuestRewardsPrompt.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_rewards_guestrewardsprompt_tsx",
-      "community": 486
+      "community": 487
     },
     {
       "label": "GuestRewardsPrompt()",
@@ -16137,7 +16137,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/GuestRewardsPrompt.tsx",
       "source_location": "L10",
       "id": "guestrewardsprompt_guestrewardsprompt",
-      "community": 486
+      "community": 487
     },
     {
       "label": "OrderPointsDisplay.tsx",
@@ -16145,7 +16145,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_rewards_orderpointsdisplay_tsx",
-      "community": 487
+      "community": 488
     },
     {
       "label": "OrderPointsDisplay()",
@@ -16153,7 +16153,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
       "source_location": "L11",
       "id": "orderpointsdisplay_orderpointsdisplay",
-      "community": 487
+      "community": 488
     },
     {
       "label": "PastOrdersRewards.tsx",
@@ -16161,7 +16161,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/PastOrdersRewards.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_rewards_pastordersrewards_tsx",
-      "community": 488
+      "community": 489
     },
     {
       "label": "handleClaimPoints()",
@@ -16169,7 +16169,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/PastOrdersRewards.tsx",
       "source_location": "L59",
       "id": "pastordersrewards_handleclaimpoints",
-      "community": 488
+      "community": 489
     },
     {
       "label": "RewardsPanel.tsx",
@@ -16177,7 +16177,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/RewardsPanel.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_rewards_rewardspanel_tsx",
-      "community": 489
+      "community": 490
     },
     {
       "label": "handleRedeemReward()",
@@ -16185,7 +16185,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/RewardsPanel.tsx",
       "source_location": "L33",
       "id": "rewardspanel_handleredeemreward",
-      "community": 489
+      "community": 490
     },
     {
       "label": "SavedBag.tsx",
@@ -16193,7 +16193,7 @@
       "source_file": "packages/storefront-webapp/src/components/saved-items/SavedBag.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_saved_items_savedbag_tsx",
-      "community": 1012
+      "community": 1013
     },
     {
       "label": "SavedIcon.tsx",
@@ -16201,7 +16201,7 @@
       "source_file": "packages/storefront-webapp/src/components/saved-items/SavedIcon.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_saved_items_savedicon_tsx",
-      "community": 1013
+      "community": 1014
     },
     {
       "label": "BagItem.tsx",
@@ -16209,7 +16209,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/BagItem.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_shopping_bag_bagitem_tsx",
-      "community": 490
+      "community": 491
     },
     {
       "label": "BagItem()",
@@ -16217,7 +16217,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/BagItem.tsx",
       "source_location": "L19",
       "id": "bagitem_bagitem",
-      "community": 490
+      "community": 491
     },
     {
       "label": "CartIcon.tsx",
@@ -16225,7 +16225,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/CartIcon.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_shopping_bag_carticon_tsx",
-      "community": 1014
+      "community": 1015
     },
     {
       "label": "ShoppingBag.tsx",
@@ -16233,7 +16233,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_tsx",
-      "community": 48
+      "community": 49
     },
     {
       "label": "PendingItem()",
@@ -16241,7 +16241,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L62",
       "id": "shoppingbag_pendingitem",
-      "community": 48
+      "community": 49
     },
     {
       "label": "handleOnCheckoutClick()",
@@ -16249,7 +16249,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L476",
       "id": "shoppingbag_handleoncheckoutclick",
-      "community": 48
+      "community": 49
     },
     {
       "label": "handleClickOnDiscountCode()",
@@ -16257,7 +16257,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L525",
       "id": "shoppingbag_handleclickondiscountcode",
-      "community": 48
+      "community": 49
     },
     {
       "label": "isSkuUnavailable()",
@@ -16265,7 +16265,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L537",
       "id": "shoppingbag_isskuunavailable",
-      "community": 48
+      "community": 49
     },
     {
       "label": "handleMoveToSaved()",
@@ -16273,7 +16273,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L552",
       "id": "shoppingbag_handlemovetosaved",
-      "community": 48
+      "community": 49
     },
     {
       "label": "handleDeleteItem()",
@@ -16281,7 +16281,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L566",
       "id": "shoppingbag_handledeleteitem",
-      "community": 48
+      "community": 49
     },
     {
       "label": "CheckoutUnavailable.tsx",
@@ -16289,7 +16289,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout unavailable/CheckoutUnavailable.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_states_checkout_unavailable_checkoutunavailable_tsx",
-      "community": 491
+      "community": 492
     },
     {
       "label": "CheckoutUnavailable()",
@@ -16297,7 +16297,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout unavailable/CheckoutUnavailable.tsx",
       "source_location": "L4",
       "id": "checkoutunavailable_checkoutunavailable",
-      "community": 491
+      "community": 492
     },
     {
       "label": "CheckoutExpired.tsx",
@@ -16305,7 +16305,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
-      "community": 72
+      "community": 73
     },
     {
       "label": "CheckoutExpired()",
@@ -16313,7 +16313,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L9",
       "id": "checkoutexpired_checkoutexpired",
-      "community": 72
+      "community": 73
     },
     {
       "label": "NoCheckoutSession()",
@@ -16321,7 +16321,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L33",
       "id": "checkoutexpired_nocheckoutsession",
-      "community": 72
+      "community": 73
     },
     {
       "label": "CheckoutSessionNotFound()",
@@ -16329,7 +16329,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L54",
       "id": "checkoutexpired_checkoutsessionnotfound",
-      "community": 72
+      "community": 73
     },
     {
       "label": "CheckoutSessionGeneric()",
@@ -16337,7 +16337,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L73",
       "id": "checkoutexpired_checkoutsessiongeneric",
-      "community": 72
+      "community": 73
     },
     {
       "label": "handleSendEmail()",
@@ -16345,7 +16345,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L98",
       "id": "checkoutexpired_handlesendemail",
-      "community": 72
+      "community": 73
     },
     {
       "label": "empty-state.tsx",
@@ -16353,7 +16353,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/empty/empty-state.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_states_empty_empty_state_tsx",
-      "community": 1015
+      "community": 1016
     },
     {
       "label": "ErrorBoundary.tsx",
@@ -16361,7 +16361,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/error/ErrorBoundary.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_states_error_errorboundary_tsx",
-      "community": 492
+      "community": 493
     },
     {
       "label": "ErrorBoundary()",
@@ -16369,7 +16369,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/error/ErrorBoundary.tsx",
       "source_location": "L22",
       "id": "errorboundary_errorboundary",
-      "community": 492
+      "community": 493
     },
     {
       "label": "SingleLineError.tsx",
@@ -16377,7 +16377,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/error/SingleLineError.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_states_error_singlelineerror_tsx",
-      "community": 186
+      "community": 188
     },
     {
       "label": "index.tsx",
@@ -16385,7 +16385,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/error/index.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_states_error_index_tsx",
-      "community": 187
+      "community": 189
     },
     {
       "label": "app-skeleton.tsx",
@@ -16393,7 +16393,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/app-skeleton.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_states_loading_app_skeleton_tsx",
-      "community": 188
+      "community": 190
     },
     {
       "label": "dashboard-skeleton.tsx",
@@ -16401,7 +16401,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/dashboard-skeleton.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_states_loading_dashboard_skeleton_tsx",
-      "community": 189
+      "community": 191
     },
     {
       "label": "table-skeleton.tsx",
@@ -16409,7 +16409,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/table-skeleton.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_states_loading_table_skeleton_tsx",
-      "community": 190
+      "community": 192
     },
     {
       "label": "transactions-skeleton.tsx",
@@ -16417,7 +16417,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/transactions-skeleton.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_states_loading_transactions_skeleton_tsx",
-      "community": 191
+      "community": 193
     },
     {
       "label": "Maintenance.tsx",
@@ -16425,7 +16425,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/maintenance/Maintenance.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_tsx",
-      "community": 1016
+      "community": 1017
     },
     {
       "label": "NotFound.tsx",
@@ -16433,7 +16433,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/not-found/NotFound.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_states_not_found_notfound_tsx",
-      "community": 192
+      "community": 194
     },
     {
       "label": "AnimatedCard.tsx",
@@ -16441,7 +16441,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/AnimatedCard.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_animatedcard_tsx",
-      "community": 1017
+      "community": 1018
     },
     {
       "label": "ScrollDownButton.tsx",
@@ -16449,7 +16449,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/ScrollDownButton.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_scrolldownbutton_tsx",
-      "community": 493
+      "community": 494
     },
     {
       "label": "ScrollDownButton()",
@@ -16457,7 +16457,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/ScrollDownButton.tsx",
       "source_location": "L11",
       "id": "scrolldownbutton_scrolldownbutton",
-      "community": 493
+      "community": 494
     },
     {
       "label": "accordion.tsx",
@@ -16465,7 +16465,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/accordion.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_accordion_tsx",
-      "community": 1018
+      "community": 1019
     },
     {
       "label": "alert.tsx",
@@ -16473,7 +16473,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/alert.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_alert_tsx",
-      "community": 1019
+      "community": 1020
     },
     {
       "label": "app-context-menu.tsx",
@@ -16481,7 +16481,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/app-context-menu.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_app_context_menu_tsx",
-      "community": 194
+      "community": 196
     },
     {
       "label": "badge.tsx",
@@ -16489,7 +16489,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/badge.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_badge_tsx",
-      "community": 195
+      "community": 197
     },
     {
       "label": "breadcrumb.tsx",
@@ -16497,7 +16497,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/breadcrumb.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_breadcrumb_tsx",
-      "community": 1020
+      "community": 1021
     },
     {
       "label": "button.tsx",
@@ -16505,7 +16505,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/button.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_button_tsx",
-      "community": 1021
+      "community": 1022
     },
     {
       "label": "card.tsx",
@@ -16513,7 +16513,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/card.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_card_tsx",
-      "community": 1022
+      "community": 1023
     },
     {
       "label": "checkbox.tsx",
@@ -16521,7 +16521,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/checkbox.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_checkbox_tsx",
-      "community": 1023
+      "community": 1024
     },
     {
       "label": "command.tsx",
@@ -16529,7 +16529,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/command.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_command_tsx",
-      "community": 1024
+      "community": 1025
     },
     {
       "label": "context-menu.tsx",
@@ -16537,7 +16537,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/context-menu.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_context_menu_tsx",
-      "community": 1025
+      "community": 1026
     },
     {
       "label": "country-select.tsx",
@@ -16545,7 +16545,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/country-select.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_country_select_tsx",
-      "community": 494
+      "community": 495
     },
     {
       "label": "CountrySelect()",
@@ -16553,7 +16553,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/country-select.tsx",
       "source_location": "L3",
       "id": "country_select_countryselect",
-      "community": 494
+      "community": 495
     },
     {
       "label": "dialog.tsx",
@@ -16561,7 +16561,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/dialog.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_dialog_tsx",
-      "community": 1026
+      "community": 1027
     },
     {
       "label": "dropdown-menu.tsx",
@@ -16569,7 +16569,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/dropdown-menu.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_dropdown_menu_tsx",
-      "community": 1027
+      "community": 1028
     },
     {
       "label": "form.tsx",
@@ -16577,7 +16577,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/form.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_form_tsx",
-      "community": 1028
+      "community": 1029
     },
     {
       "label": "ghana-region-select.tsx",
@@ -16585,7 +16585,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/ghana-region-select.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_ghana_region_select_tsx",
-      "community": 495
+      "community": 496
     },
     {
       "label": "GhanaRegionSelect()",
@@ -16593,7 +16593,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/ghana-region-select.tsx",
       "source_location": "L3",
       "id": "ghana_region_select_ghanaregionselect",
-      "community": 495
+      "community": 496
     },
     {
       "label": "ghost-button.tsx",
@@ -16601,7 +16601,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/ghost-button.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_ghost_button_tsx",
-      "community": 496
+      "community": 497
     },
     {
       "label": "GhostButton()",
@@ -16609,7 +16609,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/ghost-button.tsx",
       "source_location": "L9",
       "id": "ghost_button_ghostbutton",
-      "community": 496
+      "community": 497
     },
     {
       "label": "icons.tsx",
@@ -16617,7 +16617,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/icons.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_icons_tsx",
-      "community": 1029
+      "community": 1030
     },
     {
       "label": "image-uploader.tsx",
@@ -16625,7 +16625,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "community": 61
+      "community": 62
     },
     {
       "label": "image-with-fallback.tsx",
@@ -16633,7 +16633,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/image-with-fallback.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_image_with_fallback_tsx",
-      "community": 1030
+      "community": 1031
     },
     {
       "label": "input-otp.tsx",
@@ -16641,7 +16641,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/input-otp.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_input_otp_tsx",
-      "community": 1031
+      "community": 1032
     },
     {
       "label": "input-with-end-button.tsx",
@@ -16649,7 +16649,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/input-with-end-button.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_input_with_end_button_tsx",
-      "community": 1032
+      "community": 1033
     },
     {
       "label": "input.tsx",
@@ -16657,7 +16657,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/input.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_input_tsx",
-      "community": 1033
+      "community": 1034
     },
     {
       "label": "label.tsx",
@@ -16665,7 +16665,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/label.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_label_tsx",
-      "community": 1034
+      "community": 1035
     },
     {
       "label": "loading-button.tsx",
@@ -16673,7 +16673,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/loading-button.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_loading_button_tsx",
-      "community": 196
+      "community": 198
     },
     {
       "label": "modal.tsx",
@@ -16681,7 +16681,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modal.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modal_tsx",
-      "community": 197
+      "community": 199
     },
     {
       "label": "LeaveAReviewModal.tsx",
@@ -16689,7 +16689,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodal_tsx",
-      "community": 497
+      "community": 498
     },
     {
       "label": "handleClose()",
@@ -16697,7 +16697,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
       "source_location": "L66",
       "id": "leaveareviewmodal_handleclose",
-      "community": 497
+      "community": 498
     },
     {
       "label": "LeaveAReviewModalForm.tsx",
@@ -16705,7 +16705,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModalForm.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodalform_tsx",
-      "community": 1035
+      "community": 1036
     },
     {
       "label": "UpsellModal.tsx",
@@ -16713,7 +16713,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
-      "community": 147
+      "community": 148
     },
     {
       "label": "handleScroll()",
@@ -16721,7 +16721,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
       "source_location": "L66",
       "id": "upsellmodal_handlescroll",
-      "community": 147
+      "community": 148
     },
     {
       "label": "handleClose()",
@@ -16729,7 +16729,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
       "source_location": "L111",
       "id": "upsellmodal_handleclose",
-      "community": 147
+      "community": 148
     },
     {
       "label": "handleSuccess()",
@@ -16737,7 +16737,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
       "source_location": "L127",
       "id": "upsellmodal_handlesuccess",
-      "community": 147
+      "community": 148
     },
     {
       "label": "UpsellModalForm.tsx",
@@ -16745,7 +16745,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalform_tsx",
-      "community": 238
+      "community": 240
     },
     {
       "label": "handleSubmit()",
@@ -16753,7 +16753,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
       "source_location": "L48",
       "id": "upsellmodalform_handlesubmit",
-      "community": 238
+      "community": 240
     },
     {
       "label": "handleInputChange()",
@@ -16761,7 +16761,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
       "source_location": "L63",
       "id": "upsellmodalform_handleinputchange",
-      "community": 238
+      "community": 240
     },
     {
       "label": "UpsellModalSuccess.tsx",
@@ -16769,7 +16769,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalSuccess.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalsuccess_tsx",
-      "community": 498
+      "community": 499
     },
     {
       "label": "UpsellModalSuccess()",
@@ -16777,7 +16777,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalSuccess.tsx",
       "source_location": "L19",
       "id": "upsellmodalsuccess_upsellmodalsuccess",
-      "community": 498
+      "community": 499
     },
     {
       "label": "WelcomeBackModal.tsx",
@@ -16785,7 +16785,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodal_tsx",
-      "community": 239
+      "community": 241
     },
     {
       "label": "handleClose()",
@@ -16793,7 +16793,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
       "source_location": "L63",
       "id": "welcomebackmodal_handleclose",
-      "community": 239
+      "community": 241
     },
     {
       "label": "handleSuccess()",
@@ -16801,7 +16801,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
       "source_location": "L76",
       "id": "welcomebackmodal_handlesuccess",
-      "community": 239
+      "community": 241
     },
     {
       "label": "WelcomeBackModalForm.tsx",
@@ -16809,7 +16809,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalform_tsx",
-      "community": 240
+      "community": 242
     },
     {
       "label": "handleSubmit()",
@@ -16817,7 +16817,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
       "source_location": "L36",
       "id": "welcomebackmodalform_handlesubmit",
-      "community": 240
+      "community": 242
     },
     {
       "label": "handleInputChange()",
@@ -16825,7 +16825,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
       "source_location": "L51",
       "id": "welcomebackmodalform_handleinputchange",
-      "community": 240
+      "community": 242
     },
     {
       "label": "WelcomeBackModalSuccess.tsx",
@@ -16833,7 +16833,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalSuccess.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalsuccess_tsx",
-      "community": 499
+      "community": 500
     },
     {
       "label": "WelcomeBackModalSuccess()",
@@ -16841,7 +16841,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalSuccess.tsx",
       "source_location": "L13",
       "id": "welcomebackmodalsuccess_welcomebackmodalsuccess",
-      "community": 499
+      "community": 500
     },
     {
       "label": "action-modal.tsx",
@@ -16849,7 +16849,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/action-modal.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_action_modal_tsx",
-      "community": 1036
+      "community": 1037
     },
     {
       "label": "alert-modal.tsx",
@@ -16857,7 +16857,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/alert-modal.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_alert_modal_tsx",
-      "community": 198
+      "community": 200
     },
     {
       "label": "welcomeBackModalAnimations.ts",
@@ -16865,7 +16865,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/animations/welcomeBackModalAnimations.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_animations_welcomebackmodalanimations_ts",
-      "community": 1037
+      "community": 1038
     },
     {
       "label": "leaveReviewModalConfig.tsx",
@@ -16873,7 +16873,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/config/leaveReviewModalConfig.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_leavereviewmodalconfig_tsx",
-      "community": 500
+      "community": 501
     },
     {
       "label": "getModalConfig()",
@@ -16881,7 +16881,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/config/leaveReviewModalConfig.tsx",
       "source_location": "L46",
       "id": "leavereviewmodalconfig_getmodalconfig",
-      "community": 500
+      "community": 501
     },
     {
       "label": "welcomeBackModalConfig.tsx",
@@ -16889,7 +16889,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/config/welcomeBackModalConfig.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_welcomebackmodalconfig_tsx",
-      "community": 501
+      "community": 502
     },
     {
       "label": "getModalConfig()",
@@ -16897,7 +16897,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/config/welcomeBackModalConfig.tsx",
       "source_location": "L46",
       "id": "welcomebackmodalconfig_getmodalconfig",
-      "community": 501
+      "community": 502
     },
     {
       "label": "index.ts",
@@ -16905,7 +16905,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/index.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_index_ts",
-      "community": 1038
+      "community": 1039
     },
     {
       "label": "overlay-modal.tsx",
@@ -16913,7 +16913,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/overlay-modal.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_overlay_modal_tsx",
-      "community": 199
+      "community": 201
     },
     {
       "label": "types.ts",
@@ -16921,7 +16921,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/types.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_types_ts",
-      "community": 1039
+      "community": 1040
     },
     {
       "label": "navigation-menu.tsx",
@@ -16929,7 +16929,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/navigation-menu.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_navigation_menu_tsx",
-      "community": 1040
+      "community": 1041
     },
     {
       "label": "popover.tsx",
@@ -16937,7 +16937,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/popover.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_popover_tsx",
-      "community": 1041
+      "community": 1042
     },
     {
       "label": "radio-group.tsx",
@@ -16945,7 +16945,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/radio-group.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_radio_group_tsx",
-      "community": 1042
+      "community": 1043
     },
     {
       "label": "scroll-area.tsx",
@@ -16953,7 +16953,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/scroll-area.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_scroll_area_tsx",
-      "community": 1043
+      "community": 1044
     },
     {
       "label": "select.tsx",
@@ -16961,7 +16961,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/select.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_select_tsx",
-      "community": 1044
+      "community": 1045
     },
     {
       "label": "separator.tsx",
@@ -16969,7 +16969,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/separator.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_separator_tsx",
-      "community": 1045
+      "community": 1046
     },
     {
       "label": "sheet.tsx",
@@ -16977,7 +16977,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/sheet.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_sheet_tsx",
-      "community": 1046
+      "community": 1047
     },
     {
       "label": "skeleton.tsx",
@@ -16985,7 +16985,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/skeleton.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_skeleton_tsx",
-      "community": 200
+      "community": 202
     },
     {
       "label": "sonner.tsx",
@@ -16993,7 +16993,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/sonner.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_sonner_tsx",
-      "community": 201
+      "community": 203
     },
     {
       "label": "spinner.tsx",
@@ -17001,7 +17001,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/spinner.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_spinner_tsx",
-      "community": 202
+      "community": 204
     },
     {
       "label": "table.tsx",
@@ -17009,7 +17009,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/table.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_table_tsx",
-      "community": 1047
+      "community": 1048
     },
     {
       "label": "tabs.tsx",
@@ -17017,7 +17017,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/tabs.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_tabs_tsx",
-      "community": 1048
+      "community": 1049
     },
     {
       "label": "textarea.tsx",
@@ -17025,7 +17025,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/textarea.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_textarea_tsx",
-      "community": 1049
+      "community": 1050
     },
     {
       "label": "toggle-group.tsx",
@@ -17033,7 +17033,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/toggle-group.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_toggle_group_tsx",
-      "community": 1050
+      "community": 1051
     },
     {
       "label": "toggle.tsx",
@@ -17041,7 +17041,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/toggle.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_toggle_tsx",
-      "community": 1051
+      "community": 1052
     },
     {
       "label": "tooltip.tsx",
@@ -17049,7 +17049,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/tooltip.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_tooltip_tsx",
-      "community": 1052
+      "community": 1053
     },
     {
       "label": "webp-jpg.tsx",
@@ -17057,7 +17057,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/webp-jpg.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_webp_jpg_tsx",
-      "community": 502
+      "community": 503
     },
     {
       "label": "WebpImage()",
@@ -17065,7 +17065,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/webp-jpg.tsx",
       "source_location": "L1",
       "id": "webp_jpg_webpimage",
-      "community": 502
+      "community": 503
     },
     {
       "label": "config.ts",
@@ -17073,7 +17073,7 @@
       "source_file": "packages/storefront-webapp/src/config.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_config_ts",
-      "community": 1053
+      "community": 1054
     },
     {
       "label": "FormSubmissionProvider.tsx",
@@ -17081,7 +17081,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/FormSubmissionProvider.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_contexts_formsubmissionprovider_tsx",
-      "community": 503
+      "community": 504
     },
     {
       "label": "useFormSubmission()",
@@ -17089,7 +17089,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/FormSubmissionProvider.tsx",
       "source_location": "L15",
       "id": "formsubmissionprovider_useformsubmission",
-      "community": 503
+      "community": 504
     },
     {
       "label": "NavigationBarProvider.tsx",
@@ -17097,7 +17097,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_contexts_navigationbarprovider_tsx",
-      "community": 241
+      "community": 243
     },
     {
       "label": "NavigationBarProvider()",
@@ -17105,7 +17105,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
       "source_location": "L16",
       "id": "navigationbarprovider_navigationbarprovider",
-      "community": 241
+      "community": 243
     },
     {
       "label": "useNavigationBarContext()",
@@ -17113,7 +17113,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
       "source_location": "L39",
       "id": "navigationbarprovider_usenavigationbarcontext",
-      "community": 241
+      "community": 243
     },
     {
       "label": "StoreContext.tsx",
@@ -17121,7 +17121,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
-      "community": 242
+      "community": 244
     },
     {
       "label": "StoreProvider()",
@@ -17129,7 +17129,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
       "source_location": "L25",
       "id": "storecontext_storeprovider",
-      "community": 242
+      "community": 244
     },
     {
       "label": "useStoreContext()",
@@ -17137,7 +17137,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
       "source_location": "L82",
       "id": "storecontext_usestorecontext",
-      "community": 242
+      "community": 244
     },
     {
       "label": "StorefrontObservabilityProvider.tsx",
@@ -17145,7 +17145,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_tsx",
-      "community": 243
+      "community": 245
     },
     {
       "label": "StorefrontObservabilityProvider()",
@@ -17153,7 +17153,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
       "source_location": "L20",
       "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
-      "community": 243
+      "community": 245
     },
     {
       "label": "useStorefrontObservability()",
@@ -17161,7 +17161,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
       "source_location": "L55",
       "id": "storefrontobservabilityprovider_usestorefrontobservability",
-      "community": 243
+      "community": 245
     },
     {
       "label": "use-store-modal.tsx",
@@ -17169,7 +17169,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/use-store-modal.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_use_store_modal_tsx",
-      "community": 1054
+      "community": 1055
     },
     {
       "label": "useAuth.ts",
@@ -17177,7 +17177,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useAuth.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_useauth_ts",
-      "community": 210
+      "community": 212
     },
     {
       "label": "useCheckout.ts",
@@ -17185,7 +17185,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useCheckout.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_usecheckout_ts",
-      "community": 504
+      "community": 505
     },
     {
       "label": "useCheckout()",
@@ -17193,7 +17193,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useCheckout.ts",
       "source_location": "L5",
       "id": "usecheckout_usecheckout",
-      "community": 504
+      "community": 505
     },
     {
       "label": "useDiscountCodeAlert.tsx",
@@ -17201,7 +17201,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useDiscountCodeAlert.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_usediscountcodealert_tsx",
-      "community": 505
+      "community": 506
     },
     {
       "label": "useDiscountCodeAlert()",
@@ -17209,7 +17209,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useDiscountCodeAlert.tsx",
       "source_location": "L14",
       "id": "usediscountcodealert_usediscountcodealert",
-      "community": 505
+      "community": 506
     },
     {
       "label": "useEnhancedTracking.ts",
@@ -17217,7 +17217,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useEnhancedTracking.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_useenhancedtracking_ts",
-      "community": 506
+      "community": 507
     },
     {
       "label": "useEnhancedTracking()",
@@ -17225,7 +17225,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useEnhancedTracking.ts",
       "source_location": "L29",
       "id": "useenhancedtracking_useenhancedtracking",
-      "community": 506
+      "community": 507
     },
     {
       "label": "useGetActiveCheckoutSession.tsx",
@@ -17233,7 +17233,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetActiveCheckoutSession.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_usegetactivecheckoutsession_tsx",
-      "community": 507
+      "community": 508
     },
     {
       "label": "useGetActiveCheckoutSession()",
@@ -17241,7 +17241,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetActiveCheckoutSession.tsx",
       "source_location": "L5",
       "id": "usegetactivecheckoutsession_usegetactivecheckoutsession",
-      "community": 507
+      "community": 508
     },
     {
       "label": "useGetProduct.tsx",
@@ -17249,7 +17249,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetProduct.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_usegetproduct_tsx",
-      "community": 508
+      "community": 509
     },
     {
       "label": "useGetProductQuery()",
@@ -17257,7 +17257,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetProduct.tsx",
       "source_location": "L5",
       "id": "usegetproduct_usegetproductquery",
-      "community": 508
+      "community": 509
     },
     {
       "label": "useGetProductFilters.ts",
@@ -17265,7 +17265,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetProductFilters.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_usegetproductfilters_ts",
-      "community": 509
+      "community": 510
     },
     {
       "label": "useGetProductFilters()",
@@ -17273,7 +17273,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetProductFilters.ts",
       "source_location": "L3",
       "id": "usegetproductfilters_usegetproductfilters",
-      "community": 509
+      "community": 510
     },
     {
       "label": "useGetProductReviews.ts",
@@ -17281,7 +17281,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetProductReviews.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_usegetproductreviews_ts",
-      "community": 510
+      "community": 511
     },
     {
       "label": "useGetProductReviewsQuery()",
@@ -17289,7 +17289,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetProductReviews.ts",
       "source_location": "L4",
       "id": "usegetproductreviews_usegetproductreviewsquery",
-      "community": 510
+      "community": 511
     },
     {
       "label": "useGetStore.ts",
@@ -17297,7 +17297,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetStore.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_usegetstore_ts",
-      "community": 511
+      "community": 512
     },
     {
       "label": "useGetStore()",
@@ -17305,7 +17305,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetStore.ts",
       "source_location": "L4",
       "id": "usegetstore_usegetstore",
-      "community": 511
+      "community": 512
     },
     {
       "label": "useInventoryStatus.ts",
@@ -17313,7 +17313,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useInventoryStatus.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_useinventorystatus_ts",
-      "community": 512
+      "community": 513
     },
     {
       "label": "useInventoryStatus()",
@@ -17321,7 +17321,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useInventoryStatus.ts",
       "source_location": "L9",
       "id": "useinventorystatus_useinventorystatus",
-      "community": 512
+      "community": 513
     },
     {
       "label": "useLeaveAReviewModal.tsx",
@@ -17329,7 +17329,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useLeaveAReviewModal.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_useleaveareviewmodal_tsx",
-      "community": 513
+      "community": 514
     },
     {
       "label": "useLeaveAReviewModal()",
@@ -17337,7 +17337,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useLeaveAReviewModal.tsx",
       "source_location": "L17",
       "id": "useleaveareviewmodal_useleaveareviewmodal",
-      "community": 513
+      "community": 514
     },
     {
       "label": "useLogout.ts",
@@ -17345,7 +17345,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useLogout.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_uselogout_ts",
-      "community": 514
+      "community": 515
     },
     {
       "label": "useLogout()",
@@ -17353,7 +17353,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useLogout.ts",
       "source_location": "L5",
       "id": "uselogout_uselogout",
-      "community": 514
+      "community": 515
     },
     {
       "label": "useModalState.tsx",
@@ -17361,7 +17361,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useModalState.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_usemodalstate_tsx",
-      "community": 515
+      "community": 516
     },
     {
       "label": "useModalState()",
@@ -17369,7 +17369,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useModalState.tsx",
       "source_location": "L15",
       "id": "usemodalstate_usemodalstate",
-      "community": 515
+      "community": 516
     },
     {
       "label": "useOrganizationModal.tsx",
@@ -17377,7 +17377,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useOrganizationModal.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_useorganizationmodal_tsx",
-      "community": 1055
+      "community": 1056
     },
     {
       "label": "useProductDiscount.ts",
@@ -17385,7 +17385,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_useproductdiscount_ts",
-      "community": 244
+      "community": 246
     },
     {
       "label": "useProductDiscounts()",
@@ -17393,7 +17393,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
       "source_location": "L25",
       "id": "useproductdiscount_useproductdiscounts",
-      "community": 244
+      "community": 246
     },
     {
       "label": "useProductDiscount()",
@@ -17401,7 +17401,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
       "source_location": "L107",
       "id": "useproductdiscount_useproductdiscount",
-      "community": 244
+      "community": 246
     },
     {
       "label": "useProductPageLogic.ts",
@@ -17409,7 +17409,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useProductPageLogic.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_useproductpagelogic_ts",
-      "community": 516
+      "community": 517
     },
     {
       "label": "useProductPageLogic()",
@@ -17417,7 +17417,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useProductPageLogic.ts",
       "source_location": "L18",
       "id": "useproductpagelogic_useproductpagelogic",
-      "community": 516
+      "community": 517
     },
     {
       "label": "useProductReminder.tsx",
@@ -17425,7 +17425,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useProductReminder.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_useproductreminder_tsx",
-      "community": 517
+      "community": 518
     },
     {
       "label": "useProductReminder()",
@@ -17433,7 +17433,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useProductReminder.tsx",
       "source_location": "L9",
       "id": "useproductreminder_useproductreminder",
-      "community": 517
+      "community": 518
     },
     {
       "label": "usePromoAlert.tsx",
@@ -17441,7 +17441,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/usePromoAlert.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_usepromoalert_tsx",
-      "community": 518
+      "community": 519
     },
     {
       "label": "usePromoAlert()",
@@ -17449,7 +17449,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/usePromoAlert.tsx",
       "source_location": "L16",
       "id": "usepromoalert_usepromoalert",
-      "community": 518
+      "community": 519
     },
     {
       "label": "useQueryEnabled.ts",
@@ -17457,7 +17457,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useQueryEnabled.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_usequeryenabled_ts",
-      "community": 519
+      "community": 520
     },
     {
       "label": "useQueryEnabled()",
@@ -17465,7 +17465,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useQueryEnabled.ts",
       "source_location": "L4",
       "id": "usequeryenabled_usequeryenabled",
-      "community": 519
+      "community": 520
     },
     {
       "label": "useRewardsAlert.tsx",
@@ -17473,7 +17473,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useRewardsAlert.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_userewardsalert_tsx",
-      "community": 520
+      "community": 521
     },
     {
       "label": "useRewardsAlert()",
@@ -17481,7 +17481,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useRewardsAlert.tsx",
       "source_location": "L11",
       "id": "userewardsalert_userewardsalert",
-      "community": 520
+      "community": 521
     },
     {
       "label": "useScrollToTop.ts",
@@ -17489,7 +17489,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useScrollToTop.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_usescrolltotop_ts",
-      "community": 521
+      "community": 522
     },
     {
       "label": "useScrollToTop()",
@@ -17497,7 +17497,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useScrollToTop.ts",
       "source_location": "L3",
       "id": "usescrolltotop_usescrolltotop",
-      "community": 521
+      "community": 522
     },
     {
       "label": "useShoppingBag.ts",
@@ -17505,7 +17505,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_useshoppingbag_ts",
-      "community": 245
+      "community": 247
     },
     {
       "label": "useShoppingBag()",
@@ -17513,7 +17513,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
       "source_location": "L52",
       "id": "useshoppingbag_useshoppingbag",
-      "community": 245
+      "community": 247
     },
     {
       "label": "isUnavailableProductList()",
@@ -17521,7 +17521,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
       "source_location": "L540",
       "id": "useshoppingbag_isunavailableproductlist",
-      "community": 245
+      "community": 247
     },
     {
       "label": "useStorefrontObservability.ts",
@@ -17529,7 +17529,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useStorefrontObservability.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_usestorefrontobservability_ts",
-      "community": 1056
+      "community": 1057
     },
     {
       "label": "useTrackAction.ts",
@@ -17537,7 +17537,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useTrackAction.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_usetrackaction_ts",
-      "community": 522
+      "community": 523
     },
     {
       "label": "useTrackAction()",
@@ -17545,7 +17545,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useTrackAction.ts",
       "source_location": "L5",
       "id": "usetrackaction_usetrackaction",
-      "community": 522
+      "community": 523
     },
     {
       "label": "useTrackEvent.ts",
@@ -17553,7 +17553,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useTrackEvent.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_usetrackevent_ts",
-      "community": 523
+      "community": 524
     },
     {
       "label": "useTrackEvent()",
@@ -17561,7 +17561,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useTrackEvent.ts",
       "source_location": "L5",
       "id": "usetrackevent_usetrackevent",
-      "community": 523
+      "community": 524
     },
     {
       "label": "useUpsellModal.tsx",
@@ -17569,7 +17569,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useUpsellModal.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_useupsellmodal_tsx",
-      "community": 524
+      "community": 525
     },
     {
       "label": "useUpsellModal()",
@@ -17577,7 +17577,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useUpsellModal.tsx",
       "source_location": "L14",
       "id": "useupsellmodal_useupsellmodal",
-      "community": 524
+      "community": 525
     },
     {
       "label": "constants.ts",
@@ -17585,7 +17585,7 @@
       "source_file": "packages/storefront-webapp/src/lib/constants.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_constants_ts",
-      "community": 1057
+      "community": 1058
     },
     {
       "label": "countries.ts",
@@ -17593,7 +17593,7 @@
       "source_file": "packages/storefront-webapp/src/lib/countries.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_countries_ts",
-      "community": 1058
+      "community": 1059
     },
     {
       "label": "currency.ts",
@@ -17601,7 +17601,7 @@
       "source_file": "packages/storefront-webapp/src/lib/currency.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_currency_ts",
-      "community": 117
+      "community": 118
     },
     {
       "label": "feeUtils.test.ts",
@@ -17609,7 +17609,7 @@
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.test.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_feeutils_test_ts",
-      "community": 1059
+      "community": 1060
     },
     {
       "label": "feeUtils.ts",
@@ -17617,7 +17617,7 @@
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_feeutils_ts",
-      "community": 73
+      "community": 74
     },
     {
       "label": "meetsThreshold()",
@@ -17625,7 +17625,7 @@
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L17",
       "id": "feeutils_meetsthreshold",
-      "community": 73
+      "community": 74
     },
     {
       "label": "isFeeWaived()",
@@ -17633,7 +17633,7 @@
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L34",
       "id": "feeutils_isfeewaived",
-      "community": 73
+      "community": 74
     },
     {
       "label": "isAnyFeeWaived()",
@@ -17641,7 +17641,7 @@
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L74",
       "id": "feeutils_isanyfeewaived",
-      "community": 73
+      "community": 74
     },
     {
       "label": "hasWaiverConfigured()",
@@ -17649,7 +17649,7 @@
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L100",
       "id": "feeutils_haswaiverconfigured",
-      "community": 73
+      "community": 74
     },
     {
       "label": "getRemainingForFreeDelivery()",
@@ -17657,7 +17657,7 @@
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L138",
       "id": "feeutils_getremainingforfreedelivery",
-      "community": 73
+      "community": 74
     },
     {
       "label": "ghana.ts",
@@ -17665,7 +17665,7 @@
       "source_file": "packages/storefront-webapp/src/lib/ghana.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_ghana_ts",
-      "community": 1060
+      "community": 1061
     },
     {
       "label": "ghanaRegions.ts",
@@ -17673,7 +17673,7 @@
       "source_file": "packages/storefront-webapp/src/lib/ghanaRegions.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_ghanaregions_ts",
-      "community": 1061
+      "community": 1062
     },
     {
       "label": "maintenanceUtils.test.ts",
@@ -17681,7 +17681,7 @@
       "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.test.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_test_ts",
-      "community": 1062
+      "community": 1063
     },
     {
       "label": "maintenanceUtils.ts",
@@ -17689,7 +17689,7 @@
       "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_ts",
-      "community": 215
+      "community": 217
     },
     {
       "label": "analytics.ts",
@@ -17697,7 +17697,7 @@
       "source_file": "packages/storefront-webapp/src/lib/mutations.ts/analytics.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_analytics_ts",
-      "community": 525
+      "community": 526
     },
     {
       "label": "usePostAnalytics()",
@@ -17705,7 +17705,7 @@
       "source_file": "packages/storefront-webapp/src/lib/mutations.ts/analytics.ts",
       "source_location": "L4",
       "id": "analytics_usepostanalytics",
-      "community": 525
+      "community": 526
     },
     {
       "label": "index.ts",
@@ -17713,7 +17713,7 @@
       "source_file": "packages/storefront-webapp/src/lib/mutations.ts/index.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_index_ts",
-      "community": 1063
+      "community": 1064
     },
     {
       "label": "productUtils.ts",
@@ -17721,7 +17721,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "community": 49
+      "community": 47
     },
     {
       "label": "isSoldOut()",
@@ -17729,7 +17729,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L45",
       "id": "productutils_issoldout",
-      "community": 49
+      "community": 47
     },
     {
       "label": "hasLowStock()",
@@ -17737,7 +17737,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L52",
       "id": "productutils_haslowstock",
-      "community": 49
+      "community": 47
     },
     {
       "label": "sortSkusByLength()",
@@ -17745,7 +17745,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L62",
       "id": "productutils_sortskusbylength",
-      "community": 49
+      "community": 47
     },
     {
       "label": "bag.ts",
@@ -17753,7 +17753,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/bag.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_queries_bag_ts",
-      "community": 526
+      "community": 527
     },
     {
       "label": "useBagQueries()",
@@ -17761,7 +17761,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/bag.ts",
       "source_location": "L7",
       "id": "bag_usebagqueries",
-      "community": 526
+      "community": 527
     },
     {
       "label": "bannerMessage.ts",
@@ -17769,7 +17769,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/bannerMessage.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_queries_bannermessage_ts",
-      "community": 527
+      "community": 528
     },
     {
       "label": "useBannerMessageQueries()",
@@ -17777,7 +17777,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/bannerMessage.ts",
       "source_location": "L6",
       "id": "bannermessage_usebannermessagequeries",
-      "community": 527
+      "community": 528
     },
     {
       "label": "checkout.ts",
@@ -17785,7 +17785,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/checkout.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_queries_checkout_ts",
-      "community": 528
+      "community": 529
     },
     {
       "label": "useCheckoutSessionQueries()",
@@ -17793,7 +17793,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/checkout.ts",
       "source_location": "L10",
       "id": "checkout_usecheckoutsessionqueries",
-      "community": 528
+      "community": 529
     },
     {
       "label": "inventory.ts",
@@ -17801,7 +17801,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/inventory.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_queries_inventory_ts",
-      "community": 529
+      "community": 530
     },
     {
       "label": "useInventoryQueries()",
@@ -17809,7 +17809,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/inventory.ts",
       "source_location": "L6",
       "id": "inventory_useinventoryqueries",
-      "community": 529
+      "community": 530
     },
     {
       "label": "onlineOrder.ts",
@@ -17817,7 +17817,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/onlineOrder.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_queries_onlineorder_ts",
-      "community": 530
+      "community": 531
     },
     {
       "label": "useOnlineOrderQueries()",
@@ -17825,7 +17825,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/onlineOrder.ts",
       "source_location": "L5",
       "id": "onlineorder_useonlineorderqueries",
-      "community": 530
+      "community": 531
     },
     {
       "label": "product.ts",
@@ -17833,7 +17833,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/product.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_queries_product_ts",
-      "community": 531
+      "community": 532
     },
     {
       "label": "useProductQueries()",
@@ -17841,7 +17841,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/product.ts",
       "source_location": "L14",
       "id": "product_useproductqueries",
-      "community": 531
+      "community": 532
     },
     {
       "label": "promoCode.ts",
@@ -17849,7 +17849,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/promoCode.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_queries_promocode_ts",
-      "community": 532
+      "community": 533
     },
     {
       "label": "usePromoCodesQueries()",
@@ -17857,7 +17857,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/promoCode.ts",
       "source_location": "L9",
       "id": "promocode_usepromocodesqueries",
-      "community": 532
+      "community": 533
     },
     {
       "label": "reviews.ts",
@@ -17865,7 +17865,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/reviews.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_queries_reviews_ts",
-      "community": 533
+      "community": 534
     },
     {
       "label": "useReviewQueries()",
@@ -17873,7 +17873,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/reviews.ts",
       "source_location": "L10",
       "id": "reviews_usereviewqueries",
-      "community": 533
+      "community": 534
     },
     {
       "label": "rewards.ts",
@@ -17881,7 +17881,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/rewards.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_queries_rewards_ts",
-      "community": 534
+      "community": 535
     },
     {
       "label": "useRewardsQueries()",
@@ -17889,7 +17889,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/rewards.ts",
       "source_location": "L11",
       "id": "rewards_userewardsqueries",
-      "community": 534
+      "community": 535
     },
     {
       "label": "store.ts",
@@ -17897,7 +17897,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/store.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_queries_store_ts",
-      "community": 1064
+      "community": 1065
     },
     {
       "label": "upsells.ts",
@@ -17905,7 +17905,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/upsells.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_queries_upsells_ts",
-      "community": 535
+      "community": 536
     },
     {
       "label": "useUpsellsQueries()",
@@ -17913,7 +17913,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/upsells.ts",
       "source_location": "L6",
       "id": "upsells_useupsellsqueries",
-      "community": 535
+      "community": 536
     },
     {
       "label": "user.ts",
@@ -17921,7 +17921,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/user.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_queries_user_ts",
-      "community": 536
+      "community": 537
     },
     {
       "label": "useUserQueries()",
@@ -17929,7 +17929,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/user.ts",
       "source_location": "L5",
       "id": "user_useuserqueries",
-      "community": 536
+      "community": 537
     },
     {
       "label": "userOffers.ts",
@@ -17937,7 +17937,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/userOffers.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_queries_useroffers_ts",
-      "community": 537
+      "community": 538
     },
     {
       "label": "useUserOffersQueries()",
@@ -17945,7 +17945,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/userOffers.ts",
       "source_location": "L6",
       "id": "useroffers_useuseroffersqueries",
-      "community": 537
+      "community": 538
     },
     {
       "label": "bag.ts",
@@ -17953,7 +17953,7 @@
       "source_file": "packages/storefront-webapp/src/lib/schemas/bag.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_schemas_bag_ts",
-      "community": 1065
+      "community": 1066
     },
     {
       "label": "bagItem.ts",
@@ -17961,7 +17961,7 @@
       "source_file": "packages/storefront-webapp/src/lib/schemas/bagItem.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_schemas_bagitem_ts",
-      "community": 1066
+      "community": 1067
     },
     {
       "label": "category.ts",
@@ -17969,7 +17969,7 @@
       "source_file": "packages/storefront-webapp/src/lib/schemas/category.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_schemas_category_ts",
-      "community": 1067
+      "community": 1068
     },
     {
       "label": "organization.ts",
@@ -17977,7 +17977,7 @@
       "source_file": "packages/storefront-webapp/src/lib/schemas/organization.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_schemas_organization_ts",
-      "community": 1068
+      "community": 1069
     },
     {
       "label": "product.ts",
@@ -17985,7 +17985,7 @@
       "source_file": "packages/storefront-webapp/src/lib/schemas/product.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_schemas_product_ts",
-      "community": 1069
+      "community": 1070
     },
     {
       "label": "store.ts",
@@ -17993,7 +17993,7 @@
       "source_file": "packages/storefront-webapp/src/lib/schemas/store.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_schemas_store_ts",
-      "community": 1070
+      "community": 1071
     },
     {
       "label": "subcategory.ts",
@@ -18001,7 +18001,7 @@
       "source_file": "packages/storefront-webapp/src/lib/schemas/subcategory.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_schemas_subcategory_ts",
-      "community": 1071
+      "community": 1072
     },
     {
       "label": "user.ts",
@@ -18009,7 +18009,7 @@
       "source_file": "packages/storefront-webapp/src/lib/schemas/user.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_schemas_user_ts",
-      "community": 1072
+      "community": 1073
     },
     {
       "label": "states.ts",
@@ -18017,7 +18017,7 @@
       "source_file": "packages/storefront-webapp/src/lib/states.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_states_ts",
-      "community": 1073
+      "community": 1074
     },
     {
       "label": "storeConfig.test.ts",
@@ -18025,7 +18025,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.test.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_storeconfig_test_ts",
-      "community": 538
+      "community": 539
     },
     {
       "label": "buildV2Config()",
@@ -18033,7 +18033,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.test.ts",
       "source_location": "L10",
       "id": "storeconfig_test_buildv2config",
-      "community": 538
+      "community": 539
     },
     {
       "label": "storeConfig.ts",
@@ -18081,7 +18081,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.test.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_test_ts",
-      "community": 1074
+      "community": 1075
     },
     {
       "label": "storefrontFailureObservability.ts",
@@ -18089,7 +18089,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_ts",
-      "community": 108
+      "community": 109
     },
     {
       "label": "inferStorefrontJourneyFromRoute()",
@@ -18097,7 +18097,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
       "source_location": "L25",
       "id": "storefrontfailureobservability_inferstorefrontjourneyfromroute",
-      "community": 108
+      "community": 109
     },
     {
       "label": "normalizeStorefrontError()",
@@ -18105,7 +18105,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
       "source_location": "L47",
       "id": "storefrontfailureobservability_normalizestorefronterror",
-      "community": 108
+      "community": 109
     },
     {
       "label": "createStorefrontFailureEvent()",
@@ -18113,7 +18113,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
       "source_location": "L136",
       "id": "storefrontfailureobservability_createstorefrontfailureevent",
-      "community": 108
+      "community": 109
     },
     {
       "label": "emitStorefrontFailure()",
@@ -18121,7 +18121,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
       "source_location": "L154",
       "id": "storefrontfailureobservability_emitstorefrontfailure",
-      "community": 108
+      "community": 109
     },
     {
       "label": "storefrontJourneyEvents.test.ts",
@@ -18129,7 +18129,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.test.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_storefrontjourneyevents_test_ts",
-      "community": 1075
+      "community": 1076
     },
     {
       "label": "storefrontJourneyEvents.ts",
@@ -18505,7 +18505,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.test.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_storefrontobservability_test_ts",
-      "community": 539
+      "community": 540
     },
     {
       "label": "createMemoryStorage()",
@@ -18513,7 +18513,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.test.ts",
       "source_location": "L12",
       "id": "storefrontobservability_test_creatememorystorage",
-      "community": 539
+      "community": 540
     },
     {
       "label": "storefrontObservability.ts",
@@ -18521,7 +18521,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_storefrontobservability_ts",
-      "community": 109
+      "community": 110
     },
     {
       "label": "getOrCreateStorefrontObservabilitySessionId()",
@@ -18529,7 +18529,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L109",
       "id": "storefrontobservability_getorcreatestorefrontobservabilitysessionid",
-      "community": 109
+      "community": 110
     },
     {
       "label": "createStorefrontObservabilityContext()",
@@ -18537,7 +18537,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L134",
       "id": "storefrontobservability_createstorefrontobservabilitycontext",
-      "community": 109
+      "community": 110
     },
     {
       "label": "createStorefrontObservabilityPayload()",
@@ -18545,7 +18545,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L157",
       "id": "storefrontobservability_createstorefrontobservabilitypayload",
-      "community": 109
+      "community": 110
     },
     {
       "label": "trackStorefrontEvent()",
@@ -18553,7 +18553,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L193",
       "id": "storefrontobservability_trackstorefrontevent",
-      "community": 109
+      "community": 110
     },
     {
       "label": "utils.test.ts",
@@ -18561,7 +18561,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.test.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_utils_test_ts",
-      "community": 1076
+      "community": 1077
     },
     {
       "label": "utils.ts",
@@ -18593,7 +18593,7 @@
       "source_file": "packages/storefront-webapp/src/lib/validations/email.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_validations_email_ts",
-      "community": 540
+      "community": 541
     },
     {
       "label": "validateEmail()",
@@ -18601,7 +18601,7 @@
       "source_file": "packages/storefront-webapp/src/lib/validations/email.ts",
       "source_location": "L14",
       "id": "email_validateemail",
-      "community": 540
+      "community": 541
     },
     {
       "label": "main.tsx",
@@ -18609,7 +18609,7 @@
       "source_file": "packages/storefront-webapp/src/main.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_main_tsx",
-      "community": 216
+      "community": 218
     },
     {
       "label": "routeTree.gen.ts",
@@ -18617,7 +18617,7 @@
       "source_file": "packages/storefront-webapp/src/routeTree.gen.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routetree_gen_ts",
-      "community": 1077
+      "community": 1078
     },
     {
       "label": "router.tsx",
@@ -18625,7 +18625,7 @@
       "source_file": "packages/storefront-webapp/src/router.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_router_tsx",
-      "community": 541
+      "community": 542
     },
     {
       "label": "createRouter()",
@@ -18633,7 +18633,7 @@
       "source_file": "packages/storefront-webapp/src/router.tsx",
       "source_location": "L5",
       "id": "router_createrouter",
-      "community": 541
+      "community": 542
     },
     {
       "label": "__root.tsx",
@@ -18641,7 +18641,7 @@
       "source_file": "packages/storefront-webapp/src/routes/__root.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_root_tsx",
-      "community": 1078
+      "community": 1079
     },
     {
       "label": "$orderItemId.review.tsx",
@@ -18649,7 +18649,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/$orderItemId.review.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_orderitemid_review_tsx",
-      "community": 1079
+      "community": 1080
     },
     {
       "label": "index.tsx",
@@ -18657,7 +18657,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_index_tsx",
-      "community": 246
+      "community": 248
     },
     {
       "label": "getPaymentText()",
@@ -18665,7 +18665,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
       "source_location": "L102",
       "id": "index_getpaymenttext",
-      "community": 246
+      "community": 248
     },
     {
       "label": "getOrderMessage()",
@@ -18673,7 +18673,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
       "source_location": "L429",
       "id": "index_getordermessage",
-      "community": 246
+      "community": 248
     },
     {
       "label": "review.tsx",
@@ -18681,7 +18681,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_review_tsx",
-      "community": 247
+      "community": 249
     },
     {
       "label": "OrderNavigation()",
@@ -18689,7 +18689,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
       "source_location": "L46",
       "id": "review_ordernavigation",
-      "community": 247
+      "community": 249
     },
     {
       "label": "getOrderMessage()",
@@ -18697,7 +18697,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
       "source_location": "L250",
       "id": "review_getordermessage",
-      "community": 247
+      "community": 249
     },
     {
       "label": "index.tsx",
@@ -18705,7 +18705,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/index.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_index_tsx",
-      "community": 1080
+      "community": 1081
     },
     {
       "label": "_ordersLayout.tsx",
@@ -18713,7 +18713,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_tsx",
-      "community": 542
+      "community": 543
     },
     {
       "label": "LayoutComponent()",
@@ -18721,7 +18721,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout.tsx",
       "source_location": "L8",
       "id": "orderslayout_layoutcomponent",
-      "community": 542
+      "community": 543
     },
     {
       "label": "$subcategorySlug.tsx",
@@ -18729,7 +18729,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout/shop/$categorySlug/$subcategorySlug.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_subcategoryslug_tsx",
-      "community": 1081
+      "community": 1082
     },
     {
       "label": "index.tsx",
@@ -18737,7 +18737,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout/shop/$categorySlug/index.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_index_tsx",
-      "community": 1082
+      "community": 1083
     },
     {
       "label": "_shopLayout.tsx",
@@ -18745,7 +18745,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_tsx",
-      "community": 148
+      "community": 149
     },
     {
       "label": "onClickOnMobileFilters()",
@@ -18753,7 +18753,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
       "source_location": "L105",
       "id": "shoplayout_onclickonmobilefilters",
-      "community": 148
+      "community": 149
     },
     {
       "label": "onMobileFiltersCloseClick()",
@@ -18761,7 +18761,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
       "source_location": "L110",
       "id": "shoplayout_onmobilefilterscloseclick",
-      "community": 148
+      "community": 149
     },
     {
       "label": "clearFilters()",
@@ -18769,7 +18769,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
       "source_location": "L115",
       "id": "shoplayout_clearfilters",
-      "community": 148
+      "community": 149
     },
     {
       "label": "account.tsx",
@@ -18777,7 +18777,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_layout_account_tsx",
-      "community": 248
+      "community": 250
     },
     {
       "label": "accountBeforeLoad()",
@@ -18785,7 +18785,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
       "source_location": "L17",
       "id": "account_accountbeforeload",
-      "community": 248
+      "community": 250
     },
     {
       "label": "handleOnSubmitForm()",
@@ -18793,7 +18793,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
       "source_location": "L63",
       "id": "account_handleonsubmitform",
-      "community": 248
+      "community": 250
     },
     {
       "label": "contact-us.tsx",
@@ -18801,7 +18801,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/contact-us.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_layout_contact_us_tsx",
-      "community": 543
+      "community": 544
     },
     {
       "label": "ContactUs()",
@@ -18809,7 +18809,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/contact-us.tsx",
       "source_location": "L14",
       "id": "contact_us_contactus",
-      "community": 543
+      "community": 544
     },
     {
       "label": "delivery-returns-exchanges.index.tsx",
@@ -18817,7 +18817,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/delivery-returns-exchanges.index.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_layout_policies_delivery_returns_exchanges_index_tsx",
-      "community": 544
+      "community": 545
     },
     {
       "label": "OnlineOrderPolicy()",
@@ -18825,7 +18825,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/delivery-returns-exchanges.index.tsx",
       "source_location": "L13",
       "id": "delivery_returns_exchanges_index_onlineorderpolicy",
-      "community": 544
+      "community": 545
     },
     {
       "label": "privacy.index.tsx",
@@ -18833,7 +18833,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/privacy.index.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_layout_policies_privacy_index_tsx",
-      "community": 545
+      "community": 546
     },
     {
       "label": "PrivacyPolicy()",
@@ -18841,7 +18841,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/privacy.index.tsx",
       "source_location": "L9",
       "id": "privacy_index_privacypolicy",
-      "community": 545
+      "community": 546
     },
     {
       "label": "tos.index.tsx",
@@ -18849,7 +18849,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_layout_policies_tos_index_tsx",
-      "community": 546
+      "community": 547
     },
     {
       "label": "TosSection()",
@@ -18857,7 +18857,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
       "source_location": "L15",
       "id": "tos_index_tossection",
-      "community": 546
+      "community": 547
     },
     {
       "label": "rewards.index.tsx",
@@ -18865,7 +18865,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/rewards.index.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_layout_rewards_index_tsx",
-      "community": 1083
+      "community": 1084
     },
     {
       "label": "shop.product.$productSlug.tsx",
@@ -18873,7 +18873,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/shop.product.$productSlug.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_layout_shop_product_productslug_tsx",
-      "community": 547
+      "community": 548
     },
     {
       "label": "Component()",
@@ -18881,7 +18881,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/shop.product.$productSlug.tsx",
       "source_location": "L16",
       "id": "shop_product_productslug_component",
-      "community": 547
+      "community": 548
     },
     {
       "label": "shop.saved.index.tsx",
@@ -18889,7 +18889,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/shop.saved.index.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_layout_shop_saved_index_tsx",
-      "community": 1084
+      "community": 1085
     },
     {
       "label": "_layout.tsx",
@@ -18897,7 +18897,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_layout_tsx",
-      "community": 548
+      "community": 549
     },
     {
       "label": "LayoutComponent()",
@@ -18905,7 +18905,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout.tsx",
       "source_location": "L6",
       "id": "layout_layoutcomponent",
-      "community": 548
+      "community": 549
     },
     {
       "label": "auth.verify.tsx",
@@ -18913,7 +18913,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_auth_verify_tsx",
-      "community": 74
+      "community": 75
     },
     {
       "label": "reportAuthFailure()",
@@ -18921,7 +18921,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L93",
       "id": "auth_verify_reportauthfailure",
-      "community": 74
+      "community": 75
     },
     {
       "label": "formatTime()",
@@ -18929,7 +18929,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L149",
       "id": "auth_verify_formattime",
-      "community": 74
+      "community": 75
     },
     {
       "label": "handleCodeChange()",
@@ -18937,7 +18937,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L156",
       "id": "auth_verify_handlecodechange",
-      "community": 74
+      "community": 75
     },
     {
       "label": "onSubmit()",
@@ -18945,7 +18945,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L201",
       "id": "auth_verify_onsubmit",
-      "community": 74
+      "community": 75
     },
     {
       "label": "resendVerificationCode()",
@@ -18953,7 +18953,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L282",
       "id": "auth_verify_resendverificationcode",
-      "community": 74
+      "community": 75
     },
     {
       "label": "index.tsx",
@@ -18961,7 +18961,7 @@
       "source_file": "packages/storefront-webapp/src/routes/index.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_index_tsx",
-      "community": 1085
+      "community": 1086
     },
     {
       "label": "login.tsx",
@@ -18969,7 +18969,7 @@
       "source_file": "packages/storefront-webapp/src/routes/login.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_login_tsx",
-      "community": 249
+      "community": 251
     },
     {
       "label": "loginBeforeLoad()",
@@ -18977,7 +18977,7 @@
       "source_file": "packages/storefront-webapp/src/routes/login.tsx",
       "source_location": "L47",
       "id": "login_loginbeforeload",
-      "community": 249
+      "community": 251
     },
     {
       "label": "onSubmit()",
@@ -18985,7 +18985,7 @@
       "source_file": "packages/storefront-webapp/src/routes/login.tsx",
       "source_location": "L141",
       "id": "login_onsubmit",
-      "community": 249
+      "community": 251
     },
     {
       "label": "bag.index.tsx",
@@ -18993,7 +18993,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/bag.index.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_shop_bag_index_tsx",
-      "community": 1086
+      "community": 1087
     },
     {
       "label": "canceled.tsx",
@@ -19001,7 +19001,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/canceled.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_canceled_tsx",
-      "community": 549
+      "community": 550
     },
     {
       "label": "CheckoutCanceledView()",
@@ -19009,7 +19009,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/canceled.tsx",
       "source_location": "L21",
       "id": "canceled_checkoutcanceledview",
-      "community": 549
+      "community": 550
     },
     {
       "label": "complete.tsx",
@@ -19017,7 +19017,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/complete.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_complete_tsx",
-      "community": 1087
+      "community": 1088
     },
     {
       "label": "incomplete.tsx",
@@ -19025,7 +19025,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/incomplete.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_incomplete_tsx",
-      "community": 1088
+      "community": 1089
     },
     {
       "label": "index.tsx",
@@ -19033,7 +19033,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_index_tsx",
-      "community": 149
+      "community": 150
     },
     {
       "label": "getErrorMessage()",
@@ -19041,7 +19041,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
       "source_location": "L26",
       "id": "index_geterrormessage",
-      "community": 149
+      "community": 150
     },
     {
       "label": "placeOrder()",
@@ -19049,7 +19049,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
       "source_location": "L71",
       "id": "index_placeorder",
-      "community": 149
+      "community": 150
     },
     {
       "label": "cancelOrder()",
@@ -19057,7 +19057,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
       "source_location": "L121",
       "id": "index_cancelorder",
-      "community": 149
+      "community": 150
     },
     {
       "label": "complete.index.tsx",
@@ -19065,7 +19065,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/complete.index.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_complete_index_tsx",
-      "community": 550
+      "community": 551
     },
     {
       "label": "CheckoutComplete()",
@@ -19073,7 +19073,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/complete.index.tsx",
       "source_location": "L33",
       "id": "complete_index_checkoutcomplete",
-      "community": 550
+      "community": 551
     },
     {
       "label": "index.tsx",
@@ -19081,7 +19081,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/index.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_index_tsx",
-      "community": 1089
+      "community": 1090
     },
     {
       "label": "pending.tsx",
@@ -19089,7 +19089,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/pending.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pending_tsx",
-      "community": 1090
+      "community": 1091
     },
     {
       "label": "pod-confirmation.tsx",
@@ -19097,7 +19097,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/pod-confirmation.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pod_confirmation_tsx",
-      "community": 551
+      "community": 552
     },
     {
       "label": "completePODCheckoutSession()",
@@ -19105,7 +19105,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/pod-confirmation.tsx",
       "source_location": "L193",
       "id": "pod_confirmation_completepodcheckoutsession",
-      "community": 551
+      "community": 552
     },
     {
       "label": "verify.index.tsx",
@@ -19113,7 +19113,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_verify_index_tsx",
-      "community": 250
+      "community": 252
     },
     {
       "label": "Verify()",
@@ -19121,7 +19121,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
       "source_location": "L21",
       "id": "verify_index_verify",
-      "community": 250
+      "community": 252
     },
     {
       "label": "VerifyCheckoutSessionPayment()",
@@ -19129,7 +19129,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
       "source_location": "L107",
       "id": "verify_index_verifycheckoutsessionpayment",
-      "community": 250
+      "community": 252
     },
     {
       "label": "signup.tsx",
@@ -19137,7 +19137,7 @@
       "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_signup_tsx",
-      "community": 251
+      "community": 253
     },
     {
       "label": "signupBeforeLoad()",
@@ -19145,7 +19145,7 @@
       "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
       "source_location": "L66",
       "id": "signup_signupbeforeload",
-      "community": 251
+      "community": 253
     },
     {
       "label": "onSubmit()",
@@ -19153,7 +19153,7 @@
       "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
       "source_location": "L161",
       "id": "signup_onsubmit",
-      "community": 251
+      "community": 253
     },
     {
       "label": "ssr.tsx",
@@ -19161,7 +19161,7 @@
       "source_file": "packages/storefront-webapp/src/ssr.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_ssr_tsx",
-      "community": 1091
+      "community": 1092
     },
     {
       "label": "index.ts",
@@ -19169,7 +19169,7 @@
       "source_file": "packages/storefront-webapp/src/utils/index.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_utils_index_ts",
-      "community": 219
+      "community": 221
     },
     {
       "label": "session.ts",
@@ -19177,7 +19177,7 @@
       "source_file": "packages/storefront-webapp/src/utils/session.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_utils_session_ts",
-      "community": 220
+      "community": 222
     },
     {
       "label": "versionChecker.ts",
@@ -19185,7 +19185,7 @@
       "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
-      "community": 221
+      "community": 223
     },
     {
       "label": "tailwind.config.js",
@@ -19193,7 +19193,7 @@
       "source_file": "packages/storefront-webapp/tailwind.config.js",
       "source_location": "L1",
       "id": "packages_storefront_webapp_tailwind_config_js",
-      "community": 1092
+      "community": 1093
     },
     {
       "label": "bootstrap.ts",
@@ -19201,7 +19201,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_tests_e2e_helpers_bootstrap_ts",
-      "community": 150
+      "community": 151
     },
     {
       "label": "createMarker()",
@@ -19209,7 +19209,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
       "source_location": "L20",
       "id": "bootstrap_createmarker",
-      "community": 150
+      "community": 151
     },
     {
       "label": "createBootstrapToken()",
@@ -19217,7 +19217,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
       "source_location": "L24",
       "id": "bootstrap_createbootstraptoken",
-      "community": 150
+      "community": 151
     },
     {
       "label": "bootstrapCheckout()",
@@ -19225,7 +19225,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
       "source_location": "L46",
       "id": "bootstrap_bootstrapcheckout",
-      "community": 150
+      "community": 151
     },
     {
       "label": "env.ts",
@@ -19233,7 +19233,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_tests_e2e_helpers_env_ts",
-      "community": 252
+      "community": 254
     },
     {
       "label": "requireEnv()",
@@ -19241,7 +19241,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
       "source_location": "L1",
       "id": "env_requireenv",
-      "community": 252
+      "community": 254
     },
     {
       "label": "optionalNumberEnv()",
@@ -19249,7 +19249,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
       "source_location": "L11",
       "id": "env_optionalnumberenv",
-      "community": 252
+      "community": 254
     },
     {
       "label": "vite.config.ts",
@@ -19257,7 +19257,7 @@
       "source_file": "packages/storefront-webapp/vite.config.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_vite_config_ts",
-      "community": 222
+      "community": 224
     },
     {
       "label": "vitest.config.ts",
@@ -19265,7 +19265,7 @@
       "source_file": "packages/storefront-webapp/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_vitest_config_ts",
-      "community": 1093
+      "community": 1094
     },
     {
       "label": "vitest.setup.ts",
@@ -19273,7 +19273,7 @@
       "source_file": "packages/storefront-webapp/vitest.setup.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_vitest_setup_ts",
-      "community": 1094
+      "community": 1095
     },
     {
       "label": "index.js",
@@ -19281,7 +19281,7 @@
       "source_file": "packages/valkey-proxy-server/index.js",
       "source_location": "L1",
       "id": "packages_valkey_proxy_server_index_js",
-      "community": 1095
+      "community": 1096
     },
     {
       "label": "test-connection.js",
@@ -19289,7 +19289,7 @@
       "source_file": "packages/valkey-proxy-server/test-connection.js",
       "source_location": "L1",
       "id": "packages_valkey_proxy_server_test_connection_js",
-      "community": 110
+      "community": 111
     },
     {
       "label": "testConnection()",
@@ -19297,7 +19297,7 @@
       "source_file": "packages/valkey-proxy-server/test-connection.js",
       "source_location": "L40",
       "id": "test_connection_testconnection",
-      "community": 110
+      "community": 111
     },
     {
       "label": "testClusterInfo()",
@@ -19305,7 +19305,7 @@
       "source_file": "packages/valkey-proxy-server/test-connection.js",
       "source_location": "L52",
       "id": "test_connection_testclusterinfo",
-      "community": 110
+      "community": 111
     },
     {
       "label": "testBasicOperations()",
@@ -19313,7 +19313,7 @@
       "source_file": "packages/valkey-proxy-server/test-connection.js",
       "source_location": "L64",
       "id": "test_connection_testbasicoperations",
-      "community": 110
+      "community": 111
     },
     {
       "label": "runTests()",
@@ -19321,7 +19321,7 @@
       "source_file": "packages/valkey-proxy-server/test-connection.js",
       "source_location": "L89",
       "id": "test_connection_runtests",
-      "community": 110
+      "community": 111
     },
     {
       "label": "architecture-boundaries.test.ts",
@@ -19329,7 +19329,7 @@
       "source_file": "scripts/architecture-boundaries.test.ts",
       "source_location": "L1",
       "id": "scripts_architecture_boundaries_test_ts",
-      "community": 552
+      "community": 553
     },
     {
       "label": "createSnippetLinter()",
@@ -19337,7 +19337,7 @@
       "source_file": "scripts/architecture-boundaries.test.ts",
       "source_location": "L10",
       "id": "architecture_boundaries_test_createsnippetlinter",
-      "community": 552
+      "community": 553
     },
     {
       "label": "architecture-boundary-check.ts",
@@ -19345,7 +19345,7 @@
       "source_file": "scripts/architecture-boundary-check.ts",
       "source_location": "L1",
       "id": "scripts_architecture_boundary_check_ts",
-      "community": 553
+      "community": 554
     },
     {
       "label": "run()",
@@ -19353,7 +19353,7 @@
       "source_file": "scripts/architecture-boundary-check.ts",
       "source_location": "L29",
       "id": "architecture_boundary_check_run",
-      "community": 553
+      "community": 554
     },
     {
       "label": "graphify-check.test.ts",
@@ -19361,7 +19361,7 @@
       "source_file": "scripts/graphify-check.test.ts",
       "source_location": "L1",
       "id": "scripts_graphify_check_test_ts",
-      "community": 253
+      "community": 255
     },
     {
       "label": "write()",
@@ -19369,7 +19369,7 @@
       "source_file": "scripts/graphify-check.test.ts",
       "source_location": "L10",
       "id": "graphify_check_test_write",
-      "community": 253
+      "community": 255
     },
     {
       "label": "createFixtureRoot()",
@@ -19377,7 +19377,7 @@
       "source_file": "scripts/graphify-check.test.ts",
       "source_location": "L16",
       "id": "graphify_check_test_createfixtureroot",
-      "community": 253
+      "community": 255
     },
     {
       "label": "graphify-check.ts",
@@ -19385,7 +19385,7 @@
       "source_file": "scripts/graphify-check.ts",
       "source_location": "L1",
       "id": "scripts_graphify_check_ts",
-      "community": 75
+      "community": 76
     },
     {
       "label": "fileExists()",
@@ -19393,7 +19393,7 @@
       "source_file": "scripts/graphify-check.ts",
       "source_location": "L58",
       "id": "graphify_check_fileexists",
-      "community": 75
+      "community": 76
     },
     {
       "label": "collectRepoCodeFiles()",
@@ -19401,7 +19401,7 @@
       "source_file": "scripts/graphify-check.ts",
       "source_location": "L67",
       "id": "graphify_check_collectrepocodefiles",
-      "community": 75
+      "community": 76
     },
     {
       "label": "copyGraphifyCheckInputs()",
@@ -19409,7 +19409,7 @@
       "source_file": "scripts/graphify-check.ts",
       "source_location": "L101",
       "id": "graphify_check_copygraphifycheckinputs",
-      "community": 75
+      "community": 76
     },
     {
       "label": "collectStaleGraphifyArtifacts()",
@@ -19417,7 +19417,7 @@
       "source_file": "scripts/graphify-check.ts",
       "source_location": "L119",
       "id": "graphify_check_collectstalegraphifyartifacts",
-      "community": 75
+      "community": 76
     },
     {
       "label": "runGraphifyCheck()",
@@ -19425,7 +19425,7 @@
       "source_file": "scripts/graphify-check.ts",
       "source_location": "L146",
       "id": "graphify_check_rungraphifycheck",
-      "community": 75
+      "community": 76
     },
     {
       "label": "graphify-rebuild.test.ts",
@@ -19433,7 +19433,7 @@
       "source_file": "scripts/graphify-rebuild.test.ts",
       "source_location": "L1",
       "id": "scripts_graphify_rebuild_test_ts",
-      "community": 151
+      "community": 152
     },
     {
       "label": "write()",
@@ -19441,7 +19441,7 @@
       "source_file": "scripts/graphify-rebuild.test.ts",
       "source_location": "L10",
       "id": "graphify_rebuild_test_write",
-      "community": 151
+      "community": 152
     },
     {
       "label": "createFixtureRoot()",
@@ -19449,7 +19449,7 @@
       "source_file": "scripts/graphify-rebuild.test.ts",
       "source_location": "L16",
       "id": "graphify_rebuild_test_createfixtureroot",
-      "community": 151
+      "community": 152
     },
     {
       "label": "spawn()",
@@ -19457,7 +19457,7 @@
       "source_file": "scripts/graphify-rebuild.test.ts",
       "source_location": "L57",
       "id": "graphify_rebuild_test_spawn",
-      "community": 151
+      "community": 152
     },
     {
       "label": "graphify-rebuild.ts",
@@ -19465,7 +19465,7 @@
       "source_file": "scripts/graphify-rebuild.ts",
       "source_location": "L1",
       "id": "scripts_graphify_rebuild_ts",
-      "community": 152
+      "community": 153
     },
     {
       "label": "fileExists()",
@@ -19473,7 +19473,7 @@
       "source_file": "scripts/graphify-rebuild.ts",
       "source_location": "L78",
       "id": "graphify_rebuild_fileexists",
-      "community": 152
+      "community": 153
     },
     {
       "label": "resolveGraphifyPython()",
@@ -19481,7 +19481,7 @@
       "source_file": "scripts/graphify-rebuild.ts",
       "source_location": "L87",
       "id": "graphify_rebuild_resolvegraphifypython",
-      "community": 152
+      "community": 153
     },
     {
       "label": "runGraphifyRebuild()",
@@ -19489,7 +19489,7 @@
       "source_file": "scripts/graphify-rebuild.ts",
       "source_location": "L114",
       "id": "graphify_rebuild_rungraphifyrebuild",
-      "community": 152
+      "community": 153
     },
     {
       "label": "harness-app-registry.ts",
@@ -19497,7 +19497,7 @@
       "source_file": "scripts/harness-app-registry.ts",
       "source_location": "L1",
       "id": "scripts_harness_app_registry_ts",
-      "community": 254
+      "community": 256
     },
     {
       "label": "buildHarnessDocPaths()",
@@ -19505,7 +19505,7 @@
       "source_file": "scripts/harness-app-registry.ts",
       "source_location": "L103",
       "id": "harness_app_registry_buildharnessdocpaths",
-      "community": 254
+      "community": 256
     },
     {
       "label": "getHarnessPackageRegistration()",
@@ -19513,7 +19513,7 @@
       "source_file": "scripts/harness-app-registry.ts",
       "source_location": "L375",
       "id": "harness_app_registry_getharnesspackageregistration",
-      "community": 254
+      "community": 256
     },
     {
       "label": "harness-audit.test.ts",
@@ -19521,7 +19521,7 @@
       "source_file": "scripts/harness-audit.test.ts",
       "source_location": "L1",
       "id": "scripts_harness_audit_test_ts",
-      "community": 255
+      "community": 257
     },
     {
       "label": "write()",
@@ -19529,7 +19529,7 @@
       "source_file": "scripts/harness-audit.test.ts",
       "source_location": "L11",
       "id": "harness_audit_test_write",
-      "community": 255
+      "community": 257
     },
     {
       "label": "createFixtureRepo()",
@@ -19537,7 +19537,7 @@
       "source_file": "scripts/harness-audit.test.ts",
       "source_location": "L17",
       "id": "harness_audit_test_createfixturerepo",
-      "community": 255
+      "community": 257
     },
     {
       "label": "harness-audit.ts",
@@ -19649,7 +19649,7 @@
       "source_file": "scripts/harness-behavior-fixtures/athena-runtime-app.ts",
       "source_location": "L1",
       "id": "scripts_harness_behavior_fixtures_athena_runtime_app_ts",
-      "community": 554
+      "community": 555
     },
     {
       "label": "shutdown()",
@@ -19657,7 +19657,7 @@
       "source_file": "scripts/harness-behavior-fixtures/athena-runtime-app.ts",
       "source_location": "L211",
       "id": "athena_runtime_app_shutdown",
-      "community": 554
+      "community": 555
     },
     {
       "label": "sample-app.ts",
@@ -19665,7 +19665,7 @@
       "source_file": "scripts/harness-behavior-fixtures/sample-app.ts",
       "source_location": "L1",
       "id": "scripts_harness_behavior_fixtures_sample_app_ts",
-      "community": 555
+      "community": 556
     },
     {
       "label": "shutdown()",
@@ -19673,7 +19673,71 @@
       "source_file": "scripts/harness-behavior-fixtures/sample-app.ts",
       "source_location": "L85",
       "id": "sample_app_shutdown",
-      "community": 555
+      "community": 556
+    },
+    {
+      "label": "storefront-runtime-api.ts",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L1",
+      "id": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
+      "community": 50
+    },
+    {
+      "label": "withCorsHeaders()",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L171",
+      "id": "storefront_runtime_api_withcorsheaders",
+      "community": 50
+    },
+    {
+      "label": "jsonResponse()",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L186",
+      "id": "storefront_runtime_api_jsonresponse",
+      "community": 50
+    },
+    {
+      "label": "emitSignal()",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L195",
+      "id": "storefront_runtime_api_emitsignal",
+      "community": 50
+    },
+    {
+      "label": "handleCheckoutSessionFetch()",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L199",
+      "id": "storefront_runtime_api_handlecheckoutsessionfetch",
+      "community": 50
+    },
+    {
+      "label": "handleCheckoutSessionUpdate()",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L221",
+      "id": "storefront_runtime_api_handlecheckoutsessionupdate",
+      "community": 50
+    },
+    {
+      "label": "shutdown()",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L394",
+      "id": "storefront_runtime_api_shutdown",
+      "community": 50
+    },
+    {
+      "label": "harness-behavior-scenarios.test.ts",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior-scenarios.test.ts",
+      "source_location": "L1",
+      "id": "scripts_harness_behavior_scenarios_test_ts",
+      "community": 1097
     },
     {
       "label": "harness-behavior-scenarios.ts",
@@ -19681,23 +19745,31 @@
       "source_file": "scripts/harness-behavior-scenarios.ts",
       "source_location": "L1",
       "id": "scripts_harness_behavior_scenarios_ts",
-      "community": 256
+      "community": 154
     },
     {
       "label": "createAthenaRuntimeProcess()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L41",
+      "source_location": "L63",
       "id": "harness_behavior_scenarios_createathenaruntimeprocess",
-      "community": 256
+      "community": 154
     },
     {
       "label": "buildAthenaRuntimeUrl()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L53",
+      "source_location": "L75",
       "id": "harness_behavior_scenarios_buildathenaruntimeurl",
-      "community": 256
+      "community": 154
+    },
+    {
+      "label": "createStorefrontRuntimeProcesses()",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L79",
+      "id": "harness_behavior_scenarios_createstorefrontruntimeprocesses",
+      "community": 154
     },
     {
       "label": "harness-behavior.test.ts",
@@ -19705,39 +19777,39 @@
       "source_file": "scripts/harness-behavior.test.ts",
       "source_location": "L1",
       "id": "scripts_harness_behavior_test_ts",
-      "community": 111
+      "community": 112
     },
     {
       "label": "write()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.test.ts",
-      "source_location": "L14",
+      "source_location": "L15",
       "id": "harness_behavior_test_write",
-      "community": 111
+      "community": 112
     },
     {
       "label": "createFixtureRoot()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.test.ts",
-      "source_location": "L20",
+      "source_location": "L21",
       "id": "harness_behavior_test_createfixtureroot",
-      "community": 111
+      "community": 112
     },
     {
       "label": "log()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.test.ts",
-      "source_location": "L112",
+      "source_location": "L113",
       "id": "harness_behavior_test_log",
-      "community": 111
+      "community": 112
     },
     {
       "label": "error()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.test.ts",
-      "source_location": "L115",
+      "source_location": "L116",
       "id": "harness_behavior_test_error",
-      "community": 111
+      "community": 112
     },
     {
       "label": "harness-behavior.ts",
@@ -19745,167 +19817,175 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L1",
       "id": "scripts_harness_behavior_ts",
-      "community": 5
+      "community": 4
     },
     {
       "label": "HarnessBehaviorPhaseError",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L150",
+      "source_location": "L151",
       "id": "harness_behavior_harnessbehaviorphaseerror",
-      "community": 5
+      "community": 4
     },
     {
       "label": ".constructor()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L154",
+      "source_location": "L155",
       "id": "harness_behavior_harnessbehaviorphaseerror_constructor",
-      "community": 5
+      "community": 4
     },
     {
       "label": "logPhase()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L206",
+      "source_location": "L207",
       "id": "harness_behavior_logphase",
-      "community": 5
+      "community": 4
     },
     {
       "label": "sleep()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L214",
+      "source_location": "L215",
       "id": "harness_behavior_sleep",
-      "community": 5
+      "community": 4
     },
     {
       "label": "asRegExp()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L220",
+      "source_location": "L221",
       "id": "harness_behavior_asregexp",
-      "community": 5
+      "community": 4
     },
     {
       "label": "escapeRegExp()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L228",
+      "source_location": "L229",
       "id": "harness_behavior_escaperegexp",
-      "community": 5
+      "community": 4
     },
     {
       "label": "formatError()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L232",
+      "source_location": "L233",
       "id": "harness_behavior_formaterror",
-      "community": 5
+      "community": 4
     },
     {
       "label": "getLinesForSource()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L240",
+      "source_location": "L241",
       "id": "harness_behavior_getlinesforsource",
-      "community": 5
+      "community": 4
     },
     {
       "label": "consumeLines()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L253",
+      "source_location": "L254",
       "id": "harness_behavior_consumelines",
-      "community": 5
+      "community": 4
     },
     {
       "label": "stopProcess()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L319",
+      "source_location": "L320",
       "id": "harness_behavior_stopprocess",
-      "community": 5
+      "community": 4
     },
     {
       "label": "startProcess()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L341",
+      "source_location": "L342",
       "id": "harness_behavior_startprocess",
-      "community": 5
+      "community": 4
     },
     {
       "label": "spawnCommand()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L475",
+      "source_location": "L476",
       "id": "harness_behavior_spawncommand",
-      "community": 5
+      "community": 4
+    },
+    {
+      "label": "resolveHarnessBehaviorShell()",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L530",
+      "id": "harness_behavior_resolveharnessbehaviorshell",
+      "community": 4
     },
     {
       "label": "runHttpReadinessCheck()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L526",
+      "source_location": "L557",
       "id": "harness_behavior_runhttpreadinesscheck",
-      "community": 5
+      "community": 4
     },
     {
       "label": "collectRuntimeSignalMatches()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L558",
+      "source_location": "L589",
       "id": "harness_behavior_collectruntimesignalmatches",
-      "community": 5
+      "community": 4
     },
     {
       "label": "runPlaywrightFlow()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L658",
+      "source_location": "L689",
       "id": "harness_behavior_runplaywrightflow",
-      "community": 5
+      "community": 4
     },
     {
       "label": "wrapPhaseError()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L762",
+      "source_location": "L793",
       "id": "harness_behavior_wrapphaseerror",
-      "community": 5
+      "community": 4
     },
     {
       "label": "runHarnessBehaviorScenario()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L773",
+      "source_location": "L804",
       "id": "harness_behavior_runharnessbehaviorscenario",
-      "community": 5
+      "community": 4
     },
     {
       "label": "parseHarnessBehaviorArgs()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L925",
+      "source_location": "L956",
       "id": "harness_behavior_parseharnessbehaviorargs",
-      "community": 5
+      "community": 4
     },
     {
       "label": "printHarnessBehaviorUsage()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L997",
+      "source_location": "L1028",
       "id": "harness_behavior_printharnessbehaviorusage",
-      "community": 5
+      "community": 4
     },
     {
       "label": "runHarnessBehaviorCli()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L1005",
+      "source_location": "L1036",
       "id": "harness_behavior_runharnessbehaviorcli",
-      "community": 5
+      "community": 4
     },
     {
       "label": "harness-check.test.ts",
@@ -19913,7 +19993,7 @@
       "source_file": "scripts/harness-check.test.ts",
       "source_location": "L1",
       "id": "scripts_harness_check_test_ts",
-      "community": 257
+      "community": 258
     },
     {
       "label": "write()",
@@ -19921,7 +20001,7 @@
       "source_file": "scripts/harness-check.test.ts",
       "source_location": "L29",
       "id": "harness_check_test_write",
-      "community": 257
+      "community": 258
     },
     {
       "label": "createFixtureRepo()",
@@ -19929,7 +20009,7 @@
       "source_file": "scripts/harness-check.test.ts",
       "source_location": "L35",
       "id": "harness_check_test_createfixturerepo",
-      "community": 257
+      "community": 258
     },
     {
       "label": "harness-check.ts",
@@ -20089,7 +20169,7 @@
       "source_file": "scripts/harness-generate.test.ts",
       "source_location": "L1",
       "id": "scripts_harness_generate_test_ts",
-      "community": 258
+      "community": 259
     },
     {
       "label": "write()",
@@ -20097,7 +20177,7 @@
       "source_file": "scripts/harness-generate.test.ts",
       "source_location": "L10",
       "id": "harness_generate_test_write",
-      "community": 258
+      "community": 259
     },
     {
       "label": "createFixtureRepo()",
@@ -20105,7 +20185,7 @@
       "source_file": "scripts/harness-generate.test.ts",
       "source_location": "L16",
       "id": "harness_generate_test_createfixturerepo",
-      "community": 258
+      "community": 259
     },
     {
       "label": "harness-generate.ts",
@@ -20329,7 +20409,7 @@
       "source_file": "scripts/harness-review.test.ts",
       "source_location": "L1",
       "id": "scripts_harness_review_test_ts",
-      "community": 112
+      "community": 113
     },
     {
       "label": "write()",
@@ -20337,7 +20417,7 @@
       "source_file": "scripts/harness-review.test.ts",
       "source_location": "L10",
       "id": "harness_review_test_write",
-      "community": 112
+      "community": 113
     },
     {
       "label": "createFixtureRepo()",
@@ -20345,7 +20425,7 @@
       "source_file": "scripts/harness-review.test.ts",
       "source_location": "L16",
       "id": "harness_review_test_createfixturerepo",
-      "community": 112
+      "community": 113
     },
     {
       "label": "log()",
@@ -20353,7 +20433,7 @@
       "source_file": "scripts/harness-review.test.ts",
       "source_location": "L152",
       "id": "harness_review_test_log",
-      "community": 112
+      "community": 113
     },
     {
       "label": "error()",
@@ -20361,7 +20441,7 @@
       "source_file": "scripts/harness-review.test.ts",
       "source_location": "L153",
       "id": "harness_review_test_error",
-      "community": 112
+      "community": 113
     },
     {
       "label": "harness-review.ts",
@@ -20473,7 +20553,7 @@
       "source_file": "scripts/harness-self-review.test.ts",
       "source_location": "L1",
       "id": "scripts_harness_self_review_test_ts",
-      "community": 259
+      "community": 260
     },
     {
       "label": "write()",
@@ -20481,7 +20561,7 @@
       "source_file": "scripts/harness-self-review.test.ts",
       "source_location": "L10",
       "id": "harness_self_review_test_write",
-      "community": 259
+      "community": 260
     },
     {
       "label": "createFixtureRepo()",
@@ -20489,7 +20569,7 @@
       "source_file": "scripts/harness-self-review.test.ts",
       "source_location": "L16",
       "id": "harness_self_review_test_createfixturerepo",
-      "community": 259
+      "community": 260
     },
     {
       "label": "harness-self-review.ts",
@@ -20497,7 +20577,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L1",
       "id": "scripts_harness_self_review_ts",
-      "community": 4
+      "community": 5
     },
     {
       "label": "normalizeRepoPath()",
@@ -20505,7 +20585,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L91",
       "id": "harness_self_review_normalizerepopath",
-      "community": 4
+      "community": 5
     },
     {
       "label": "sortUniquePaths()",
@@ -20513,7 +20593,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L95",
       "id": "harness_self_review_sortuniquepaths",
-      "community": 4
+      "community": 5
     },
     {
       "label": "matchesPathPrefix()",
@@ -20521,7 +20601,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L101",
       "id": "harness_self_review_matchespathprefix",
-      "community": 4
+      "community": 5
     },
     {
       "label": "normalizeValidationCommand()",
@@ -20529,7 +20609,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L115",
       "id": "harness_self_review_normalizevalidationcommand",
-      "community": 4
+      "community": 5
     },
     {
       "label": "formatValidationCommand()",
@@ -20537,7 +20617,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L123",
       "id": "harness_self_review_formatvalidationcommand",
-      "community": 4
+      "community": 5
     },
     {
       "label": "quoteCode()",
@@ -20545,7 +20625,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L131",
       "id": "harness_self_review_quotecode",
-      "community": 4
+      "community": 5
     },
     {
       "label": "fileExists()",
@@ -20553,7 +20633,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L135",
       "id": "harness_self_review_fileexists",
-      "community": 4
+      "community": 5
     },
     {
       "label": "readJsonFile()",
@@ -20561,7 +20641,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L144",
       "id": "harness_self_review_readjsonfile",
-      "community": 4
+      "community": 5
     },
     {
       "label": "runCommand()",
@@ -20569,7 +20649,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L148",
       "id": "harness_self_review_runcommand",
-      "community": 4
+      "community": 5
     },
     {
       "label": "getChangedFilesFromGit()",
@@ -20577,7 +20657,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L168",
       "id": "harness_self_review_getchangedfilesfromgit",
-      "community": 4
+      "community": 5
     },
     {
       "label": "parseRuntimeScenarios()",
@@ -20585,7 +20665,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L232",
       "id": "harness_self_review_parseruntimescenarios",
-      "community": 4
+      "community": 5
     },
     {
       "label": "loadSelfReviewTarget()",
@@ -20593,7 +20673,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L238",
       "id": "harness_self_review_loadselfreviewtarget",
-      "community": 4
+      "community": 5
     },
     {
       "label": "loadSelfReviewTargets()",
@@ -20601,7 +20681,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L350",
       "id": "harness_self_review_loadselfreviewtargets",
-      "community": 4
+      "community": 5
     },
     {
       "label": "collectCoverage()",
@@ -20609,7 +20689,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L369",
       "id": "harness_self_review_collectcoverage",
-      "community": 4
+      "community": 5
     },
     {
       "label": "isLikelyCodeOrConfig()",
@@ -20617,7 +20697,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L447",
       "id": "harness_self_review_islikelycodeorconfig",
-      "community": 4
+      "community": 5
     },
     {
       "label": "evaluateGraphifyFreshness()",
@@ -20625,7 +20705,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L468",
       "id": "harness_self_review_evaluategraphifyfreshness",
-      "community": 4
+      "community": 5
     },
     {
       "label": "runQuietHarnessCheck()",
@@ -20633,7 +20713,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L532",
       "id": "harness_self_review_runquietharnesscheck",
-      "community": 4
+      "community": 5
     },
     {
       "label": "appendListSection()",
@@ -20641,7 +20721,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L541",
       "id": "harness_self_review_appendlistsection",
-      "community": 4
+      "community": 5
     },
     {
       "label": "buildMarkdownBundle()",
@@ -20649,7 +20729,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L560",
       "id": "harness_self_review_buildmarkdownbundle",
-      "community": 4
+      "community": 5
     },
     {
       "label": "parseCliArguments()",
@@ -20657,7 +20737,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L717",
       "id": "harness_self_review_parsecliarguments",
-      "community": 4
+      "community": 5
     },
     {
       "label": "runHarnessSelfReview()",
@@ -20665,7 +20745,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L766",
       "id": "harness_self_review_runharnessselfreview",
-      "community": 4
+      "community": 5
     },
     {
       "label": "pre-push-review.test.ts",
@@ -20673,7 +20753,7 @@
       "source_file": "scripts/pre-push-review.test.ts",
       "source_location": "L1",
       "id": "scripts_pre_push_review_test_ts",
-      "community": 153
+      "community": 155
     },
     {
       "label": "log()",
@@ -20681,7 +20761,7 @@
       "source_file": "scripts/pre-push-review.test.ts",
       "source_location": "L81",
       "id": "pre_push_review_test_log",
-      "community": 153
+      "community": 155
     },
     {
       "label": "warn()",
@@ -20689,7 +20769,7 @@
       "source_file": "scripts/pre-push-review.test.ts",
       "source_location": "L82",
       "id": "pre_push_review_test_warn",
-      "community": 153
+      "community": 155
     },
     {
       "label": "error()",
@@ -20697,7 +20777,7 @@
       "source_file": "scripts/pre-push-review.test.ts",
       "source_location": "L83",
       "id": "pre_push_review_test_error",
-      "community": 153
+      "community": 155
     },
     {
       "label": "pre-push-review.ts",
@@ -20705,7 +20785,7 @@
       "source_file": "scripts/pre-push-review.ts",
       "source_location": "L1",
       "id": "scripts_pre_push_review_ts",
-      "community": 154
+      "community": 156
     },
     {
       "label": "getChangedFilesVsOriginMain()",
@@ -20713,7 +20793,7 @@
       "source_file": "scripts/pre-push-review.ts",
       "source_location": "L24",
       "id": "pre_push_review_getchangedfilesvsoriginmain",
-      "community": 154
+      "community": 156
     },
     {
       "label": "runArchitectureCheck()",
@@ -20721,7 +20801,7 @@
       "source_file": "scripts/pre-push-review.ts",
       "source_location": "L65",
       "id": "pre_push_review_runarchitecturecheck",
-      "community": 154
+      "community": 156
     },
     {
       "label": "runPrePushReview()",
@@ -20729,7 +20809,7 @@
       "source_file": "scripts/pre-push-review.ts",
       "source_location": "L77",
       "id": "pre_push_review_runprepushreview",
-      "community": 154
+      "community": 156
     }
   ],
   "links": [
@@ -41808,8 +41888,140 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L171",
+      "weight": 1.0,
+      "_src": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
+      "_tgt": "storefront_runtime_api_withcorsheaders",
+      "source": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
+      "target": "storefront_runtime_api_withcorsheaders",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L186",
+      "weight": 1.0,
+      "_src": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
+      "_tgt": "storefront_runtime_api_jsonresponse",
+      "source": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
+      "target": "storefront_runtime_api_jsonresponse",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L195",
+      "weight": 1.0,
+      "_src": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
+      "_tgt": "storefront_runtime_api_emitsignal",
+      "source": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
+      "target": "storefront_runtime_api_emitsignal",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L199",
+      "weight": 1.0,
+      "_src": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
+      "_tgt": "storefront_runtime_api_handlecheckoutsessionfetch",
+      "source": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
+      "target": "storefront_runtime_api_handlecheckoutsessionfetch",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L221",
+      "weight": 1.0,
+      "_src": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
+      "_tgt": "storefront_runtime_api_handlecheckoutsessionupdate",
+      "source": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
+      "target": "storefront_runtime_api_handlecheckoutsessionupdate",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L394",
+      "weight": 1.0,
+      "_src": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
+      "_tgt": "storefront_runtime_api_shutdown",
+      "source": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
+      "target": "storefront_runtime_api_shutdown",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L189",
+      "weight": 1.0,
+      "_src": "storefront_runtime_api_jsonresponse",
+      "_tgt": "storefront_runtime_api_withcorsheaders",
+      "source": "storefront_runtime_api_withcorsheaders",
+      "target": "storefront_runtime_api_jsonresponse",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L203",
+      "weight": 1.0,
+      "_src": "storefront_runtime_api_handlecheckoutsessionfetch",
+      "_tgt": "storefront_runtime_api_jsonresponse",
+      "source": "storefront_runtime_api_jsonresponse",
+      "target": "storefront_runtime_api_handlecheckoutsessionfetch",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L228",
+      "weight": 1.0,
+      "_src": "storefront_runtime_api_handlecheckoutsessionupdate",
+      "_tgt": "storefront_runtime_api_jsonresponse",
+      "source": "storefront_runtime_api_jsonresponse",
+      "target": "storefront_runtime_api_handlecheckoutsessionupdate",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L210",
+      "weight": 1.0,
+      "_src": "storefront_runtime_api_handlecheckoutsessionfetch",
+      "_tgt": "storefront_runtime_api_emitsignal",
+      "source": "storefront_runtime_api_emitsignal",
+      "target": "storefront_runtime_api_handlecheckoutsessionfetch",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      "source_location": "L227",
+      "weight": 1.0,
+      "_src": "storefront_runtime_api_handlecheckoutsessionupdate",
+      "_tgt": "storefront_runtime_api_emitsignal",
+      "source": "storefront_runtime_api_emitsignal",
+      "target": "storefront_runtime_api_handlecheckoutsessionupdate",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L41",
+      "source_location": "L63",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_scenarios_ts",
       "_tgt": "harness_behavior_scenarios_createathenaruntimeprocess",
@@ -41821,7 +42033,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L53",
+      "source_location": "L75",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_scenarios_ts",
       "_tgt": "harness_behavior_scenarios_buildathenaruntimeurl",
@@ -41832,8 +42044,20 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L79",
+      "weight": 1.0,
+      "_src": "scripts_harness_behavior_scenarios_ts",
+      "_tgt": "harness_behavior_scenarios_createstorefrontruntimeprocesses",
+      "source": "scripts_harness_behavior_scenarios_ts",
+      "target": "harness_behavior_scenarios_createstorefrontruntimeprocesses",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.test.ts",
-      "source_location": "L14",
+      "source_location": "L15",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_test_ts",
       "_tgt": "harness_behavior_test_write",
@@ -41845,7 +42069,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.test.ts",
-      "source_location": "L20",
+      "source_location": "L21",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_test_ts",
       "_tgt": "harness_behavior_test_createfixtureroot",
@@ -41857,7 +42081,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.test.ts",
-      "source_location": "L112",
+      "source_location": "L113",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_test_ts",
       "_tgt": "harness_behavior_test_log",
@@ -41869,7 +42093,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.test.ts",
-      "source_location": "L115",
+      "source_location": "L116",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_test_ts",
       "_tgt": "harness_behavior_test_error",
@@ -41881,7 +42105,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L150",
+      "source_location": "L151",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_ts",
       "_tgt": "harness_behavior_harnessbehaviorphaseerror",
@@ -41893,7 +42117,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L206",
+      "source_location": "L207",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_ts",
       "_tgt": "harness_behavior_logphase",
@@ -41905,7 +42129,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L214",
+      "source_location": "L215",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_ts",
       "_tgt": "harness_behavior_sleep",
@@ -41917,7 +42141,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L220",
+      "source_location": "L221",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_ts",
       "_tgt": "harness_behavior_asregexp",
@@ -41929,7 +42153,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L228",
+      "source_location": "L229",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_ts",
       "_tgt": "harness_behavior_escaperegexp",
@@ -41941,7 +42165,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L232",
+      "source_location": "L233",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_ts",
       "_tgt": "harness_behavior_formaterror",
@@ -41953,7 +42177,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L240",
+      "source_location": "L241",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_ts",
       "_tgt": "harness_behavior_getlinesforsource",
@@ -41965,7 +42189,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L253",
+      "source_location": "L254",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_ts",
       "_tgt": "harness_behavior_consumelines",
@@ -41977,7 +42201,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L319",
+      "source_location": "L320",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_ts",
       "_tgt": "harness_behavior_stopprocess",
@@ -41989,7 +42213,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L341",
+      "source_location": "L342",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_ts",
       "_tgt": "harness_behavior_startprocess",
@@ -42001,7 +42225,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L475",
+      "source_location": "L476",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_ts",
       "_tgt": "harness_behavior_spawncommand",
@@ -42013,7 +42237,19 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L526",
+      "source_location": "L530",
+      "weight": 1.0,
+      "_src": "scripts_harness_behavior_ts",
+      "_tgt": "harness_behavior_resolveharnessbehaviorshell",
+      "source": "scripts_harness_behavior_ts",
+      "target": "harness_behavior_resolveharnessbehaviorshell",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L557",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_ts",
       "_tgt": "harness_behavior_runhttpreadinesscheck",
@@ -42025,7 +42261,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L558",
+      "source_location": "L589",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_ts",
       "_tgt": "harness_behavior_collectruntimesignalmatches",
@@ -42037,7 +42273,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L658",
+      "source_location": "L689",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_ts",
       "_tgt": "harness_behavior_runplaywrightflow",
@@ -42049,7 +42285,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L762",
+      "source_location": "L793",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_ts",
       "_tgt": "harness_behavior_wrapphaseerror",
@@ -42061,7 +42297,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L773",
+      "source_location": "L804",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_ts",
       "_tgt": "harness_behavior_runharnessbehaviorscenario",
@@ -42073,7 +42309,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L925",
+      "source_location": "L956",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_ts",
       "_tgt": "harness_behavior_parseharnessbehaviorargs",
@@ -42085,7 +42321,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L997",
+      "source_location": "L1028",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_ts",
       "_tgt": "harness_behavior_printharnessbehaviorusage",
@@ -42097,7 +42333,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L1005",
+      "source_location": "L1036",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_ts",
       "_tgt": "harness_behavior_runharnessbehaviorcli",
@@ -42109,7 +42345,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L154",
+      "source_location": "L155",
       "weight": 1.0,
       "_src": "harness_behavior_harnessbehaviorphaseerror",
       "_tgt": "harness_behavior_harnessbehaviorphaseerror_constructor",
@@ -42121,7 +42357,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L352",
+      "source_location": "L353",
       "weight": 1.0,
       "_src": "harness_behavior_startprocess",
       "_tgt": "harness_behavior_logphase",
@@ -42133,7 +42369,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L811",
+      "source_location": "L842",
       "weight": 1.0,
       "_src": "harness_behavior_runharnessbehaviorscenario",
       "_tgt": "harness_behavior_logphase",
@@ -42145,7 +42381,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L330",
+      "source_location": "L331",
       "weight": 1.0,
       "_src": "harness_behavior_stopprocess",
       "_tgt": "harness_behavior_sleep",
@@ -42157,7 +42393,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L225",
+      "source_location": "L226",
       "weight": 1.0,
       "_src": "harness_behavior_asregexp",
       "_tgt": "harness_behavior_escaperegexp",
@@ -42169,7 +42405,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L447",
+      "source_location": "L448",
       "weight": 1.0,
       "_src": "harness_behavior_startprocess",
       "_tgt": "harness_behavior_asregexp",
@@ -42181,7 +42417,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L566",
+      "source_location": "L597",
       "weight": 1.0,
       "_src": "harness_behavior_collectruntimesignalmatches",
       "_tgt": "harness_behavior_asregexp",
@@ -42193,7 +42429,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L545",
+      "source_location": "L576",
       "weight": 1.0,
       "_src": "harness_behavior_runhttpreadinesscheck",
       "_tgt": "harness_behavior_formaterror",
@@ -42205,7 +42441,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L738",
+      "source_location": "L769",
       "weight": 1.0,
       "_src": "harness_behavior_runplaywrightflow",
       "_tgt": "harness_behavior_formaterror",
@@ -42217,7 +42453,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L770",
+      "source_location": "L801",
       "weight": 1.0,
       "_src": "harness_behavior_wrapphaseerror",
       "_tgt": "harness_behavior_formaterror",
@@ -42229,7 +42465,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L377",
+      "source_location": "L378",
       "weight": 1.0,
       "_src": "harness_behavior_startprocess",
       "_tgt": "harness_behavior_consumelines",
@@ -42241,7 +42477,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L354",
+      "source_location": "L355",
       "weight": 1.0,
       "_src": "harness_behavior_startprocess",
       "_tgt": "harness_behavior_spawncommand",
@@ -42253,7 +42489,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L813",
+      "source_location": "L844",
       "weight": 1.0,
       "_src": "harness_behavior_runharnessbehaviorscenario",
       "_tgt": "harness_behavior_startprocess",
@@ -42265,7 +42501,19 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L826",
+      "source_location": "L481",
+      "weight": 1.0,
+      "_src": "harness_behavior_spawncommand",
+      "_tgt": "harness_behavior_resolveharnessbehaviorshell",
+      "source": "harness_behavior_spawncommand",
+      "target": "harness_behavior_resolveharnessbehaviorshell",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L857",
       "weight": 1.0,
       "_src": "harness_behavior_runharnessbehaviorscenario",
       "_tgt": "harness_behavior_runhttpreadinesscheck",
@@ -42277,7 +42525,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L862",
+      "source_location": "L893",
       "weight": 1.0,
       "_src": "harness_behavior_runharnessbehaviorscenario",
       "_tgt": "harness_behavior_collectruntimesignalmatches",
@@ -42289,7 +42537,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L883",
+      "source_location": "L914",
       "weight": 1.0,
       "_src": "harness_behavior_runharnessbehaviorscenario",
       "_tgt": "harness_behavior_wrapphaseerror",
@@ -42301,7 +42549,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L1087",
+      "source_location": "L1118",
       "weight": 1.0,
       "_src": "harness_behavior_runharnessbehaviorcli",
       "_tgt": "harness_behavior_runharnessbehaviorscenario",
@@ -42313,7 +42561,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L1015",
+      "source_location": "L1046",
       "weight": 1.0,
       "_src": "harness_behavior_runharnessbehaviorcli",
       "_tgt": "harness_behavior_parseharnessbehaviorargs",
@@ -42325,7 +42573,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L1018",
+      "source_location": "L1049",
       "weight": 1.0,
       "_src": "harness_behavior_runharnessbehaviorcli",
       "_tgt": "harness_behavior_printharnessbehaviorusage",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "harness:generate": "bun scripts/harness-generate.ts",
     "harness:self-review": "bun scripts/harness-self-review.ts",
     "harness:review": "bun scripts/harness-review.ts",
-    "harness:test": "bun test scripts/harness-audit.test.ts scripts/harness-check.test.ts scripts/harness-generate.test.ts scripts/harness-review.test.ts scripts/graphify-rebuild.test.ts scripts/pre-push-review.test.ts",
+    "harness:test": "bun test scripts/harness-audit.test.ts scripts/harness-behavior.test.ts scripts/harness-behavior-scenarios.test.ts scripts/harness-check.test.ts scripts/harness-generate.test.ts scripts/harness-review.test.ts scripts/graphify-rebuild.test.ts scripts/pre-push-review.test.ts",
     "pre-push:review": "bun scripts/pre-push-review.ts",
     "pr:athena": "bun run --filter '@athena/webapp' audit:convex && bun run --filter '@athena/webapp' lint:convex:changed && bun run architecture:check && bun run --filter '@athena/webapp' test && bun run --filter '@athena/storefront-webapp' test && bun run harness:test && bun run harness:check && bun run harness:audit && bun run graphify:check",
     "test": "bun run --filter '@athena/webapp' test && bun run --filter '@athena/storefront-webapp' test",

--- a/packages/storefront-webapp/docs/agent/testing.md
+++ b/packages/storefront-webapp/docs/agent/testing.md
@@ -16,9 +16,14 @@ If `bun run harness:review` reports a coverage gap, the touched `packages/storef
 If `bun run harness:audit` reports a coverage gap, a live `src/` or `tests/` surface exists without a corresponding validation-map entry. Add or tighten the affected surface mapping before handoff so future agents can trust the repo-wide scan.
 
 Use `bun run harness:behavior --list` to inspect available runtime scenarios.
-Current shared scenarios include `sample-runtime-smoke`,
-`athena-admin-shell-boot`, `athena-convex-storefront-composition`, and
-`athena-convex-storefront-failure-visibility`.
+Current shared scenarios include:
+- `sample-runtime-smoke` (shared contract smoke check)
+- `athena-admin-shell-boot`
+- `athena-convex-storefront-composition`
+- `athena-convex-storefront-failure-visibility`
+- `storefront-checkout-bootstrap`
+- `storefront-checkout-validation-blocker`
+- `storefront-checkout-verification-recovery`
 
 Start with the package suite in [vitest.config.ts](../../vitest.config.ts): `bun run --filter '@athena/storefront-webapp' test`. It is the default regression pass for API wrappers, route helpers, checkout state, and shared utility logic.
 

--- a/scripts/harness-behavior-fixtures/storefront-runtime-api.ts
+++ b/scripts/harness-behavior-fixtures/storefront-runtime-api.ts
@@ -1,0 +1,400 @@
+type StorefrontBehaviorMode =
+  | "checkout-bootstrap"
+  | "validation-blocker"
+  | "verification-recovery";
+
+const API_PORT = Number.parseInt(process.env.HARNESS_STOREFRONT_API_PORT ?? "4312", 10);
+const mode = process.env.HARNESS_STOREFRONT_BEHAVIOR_MODE;
+
+const SUPPORTED_MODES = new Set<StorefrontBehaviorMode>([
+  "checkout-bootstrap",
+  "validation-blocker",
+  "verification-recovery",
+]);
+
+if (!mode || !SUPPORTED_MODES.has(mode as StorefrontBehaviorMode)) {
+  throw new Error(
+    `Unsupported HARNESS_STOREFRONT_BEHAVIOR_MODE "${mode ?? "<missing>"}". Expected one of ${[
+      ...SUPPORTED_MODES,
+    ].join(", ")}.`
+  );
+}
+
+const behaviorMode = mode as StorefrontBehaviorMode;
+
+const STOREFRONT_ORGANIZATION_ID = "org_harness";
+const STOREFRONT_STORE_ID = "store_harness";
+
+const BOOTSTRAP_SESSION_ID = "checkout_session_bootstrap";
+const RECOVERY_SESSION_ID = "checkout_session_recovery";
+const RECOVERY_ORDER_ID = "order_checkout_recovery";
+const RECOVERY_REFERENCE = "paystack_recovery_reference";
+
+const now = Date.now();
+
+const sharedStore = {
+  _id: STOREFRONT_STORE_ID,
+  name: "Harness Storefront",
+  organizationId: STOREFRONT_ORGANIZATION_ID,
+  currency: "usd",
+  config: {
+    operations: {
+      availability: {
+        inMaintenanceMode: false,
+      },
+      visibility: {
+        inReadOnlyMode: false,
+      },
+    },
+    commerce: {
+      deliveryFees: {
+        withinAccra: 0,
+        otherRegions: 0,
+        international: 0,
+      },
+      waiveDeliveryFees: {
+        all: true,
+      },
+      fulfillment: {
+        enableStorePickup: true,
+        enableDelivery: true,
+      },
+    },
+  },
+};
+
+const sharedBag = {
+  _id: "bag_harness",
+  storeId: STOREFRONT_STORE_ID,
+  organizationId: STOREFRONT_ORGANIZATION_ID,
+  items: [
+    {
+      _id: "bag_item_harness",
+      productSkuId: "sku_harness",
+      productName: "Harness Wig",
+      productImage: "",
+      quantity: 1,
+      price: 12000,
+    },
+  ],
+};
+
+const emptySavedBag = {
+  _id: "saved_bag_harness",
+  storeId: STOREFRONT_STORE_ID,
+  organizationId: STOREFRONT_ORGANIZATION_ID,
+  items: [],
+};
+
+const checkoutItem = {
+  _id: "sku_harness",
+  sku: "SKU-HARNESS-1",
+  productName: "Harness Wig",
+  productCategory: "wigs",
+  price: 12000,
+  images: [""],
+  colorName: "Natural Black",
+  size: "M",
+  length: 16,
+};
+
+const bootstrapSession = {
+  _id: BOOTSTRAP_SESSION_ID,
+  amount: 12000,
+  deliveryFee: 0,
+  deliveryMethod: "pickup",
+  paymentMethod: null,
+  customerDetails: {
+    firstName: "Ada",
+    lastName: "Harness",
+    email: "ada@example.com",
+    phoneNumber: "+15555550123",
+  },
+  deliveryDetails: null,
+  discount: null,
+  items: [checkoutItem],
+  externalReference: null,
+  hasCompletedPayment: false,
+  hasVerifiedPayment: false,
+  hasCompletedCheckoutSession: false,
+  placedOrderId: null,
+  isPaymentRefunded: false,
+};
+
+const recoverySession = {
+  _id: RECOVERY_SESSION_ID,
+  amount: 18000,
+  deliveryFee: 0,
+  deliveryMethod: "pickup",
+  paymentMethod: {
+    channel: "card",
+    bank: "Visa",
+    last4: "4242",
+  },
+  customerDetails: {
+    firstName: "Ada",
+    lastName: "Harness",
+    email: "ada@example.com",
+    phoneNumber: "+15555550123",
+  },
+  deliveryDetails: null,
+  discount: null,
+  items: [checkoutItem],
+  externalReference: RECOVERY_REFERENCE,
+  hasCompletedPayment: true,
+  hasVerifiedPayment: true,
+  hasCompletedCheckoutSession: false,
+  placedOrderId: RECOVERY_ORDER_ID,
+  isPaymentRefunded: false,
+};
+
+const recoveryOrder = {
+  _id: RECOVERY_ORDER_ID,
+  _creationTime: now,
+  checkoutSessionId: RECOVERY_SESSION_ID,
+  orderNumber: "WC-1001",
+  amount: recoverySession.amount,
+  deliveryFee: recoverySession.deliveryFee,
+  deliveryMethod: recoverySession.deliveryMethod,
+  externalReference: RECOVERY_REFERENCE,
+  discount: null,
+  items: [
+    {
+      productSkuId: checkoutItem._id,
+      productName: checkoutItem.productName,
+      quantity: 1,
+      price: recoverySession.amount,
+    },
+  ],
+};
+
+function withCorsHeaders(
+  request: Request,
+  headers: Record<string, string> = {}
+): Record<string, string> {
+  const origin = request.headers.get("origin");
+
+  return {
+    ...headers,
+    "access-control-allow-origin": origin ?? "http://127.0.0.1",
+    "access-control-allow-credentials": "true",
+    "access-control-allow-methods": "GET,POST,PUT,DELETE,OPTIONS",
+    "access-control-allow-headers": "Content-Type,Authorization",
+  };
+}
+
+function jsonResponse(request: Request, body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: withCorsHeaders(request, {
+      "content-type": "application/json; charset=utf-8",
+    }),
+  });
+}
+
+function emitSignal(signalName: string) {
+  console.log(`RUNTIME_SIGNAL:${signalName}`);
+}
+
+function handleCheckoutSessionFetch(request: Request, pathname: string) {
+  const sessionId = decodeURIComponent(pathname.slice("/checkout/".length));
+
+  if (sessionId === BOOTSTRAP_SESSION_ID) {
+    return jsonResponse(request, bootstrapSession);
+  }
+
+  if (sessionId === RECOVERY_SESSION_ID) {
+    return jsonResponse(request, recoverySession);
+  }
+
+  emitSignal("storefront-checkout-session-missing");
+  return jsonResponse(
+    request,
+    {
+      error: "Checkout session not found",
+      code: "CHECKOUT_SESSION_NOT_FOUND",
+    },
+    404
+  );
+}
+
+async function handleCheckoutSessionUpdate(request: Request) {
+  const payload = (await request.json().catch(() => ({}))) as {
+    action?: string;
+  };
+
+  if (payload.action === "complete-checkout") {
+    emitSignal("storefront-checkout-completion-requested");
+    return jsonResponse(request, {
+      success: true,
+      orderId: RECOVERY_ORDER_ID,
+    });
+  }
+
+  return jsonResponse(request, {
+    success: true,
+  });
+}
+
+const server = Bun.serve({
+  port: API_PORT,
+  async fetch(request) {
+    const url = new URL(request.url);
+    const { pathname } = url;
+
+    if (request.method === "OPTIONS") {
+      return new Response(null, {
+        status: 204,
+        headers: withCorsHeaders(request),
+      });
+    }
+
+    if (pathname === "/health") {
+      return jsonResponse(request, {
+        ok: true,
+        mode: behaviorMode,
+      });
+    }
+
+    if (pathname === "/storefront") {
+      return jsonResponse(request, sharedStore);
+    }
+
+    if (pathname === "/users/me") {
+      return jsonResponse(request, {});
+    }
+
+    if (pathname === "/guests") {
+      return jsonResponse(request, {
+        _id: "guest_harness",
+        organizationId: STOREFRONT_ORGANIZATION_ID,
+        storeId: STOREFRONT_STORE_ID,
+      });
+    }
+
+    if (pathname === "/categories") {
+      return jsonResponse(request, {
+        categories: [],
+      });
+    }
+
+    if (pathname === "/subcategories") {
+      return jsonResponse(request, {
+        subcategories: [],
+      });
+    }
+
+    if (pathname === "/stores/promoCodes") {
+      return jsonResponse(request, []);
+    }
+
+    if (pathname === "/stores/promoCodeItems") {
+      return jsonResponse(request, []);
+    }
+
+    if (pathname === "/stores/redeemedPromoCodes") {
+      return jsonResponse(request, []);
+    }
+
+    if (pathname === "/banner-message") {
+      return jsonResponse(request, {
+        bannerMessage: null,
+      });
+    }
+
+    if (pathname === "/bags/active") {
+      return jsonResponse(request, sharedBag);
+    }
+
+    if (pathname === "/savedBags/active") {
+      return jsonResponse(request, emptySavedBag);
+    }
+
+    if (pathname === "/orders" && request.method === "GET") {
+      return jsonResponse(request, [recoveryOrder]);
+    }
+
+    if (pathname.startsWith("/orders/") && request.method === "GET") {
+      const orderId = decodeURIComponent(pathname.slice("/orders/".length));
+      return jsonResponse(request, {
+        ...recoveryOrder,
+        _id: orderId || RECOVERY_ORDER_ID,
+      });
+    }
+
+    if (pathname === "/checkout/active" && request.method === "GET") {
+      if (behaviorMode === "checkout-bootstrap") {
+        emitSignal("storefront-checkout-bootstrap-loaded");
+        return jsonResponse(request, bootstrapSession);
+      }
+
+      if (behaviorMode === "verification-recovery") {
+        return jsonResponse(request, recoverySession);
+      }
+
+      return jsonResponse(request, null);
+    }
+
+    if (pathname.startsWith("/checkout/verify/") && request.method === "GET") {
+      const reference = decodeURIComponent(pathname.slice("/checkout/verify/".length));
+      emitSignal("storefront-payment-verification-requested");
+      return jsonResponse(request, {
+        verified: reference === RECOVERY_REFERENCE,
+      });
+    }
+
+    if (pathname.startsWith("/checkout/") && request.method === "GET") {
+      return handleCheckoutSessionFetch(request, pathname);
+    }
+
+    if (pathname.startsWith("/checkout/") && request.method === "POST") {
+      return handleCheckoutSessionUpdate(request);
+    }
+
+    if (pathname === "/analytics" && request.method === "POST") {
+      const payload = (await request.json().catch(() => ({}))) as {
+        data?: {
+          step?: string;
+          status?: string;
+        };
+      };
+
+      if (payload.data?.step === "checkout_details") {
+        emitSignal("storefront-checkout-details-tracked");
+      }
+
+      if (payload.data?.step === "payment_verification") {
+        emitSignal("storefront-payment-verification-tracked");
+      }
+
+      if (
+        payload.data?.step === "checkout_completion" &&
+        payload.data?.status === "succeeded"
+      ) {
+        emitSignal("storefront-checkout-completion-tracked");
+      }
+
+      return jsonResponse(request, {
+        success: true,
+      });
+    }
+
+    return jsonResponse(
+      request,
+      {
+        error: `Unhandled fixture route: ${pathname}`,
+      },
+      404
+    );
+  },
+});
+
+console.log(`STOREFRONT_RUNTIME_API_READY:${API_PORT}`);
+
+async function shutdown() {
+  server.stop(true);
+  process.exit(0);
+}
+
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);

--- a/scripts/harness-behavior-scenarios.test.ts
+++ b/scripts/harness-behavior-scenarios.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { HARNESS_BEHAVIOR_SCENARIOS } from "./harness-behavior-scenarios";
+
+describe("HARNESS_BEHAVIOR_SCENARIOS", () => {
+  it("registers storefront checkout bootstrap, blocker, and recovery scenarios", () => {
+    const names = HARNESS_BEHAVIOR_SCENARIOS.map((scenario) => scenario.name);
+
+    expect(names).toContain("storefront-checkout-bootstrap");
+    expect(names).toContain("storefront-checkout-validation-blocker");
+    expect(names).toContain("storefront-checkout-verification-recovery");
+  });
+
+  it("captures runtime signals for each storefront scenario", () => {
+    const scenarioByName = new Map(
+      HARNESS_BEHAVIOR_SCENARIOS.map((scenario) => [scenario.name, scenario])
+    );
+
+    const bootstrapScenario = scenarioByName.get("storefront-checkout-bootstrap");
+    const validationScenario = scenarioByName.get(
+      "storefront-checkout-validation-blocker"
+    );
+    const recoveryScenario = scenarioByName.get(
+      "storefront-checkout-verification-recovery"
+    );
+
+    expect(bootstrapScenario?.runtimeSignals?.map((signal) => signal.name)).toContain(
+      "storefront-checkout-bootstrap-loaded"
+    );
+    expect(validationScenario?.runtimeSignals?.map((signal) => signal.name)).toContain(
+      "storefront-checkout-session-missing"
+    );
+    expect(recoveryScenario?.runtimeSignals?.map((signal) => signal.name)).toContain(
+      "storefront-payment-verification-requested"
+    );
+  });
+});

--- a/scripts/harness-behavior-scenarios.ts
+++ b/scripts/harness-behavior-scenarios.ts
@@ -14,6 +14,24 @@ const ATHENA_RUNTIME_PORT = Number.parseInt(
 const ATHENA_BOOTSTRAP_USER_ID = "athena-harness-user";
 const ATHENA_EXPECTED_STORE_NAME = "athena-harness-store";
 const ATHENA_EXPECTED_INVENTORY_SKU_COUNT = "7";
+const STOREFRONT_RUNTIME_API_PORT = Number.parseInt(
+  process.env.HARNESS_BEHAVIOR_STOREFRONT_API_PORT ?? "4313",
+  10
+);
+const STOREFRONT_RUNTIME_APP_PORT = Number.parseInt(
+  process.env.HARNESS_BEHAVIOR_STOREFRONT_APP_PORT ?? "4314",
+  10
+);
+
+const STOREFRONT_CHECKOUT_BOOTSTRAP_PATH = "/shop/checkout";
+const STOREFRONT_CHECKOUT_VALIDATION_BLOCKER_PATH =
+  "/shop/checkout/not-a-real-session";
+const STOREFRONT_CHECKOUT_RECOVERY_PATH = "/shop/checkout?origin=paystack";
+
+type StorefrontBehaviorMode =
+  | "checkout-bootstrap"
+  | "validation-blocker"
+  | "verification-recovery";
 
 type SampleScenarioBrowserResult = {
   signalStatus: string;
@@ -37,6 +55,10 @@ type AthenaConvexFailureBrowserResult = {
   storefrontStatusLine: string;
   consoleMessages: string[];
 };
+type StorefrontScenarioBrowserResult = {
+  observedText: string;
+  consoleMessages: string[];
+};
 
 function createAthenaRuntimeProcess(): HarnessBehaviorProcessDefinition {
   return {
@@ -53,6 +75,47 @@ function createAthenaRuntimeProcess(): HarnessBehaviorProcessDefinition {
 function buildAthenaRuntimeUrl(pathname: string) {
   return `http://127.0.0.1:${ATHENA_RUNTIME_PORT}${pathname}`;
 }
+
+function createStorefrontRuntimeProcesses(mode: StorefrontBehaviorMode) {
+  return [
+    {
+      id: "storefront-api",
+      command: "bun scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
+      env: {
+        HARNESS_STOREFRONT_API_PORT: String(STOREFRONT_RUNTIME_API_PORT),
+        HARNESS_STOREFRONT_BEHAVIOR_MODE: mode,
+      },
+      readyPattern: `STOREFRONT_RUNTIME_API_READY:${STOREFRONT_RUNTIME_API_PORT}`,
+      readyTimeoutMs: 20_000,
+    },
+    {
+      id: "storefront-webapp",
+      command: `bun run --filter '@athena/storefront-webapp' dev --host 127.0.0.1 --port ${STOREFRONT_RUNTIME_APP_PORT}`,
+      env: {
+        VITE_API_URL: `http://127.0.0.1:${STOREFRONT_RUNTIME_API_PORT}`,
+      },
+    },
+  ] satisfies HarnessBehaviorScenario["processes"];
+}
+
+const STOREFRONT_RUNTIME_READINESS_CHECKS: HarnessBehaviorScenario["readiness"] = [
+  {
+    kind: "http",
+    name: "storefront-runtime-api-health",
+    url: `http://127.0.0.1:${STOREFRONT_RUNTIME_API_PORT}/health`,
+    expectedStatus: 200,
+    timeoutMs: 20_000,
+    intervalMs: 250,
+  },
+  {
+    kind: "http",
+    name: "storefront-runtime-app-shell",
+    url: `http://127.0.0.1:${STOREFRONT_RUNTIME_APP_PORT}/`,
+    expectedStatus: 200,
+    timeoutMs: 120_000,
+    intervalMs: 500,
+  },
+];
 
 export const SAMPLE_RUNTIME_SMOKE_SCENARIO: HarnessBehaviorScenario<SampleScenarioBrowserResult> =
   {
@@ -424,9 +487,172 @@ export const ATHENA_CONVEX_FAILURE_VISIBILITY_SCENARIO: HarnessBehaviorScenario<
     },
   };
 
+export const STOREFRONT_CHECKOUT_BOOTSTRAP_SCENARIO: HarnessBehaviorScenario<StorefrontScenarioBrowserResult> =
+  {
+    name: "storefront-checkout-bootstrap",
+    description:
+      "Boots the storefront app and mock runtime API, verifies checkout bootstrap UI renders, and asserts checkout bootstrap runtime signals.",
+    processes: createStorefrontRuntimeProcesses("checkout-bootstrap"),
+    readiness: STOREFRONT_RUNTIME_READINESS_CHECKS,
+    browser: async ({ runPlaywrightFlow }) => {
+      const flowResult = await runPlaywrightFlow({
+        url: `http://127.0.0.1:${STOREFRONT_RUNTIME_APP_PORT}${STOREFRONT_CHECKOUT_BOOTSTRAP_PATH}`,
+        steps: async ({ page }) => {
+          await page.waitForSelector("text=Checkout", {
+            timeout: 30_000,
+          });
+
+          const observedText =
+            (await page.textContent("text=Checkout"))?.trim() ?? "";
+          return { observedText };
+        },
+      });
+
+      return {
+        observedText: flowResult.stepResult.observedText,
+        consoleMessages: flowResult.consoleMessages,
+      };
+    },
+    runtimeSignals: [
+      {
+        name: "storefront-checkout-bootstrap-loaded",
+        processId: "storefront-api",
+        source: "stdout",
+        pattern: "RUNTIME_SIGNAL:storefront-checkout-bootstrap-loaded",
+        minMatches: 1,
+      },
+    ],
+    assert: async ({ browserResult, runtimeSignals }) => {
+      if (browserResult.observedText !== "Checkout") {
+        throw new Error(
+          `Expected storefront checkout heading "Checkout", received "${browserResult.observedText}".`
+        );
+      }
+
+      const bootstrapSignal = runtimeSignals["storefront-checkout-bootstrap-loaded"];
+      if (!bootstrapSignal || bootstrapSignal.matchCount < 1) {
+        throw new Error(
+          "Expected storefront bootstrap runtime signal to appear in fixture API logs."
+        );
+      }
+    },
+  };
+
+export const STOREFRONT_CHECKOUT_VALIDATION_BLOCKER_SCENARIO: HarnessBehaviorScenario<StorefrontScenarioBrowserResult> =
+  {
+    name: "storefront-checkout-validation-blocker",
+    description:
+      "Boots storefront runtime and asserts invalid checkout-session routing surfaces the validation blocker UI and runtime signal.",
+    processes: createStorefrontRuntimeProcesses("validation-blocker"),
+    readiness: STOREFRONT_RUNTIME_READINESS_CHECKS,
+    browser: async ({ runPlaywrightFlow }) => {
+      const flowResult = await runPlaywrightFlow({
+        url: `http://127.0.0.1:${STOREFRONT_RUNTIME_APP_PORT}${STOREFRONT_CHECKOUT_VALIDATION_BLOCKER_PATH}`,
+        steps: async ({ page }) => {
+          await page.waitForSelector("text=This checkout session does not exist", {
+            timeout: 30_000,
+          });
+
+          const observedText =
+            (await page.textContent("text=This checkout session does not exist"))?.trim() ??
+            "";
+          return { observedText };
+        },
+      });
+
+      return {
+        observedText: flowResult.stepResult.observedText,
+        consoleMessages: flowResult.consoleMessages,
+      };
+    },
+    runtimeSignals: [
+      {
+        name: "storefront-checkout-session-missing",
+        processId: "storefront-api",
+        source: "stdout",
+        pattern: "RUNTIME_SIGNAL:storefront-checkout-session-missing",
+        minMatches: 1,
+      },
+    ],
+    assert: async ({ browserResult, runtimeSignals }) => {
+      if (
+        !browserResult.observedText.includes("This checkout session does not exist")
+      ) {
+        throw new Error(
+          `Expected validation blocker copy for invalid checkout session, received "${browserResult.observedText}".`
+        );
+      }
+
+      const blockerSignal = runtimeSignals["storefront-checkout-session-missing"];
+      if (!blockerSignal || blockerSignal.matchCount < 1) {
+        throw new Error(
+          "Expected storefront checkout-session-missing signal in fixture API logs."
+        );
+      }
+    },
+  };
+
+export const STOREFRONT_CHECKOUT_VERIFICATION_RECOVERY_SCENARIO: HarnessBehaviorScenario<StorefrontScenarioBrowserResult> =
+  {
+    name: "storefront-checkout-verification-recovery",
+    description:
+      "Exercises storefront paystack-origin redirect and verification recovery to the checkout complete view with runtime signal assertions.",
+    processes: createStorefrontRuntimeProcesses("verification-recovery"),
+    readiness: STOREFRONT_RUNTIME_READINESS_CHECKS,
+    browser: async ({ runPlaywrightFlow }) => {
+      const flowResult = await runPlaywrightFlow({
+        url: `http://127.0.0.1:${STOREFRONT_RUNTIME_APP_PORT}${STOREFRONT_CHECKOUT_RECOVERY_PATH}`,
+        steps: async ({ page }) => {
+          await page.waitForSelector("text=Get excited, Ada!", {
+            timeout: 40_000,
+          });
+          await page.waitForSelector("text=View order", {
+            timeout: 10_000,
+          });
+
+          const observedText =
+            (await page.textContent("text=Get excited, Ada!"))?.trim() ?? "";
+          return { observedText };
+        },
+      });
+
+      return {
+        observedText: flowResult.stepResult.observedText,
+        consoleMessages: flowResult.consoleMessages,
+      };
+    },
+    runtimeSignals: [
+      {
+        name: "storefront-payment-verification-requested",
+        processId: "storefront-api",
+        source: "stdout",
+        pattern: "RUNTIME_SIGNAL:storefront-payment-verification-requested",
+        minMatches: 1,
+      },
+    ],
+    assert: async ({ browserResult, runtimeSignals }) => {
+      if (!browserResult.observedText.includes("Get excited, Ada!")) {
+        throw new Error(
+          `Expected storefront verification recovery to reach checkout complete UI, received "${browserResult.observedText}".`
+        );
+      }
+
+      const verificationSignal =
+        runtimeSignals["storefront-payment-verification-requested"];
+      if (!verificationSignal || verificationSignal.matchCount < 1) {
+        throw new Error(
+          "Expected storefront payment verification runtime signal in fixture API logs."
+        );
+      }
+    },
+  };
+
 export const HARNESS_BEHAVIOR_SCENARIOS: HarnessBehaviorScenario[] = [
   SAMPLE_RUNTIME_SMOKE_SCENARIO,
   ATHENA_ADMIN_SHELL_BOOT_SCENARIO,
   ATHENA_CONVEX_COMPOSITION_SCENARIO,
   ATHENA_CONVEX_FAILURE_VISIBILITY_SCENARIO,
+  STOREFRONT_CHECKOUT_BOOTSTRAP_SCENARIO,
+  STOREFRONT_CHECKOUT_VALIDATION_BLOCKER_SCENARIO,
+  STOREFRONT_CHECKOUT_VERIFICATION_RECOVERY_SCENARIO,
 ];

--- a/scripts/harness-behavior.test.ts
+++ b/scripts/harness-behavior.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   HarnessBehaviorPhaseError,
   parseHarnessBehaviorArgs,
+  resolveHarnessBehaviorShell,
   runHarnessBehaviorScenario,
 } from "./harness-behavior";
 
@@ -311,5 +312,31 @@ describe("parseHarnessBehaviorArgs", () => {
         "--record-video=maybe",
       ])
     ).toThrow("Invalid value for --record-video");
+  });
+});
+
+describe("resolveHarnessBehaviorShell", () => {
+  it("prefers HARNESS_BEHAVIOR_SHELL when available", () => {
+    const shellPath = resolveHarnessBehaviorShell({
+      env: {
+        HARNESS_BEHAVIOR_SHELL: "/custom/shell",
+        SHELL: "/env/shell",
+      },
+      fileExists: (filePath) => filePath === "/custom/shell",
+    });
+
+    expect(shellPath).toBe("/custom/shell");
+  });
+
+  it("falls back to a known shell path when preferred shells are missing", () => {
+    const shellPath = resolveHarnessBehaviorShell({
+      env: {
+        HARNESS_BEHAVIOR_SHELL: "/missing/custom",
+        SHELL: "/missing/env",
+      },
+      fileExists: (filePath) => filePath === "/bin/bash",
+    });
+
+    expect(shellPath).toBe("/bin/bash");
   });
 });

--- a/scripts/harness-behavior.ts
+++ b/scripts/harness-behavior.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { spawn as spawnChildProcess } from "node:child_process";
+import { existsSync } from "node:fs";
 import { mkdir } from "node:fs/promises";
 
 import { HARNESS_BEHAVIOR_SCENARIOS } from "./harness-behavior-scenarios";
@@ -477,6 +478,9 @@ function spawnCommand(
   cwd: string,
   envOverrides: Record<string, string> | undefined
 ) {
+  const shellPath = resolveHarnessBehaviorShell({
+    env: process.env,
+  });
   const runtime = (globalThis as { Bun?: typeof Bun }).Bun;
   const mergedEnv = {
     ...process.env,
@@ -484,7 +488,7 @@ function spawnCommand(
   };
 
   if (runtime) {
-    const bunSubprocess = runtime.spawn(["/bin/zsh", "-lc", command], {
+    const bunSubprocess = runtime.spawn([shellPath, "-lc", command], {
       cwd,
       env: mergedEnv,
       stdout: "pipe",
@@ -502,7 +506,7 @@ function spawnCommand(
     };
   }
 
-  const nodeSubprocess = spawnChildProcess("/bin/zsh", ["-lc", command], {
+  const nodeSubprocess = spawnChildProcess(shellPath, ["-lc", command], {
     cwd,
     env: mergedEnv,
     stdio: ["ignore", "pipe", "pipe"],
@@ -521,6 +525,33 @@ function spawnCommand(
       });
     }),
   };
+}
+
+export function resolveHarnessBehaviorShell(options: {
+  env?: NodeJS.ProcessEnv;
+  fileExists?: (filePath: string) => boolean;
+} = {}) {
+  const env = options.env ?? process.env;
+  const fileExists = options.fileExists ?? existsSync;
+  const candidates = [
+    env.HARNESS_BEHAVIOR_SHELL,
+    env.SHELL,
+    "/bin/zsh",
+    "/bin/bash",
+    "/bin/sh",
+  ];
+
+  for (const candidate of candidates) {
+    if (!candidate) {
+      continue;
+    }
+
+    if (fileExists(candidate)) {
+      return candidate;
+    }
+  }
+
+  return "/bin/sh";
 }
 
 async function runHttpReadinessCheck(


### PR DESCRIPTION
## Summary
- add three storefront runtime behavior scenarios to the shared harness runner:
  - `storefront-checkout-bootstrap`
  - `storefront-checkout-validation-blocker`
  - `storefront-checkout-verification-recovery`
- add a deterministic mock storefront API fixture used by the runtime harness to exercise checkout, blocker, and verify/recovery paths
- add scenario-catalog coverage in `scripts/harness-behavior-scenarios.test.ts`
- wire scenario tests into `harness:test` and document the new shared runtime scenarios in storefront testing docs
- rebuild graphify artifacts after code changes

## Why
- V26-202 requires a storefront-specific vertical slice on top of the shared `V26-200` behavior runner
- checkout bootstrap, validation blocker, and verification recovery are high-signal runtime journeys that should be discoverable and invocable through one shared scenario catalog
- these scenarios assert both UI outcomes and runtime signals, giving deterministic end-to-end confidence without broadening into unrelated checkout feature changes

## Validation
- `bun test scripts/harness-behavior.test.ts scripts/harness-behavior-scenarios.test.ts`
- `bun run harness:behavior --scenario storefront-checkout-bootstrap`
- `bun run harness:behavior --scenario storefront-checkout-validation-blocker`
- `bun run harness:behavior --scenario storefront-checkout-verification-recovery`
- `bun run harness:test`
- `bun run graphify:rebuild`
- `bun run pr:athena`
- `git diff --check`

https://linear.app/v26-labs/issue/V26-202/cover-storefront-checkout-and-redirect-journeys-with-the-runtime
