### PR TITLE
[V26-206]: Run mapped behavior scenarios from harness review surfaces

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 2601 nodes · 1999 edges · 1098 communities detected
+- 2605 nodes · 2006 edges · 1098 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1148,16 +1148,16 @@ Cohesion: 0.18
 Nodes (24): buildGeneratedDoc(), buildKeyFolderIndex(), buildRouteIndex(), buildTestIndex(), buildValidationGuide(), buildValidationMap(), collectFolderFacts(), collectRouteGroups() (+16 more)
 
 ### Community 3 - "Community 3"
+Cohesion: 0.16
+Nodes (17): appendListSection(), buildMarkdownBundle(), collectCoverage(), evaluateGraphifyFreshness(), fileExists(), formatValidationCommand(), getChangedFilesFromGit(), loadSelfReviewTarget() (+9 more)
+
+### Community 4 - "Community 4"
 Cohesion: 0.27
 Nodes (20): asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), asString(), cleanUndefined(), firstDefined() (+12 more)
 
-### Community 4 - "Community 4"
-Cohesion: 0.17
-Nodes (19): asRegExp(), collectRuntimeSignalMatches(), consumeLines(), escapeRegExp(), formatError(), HarnessBehaviorPhaseError, logPhase(), parseHarnessBehaviorArgs() (+11 more)
-
 ### Community 5 - "Community 5"
 Cohesion: 0.17
-Nodes (16): appendListSection(), buildMarkdownBundle(), collectCoverage(), evaluateGraphifyFreshness(), fileExists(), formatValidationCommand(), getChangedFilesFromGit(), loadSelfReviewTarget() (+8 more)
+Nodes (19): asRegExp(), collectRuntimeSignalMatches(), consumeLines(), escapeRegExp(), formatError(), HarnessBehaviorPhaseError, logPhase(), parseHarnessBehaviorArgs() (+11 more)
 
 ### Community 6 - "Community 6"
 Cohesion: 0.11
@@ -1188,24 +1188,24 @@ Cohesion: 0.13
 Nodes (1): DataTableColumnHeader()
 
 ### Community 13 - "Community 13"
-Cohesion: 0.18
-Nodes (5): handleSave(), hasReceivingAccountDetails(), normalizePrimaryAccounts(), toPatchReceivingAccounts(), trimToUndefined()
+Cohesion: 0.2
+Nodes (8): collectCommandsForChangedFiles(), fileExists(), loadReviewTarget(), loadReviewTargets(), matchesPathPrefix(), normalizeBehaviorScenarioName(), normalizeRepoPath(), runHarnessReview()
 
 ### Community 14 - "Community 14"
 Cohesion: 0.18
-Nodes (3): isValidEmail(), isValidPhone(), validateCustomer()
+Nodes (5): handleSave(), hasReceivingAccountDetails(), normalizePrimaryAccounts(), toPatchReceivingAccounts(), trimToUndefined()
 
 ### Community 15 - "Community 15"
 Cohesion: 0.29
-Nodes (12): createReview(), deleteReview(), getBaseUrl(), getReviewByOrderItem(), getReviewsByProductId(), getReviewsByProductSkuId(), getUserReviews(), getUserReviewsForProduct() (+4 more)
+Nodes (11): addGroupedError(), collectLiveSurfaceEntries(), fileExists(), formatGroupedErrors(), inferGroupFromError(), loadAuditTarget(), matchesPathPrefix(), normalizeBehaviorScenarioName() (+3 more)
 
 ### Community 16 - "Community 16"
-Cohesion: 0.31
-Nodes (10): addGroupedError(), collectLiveSurfaceEntries(), fileExists(), formatGroupedErrors(), inferGroupFromError(), loadAuditTarget(), matchesPathPrefix(), normalizeRepoPath() (+2 more)
+Cohesion: 0.18
+Nodes (3): isValidEmail(), isValidPhone(), validateCustomer()
 
 ### Community 17 - "Community 17"
-Cohesion: 0.23
-Nodes (7): collectCommandsForChangedFiles(), fileExists(), loadReviewTarget(), loadReviewTargets(), matchesPathPrefix(), normalizeRepoPath(), runHarnessReview()
+Cohesion: 0.29
+Nodes (12): createReview(), deleteReview(), getBaseUrl(), getReviewByOrderItem(), getReviewsByProductId(), getReviewsByProductSkuId(), getUserReviews(), getUserReviewsForProduct() (+4 more)
 
 ### Community 18 - "Community 18"
 Cohesion: 0.33
@@ -1324,16 +1324,16 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 47 - "Community 47"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
-
-### Community 48 - "Community 48"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
-### Community 49 - "Community 49"
+### Community 48 - "Community 48"
 Cohesion: 0.29
 Nodes (0):
+
+### Community 49 - "Community 49"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
 
 ### Community 50 - "Community 50"
 Cohesion: 0.52

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -9153,7 +9153,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_tsx",
-      "community": 13
+      "community": 14
     },
     {
       "label": "cloneReceivingAccount()",
@@ -9161,7 +9161,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L27",
       "id": "mtnmomoview_clonereceivingaccount",
-      "community": 13
+      "community": 14
     },
     {
       "label": "createEmptyReceivingAccount()",
@@ -9169,7 +9169,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L35",
       "id": "mtnmomoview_createemptyreceivingaccount",
-      "community": 13
+      "community": 14
     },
     {
       "label": "trimToUndefined()",
@@ -9177,7 +9177,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L47",
       "id": "mtnmomoview_trimtoundefined",
-      "community": 13
+      "community": 14
     },
     {
       "label": "cleanUndefinedFields()",
@@ -9185,7 +9185,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L52",
       "id": "mtnmomoview_cleanundefinedfields",
-      "community": 13
+      "community": 14
     },
     {
       "label": "hasReceivingAccountDetails()",
@@ -9193,7 +9193,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L64",
       "id": "mtnmomoview_hasreceivingaccountdetails",
-      "community": 13
+      "community": 14
     },
     {
       "label": "normalizePrimaryAccounts()",
@@ -9201,7 +9201,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L77",
       "id": "mtnmomoview_normalizeprimaryaccounts",
-      "community": 13
+      "community": 14
     },
     {
       "label": "toPatchReceivingAccounts()",
@@ -9209,7 +9209,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L93",
       "id": "mtnmomoview_topatchreceivingaccounts",
-      "community": 13
+      "community": 14
     },
     {
       "label": "getStatusBadgeVariant()",
@@ -9217,7 +9217,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L114",
       "id": "mtnmomoview_getstatusbadgevariant",
-      "community": 13
+      "community": 14
     },
     {
       "label": "updateAccount()",
@@ -9225,7 +9225,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L141",
       "id": "mtnmomoview_updateaccount",
-      "community": 13
+      "community": 14
     },
     {
       "label": "handleAddAccount()",
@@ -9233,7 +9233,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L152",
       "id": "mtnmomoview_handleaddaccount",
-      "community": 13
+      "community": 14
     },
     {
       "label": "handleMakePrimary()",
@@ -9241,7 +9241,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L159",
       "id": "mtnmomoview_handlemakeprimary",
-      "community": 13
+      "community": 14
     },
     {
       "label": "handleRemoveAccount()",
@@ -9249,7 +9249,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L168",
       "id": "mtnmomoview_handleremoveaccount",
-      "community": 13
+      "community": 14
     },
     {
       "label": "handleSave()",
@@ -9257,7 +9257,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L188",
       "id": "mtnmomoview_handlesave",
-      "community": 13
+      "community": 14
     },
     {
       "label": "TaxView.tsx",
@@ -12121,7 +12121,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_pos_validation_ts",
-      "community": 14
+      "community": 16
     },
     {
       "label": "validateCart()",
@@ -12129,7 +12129,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L21",
       "id": "validation_validatecart",
-      "community": 14
+      "community": 16
     },
     {
       "label": "validateProduct()",
@@ -12137,7 +12137,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L68",
       "id": "validation_validateproduct",
-      "community": 14
+      "community": 16
     },
     {
       "label": "validateCustomer()",
@@ -12145,7 +12145,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L108",
       "id": "validation_validatecustomer",
-      "community": 14
+      "community": 16
     },
     {
       "label": "validatePayment()",
@@ -12153,7 +12153,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L146",
       "id": "validation_validatepayment",
-      "community": 14
+      "community": 16
     },
     {
       "label": "validateBarcode()",
@@ -12161,7 +12161,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L185",
       "id": "validation_validatebarcode",
-      "community": 14
+      "community": 16
     },
     {
       "label": "validateQuantity()",
@@ -12169,7 +12169,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L213",
       "id": "validation_validatequantity",
-      "community": 14
+      "community": 16
     },
     {
       "label": "isValidEmail()",
@@ -12177,7 +12177,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L244",
       "id": "validation_isvalidemail",
-      "community": 14
+      "community": 16
     },
     {
       "label": "validateSession()",
@@ -12185,7 +12185,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L252",
       "id": "validation_validatesession",
-      "community": 14
+      "community": 16
     },
     {
       "label": "isValidPhone()",
@@ -12193,7 +12193,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L304",
       "id": "validation_isvalidphone",
-      "community": 14
+      "community": 16
     },
     {
       "label": "validatePaymentAmount()",
@@ -12201,7 +12201,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L317",
       "id": "validation_validatepaymentamount",
-      "community": 14
+      "community": 16
     },
     {
       "label": "validatePayments()",
@@ -12209,7 +12209,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L359",
       "id": "validation_validatepayments",
-      "community": 14
+      "community": 16
     },
     {
       "label": "canCompleteTransaction()",
@@ -12217,7 +12217,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L404",
       "id": "validation_cancompletetransaction",
-      "community": 14
+      "community": 16
     },
     {
       "label": "productUtils.test.ts",
@@ -12233,7 +12233,7 @@
       "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "community": 47
+      "community": 49
     },
     {
       "label": "getProductName()",
@@ -12241,7 +12241,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L18",
       "id": "productutils_getproductname",
-      "community": 47
+      "community": 49
     },
     {
       "label": "sortProduct()",
@@ -12249,7 +12249,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L66",
       "id": "productutils_sortproduct",
-      "community": 47
+      "community": 49
     },
     {
       "label": "category.ts",
@@ -12321,7 +12321,7 @@
       "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_storeconfig_ts",
-      "community": 3
+      "community": 4
     },
     {
       "label": "asRecord()",
@@ -12329,7 +12329,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L103",
       "id": "storeconfig_asrecord",
-      "community": 3
+      "community": 4
     },
     {
       "label": "asString()",
@@ -12337,7 +12337,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L111",
       "id": "storeconfig_asstring",
-      "community": 3
+      "community": 4
     },
     {
       "label": "asNumber()",
@@ -12345,7 +12345,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L114",
       "id": "storeconfig_asnumber",
-      "community": 3
+      "community": 4
     },
     {
       "label": "asBoolean()",
@@ -12353,7 +12353,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L117",
       "id": "storeconfig_asboolean",
-      "community": 3
+      "community": 4
     },
     {
       "label": "asOptionalArray()",
@@ -12361,7 +12361,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L132",
       "id": "storeconfig_asoptionalarray",
-      "community": 3
+      "community": 4
     },
     {
       "label": "firstDefined()",
@@ -12369,7 +12369,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L120",
       "id": "storeconfig_firstdefined",
-      "community": 3
+      "community": 4
     },
     {
       "label": "cleanUndefined()",
@@ -12377,7 +12377,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L143",
       "id": "storeconfig_cleanundefined",
-      "community": 3
+      "community": 4
     },
     {
       "label": "asMtnMomoSetupStatus()",
@@ -12385,7 +12385,7 @@
       "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L80",
       "id": "storeconfig_asmtnmomosetupstatus",
-      "community": 3
+      "community": 4
     },
     {
       "label": "hasMtnMomoReceivingAccountDetails()",
@@ -12393,7 +12393,7 @@
       "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L93",
       "id": "storeconfig_hasmtnmomoreceivingaccountdetails",
-      "community": 3
+      "community": 4
     },
     {
       "label": "mapMtnMomoReceivingAccount()",
@@ -12401,7 +12401,7 @@
       "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L106",
       "id": "storeconfig_mapmtnmomoreceivingaccount",
-      "community": 3
+      "community": 4
     },
     {
       "label": "normalizeMtnMomoReceivingAccounts()",
@@ -12409,7 +12409,7 @@
       "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L126",
       "id": "storeconfig_normalizemtnmomoreceivingaccounts",
-      "community": 3
+      "community": 4
     },
     {
       "label": "getRawConfig()",
@@ -12417,7 +12417,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L196",
       "id": "storeconfig_getrawconfig",
-      "community": 3
+      "community": 4
     },
     {
       "label": "mapStreamReel()",
@@ -12425,7 +12425,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L155",
       "id": "storeconfig_mapstreamreel",
-      "community": 3
+      "community": 4
     },
     {
       "label": "mapPromotion()",
@@ -12433,7 +12433,7 @@
       "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L172",
       "id": "storeconfig_mappromotion",
-      "community": 3
+      "community": 4
     },
     {
       "label": "normalizeWaiveDeliveryFees()",
@@ -12441,7 +12441,7 @@
       "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L177",
       "id": "storeconfig_normalizewaivedeliveryfees",
-      "community": 3
+      "community": 4
     },
     {
       "label": "getStoreConfigV2()",
@@ -12449,7 +12449,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L208",
       "id": "storeconfig_getstoreconfigv2",
-      "community": 3
+      "community": 4
     },
     {
       "label": "timelineUtils.ts",
@@ -14145,7 +14145,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_reviews_ts",
-      "community": 15
+      "community": 17
     },
     {
       "label": "getBaseUrl()",
@@ -14153,7 +14153,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L4",
       "id": "reviews_getbaseurl",
-      "community": 15
+      "community": 17
     },
     {
       "label": "createReview()",
@@ -14161,7 +14161,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L13",
       "id": "reviews_createreview",
-      "community": 15
+      "community": 17
     },
     {
       "label": "getReviewByOrderItem()",
@@ -14169,7 +14169,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L32",
       "id": "reviews_getreviewbyorderitem",
-      "community": 15
+      "community": 17
     },
     {
       "label": "updateReview()",
@@ -14177,7 +14177,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L48",
       "id": "reviews_updatereview",
-      "community": 15
+      "community": 17
     },
     {
       "label": "deleteReview()",
@@ -14185,7 +14185,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L69",
       "id": "reviews_deletereview",
-      "community": 15
+      "community": 17
     },
     {
       "label": "getReviewsByProductSkuId()",
@@ -14193,7 +14193,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L83",
       "id": "reviews_getreviewsbyproductskuid",
-      "community": 15
+      "community": 17
     },
     {
       "label": "getUserReviews()",
@@ -14201,7 +14201,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L99",
       "id": "reviews_getuserreviews",
-      "community": 15
+      "community": 17
     },
     {
       "label": "getUserReviewsForProduct()",
@@ -14209,7 +14209,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L113",
       "id": "reviews_getuserreviewsforproduct",
-      "community": 15
+      "community": 17
     },
     {
       "label": "getReviewsByProductId()",
@@ -14217,7 +14217,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L132",
       "id": "reviews_getreviewsbyproductid",
-      "community": 15
+      "community": 17
     },
     {
       "label": "markReviewHelpful()",
@@ -14225,7 +14225,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L148",
       "id": "reviews_markreviewhelpful",
-      "community": 15
+      "community": 17
     },
     {
       "label": "hasReviewForOrderItem()",
@@ -14233,7 +14233,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L164",
       "id": "reviews_hasreviewfororderitem",
-      "community": 15
+      "community": 17
     },
     {
       "label": "hasUserReviewForOrderItem()",
@@ -14241,7 +14241,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L183",
       "id": "reviews_hasuserreviewfororderitem",
-      "community": 15
+      "community": 17
     },
     {
       "label": "rewards.ts",
@@ -14329,7 +14329,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_savedbag_ts",
-      "community": 48
+      "community": 47
     },
     {
       "label": "getBaseUrl()",
@@ -14337,7 +14337,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L8",
       "id": "savedbag_getbaseurl",
-      "community": 48
+      "community": 47
     },
     {
       "label": "getActiveSavedBag()",
@@ -14345,7 +14345,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L10",
       "id": "savedbag_getactivesavedbag",
-      "community": 48
+      "community": 47
     },
     {
       "label": "addItemToSavedBag()",
@@ -14353,7 +14353,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L25",
       "id": "savedbag_additemtosavedbag",
-      "community": 48
+      "community": 47
     },
     {
       "label": "updateSavedBagItem()",
@@ -14361,7 +14361,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L61",
       "id": "savedbag_updatesavedbagitem",
-      "community": 48
+      "community": 47
     },
     {
       "label": "removeItemFromSavedBag()",
@@ -14369,7 +14369,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L91",
       "id": "savedbag_removeitemfromsavedbag",
-      "community": 48
+      "community": 47
     },
     {
       "label": "updateSavedBagOwner()",
@@ -14377,7 +14377,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L109",
       "id": "savedbag_updatesavedbagowner",
-      "community": 48
+      "community": 47
     },
     {
       "label": "storeFrontUser.ts",
@@ -16233,7 +16233,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_tsx",
-      "community": 49
+      "community": 48
     },
     {
       "label": "PendingItem()",
@@ -16241,7 +16241,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L62",
       "id": "shoppingbag_pendingitem",
-      "community": 49
+      "community": 48
     },
     {
       "label": "handleOnCheckoutClick()",
@@ -16249,7 +16249,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L476",
       "id": "shoppingbag_handleoncheckoutclick",
-      "community": 49
+      "community": 48
     },
     {
       "label": "handleClickOnDiscountCode()",
@@ -16257,7 +16257,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L525",
       "id": "shoppingbag_handleclickondiscountcode",
-      "community": 49
+      "community": 48
     },
     {
       "label": "isSkuUnavailable()",
@@ -16265,7 +16265,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L537",
       "id": "shoppingbag_isskuunavailable",
-      "community": 49
+      "community": 48
     },
     {
       "label": "handleMoveToSaved()",
@@ -16273,7 +16273,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L552",
       "id": "shoppingbag_handlemovetosaved",
-      "community": 49
+      "community": 48
     },
     {
       "label": "handleDeleteItem()",
@@ -16281,7 +16281,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L566",
       "id": "shoppingbag_handledeleteitem",
-      "community": 49
+      "community": 48
     },
     {
       "label": "CheckoutUnavailable.tsx",
@@ -17721,7 +17721,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "community": 47
+      "community": 49
     },
     {
       "label": "isSoldOut()",
@@ -17729,7 +17729,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L45",
       "id": "productutils_issoldout",
-      "community": 47
+      "community": 49
     },
     {
       "label": "hasLowStock()",
@@ -17737,7 +17737,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L52",
       "id": "productutils_haslowstock",
-      "community": 47
+      "community": 49
     },
     {
       "label": "sortSkusByLength()",
@@ -17745,7 +17745,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L62",
       "id": "productutils_sortskusbylength",
-      "community": 47
+      "community": 49
     },
     {
       "label": "bag.ts",
@@ -18041,7 +18041,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_storeconfig_ts",
-      "community": 3
+      "community": 4
     },
     {
       "label": "mapPromo()",
@@ -18049,7 +18049,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L172",
       "id": "storeconfig_mappromo",
-      "community": 3
+      "community": 4
     },
     {
       "label": "isStoreReadOnlyMode()",
@@ -18057,7 +18057,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L461",
       "id": "storeconfig_isstorereadonlymode",
-      "community": 3
+      "community": 4
     },
     {
       "label": "isStoreMaintenanceMode()",
@@ -18065,7 +18065,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L465",
       "id": "storeconfig_isstoremaintenancemode",
-      "community": 3
+      "community": 4
     },
     {
       "label": "getStoreFallbackImageUrl()",
@@ -18073,7 +18073,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L479",
       "id": "storeconfig_getstorefallbackimageurl",
-      "community": 3
+      "community": 4
     },
     {
       "label": "storefrontFailureObservability.test.ts",
@@ -19503,7 +19503,7 @@
       "label": "buildHarnessDocPaths()",
       "file_type": "code",
       "source_file": "scripts/harness-app-registry.ts",
-      "source_location": "L103",
+      "source_location": "L104",
       "id": "harness_app_registry_buildharnessdocpaths",
       "community": 256
     },
@@ -19511,7 +19511,7 @@
       "label": "getHarnessPackageRegistration()",
       "file_type": "code",
       "source_file": "scripts/harness-app-registry.ts",
-      "source_location": "L375",
+      "source_location": "L387",
       "id": "harness_app_registry_getharnesspackageregistration",
       "community": 256
     },
@@ -19545,103 +19545,111 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L1",
       "id": "scripts_harness_audit_ts",
-      "community": 16
+      "community": 15
     },
     {
       "label": "normalizeRepoPath()",
       "file_type": "code",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L38",
+      "source_location": "L39",
       "id": "harness_audit_normalizerepopath",
-      "community": 16
+      "community": 15
     },
     {
       "label": "matchesPathPrefix()",
       "file_type": "code",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L42",
+      "source_location": "L43",
       "id": "harness_audit_matchespathprefix",
-      "community": 16
+      "community": 15
     },
     {
       "label": "fileExists()",
       "file_type": "code",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L56",
+      "source_location": "L57",
       "id": "harness_audit_fileexists",
-      "community": 16
+      "community": 15
     },
     {
       "label": "readJsonFile()",
       "file_type": "code",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L65",
+      "source_location": "L66",
       "id": "harness_audit_readjsonfile",
-      "community": 16
+      "community": 15
     },
     {
       "label": "normalizeValidationCommand()",
       "file_type": "code",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L69",
+      "source_location": "L70",
       "id": "harness_audit_normalizevalidationcommand",
-      "community": 16
+      "community": 15
+    },
+    {
+      "label": "normalizeBehaviorScenarioName()",
+      "file_type": "code",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L78",
+      "id": "harness_audit_normalizebehaviorscenarioname",
+      "community": 15
     },
     {
       "label": "addGroupedError()",
       "file_type": "code",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L77",
+      "source_location": "L82",
       "id": "harness_audit_addgroupederror",
-      "community": 16
+      "community": 15
     },
     {
       "label": "inferGroupFromError()",
       "file_type": "code",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L91",
+      "source_location": "L96",
       "id": "harness_audit_infergroupfromerror",
-      "community": 16
+      "community": 15
     },
     {
       "label": "shouldSkipSurfaceEntry()",
       "file_type": "code",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L96",
+      "source_location": "L101",
       "id": "harness_audit_shouldskipsurfaceentry",
-      "community": 16
+      "community": 15
     },
     {
       "label": "collectLiveSurfaceEntries()",
       "file_type": "code",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L107",
+      "source_location": "L112",
       "id": "harness_audit_collectlivesurfaceentries",
-      "community": 16
+      "community": 15
     },
     {
       "label": "loadAuditTarget()",
       "file_type": "code",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L136",
+      "source_location": "L141",
       "id": "harness_audit_loadaudittarget",
-      "community": 16
+      "community": 15
     },
     {
       "label": "formatGroupedErrors()",
       "file_type": "code",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L290",
+      "source_location": "L319",
       "id": "harness_audit_formatgroupederrors",
-      "community": 16
+      "community": 15
     },
     {
       "label": "runHarnessAudit()",
       "file_type": "code",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L305",
+      "source_location": "L334",
       "id": "harness_audit_runharnessaudit",
-      "community": 16
+      "community": 15
     },
     {
       "label": "athena-runtime-app.ts",
@@ -19817,7 +19825,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L1",
       "id": "scripts_harness_behavior_ts",
-      "community": 4
+      "community": 5
     },
     {
       "label": "HarnessBehaviorPhaseError",
@@ -19825,7 +19833,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L151",
       "id": "harness_behavior_harnessbehaviorphaseerror",
-      "community": 4
+      "community": 5
     },
     {
       "label": ".constructor()",
@@ -19833,7 +19841,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L155",
       "id": "harness_behavior_harnessbehaviorphaseerror_constructor",
-      "community": 4
+      "community": 5
     },
     {
       "label": "logPhase()",
@@ -19841,7 +19849,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L207",
       "id": "harness_behavior_logphase",
-      "community": 4
+      "community": 5
     },
     {
       "label": "sleep()",
@@ -19849,7 +19857,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L215",
       "id": "harness_behavior_sleep",
-      "community": 4
+      "community": 5
     },
     {
       "label": "asRegExp()",
@@ -19857,7 +19865,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L221",
       "id": "harness_behavior_asregexp",
-      "community": 4
+      "community": 5
     },
     {
       "label": "escapeRegExp()",
@@ -19865,7 +19873,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L229",
       "id": "harness_behavior_escaperegexp",
-      "community": 4
+      "community": 5
     },
     {
       "label": "formatError()",
@@ -19873,7 +19881,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L233",
       "id": "harness_behavior_formaterror",
-      "community": 4
+      "community": 5
     },
     {
       "label": "getLinesForSource()",
@@ -19881,7 +19889,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L241",
       "id": "harness_behavior_getlinesforsource",
-      "community": 4
+      "community": 5
     },
     {
       "label": "consumeLines()",
@@ -19889,7 +19897,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L254",
       "id": "harness_behavior_consumelines",
-      "community": 4
+      "community": 5
     },
     {
       "label": "stopProcess()",
@@ -19897,7 +19905,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L320",
       "id": "harness_behavior_stopprocess",
-      "community": 4
+      "community": 5
     },
     {
       "label": "startProcess()",
@@ -19905,7 +19913,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L342",
       "id": "harness_behavior_startprocess",
-      "community": 4
+      "community": 5
     },
     {
       "label": "spawnCommand()",
@@ -19913,7 +19921,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L476",
       "id": "harness_behavior_spawncommand",
-      "community": 4
+      "community": 5
     },
     {
       "label": "resolveHarnessBehaviorShell()",
@@ -19921,7 +19929,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L530",
       "id": "harness_behavior_resolveharnessbehaviorshell",
-      "community": 4
+      "community": 5
     },
     {
       "label": "runHttpReadinessCheck()",
@@ -19929,7 +19937,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L557",
       "id": "harness_behavior_runhttpreadinesscheck",
-      "community": 4
+      "community": 5
     },
     {
       "label": "collectRuntimeSignalMatches()",
@@ -19937,7 +19945,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L589",
       "id": "harness_behavior_collectruntimesignalmatches",
-      "community": 4
+      "community": 5
     },
     {
       "label": "runPlaywrightFlow()",
@@ -19945,7 +19953,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L689",
       "id": "harness_behavior_runplaywrightflow",
-      "community": 4
+      "community": 5
     },
     {
       "label": "wrapPhaseError()",
@@ -19953,7 +19961,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L793",
       "id": "harness_behavior_wrapphaseerror",
-      "community": 4
+      "community": 5
     },
     {
       "label": "runHarnessBehaviorScenario()",
@@ -19961,7 +19969,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L804",
       "id": "harness_behavior_runharnessbehaviorscenario",
-      "community": 4
+      "community": 5
     },
     {
       "label": "parseHarnessBehaviorArgs()",
@@ -19969,7 +19977,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L956",
       "id": "harness_behavior_parseharnessbehaviorargs",
-      "community": 4
+      "community": 5
     },
     {
       "label": "printHarnessBehaviorUsage()",
@@ -19977,7 +19985,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L1028",
       "id": "harness_behavior_printharnessbehaviorusage",
-      "community": 4
+      "community": 5
     },
     {
       "label": "runHarnessBehaviorCli()",
@@ -19985,7 +19993,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L1036",
       "id": "harness_behavior_runharnessbehaviorcli",
-      "community": 4
+      "community": 5
     },
     {
       "label": "harness-check.test.ts",
@@ -20343,7 +20351,7 @@
       "label": "buildGeneratedDoc()",
       "file_type": "code",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L283",
+      "source_location": "L285",
       "id": "harness_generate_buildgenerateddoc",
       "community": 2
     },
@@ -20351,7 +20359,7 @@
       "label": "buildRouteIndex()",
       "file_type": "code",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L293",
+      "source_location": "L295",
       "id": "harness_generate_buildrouteindex",
       "community": 2
     },
@@ -20359,7 +20367,7 @@
       "label": "buildTestIndex()",
       "file_type": "code",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L320",
+      "source_location": "L322",
       "id": "harness_generate_buildtestindex",
       "community": 2
     },
@@ -20367,7 +20375,7 @@
       "label": "buildKeyFolderIndex()",
       "file_type": "code",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L365",
+      "source_location": "L367",
       "id": "harness_generate_buildkeyfolderindex",
       "community": 2
     },
@@ -20375,7 +20383,7 @@
       "label": "buildValidationGuide()",
       "file_type": "code",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L398",
+      "source_location": "L400",
       "id": "harness_generate_buildvalidationguide",
       "community": 2
     },
@@ -20383,7 +20391,7 @@
       "label": "buildValidationMap()",
       "file_type": "code",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L431",
+      "source_location": "L442",
       "id": "harness_generate_buildvalidationmap",
       "community": 2
     },
@@ -20391,7 +20399,7 @@
       "label": "generateHarnessDocs()",
       "file_type": "code",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L438",
+      "source_location": "L449",
       "id": "harness_generate_generateharnessdocs",
       "community": 2
     },
@@ -20399,7 +20407,7 @@
       "label": "writeGeneratedHarnessDocs()",
       "file_type": "code",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L468",
+      "source_location": "L479",
       "id": "harness_generate_writegeneratedharnessdocs",
       "community": 2
     },
@@ -20431,7 +20439,7 @@
       "label": "log()",
       "file_type": "code",
       "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L152",
+      "source_location": "L167",
       "id": "harness_review_test_log",
       "community": 113
     },
@@ -20439,7 +20447,7 @@
       "label": "error()",
       "file_type": "code",
       "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L153",
+      "source_location": "L168",
       "id": "harness_review_test_error",
       "community": 113
     },
@@ -20449,103 +20457,119 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L1",
       "id": "scripts_harness_review_ts",
-      "community": 17
+      "community": 13
     },
     {
       "label": "normalizeRepoPath()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L42",
+      "source_location": "L44",
       "id": "harness_review_normalizerepopath",
-      "community": 17
+      "community": 13
     },
     {
       "label": "matchesPathPrefix()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L46",
+      "source_location": "L48",
       "id": "harness_review_matchespathprefix",
-      "community": 17
+      "community": 13
     },
     {
       "label": "normalizeValidationCommand()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L60",
+      "source_location": "L62",
       "id": "harness_review_normalizevalidationcommand",
-      "community": 17
+      "community": 13
+    },
+    {
+      "label": "normalizeBehaviorScenarioName()",
+      "file_type": "code",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L70",
+      "id": "harness_review_normalizebehaviorscenarioname",
+      "community": 13
     },
     {
       "label": "fileExists()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L68",
+      "source_location": "L74",
       "id": "harness_review_fileexists",
-      "community": 17
+      "community": 13
     },
     {
       "label": "readJsonFile()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L77",
+      "source_location": "L83",
       "id": "harness_review_readjsonfile",
-      "community": 17
+      "community": 13
     },
     {
       "label": "loadReviewTarget()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L81",
+      "source_location": "L87",
       "id": "harness_review_loadreviewtarget",
-      "community": 17
+      "community": 13
     },
     {
       "label": "loadReviewTargets()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L185",
+      "source_location": "L211",
       "id": "harness_review_loadreviewtargets",
-      "community": 17
+      "community": 13
     },
     {
       "label": "collectCommandsForChangedFiles()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L201",
+      "source_location": "L227",
       "id": "harness_review_collectcommandsforchangedfiles",
-      "community": 17
+      "community": 13
     },
     {
       "label": "getChangedFilesFromGit()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L274",
+      "source_location": "L312",
       "id": "harness_review_getchangedfilesfromgit",
-      "community": 17
+      "community": 13
     },
     {
       "label": "runPackageScript()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L312",
+      "source_location": "L350",
       "id": "harness_review_runpackagescript",
-      "community": 17
+      "community": 13
     },
     {
       "label": "runRawCommand()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L326",
+      "source_location": "L364",
       "id": "harness_review_runrawcommand",
-      "community": 17
+      "community": 13
+    },
+    {
+      "label": "runHarnessBehaviorScenario()",
+      "file_type": "code",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L377",
+      "id": "harness_review_runharnessbehaviorscenario",
+      "community": 13
     },
     {
       "label": "runHarnessReview()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L339",
+      "source_location": "L391",
       "id": "harness_review_runharnessreview",
-      "community": 17
+      "community": 13
     },
     {
       "label": "harness-self-review.test.ts",
@@ -20577,175 +20601,183 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L1",
       "id": "scripts_harness_self_review_ts",
-      "community": 5
+      "community": 3
     },
     {
       "label": "normalizeRepoPath()",
       "file_type": "code",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L91",
+      "source_location": "L92",
       "id": "harness_self_review_normalizerepopath",
-      "community": 5
+      "community": 3
     },
     {
       "label": "sortUniquePaths()",
       "file_type": "code",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L95",
+      "source_location": "L96",
       "id": "harness_self_review_sortuniquepaths",
-      "community": 5
+      "community": 3
     },
     {
       "label": "matchesPathPrefix()",
       "file_type": "code",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L101",
+      "source_location": "L102",
       "id": "harness_self_review_matchespathprefix",
-      "community": 5
+      "community": 3
     },
     {
       "label": "normalizeValidationCommand()",
       "file_type": "code",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L115",
+      "source_location": "L116",
       "id": "harness_self_review_normalizevalidationcommand",
-      "community": 5
+      "community": 3
+    },
+    {
+      "label": "normalizeBehaviorScenarioName()",
+      "file_type": "code",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L124",
+      "id": "harness_self_review_normalizebehaviorscenarioname",
+      "community": 3
     },
     {
       "label": "formatValidationCommand()",
       "file_type": "code",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L123",
+      "source_location": "L128",
       "id": "harness_self_review_formatvalidationcommand",
-      "community": 5
+      "community": 3
     },
     {
       "label": "quoteCode()",
       "file_type": "code",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L131",
+      "source_location": "L136",
       "id": "harness_self_review_quotecode",
-      "community": 5
+      "community": 3
     },
     {
       "label": "fileExists()",
       "file_type": "code",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L135",
+      "source_location": "L140",
       "id": "harness_self_review_fileexists",
-      "community": 5
+      "community": 3
     },
     {
       "label": "readJsonFile()",
       "file_type": "code",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L144",
+      "source_location": "L149",
       "id": "harness_self_review_readjsonfile",
-      "community": 5
+      "community": 3
     },
     {
       "label": "runCommand()",
       "file_type": "code",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L148",
+      "source_location": "L153",
       "id": "harness_self_review_runcommand",
-      "community": 5
+      "community": 3
     },
     {
       "label": "getChangedFilesFromGit()",
       "file_type": "code",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L168",
+      "source_location": "L173",
       "id": "harness_self_review_getchangedfilesfromgit",
-      "community": 5
+      "community": 3
     },
     {
       "label": "parseRuntimeScenarios()",
       "file_type": "code",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L232",
+      "source_location": "L237",
       "id": "harness_self_review_parseruntimescenarios",
-      "community": 5
+      "community": 3
     },
     {
       "label": "loadSelfReviewTarget()",
       "file_type": "code",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L238",
+      "source_location": "L243",
       "id": "harness_self_review_loadselfreviewtarget",
-      "community": 5
+      "community": 3
     },
     {
       "label": "loadSelfReviewTargets()",
       "file_type": "code",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L350",
+      "source_location": "L375",
       "id": "harness_self_review_loadselfreviewtargets",
-      "community": 5
+      "community": 3
     },
     {
       "label": "collectCoverage()",
       "file_type": "code",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L369",
+      "source_location": "L394",
       "id": "harness_self_review_collectcoverage",
-      "community": 5
+      "community": 3
     },
     {
       "label": "isLikelyCodeOrConfig()",
       "file_type": "code",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L447",
+      "source_location": "L472",
       "id": "harness_self_review_islikelycodeorconfig",
-      "community": 5
+      "community": 3
     },
     {
       "label": "evaluateGraphifyFreshness()",
       "file_type": "code",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L468",
+      "source_location": "L493",
       "id": "harness_self_review_evaluategraphifyfreshness",
-      "community": 5
+      "community": 3
     },
     {
       "label": "runQuietHarnessCheck()",
       "file_type": "code",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L532",
+      "source_location": "L557",
       "id": "harness_self_review_runquietharnesscheck",
-      "community": 5
+      "community": 3
     },
     {
       "label": "appendListSection()",
       "file_type": "code",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L541",
+      "source_location": "L566",
       "id": "harness_self_review_appendlistsection",
-      "community": 5
+      "community": 3
     },
     {
       "label": "buildMarkdownBundle()",
       "file_type": "code",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L560",
+      "source_location": "L585",
       "id": "harness_self_review_buildmarkdownbundle",
-      "community": 5
+      "community": 3
     },
     {
       "label": "parseCliArguments()",
       "file_type": "code",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L717",
+      "source_location": "L742",
       "id": "harness_self_review_parsecliarguments",
-      "community": 5
+      "community": 3
     },
     {
       "label": "runHarnessSelfReview()",
       "file_type": "code",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L766",
+      "source_location": "L791",
       "id": "harness_self_review_runharnessselfreview",
-      "community": 5
+      "community": 3
     },
     {
       "label": "pre-push-review.test.ts",
@@ -41517,7 +41549,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-app-registry.ts",
-      "source_location": "L103",
+      "source_location": "L104",
       "weight": 1.0,
       "_src": "scripts_harness_app_registry_ts",
       "_tgt": "harness_app_registry_buildharnessdocpaths",
@@ -41529,7 +41561,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-app-registry.ts",
-      "source_location": "L375",
+      "source_location": "L387",
       "weight": 1.0,
       "_src": "scripts_harness_app_registry_ts",
       "_tgt": "harness_app_registry_getharnesspackageregistration",
@@ -41577,7 +41609,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L38",
+      "source_location": "L39",
       "weight": 1.0,
       "_src": "scripts_harness_audit_ts",
       "_tgt": "harness_audit_normalizerepopath",
@@ -41589,7 +41621,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L42",
+      "source_location": "L43",
       "weight": 1.0,
       "_src": "scripts_harness_audit_ts",
       "_tgt": "harness_audit_matchespathprefix",
@@ -41601,7 +41633,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L56",
+      "source_location": "L57",
       "weight": 1.0,
       "_src": "scripts_harness_audit_ts",
       "_tgt": "harness_audit_fileexists",
@@ -41613,7 +41645,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L65",
+      "source_location": "L66",
       "weight": 1.0,
       "_src": "scripts_harness_audit_ts",
       "_tgt": "harness_audit_readjsonfile",
@@ -41625,7 +41657,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L69",
+      "source_location": "L70",
       "weight": 1.0,
       "_src": "scripts_harness_audit_ts",
       "_tgt": "harness_audit_normalizevalidationcommand",
@@ -41637,7 +41669,19 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L77",
+      "source_location": "L78",
+      "weight": 1.0,
+      "_src": "scripts_harness_audit_ts",
+      "_tgt": "harness_audit_normalizebehaviorscenarioname",
+      "source": "scripts_harness_audit_ts",
+      "target": "harness_audit_normalizebehaviorscenarioname",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L82",
       "weight": 1.0,
       "_src": "scripts_harness_audit_ts",
       "_tgt": "harness_audit_addgroupederror",
@@ -41649,7 +41693,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L91",
+      "source_location": "L96",
       "weight": 1.0,
       "_src": "scripts_harness_audit_ts",
       "_tgt": "harness_audit_infergroupfromerror",
@@ -41661,7 +41705,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L96",
+      "source_location": "L101",
       "weight": 1.0,
       "_src": "scripts_harness_audit_ts",
       "_tgt": "harness_audit_shouldskipsurfaceentry",
@@ -41673,7 +41717,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L107",
+      "source_location": "L112",
       "weight": 1.0,
       "_src": "scripts_harness_audit_ts",
       "_tgt": "harness_audit_collectlivesurfaceentries",
@@ -41685,7 +41729,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L136",
+      "source_location": "L141",
       "weight": 1.0,
       "_src": "scripts_harness_audit_ts",
       "_tgt": "harness_audit_loadaudittarget",
@@ -41697,7 +41741,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L290",
+      "source_location": "L319",
       "weight": 1.0,
       "_src": "scripts_harness_audit_ts",
       "_tgt": "harness_audit_formatgroupederrors",
@@ -41709,7 +41753,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L305",
+      "source_location": "L334",
       "weight": 1.0,
       "_src": "scripts_harness_audit_ts",
       "_tgt": "harness_audit_runharnessaudit",
@@ -41721,7 +41765,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L43",
+      "source_location": "L44",
       "weight": 1.0,
       "_src": "harness_audit_matchespathprefix",
       "_tgt": "harness_audit_normalizerepopath",
@@ -41733,7 +41777,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L126",
+      "source_location": "L131",
       "weight": 1.0,
       "_src": "harness_audit_collectlivesurfaceentries",
       "_tgt": "harness_audit_normalizerepopath",
@@ -41745,7 +41789,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L279",
+      "source_location": "L305",
       "weight": 1.0,
       "_src": "harness_audit_loadaudittarget",
       "_tgt": "harness_audit_normalizerepopath",
@@ -41757,7 +41801,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L116",
+      "source_location": "L121",
       "weight": 1.0,
       "_src": "harness_audit_collectlivesurfaceentries",
       "_tgt": "harness_audit_fileexists",
@@ -41769,7 +41813,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L144",
+      "source_location": "L149",
       "weight": 1.0,
       "_src": "harness_audit_loadaudittarget",
       "_tgt": "harness_audit_fileexists",
@@ -41781,7 +41825,19 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L145",
+      "source_location": "L290",
+      "weight": 1.0,
+      "_src": "harness_audit_loadaudittarget",
+      "_tgt": "harness_audit_normalizebehaviorscenarioname",
+      "source": "harness_audit_normalizebehaviorscenarioname",
+      "target": "harness_audit_loadaudittarget",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-audit.ts",
+      "source_location": "L150",
       "weight": 1.0,
       "_src": "harness_audit_loadaudittarget",
       "_tgt": "harness_audit_addgroupederror",
@@ -41793,7 +41849,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L309",
+      "source_location": "L338",
       "weight": 1.0,
       "_src": "harness_audit_runharnessaudit",
       "_tgt": "harness_audit_addgroupederror",
@@ -41805,7 +41861,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L309",
+      "source_location": "L338",
       "weight": 1.0,
       "_src": "harness_audit_runharnessaudit",
       "_tgt": "harness_audit_infergroupfromerror",
@@ -41817,7 +41873,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L122",
+      "source_location": "L127",
       "weight": 1.0,
       "_src": "harness_audit_collectlivesurfaceentries",
       "_tgt": "harness_audit_shouldskipsurfaceentry",
@@ -41829,7 +41885,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L331",
+      "source_location": "L360",
       "weight": 1.0,
       "_src": "harness_audit_runharnessaudit",
       "_tgt": "harness_audit_collectlivesurfaceentries",
@@ -41841,7 +41897,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L314",
+      "source_location": "L343",
       "weight": 1.0,
       "_src": "harness_audit_runharnessaudit",
       "_tgt": "harness_audit_loadaudittarget",
@@ -41853,7 +41909,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-audit.ts",
-      "source_location": "L358",
+      "source_location": "L387",
       "weight": 1.0,
       "_src": "harness_audit_runharnessaudit",
       "_tgt": "harness_audit_formatgroupederrors",
@@ -43425,7 +43481,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L283",
+      "source_location": "L285",
       "weight": 1.0,
       "_src": "scripts_harness_generate_ts",
       "_tgt": "harness_generate_buildgenerateddoc",
@@ -43437,7 +43493,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L293",
+      "source_location": "L295",
       "weight": 1.0,
       "_src": "scripts_harness_generate_ts",
       "_tgt": "harness_generate_buildrouteindex",
@@ -43449,7 +43505,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L320",
+      "source_location": "L322",
       "weight": 1.0,
       "_src": "scripts_harness_generate_ts",
       "_tgt": "harness_generate_buildtestindex",
@@ -43461,7 +43517,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L365",
+      "source_location": "L367",
       "weight": 1.0,
       "_src": "scripts_harness_generate_ts",
       "_tgt": "harness_generate_buildkeyfolderindex",
@@ -43473,7 +43529,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L398",
+      "source_location": "L400",
       "weight": 1.0,
       "_src": "scripts_harness_generate_ts",
       "_tgt": "harness_generate_buildvalidationguide",
@@ -43485,7 +43541,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L431",
+      "source_location": "L442",
       "weight": 1.0,
       "_src": "scripts_harness_generate_ts",
       "_tgt": "harness_generate_buildvalidationmap",
@@ -43497,7 +43553,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L438",
+      "source_location": "L449",
       "weight": 1.0,
       "_src": "scripts_harness_generate_ts",
       "_tgt": "harness_generate_generateharnessdocs",
@@ -43509,7 +43565,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L468",
+      "source_location": "L479",
       "weight": 1.0,
       "_src": "scripts_harness_generate_ts",
       "_tgt": "harness_generate_writegeneratedharnessdocs",
@@ -43641,7 +43697,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L442",
+      "source_location": "L453",
       "weight": 1.0,
       "_src": "harness_generate_generateharnessdocs",
       "_tgt": "harness_generate_readpackageconfig",
@@ -43665,7 +43721,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L306",
+      "source_location": "L308",
       "weight": 1.0,
       "_src": "harness_generate_buildrouteindex",
       "_tgt": "harness_generate_formatmarkdownlink",
@@ -43677,7 +43733,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L351",
+      "source_location": "L353",
       "weight": 1.0,
       "_src": "harness_generate_buildtestindex",
       "_tgt": "harness_generate_formatmarkdownlink",
@@ -43689,7 +43745,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L382",
+      "source_location": "L384",
       "weight": 1.0,
       "_src": "harness_generate_buildkeyfolderindex",
       "_tgt": "harness_generate_formatmarkdownlink",
@@ -43701,7 +43757,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L303",
+      "source_location": "L305",
       "weight": 1.0,
       "_src": "harness_generate_buildrouteindex",
       "_tgt": "harness_generate_headingfromsegment",
@@ -43713,7 +43769,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L348",
+      "source_location": "L350",
       "weight": 1.0,
       "_src": "harness_generate_buildtestindex",
       "_tgt": "harness_generate_headingfromsegment",
@@ -43737,7 +43793,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L297",
+      "source_location": "L299",
       "weight": 1.0,
       "_src": "harness_generate_buildrouteindex",
       "_tgt": "harness_generate_collectroutegroups",
@@ -43749,7 +43805,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L325",
+      "source_location": "L327",
       "weight": 1.0,
       "_src": "harness_generate_buildtestindex",
       "_tgt": "harness_generate_collecttestfiles",
@@ -43761,7 +43817,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L326",
+      "source_location": "L328",
       "weight": 1.0,
       "_src": "harness_generate_buildtestindex",
       "_tgt": "harness_generate_collecttestsurfaceroots",
@@ -43773,7 +43829,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L376",
+      "source_location": "L378",
       "weight": 1.0,
       "_src": "harness_generate_buildkeyfolderindex",
       "_tgt": "harness_generate_collectfolderfacts",
@@ -43797,7 +43853,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L334",
+      "source_location": "L336",
       "weight": 1.0,
       "_src": "harness_generate_buildtestindex",
       "_tgt": "harness_generate_formatscriptcommand",
@@ -43809,7 +43865,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L416",
+      "source_location": "L418",
       "weight": 1.0,
       "_src": "harness_generate_buildvalidationguide",
       "_tgt": "harness_generate_formatvalidationcommandfordoc",
@@ -43821,7 +43877,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L435",
+      "source_location": "L446",
       "weight": 1.0,
       "_src": "harness_generate_buildvalidationmap",
       "_tgt": "harness_generate_togeneratedvalidationmap",
@@ -43833,7 +43889,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L311",
+      "source_location": "L313",
       "weight": 1.0,
       "_src": "harness_generate_buildrouteindex",
       "_tgt": "harness_generate_buildgenerateddoc",
@@ -43845,7 +43901,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L356",
+      "source_location": "L358",
       "weight": 1.0,
       "_src": "harness_generate_buildtestindex",
       "_tgt": "harness_generate_buildgenerateddoc",
@@ -43857,7 +43913,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L389",
+      "source_location": "L391",
       "weight": 1.0,
       "_src": "harness_generate_buildkeyfolderindex",
       "_tgt": "harness_generate_buildgenerateddoc",
@@ -43869,7 +43925,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L424",
+      "source_location": "L435",
       "weight": 1.0,
       "_src": "harness_generate_buildvalidationguide",
       "_tgt": "harness_generate_buildgenerateddoc",
@@ -43881,7 +43937,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L445",
+      "source_location": "L456",
       "weight": 1.0,
       "_src": "harness_generate_generateharnessdocs",
       "_tgt": "harness_generate_buildrouteindex",
@@ -43893,7 +43949,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L449",
+      "source_location": "L460",
       "weight": 1.0,
       "_src": "harness_generate_generateharnessdocs",
       "_tgt": "harness_generate_buildtestindex",
@@ -43905,7 +43961,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L453",
+      "source_location": "L464",
       "weight": 1.0,
       "_src": "harness_generate_generateharnessdocs",
       "_tgt": "harness_generate_buildkeyfolderindex",
@@ -43917,7 +43973,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L457",
+      "source_location": "L468",
       "weight": 1.0,
       "_src": "harness_generate_generateharnessdocs",
       "_tgt": "harness_generate_buildvalidationguide",
@@ -43929,7 +43985,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L461",
+      "source_location": "L472",
       "weight": 1.0,
       "_src": "harness_generate_generateharnessdocs",
       "_tgt": "harness_generate_buildvalidationmap",
@@ -43941,7 +43997,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-generate.ts",
-      "source_location": "L469",
+      "source_location": "L480",
       "weight": 1.0,
       "_src": "harness_generate_writegeneratedharnessdocs",
       "_tgt": "harness_generate_generateharnessdocs",
@@ -43977,7 +44033,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L386",
+      "source_location": "L631",
       "weight": 1.0,
       "_src": "scripts_harness_review_test_ts",
       "_tgt": "harness_review_test_log",
@@ -43989,7 +44045,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L387",
+      "source_location": "L632",
       "weight": 1.0,
       "_src": "scripts_harness_review_test_ts",
       "_tgt": "harness_review_test_error",
@@ -44013,7 +44069,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L42",
+      "source_location": "L44",
       "weight": 1.0,
       "_src": "scripts_harness_review_ts",
       "_tgt": "harness_review_normalizerepopath",
@@ -44025,7 +44081,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L46",
+      "source_location": "L48",
       "weight": 1.0,
       "_src": "scripts_harness_review_ts",
       "_tgt": "harness_review_matchespathprefix",
@@ -44037,7 +44093,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L60",
+      "source_location": "L62",
       "weight": 1.0,
       "_src": "scripts_harness_review_ts",
       "_tgt": "harness_review_normalizevalidationcommand",
@@ -44049,7 +44105,19 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L68",
+      "source_location": "L70",
+      "weight": 1.0,
+      "_src": "scripts_harness_review_ts",
+      "_tgt": "harness_review_normalizebehaviorscenarioname",
+      "source": "scripts_harness_review_ts",
+      "target": "harness_review_normalizebehaviorscenarioname",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L74",
       "weight": 1.0,
       "_src": "scripts_harness_review_ts",
       "_tgt": "harness_review_fileexists",
@@ -44061,7 +44129,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L77",
+      "source_location": "L83",
       "weight": 1.0,
       "_src": "scripts_harness_review_ts",
       "_tgt": "harness_review_readjsonfile",
@@ -44073,7 +44141,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L81",
+      "source_location": "L87",
       "weight": 1.0,
       "_src": "scripts_harness_review_ts",
       "_tgt": "harness_review_loadreviewtarget",
@@ -44085,7 +44153,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L185",
+      "source_location": "L211",
       "weight": 1.0,
       "_src": "scripts_harness_review_ts",
       "_tgt": "harness_review_loadreviewtargets",
@@ -44097,7 +44165,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L201",
+      "source_location": "L227",
       "weight": 1.0,
       "_src": "scripts_harness_review_ts",
       "_tgt": "harness_review_collectcommandsforchangedfiles",
@@ -44109,7 +44177,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L274",
+      "source_location": "L312",
       "weight": 1.0,
       "_src": "scripts_harness_review_ts",
       "_tgt": "harness_review_getchangedfilesfromgit",
@@ -44121,7 +44189,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L312",
+      "source_location": "L350",
       "weight": 1.0,
       "_src": "scripts_harness_review_ts",
       "_tgt": "harness_review_runpackagescript",
@@ -44133,7 +44201,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L326",
+      "source_location": "L364",
       "weight": 1.0,
       "_src": "scripts_harness_review_ts",
       "_tgt": "harness_review_runrawcommand",
@@ -44145,7 +44213,19 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L339",
+      "source_location": "L377",
+      "weight": 1.0,
+      "_src": "scripts_harness_review_ts",
+      "_tgt": "harness_review_runharnessbehaviorscenario",
+      "source": "scripts_harness_review_ts",
+      "target": "harness_review_runharnessbehaviorscenario",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L391",
       "weight": 1.0,
       "_src": "scripts_harness_review_ts",
       "_tgt": "harness_review_runharnessreview",
@@ -44157,7 +44237,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L47",
+      "source_location": "L49",
       "weight": 1.0,
       "_src": "harness_review_matchespathprefix",
       "_tgt": "harness_review_normalizerepopath",
@@ -44169,7 +44249,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L174",
+      "source_location": "L197",
       "weight": 1.0,
       "_src": "harness_review_loadreviewtarget",
       "_tgt": "harness_review_normalizerepopath",
@@ -44181,7 +44261,19 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L107",
+      "source_location": "L188",
+      "weight": 1.0,
+      "_src": "harness_review_loadreviewtarget",
+      "_tgt": "harness_review_normalizebehaviorscenarioname",
+      "source": "harness_review_normalizebehaviorscenarioname",
+      "target": "harness_review_loadreviewtarget",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L113",
       "weight": 1.0,
       "_src": "harness_review_loadreviewtarget",
       "_tgt": "harness_review_fileexists",
@@ -44193,7 +44285,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L190",
+      "source_location": "L216",
       "weight": 1.0,
       "_src": "harness_review_loadreviewtargets",
       "_tgt": "harness_review_loadreviewtarget",
@@ -44205,7 +44297,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L350",
+      "source_location": "L402",
       "weight": 1.0,
       "_src": "harness_review_runharnessreview",
       "_tgt": "harness_review_loadreviewtargets",
@@ -44217,7 +44309,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L352",
+      "source_location": "L409",
       "weight": 1.0,
       "_src": "harness_review_runharnessreview",
       "_tgt": "harness_review_collectcommandsforchangedfiles",
@@ -44265,7 +44357,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L91",
+      "source_location": "L92",
       "weight": 1.0,
       "_src": "scripts_harness_self_review_ts",
       "_tgt": "harness_self_review_normalizerepopath",
@@ -44277,7 +44369,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L95",
+      "source_location": "L96",
       "weight": 1.0,
       "_src": "scripts_harness_self_review_ts",
       "_tgt": "harness_self_review_sortuniquepaths",
@@ -44289,7 +44381,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L101",
+      "source_location": "L102",
       "weight": 1.0,
       "_src": "scripts_harness_self_review_ts",
       "_tgt": "harness_self_review_matchespathprefix",
@@ -44301,7 +44393,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L115",
+      "source_location": "L116",
       "weight": 1.0,
       "_src": "scripts_harness_self_review_ts",
       "_tgt": "harness_self_review_normalizevalidationcommand",
@@ -44313,7 +44405,19 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L123",
+      "source_location": "L124",
+      "weight": 1.0,
+      "_src": "scripts_harness_self_review_ts",
+      "_tgt": "harness_self_review_normalizebehaviorscenarioname",
+      "source": "scripts_harness_self_review_ts",
+      "target": "harness_self_review_normalizebehaviorscenarioname",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L128",
       "weight": 1.0,
       "_src": "scripts_harness_self_review_ts",
       "_tgt": "harness_self_review_formatvalidationcommand",
@@ -44325,7 +44429,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L131",
+      "source_location": "L136",
       "weight": 1.0,
       "_src": "scripts_harness_self_review_ts",
       "_tgt": "harness_self_review_quotecode",
@@ -44337,7 +44441,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L135",
+      "source_location": "L140",
       "weight": 1.0,
       "_src": "scripts_harness_self_review_ts",
       "_tgt": "harness_self_review_fileexists",
@@ -44349,7 +44453,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L144",
+      "source_location": "L149",
       "weight": 1.0,
       "_src": "scripts_harness_self_review_ts",
       "_tgt": "harness_self_review_readjsonfile",
@@ -44361,7 +44465,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L148",
+      "source_location": "L153",
       "weight": 1.0,
       "_src": "scripts_harness_self_review_ts",
       "_tgt": "harness_self_review_runcommand",
@@ -44373,7 +44477,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L168",
+      "source_location": "L173",
       "weight": 1.0,
       "_src": "scripts_harness_self_review_ts",
       "_tgt": "harness_self_review_getchangedfilesfromgit",
@@ -44385,7 +44489,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L232",
+      "source_location": "L237",
       "weight": 1.0,
       "_src": "scripts_harness_self_review_ts",
       "_tgt": "harness_self_review_parseruntimescenarios",
@@ -44397,7 +44501,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L238",
+      "source_location": "L243",
       "weight": 1.0,
       "_src": "scripts_harness_self_review_ts",
       "_tgt": "harness_self_review_loadselfreviewtarget",
@@ -44409,7 +44513,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L350",
+      "source_location": "L375",
       "weight": 1.0,
       "_src": "scripts_harness_self_review_ts",
       "_tgt": "harness_self_review_loadselfreviewtargets",
@@ -44421,7 +44525,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L369",
+      "source_location": "L394",
       "weight": 1.0,
       "_src": "scripts_harness_self_review_ts",
       "_tgt": "harness_self_review_collectcoverage",
@@ -44433,7 +44537,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L447",
+      "source_location": "L472",
       "weight": 1.0,
       "_src": "scripts_harness_self_review_ts",
       "_tgt": "harness_self_review_islikelycodeorconfig",
@@ -44445,7 +44549,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L468",
+      "source_location": "L493",
       "weight": 1.0,
       "_src": "scripts_harness_self_review_ts",
       "_tgt": "harness_self_review_evaluategraphifyfreshness",
@@ -44457,7 +44561,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L532",
+      "source_location": "L557",
       "weight": 1.0,
       "_src": "scripts_harness_self_review_ts",
       "_tgt": "harness_self_review_runquietharnesscheck",
@@ -44469,7 +44573,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L541",
+      "source_location": "L566",
       "weight": 1.0,
       "_src": "scripts_harness_self_review_ts",
       "_tgt": "harness_self_review_appendlistsection",
@@ -44481,7 +44585,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L560",
+      "source_location": "L585",
       "weight": 1.0,
       "_src": "scripts_harness_self_review_ts",
       "_tgt": "harness_self_review_buildmarkdownbundle",
@@ -44493,7 +44597,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L717",
+      "source_location": "L742",
       "weight": 1.0,
       "_src": "scripts_harness_self_review_ts",
       "_tgt": "harness_self_review_parsecliarguments",
@@ -44505,7 +44609,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L766",
+      "source_location": "L791",
       "weight": 1.0,
       "_src": "scripts_harness_self_review_ts",
       "_tgt": "harness_self_review_runharnessselfreview",
@@ -44517,7 +44621,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L102",
+      "source_location": "L103",
       "weight": 1.0,
       "_src": "harness_self_review_matchespathprefix",
       "_tgt": "harness_self_review_normalizerepopath",
@@ -44529,7 +44633,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L338",
+      "source_location": "L360",
       "weight": 1.0,
       "_src": "harness_self_review_loadselfreviewtarget",
       "_tgt": "harness_self_review_normalizerepopath",
@@ -44541,7 +44645,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L226",
+      "source_location": "L231",
       "weight": 1.0,
       "_src": "harness_self_review_getchangedfilesfromgit",
       "_tgt": "harness_self_review_sortuniquepaths",
@@ -44553,7 +44657,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L365",
+      "source_location": "L390",
       "weight": 1.0,
       "_src": "harness_self_review_loadselfreviewtargets",
       "_tgt": "harness_self_review_sortuniquepaths",
@@ -44565,7 +44669,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L401",
+      "source_location": "L426",
       "weight": 1.0,
       "_src": "harness_self_review_collectcoverage",
       "_tgt": "harness_self_review_sortuniquepaths",
@@ -44577,7 +44681,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L493",
+      "source_location": "L518",
       "weight": 1.0,
       "_src": "harness_self_review_evaluategraphifyfreshness",
       "_tgt": "harness_self_review_sortuniquepaths",
@@ -44589,7 +44693,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L802",
+      "source_location": "L827",
       "weight": 1.0,
       "_src": "harness_self_review_runharnessselfreview",
       "_tgt": "harness_self_review_sortuniquepaths",
@@ -44601,7 +44705,19 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L412",
+      "source_location": "L343",
+      "weight": 1.0,
+      "_src": "harness_self_review_loadselfreviewtarget",
+      "_tgt": "harness_self_review_normalizebehaviorscenarioname",
+      "source": "harness_self_review_normalizebehaviorscenarioname",
+      "target": "harness_self_review_loadselfreviewtarget",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L437",
       "weight": 1.0,
       "_src": "harness_self_review_collectcoverage",
       "_tgt": "harness_self_review_formatvalidationcommand",
@@ -44613,7 +44729,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L578",
+      "source_location": "L603",
       "weight": 1.0,
       "_src": "harness_self_review_buildmarkdownbundle",
       "_tgt": "harness_self_review_quotecode",
@@ -44625,7 +44741,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L263",
+      "source_location": "L268",
       "weight": 1.0,
       "_src": "harness_self_review_loadselfreviewtarget",
       "_tgt": "harness_self_review_fileexists",
@@ -44637,7 +44753,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L172",
+      "source_location": "L177",
       "weight": 1.0,
       "_src": "harness_self_review_getchangedfilesfromgit",
       "_tgt": "harness_self_review_runcommand",
@@ -44649,7 +44765,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L331",
+      "source_location": "L353",
       "weight": 1.0,
       "_src": "harness_self_review_loadselfreviewtarget",
       "_tgt": "harness_self_review_parseruntimescenarios",
@@ -44661,7 +44777,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L356",
+      "source_location": "L381",
       "weight": 1.0,
       "_src": "harness_self_review_loadselfreviewtargets",
       "_tgt": "harness_self_review_loadselfreviewtarget",
@@ -44673,7 +44789,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L799",
+      "source_location": "L824",
       "weight": 1.0,
       "_src": "harness_self_review_runharnessselfreview",
       "_tgt": "harness_self_review_loadselfreviewtargets",
@@ -44685,7 +44801,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L809",
+      "source_location": "L834",
       "weight": 1.0,
       "_src": "harness_self_review_runharnessselfreview",
       "_tgt": "harness_self_review_collectcoverage",
@@ -44697,7 +44813,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L823",
+      "source_location": "L848",
       "weight": 1.0,
       "_src": "harness_self_review_runharnessselfreview",
       "_tgt": "harness_self_review_evaluategraphifyfreshness",
@@ -44709,7 +44825,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L585",
+      "source_location": "L610",
       "weight": 1.0,
       "_src": "harness_self_review_buildmarkdownbundle",
       "_tgt": "harness_self_review_appendlistsection",
@@ -44721,7 +44837,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L842",
+      "source_location": "L867",
       "weight": 1.0,
       "_src": "harness_self_review_runharnessselfreview",
       "_tgt": "harness_self_review_buildmarkdownbundle",

--- a/packages/athena-webapp/docs/agent/testing.md
+++ b/packages/athena-webapp/docs/agent/testing.md
@@ -3,7 +3,7 @@
 Use the repo-root harness commands together:
 
 - `bun run harness:check` validates the docs themselves: required files, links, path references, and documented test commands.
-- `bun run harness:review` is the touched-file pass. It always runs `bun run harness:check` first, then uses the machine-readable [validation map](./validation-map.json) to decide whether `@athena/webapp` baseline validations should run for the files you changed.
+- `bun run harness:review` is the touched-file pass. It always runs `bun run harness:check` first, then uses the machine-readable [validation map](./validation-map.json) to decide whether `@athena/webapp` baseline validations and mapped runtime behavior scenarios should run for the files you changed.
 - `bun run harness:audit` is the full-app pass. It scans the current `athena-webapp` surface even when nothing is touched and fails on stale harness docs, stale validation-map paths, or live surfaces that the validation map does not cover yet.
 - `bun run harness:behavior --scenario <name>` runs shared runtime behavior scenarios that boot app processes, wait for readiness, drive browser interactions, assert runtime signals, and clean up automatically.
 - `bun run harness:behavior --scenario <name> --record-video` captures browser-flow evidence for handoff under `artifacts/harness-behavior/videos/<scenario>/<run-stamp>/`.
@@ -11,7 +11,7 @@ Use the repo-root harness commands together:
 - [Test index](./test-index.md)
 - [Validation guide](./validation-guide.md)
 
-If `bun run harness:review` reports a coverage gap, the touched `packages/athena-webapp` file is not represented in the validation map yet. Update the map and this testing guide together before handoff so the harness stays honest.
+If `bun run harness:review` reports a coverage gap, the touched `packages/athena-webapp` file is not represented in the validation map yet. Update the map (including `behaviorScenarios` when runtime checks are required) and this testing guide together before handoff so the harness stays honest.
 
 If `bun run harness:audit` reports a coverage gap, a live `src/` or `convex/` surface exists without a corresponding validation-map entry. Add or tighten the affected surface mapping before handoff so future agents can trust the repo-wide scan.
 

--- a/packages/athena-webapp/docs/agent/validation-guide.md
+++ b/packages/athena-webapp/docs/agent/validation-guide.md
@@ -46,6 +46,11 @@ Run:
 - `bun run --filter '@athena/webapp' audit:convex`
 - `bun run --filter '@athena/webapp' lint:convex:changed`
 
+Behavior scenarios:
+
+- `athena-convex-storefront-composition`
+- `athena-convex-storefront-failure-visibility`
+
 Any change that can affect Convex HTTP wiring, schemas, queries, or route-to-backend composition should include the Convex audit pair.
 
 ## Route runtime or build-pipeline edits
@@ -56,6 +61,10 @@ Run:
 
 - `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`
 - `bun run --filter '@athena/webapp' build`
+
+Behavior scenarios:
+
+- `athena-admin-shell-boot`
 
 Run these when bootstrap, generated router state, or package build configuration changes.
 

--- a/packages/athena-webapp/docs/agent/validation-map.json
+++ b/packages/athena-webapp/docs/agent/validation-map.json
@@ -22,7 +22,8 @@
           "kind": "script",
           "script": "lint:architecture"
         }
-      ]
+      ],
+      "behaviorScenarios": []
     },
     {
       "name": "shared-lib-or-utility-edits",
@@ -41,7 +42,8 @@
           "kind": "raw",
           "command": "bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json"
         }
-      ]
+      ],
+      "behaviorScenarios": []
     },
     {
       "name": "frontend-test-harness-edits",
@@ -54,7 +56,8 @@
           "kind": "script",
           "script": "test"
         }
-      ]
+      ],
+      "behaviorScenarios": []
     },
     {
       "name": "convex-or-backend-adjacent-edits",
@@ -76,6 +79,10 @@
           "kind": "script",
           "script": "lint:convex:changed"
         }
+      ],
+      "behaviorScenarios": [
+        "athena-convex-storefront-composition",
+        "athena-convex-storefront-failure-visibility"
       ]
     },
     {
@@ -94,6 +101,9 @@
           "kind": "script",
           "script": "build"
         }
+      ],
+      "behaviorScenarios": [
+        "athena-admin-shell-boot"
       ]
     },
     {
@@ -102,7 +112,8 @@
         "packages/athena-webapp/AGENTS.md",
         "packages/athena-webapp/docs/agent"
       ],
-      "commands": []
+      "commands": [],
+      "behaviorScenarios": []
     }
   ]
 }

--- a/packages/storefront-webapp/docs/agent/testing.md
+++ b/packages/storefront-webapp/docs/agent/testing.md
@@ -3,7 +3,7 @@
 Use the repo-root harness commands together:
 
 - `bun run harness:check` validates the docs themselves: required files, links, path references, and documented test commands.
-- `bun run harness:review` is the touched-file pass. It always runs `bun run harness:check` first, then uses the machine-readable [validation map](./validation-map.json) to decide whether `@athena/storefront-webapp` baseline validations should run for the files you changed.
+- `bun run harness:review` is the touched-file pass. It always runs `bun run harness:check` first, then uses the machine-readable [validation map](./validation-map.json) to decide whether `@athena/storefront-webapp` baseline validations and mapped runtime behavior scenarios should run for the files you changed.
 - `bun run harness:audit` is the full-app pass. It scans the current `storefront-webapp` surface even when nothing is touched and fails on stale harness docs, stale validation-map paths, or live surfaces that the validation map does not cover yet.
 - `bun run harness:behavior --scenario <name>` runs shared runtime behavior scenarios that boot app processes, wait for readiness, drive browser interactions, assert runtime signals, and clean up automatically.
 - `bun run harness:behavior --scenario <name> --record-video` captures browser-flow evidence for handoff under `artifacts/harness-behavior/videos/<scenario>/<run-stamp>/`.
@@ -11,7 +11,7 @@ Use the repo-root harness commands together:
 - [Test index](./test-index.md)
 - [Validation guide](./validation-guide.md)
 
-If `bun run harness:review` reports a coverage gap, the touched `packages/storefront-webapp` file is not represented in the validation map yet. Update the map and this testing guide together before handoff so the harness stays honest.
+If `bun run harness:review` reports a coverage gap, the touched `packages/storefront-webapp` file is not represented in the validation map yet. Update the map (including `behaviorScenarios` when runtime checks are required) and this testing guide together before handoff so the harness stays honest.
 
 If `bun run harness:audit` reports a coverage gap, a live `src/` or `tests/` surface exists without a corresponding validation-map entry. Add or tighten the affected surface mapping before handoff so future agents can trust the repo-wide scan.
 

--- a/packages/storefront-webapp/docs/agent/validation-guide.md
+++ b/packages/storefront-webapp/docs/agent/validation-guide.md
@@ -34,6 +34,10 @@ Run:
 - `bun run --filter '@athena/storefront-webapp' test`
 - `bun run --filter '@athena/storefront-webapp' lint:architecture`
 
+Behavior scenarios:
+
+- `storefront-checkout-bootstrap`
+
 Use the scoped architecture lint when lower-level helpers could accidentally depend on checkout or auth route entrypoints.
 
 ## Full browser journeys and payment redirects
@@ -44,6 +48,12 @@ Run:
 
 - `bun run --filter '@athena/storefront-webapp' test`
 - `bun run --filter '@athena/storefront-webapp' test:e2e`
+
+Behavior scenarios:
+
+- `storefront-checkout-bootstrap`
+- `storefront-checkout-validation-blocker`
+- `storefront-checkout-verification-recovery`
 
 Run the Playwright layer when navigation, checkout, or redirect behavior could change the end-to-end customer path.
 

--- a/packages/storefront-webapp/docs/agent/validation-map.json
+++ b/packages/storefront-webapp/docs/agent/validation-map.json
@@ -23,7 +23,8 @@
           "kind": "script",
           "script": "test"
         }
-      ]
+      ],
+      "behaviorScenarios": []
     },
     {
       "name": "shared-lib-utility-or-api-wrapper-edits",
@@ -41,7 +42,8 @@
           "kind": "raw",
           "command": "bunx tsc --noEmit -p packages/storefront-webapp/tsconfig.json"
         }
-      ]
+      ],
+      "behaviorScenarios": []
     },
     {
       "name": "checkout-or-auth-route-boundary-edits",
@@ -59,6 +61,9 @@
           "kind": "script",
           "script": "lint:architecture"
         }
+      ],
+      "behaviorScenarios": [
+        "storefront-checkout-bootstrap"
       ]
     },
     {
@@ -77,6 +82,11 @@
           "kind": "script",
           "script": "test:e2e"
         }
+      ],
+      "behaviorScenarios": [
+        "storefront-checkout-bootstrap",
+        "storefront-checkout-validation-blocker",
+        "storefront-checkout-verification-recovery"
       ]
     },
     {
@@ -85,7 +95,8 @@
         "packages/storefront-webapp/AGENTS.md",
         "packages/storefront-webapp/docs/agent"
       ],
-      "commands": []
+      "commands": [],
+      "behaviorScenarios": []
     }
   ]
 }

--- a/scripts/harness-app-registry.ts
+++ b/scripts/harness-app-registry.ts
@@ -52,6 +52,7 @@ export type HarnessValidationScenario = {
   title: string;
   touchedPaths: string[];
   commands: ValidationCommand[];
+  behaviorScenarios?: string[];
   note: string;
 };
 
@@ -224,6 +225,10 @@ export const HARNESS_APP_REGISTRY = [
           { kind: "script", script: "audit:convex" },
           { kind: "script", script: "lint:convex:changed" },
         ],
+        behaviorScenarios: [
+          "athena-convex-storefront-composition",
+          "athena-convex-storefront-failure-visibility",
+        ],
         note: "Any change that can affect Convex HTTP wiring, schemas, queries, or route-to-backend composition should include the Convex audit pair.",
       },
       {
@@ -236,6 +241,7 @@ export const HARNESS_APP_REGISTRY = [
           },
           { kind: "script", script: "build" },
         ],
+        behaviorScenarios: ["athena-admin-shell-boot"],
         note: "Run these when bootstrap, generated router state, or package build configuration changes.",
       },
     ],
@@ -335,6 +341,7 @@ export const HARNESS_APP_REGISTRY = [
           { kind: "script", script: "test" },
           { kind: "script", script: "lint:architecture" },
         ],
+        behaviorScenarios: ["storefront-checkout-bootstrap"],
         note: "Use the scoped architecture lint when lower-level helpers could accidentally depend on checkout or auth route entrypoints.",
       },
       {
@@ -347,6 +354,11 @@ export const HARNESS_APP_REGISTRY = [
         commands: [
           { kind: "script", script: "test" },
           { kind: "script", script: "test:e2e" },
+        ],
+        behaviorScenarios: [
+          "storefront-checkout-bootstrap",
+          "storefront-checkout-validation-blocker",
+          "storefront-checkout-verification-recovery",
         ],
         note: "Run the Playwright layer when navigation, checkout, or redirect behavior could change the end-to-end customer path.",
       },
@@ -375,4 +387,3 @@ export const HARNESS_PACKAGE_REGISTRY = [
 export function getHarnessPackageRegistration(packageDir: string) {
   return HARNESS_PACKAGE_REGISTRY.find((entry) => entry.packageDir === packageDir);
 }
-

--- a/scripts/harness-audit.ts
+++ b/scripts/harness-audit.ts
@@ -19,6 +19,7 @@ type ValidationSurface = {
   name: string;
   pathPrefixes: string[];
   commands: ValidationCommand[];
+  behaviorScenarios?: string[];
 };
 
 type ValidationMap = {
@@ -72,6 +73,10 @@ function normalizeValidationCommand(
   return command.kind === "raw"
     ? { kind: "raw", command: command.command.trim() }
     : { kind: "script", script: command.script };
+}
+
+function normalizeBehaviorScenarioName(scenario: string) {
+  return scenario.trim();
 }
 
 function addGroupedError(
@@ -269,6 +274,27 @@ async function loadAuditTarget(
         );
       }
     }
+
+    if (
+      surface.behaviorScenarios !== undefined &&
+      !Array.isArray(surface.behaviorScenarios)
+    ) {
+      addGroupedError(
+        groupedErrors,
+        target.appName,
+        `Stale validation surface: ${target.validationMapPath} includes invalid behavior scenarios in "${surface.name}".`
+      );
+    }
+
+    for (const scenario of surface.behaviorScenarios ?? []) {
+      if (typeof scenario !== "string" || !normalizeBehaviorScenarioName(scenario)) {
+        addGroupedError(
+          groupedErrors,
+          target.appName,
+          `Stale validation surface: ${target.validationMapPath} includes an empty behavior scenario in "${surface.name}".`
+        );
+      }
+    }
   }
 
   return {
@@ -281,6 +307,9 @@ async function loadAuditTarget(
         name: surface.name,
         pathPrefixes: surface.pathPrefixes.map(normalizeRepoPath),
         commands: surface.commands.map(normalizeValidationCommand),
+        behaviorScenarios: (surface.behaviorScenarios ?? []).map(
+          normalizeBehaviorScenarioName
+        ),
       })),
       testingDocContents,
     } satisfies LoadedAuditTarget,

--- a/scripts/harness-generate.test.ts
+++ b/scripts/harness-generate.test.ts
@@ -106,6 +106,9 @@ describe("generateHarnessDocs", () => {
     expect(docs.get("packages/athena-webapp/docs/agent/validation-map.json")).toContain(
       "\"commands\""
     );
+    expect(docs.get("packages/athena-webapp/docs/agent/validation-map.json")).toContain(
+      "\"behaviorScenarios\""
+    );
     expect(docs.get("packages/storefront-webapp/docs/agent/validation-map.json")).toContain(
       "\"kind\": \"raw\""
     );

--- a/scripts/harness-generate.ts
+++ b/scripts/harness-generate.ts
@@ -267,6 +267,7 @@ function toGeneratedValidationMap(
           toRepoValidationPath(config.packageDir, touchedPath)
         ),
         commands: scenario.commands,
+        behaviorScenarios: scenario.behaviorScenarios ?? [],
       })),
       {
         name: "harness-docs",
@@ -275,6 +276,7 @@ function toGeneratedValidationMap(
           path.posix.dirname(config.harnessDocs.indexPath),
         ],
         commands: [] as ValidationCommand[],
+        behaviorScenarios: [] as string[],
       },
     ],
   };
@@ -414,6 +416,15 @@ async function buildValidationGuide(
 
     for (const command of scenario.commands) {
       bodyLines.push(`- \`${formatValidationCommandForDoc(packageConfig, command)}\``);
+    }
+
+    if ((scenario.behaviorScenarios?.length ?? 0) > 0) {
+      bodyLines.push("");
+      bodyLines.push("Behavior scenarios:");
+      bodyLines.push("");
+      for (const behaviorScenario of scenario.behaviorScenarios ?? []) {
+        bodyLines.push(`- \`${behaviorScenario}\``);
+      }
     }
 
     bodyLines.push("");

--- a/scripts/harness-review.test.ts
+++ b/scripts/harness-review.test.ts
@@ -123,6 +123,21 @@ async function createFixtureRepo() {
     "export const storefront = true;\n",
     rootDir
   );
+  await write(
+    "packages/storefront-webapp/src/routes/shop/checkout/index.tsx",
+    "export const checkoutRoute = true;\n",
+    rootDir
+  );
+  await write(
+    "packages/storefront-webapp/src/components/checkout/CheckoutProvider.tsx",
+    "export const checkoutProvider = true;\n",
+    rootDir
+  );
+  await write(
+    "packages/storefront-webapp/src/routes/auth.verify.tsx",
+    "export const authVerifyRoute = true;\n",
+    rootDir
+  );
 
   return rootDir;
 }
@@ -393,5 +408,231 @@ describe("runHarnessReview", () => {
       "@athena/webapp:test",
       "raw:bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json",
     ]);
+  });
+
+  it("runs mapped storefront behavior scenarios for checkout-critical surfaces", async () => {
+    const rootDir = await createFixtureRepo();
+    const steps: string[] = [];
+
+    await write(
+      "packages/storefront-webapp/docs/agent/validation-map.json",
+      JSON.stringify(
+        {
+          workspace: "@athena/storefront-webapp",
+          packageDir: "packages/storefront-webapp",
+          surfaces: [
+            {
+              name: "checkout-or-auth-route-boundary-edits",
+              pathPrefixes: [
+                "packages/storefront-webapp/src/routes/shop/checkout",
+                "packages/storefront-webapp/src/components/checkout",
+                "packages/storefront-webapp/src/routes/auth.verify.tsx",
+              ],
+              commands: [{ kind: "script", script: "test" }],
+              behaviorScenarios: ["storefront-checkout-bootstrap"],
+            },
+          ],
+        },
+        null,
+        2
+      ),
+      rootDir
+    );
+
+    await runHarnessReview(rootDir, {
+      getChangedFiles: async () => [
+        "packages/storefront-webapp/src/routes/shop/checkout/index.tsx",
+      ],
+      runHarnessCheck: async () => {
+        steps.push("harness:check");
+      },
+      runPackageScript: async (workspace, script) => {
+        steps.push(`${workspace}:${script}`);
+      },
+      runHarnessBehaviorScenario: async (scenario) => {
+        steps.push(`behavior:${scenario}`);
+      },
+      logger: {
+        log() {},
+        error() {},
+      },
+    });
+
+    expect(steps).toEqual([
+      "harness:check",
+      "@athena/storefront-webapp:test",
+      "behavior:storefront-checkout-bootstrap",
+    ]);
+  });
+
+  it("runs mapped athena behavior scenarios for convex composition surfaces", async () => {
+    const rootDir = await createFixtureRepo();
+    const steps: string[] = [];
+
+    await write(
+      "packages/athena-webapp/docs/agent/validation-map.json",
+      JSON.stringify(
+        {
+          workspace: "@athena/webapp",
+          packageDir: "packages/athena-webapp",
+          surfaces: [
+            {
+              name: "convex-or-backend-adjacent-edits",
+              pathPrefixes: ["packages/athena-webapp/convex"],
+              commands: [{ kind: "script", script: "test" }],
+              behaviorScenarios: [
+                "athena-convex-storefront-composition",
+                "athena-convex-storefront-failure-visibility",
+              ],
+            },
+          ],
+        },
+        null,
+        2
+      ),
+      rootDir
+    );
+
+    await runHarnessReview(rootDir, {
+      getChangedFiles: async () => ["packages/athena-webapp/convex/placeholder.ts"],
+      runHarnessCheck: async () => {
+        steps.push("harness:check");
+      },
+      runPackageScript: async (workspace, script) => {
+        steps.push(`${workspace}:${script}`);
+      },
+      runHarnessBehaviorScenario: async (scenario) => {
+        steps.push(`behavior:${scenario}`);
+      },
+      logger: {
+        log() {},
+        error() {},
+      },
+    });
+
+    expect(steps).toEqual([
+      "harness:check",
+      "@athena/webapp:test",
+      "behavior:athena-convex-storefront-composition",
+      "behavior:athena-convex-storefront-failure-visibility",
+    ]);
+  });
+
+  it("dedupes behavior scenarios selected by multiple touched files", async () => {
+    const rootDir = await createFixtureRepo();
+    const steps: string[] = [];
+
+    await write(
+      "packages/storefront-webapp/docs/agent/validation-map.json",
+      JSON.stringify(
+        {
+          workspace: "@athena/storefront-webapp",
+          packageDir: "packages/storefront-webapp",
+          surfaces: [
+            {
+              name: "checkout-route-edits",
+              pathPrefixes: ["packages/storefront-webapp/src/routes/shop/checkout"],
+              commands: [{ kind: "script", script: "test" }],
+              behaviorScenarios: ["storefront-checkout-bootstrap"],
+            },
+            {
+              name: "checkout-component-edits",
+              pathPrefixes: ["packages/storefront-webapp/src/components/checkout"],
+              commands: [{ kind: "script", script: "test" }],
+              behaviorScenarios: ["storefront-checkout-bootstrap"],
+            },
+          ],
+        },
+        null,
+        2
+      ),
+      rootDir
+    );
+    await write(
+      "packages/storefront-webapp/src/components/checkout/CheckoutProvider.tsx",
+      "export const provider = true;\n",
+      rootDir
+    );
+
+    await runHarnessReview(rootDir, {
+      getChangedFiles: async () => [
+        "packages/storefront-webapp/src/routes/shop/checkout/index.tsx",
+        "packages/storefront-webapp/src/components/checkout/CheckoutProvider.tsx",
+      ],
+      runHarnessCheck: async () => {
+        steps.push("harness:check");
+      },
+      runPackageScript: async (workspace, script) => {
+        steps.push(`${workspace}:${script}`);
+      },
+      runHarnessBehaviorScenario: async (scenario) => {
+        steps.push(`behavior:${scenario}`);
+      },
+      logger: {
+        log() {},
+        error() {},
+      },
+    });
+
+    expect(steps).toEqual([
+      "harness:check",
+      "@athena/storefront-webapp:test",
+      "behavior:storefront-checkout-bootstrap",
+    ]);
+  });
+
+  it("does not run behavior scenarios for docs-only touched files", async () => {
+    const rootDir = await createFixtureRepo();
+    const steps: string[] = [];
+
+    await write(
+      "packages/storefront-webapp/docs/agent/testing.md",
+      [
+        "# Storefront Webapp Testing",
+        "",
+        "Run `bun run harness:review` from the repo root for touched-file validation coverage.",
+        "Machine-readable review coverage lives in [validation-map.json](./validation-map.json).",
+      ].join("\n"),
+      rootDir
+    );
+    await write(
+      "packages/storefront-webapp/docs/agent/validation-map.json",
+      JSON.stringify(
+        {
+          workspace: "@athena/storefront-webapp",
+          packageDir: "packages/storefront-webapp",
+          surfaces: [
+            {
+              name: "harness-docs",
+              pathPrefixes: ["packages/storefront-webapp/docs/agent"],
+              commands: [],
+              behaviorScenarios: [],
+            },
+          ],
+        },
+        null,
+        2
+      ),
+      rootDir
+    );
+
+    await runHarnessReview(rootDir, {
+      getChangedFiles: async () => ["packages/storefront-webapp/docs/agent/testing.md"],
+      runHarnessCheck: async () => {
+        steps.push("harness:check");
+      },
+      runPackageScript: async (workspace, script) => {
+        steps.push(`${workspace}:${script}`);
+      },
+      runHarnessBehaviorScenario: async (scenario) => {
+        steps.push(`behavior:${scenario}`);
+      },
+      logger: {
+        log() {},
+        error() {},
+      },
+    });
+
+    expect(steps).toEqual(["harness:check"]);
   });
 });

--- a/scripts/harness-review.ts
+++ b/scripts/harness-review.ts
@@ -14,6 +14,7 @@ type ValidationSurface = {
   name: string;
   pathPrefixes: string[];
   commands: ValidationCommand[];
+  behaviorScenarios?: string[];
 };
 
 type ValidationMap = {
@@ -37,6 +38,7 @@ type HarnessReviewOptions = {
   runHarnessCheck?: (rootDir: string) => Promise<void>;
   runPackageScript?: (workspace: string, script: string) => Promise<void>;
   runRawCommand?: (command: string) => Promise<void>;
+  runHarnessBehaviorScenario?: (scenario: string) => Promise<void>;
 };
 
 function normalizeRepoPath(repoPath: string) {
@@ -63,6 +65,10 @@ function normalizeValidationCommand(
   return command.kind === "raw"
     ? { kind: "raw", command: command.command.trim() }
     : { kind: "script", script: command.script };
+}
+
+function normalizeBehaviorScenarioName(scenario: string) {
+  return scenario.trim();
 }
 
 async function fileExists(filePath: string) {
@@ -168,6 +174,23 @@ async function loadReviewTarget(
         );
       }
     }
+
+    if (
+      surface.behaviorScenarios !== undefined &&
+      !Array.isArray(surface.behaviorScenarios)
+    ) {
+      throw new Error(
+        `Stale harness review config: ${validationMapPath} includes invalid behavior scenarios for "${surface.name}".`
+      );
+    }
+
+    for (const scenario of surface.behaviorScenarios ?? []) {
+      if (typeof scenario !== "string" || !normalizeBehaviorScenarioName(scenario)) {
+        throw new Error(
+          `Stale harness review config: ${validationMapPath} includes an empty behavior scenario for "${surface.name}".`
+        );
+      }
+    }
   }
 
   return {
@@ -178,6 +201,9 @@ async function loadReviewTarget(
       name: surface.name,
       pathPrefixes: surface.pathPrefixes.map(normalizeRepoPath),
       commands: surface.commands.map(normalizeValidationCommand),
+      behaviorScenarios: (surface.behaviorScenarios ?? []).map(
+        normalizeBehaviorScenarioName
+      ),
     })),
   } satisfies LoadedReviewTarget;
 }
@@ -202,11 +228,13 @@ function collectCommandsForChangedFiles(
   changedFiles: string[],
   targets: LoadedReviewTarget[]
 ) {
-  const normalizedChangedFiles = changedFiles.map(normalizeRepoPath);
+  const normalizedChangedFiles = changedFiles.map(normalizeRepoPath).sort();
   const selectedCommands: Array<
     | { kind: "script"; workspace: string; script: string }
     | { kind: "raw"; command: string }
   > = [];
+  const selectedBehaviorScenarios: string[] = [];
+  const seenBehaviorScenarios = new Set<string>();
   const uncoveredFiles: string[] = [];
   const targetFiles = normalizedChangedFiles.filter((filePath) =>
     targets.some((target) => matchesPathPrefix(filePath, `${target.packageDir}/`))
@@ -260,12 +288,22 @@ function collectCommandsForChangedFiles(
           }
           seenCommands.add(commandKey);
         }
+
+        for (const scenario of surface.behaviorScenarios ?? []) {
+          if (seenBehaviorScenarios.has(scenario)) {
+            continue;
+          }
+
+          selectedBehaviorScenarios.push(scenario);
+          seenBehaviorScenarios.add(scenario);
+        }
       }
     }
   }
 
   return {
     selectedCommands,
+    selectedBehaviorScenarios,
     uncoveredFiles,
     targetFiles,
   };
@@ -336,6 +374,20 @@ async function runRawCommand(rootDir: string, command: string) {
   }
 }
 
+async function runHarnessBehaviorScenario(rootDir: string, scenario: string) {
+  const command = ["bun", "run", "harness:behavior", "--scenario", scenario];
+  const subprocess = Bun.spawn(command, {
+    cwd: rootDir,
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  const exitCode = await subprocess.exited;
+
+  if (exitCode !== 0) {
+    throw new Error(`Command failed (${exitCode}): ${command.join(" ")}`);
+  }
+}
+
 export async function runHarnessReview(
   rootDir: string,
   options: HarnessReviewOptions = {}
@@ -348,7 +400,12 @@ export async function runHarnessReview(
   await runCheck(rootDir);
 
   const reviewTargets = await loadReviewTargets(rootDir);
-  const { selectedCommands, uncoveredFiles, targetFiles } =
+  const {
+    selectedCommands,
+    selectedBehaviorScenarios,
+    uncoveredFiles,
+    targetFiles,
+  } =
     collectCommandsForChangedFiles(changedFiles, reviewTargets);
 
   if (uncoveredFiles.length > 0) {
@@ -384,6 +441,21 @@ export async function runHarnessReview(
     logger.log(`Running raw command: ${command.command}`);
     await (options.runRawCommand ?? ((nextCommand) =>
       runRawCommand(rootDir, nextCommand)))(command.command);
+  }
+
+  if (selectedBehaviorScenarios.length === 0) {
+    logger.log("No runtime behavior scenarios selected from touched surfaces.");
+    return;
+  }
+
+  logger.log(
+    `Selected runtime behavior scenarios: ${selectedBehaviorScenarios.join(", ")}`
+  );
+
+  for (const scenario of selectedBehaviorScenarios) {
+    logger.log(`Running harness:behavior scenario: ${scenario}`);
+    await (options.runHarnessBehaviorScenario ?? ((nextScenario) =>
+      runHarnessBehaviorScenario(rootDir, nextScenario)))(scenario);
   }
 }
 

--- a/scripts/harness-self-review.ts
+++ b/scripts/harness-self-review.ts
@@ -33,6 +33,7 @@ type ValidationSurface = {
   name: string;
   pathPrefixes: string[];
   commands: ValidationCommand[];
+  behaviorScenarios?: string[];
 };
 
 type ValidationMap = {
@@ -118,6 +119,10 @@ function normalizeValidationCommand(
   return command.kind === "raw"
     ? { kind: "raw", command: command.command.trim() }
     : { kind: "script", script: command.script };
+}
+
+function normalizeBehaviorScenarioName(scenario: string) {
+  return scenario.trim();
 }
 
 function formatValidationCommand(workspace: string, command: ValidationCommand) {
@@ -324,6 +329,23 @@ async function loadSelfReviewTarget(
         );
       }
     }
+
+    if (
+      surface.behaviorScenarios !== undefined &&
+      !Array.isArray(surface.behaviorScenarios)
+    ) {
+      throw new Error(
+        `Stale harness self-review config: ${target.validationMapPath} includes invalid behavior scenarios for "${surface.name}".`
+      );
+    }
+
+    for (const scenario of surface.behaviorScenarios ?? []) {
+      if (typeof scenario !== "string" || !normalizeBehaviorScenarioName(scenario)) {
+        throw new Error(
+          `Stale harness self-review config: ${target.validationMapPath} includes an empty behavior scenario for "${surface.name}".`
+        );
+      }
+    }
   }
 
   const absoluteValidationGuidePath = path.join(rootDir, target.validationGuidePath);
@@ -342,6 +364,9 @@ async function loadSelfReviewTarget(
       name: surface.name,
       pathPrefixes: surface.pathPrefixes.map(normalizeRepoPath),
       commands: surface.commands.map(normalizeValidationCommand),
+      behaviorScenarios: (surface.behaviorScenarios ?? []).map(
+        normalizeBehaviorScenarioName
+      ),
     })),
     runtimeScenarios,
   } satisfies LoadedSelfReviewTarget;


### PR DESCRIPTION
## Summary
- extend harness validation surface schema to include per-surface `behaviorScenarios`
- teach `harness:review` to deterministically select, dedupe, and run mapped `harness:behavior --scenario ...` executions for touched high-risk surfaces
- regenerate harness docs/maps so both webapps document and encode behavior-scenario mappings in generated validation artifacts
- add/expand harness tests for storefront/athena scenario mapping, dedupe, docs-only behavior, and schema coverage

## Why
- closes the gap between touched-file static validation mapping and runtime behavior validation for high-risk surfaces
- keeps strict coverage-gap blocking for unmapped touched files while enabling automatic behavior checks when mappings exist
- makes scenario selection diagnosable and deterministic in review logs and generated docs

## Validation
- `bun test scripts/harness-review.test.ts scripts/harness-generate.test.ts scripts/harness-audit.test.ts scripts/harness-self-review.test.ts`
- `bun run harness:test`
- `bun run harness:review`
- `bun run graphify:rebuild`
- `bun run pr:athena`
- `git diff --check`
- `bun run harness:behavior --scenario sample-runtime-smoke --record-video`

https://linear.app/v26-labs/issue/V26-206
