### PR TITLE
[V26-207]: Add performance and runtime-signal quality assertions to behavior harness scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,23 @@ Bundled scenarios include:
 - `athena-admin-shell-boot`
 - `athena-convex-storefront-composition`
 - `athena-convex-storefront-failure-visibility`
+- `storefront-checkout-bootstrap`
+- `storefront-checkout-validation-blocker`
+- `storefront-checkout-verification-recovery`
 
 Add `--record-video` to persist browser-flow evidence under
 `artifacts/harness-behavior/videos/<scenario>/<run-stamp>/`.
+
+`harness:behavior` now emits a machine-parseable per-scenario report line:
+
+- `[harness:behavior:report] { ...json... }`
+
+Each report includes phase durations, runtime-signal summaries, and threshold diagnostics.
+Scenario thresholds are configured in `scripts/harness-behavior-scenarios.ts` via:
+
+- `runtimeSignals[].minMatches` / `runtimeSignals[].maxMatches`
+- `thresholds.latency.maxPhaseDurationMs`
+- `thresholds.latency.maxTotalDurationMs`
 
 ## Graphify
 

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 2605 nodes · 2006 edges · 1098 communities detected
+- 2607 nodes · 2007 edges · 1098 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1148,16 +1148,16 @@ Cohesion: 0.18
 Nodes (24): buildGeneratedDoc(), buildKeyFolderIndex(), buildRouteIndex(), buildTestIndex(), buildValidationGuide(), buildValidationMap(), collectFolderFacts(), collectRouteGroups() (+16 more)
 
 ### Community 3 - "Community 3"
+Cohesion: 0.13
+Nodes (22): asRegExp(), collectLatencyDiagnostics(), collectRuntimeSignalDiagnostics(), collectRuntimeSignalMatches(), consumeLines(), escapeRegExp(), formatAssertionDiagnostics(), formatError() (+14 more)
+
+### Community 4 - "Community 4"
 Cohesion: 0.16
 Nodes (17): appendListSection(), buildMarkdownBundle(), collectCoverage(), evaluateGraphifyFreshness(), fileExists(), formatValidationCommand(), getChangedFilesFromGit(), loadSelfReviewTarget() (+9 more)
 
-### Community 4 - "Community 4"
+### Community 5 - "Community 5"
 Cohesion: 0.27
 Nodes (20): asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), asString(), cleanUndefined(), firstDefined() (+12 more)
-
-### Community 5 - "Community 5"
-Cohesion: 0.17
-Nodes (19): asRegExp(), collectRuntimeSignalMatches(), consumeLines(), escapeRegExp(), formatError(), HarnessBehaviorPhaseError, logPhase(), parseHarnessBehaviorArgs() (+11 more)
 
 ### Community 6 - "Community 6"
 Cohesion: 0.11
@@ -1273,11 +1273,11 @@ Nodes (1): Logger
 
 ### Community 34 - "Community 34"
 Cohesion: 0.43
-Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
+Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 35 - "Community 35"
 Cohesion: 0.43
-Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
+Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
 ### Community 36 - "Community 36"
 Cohesion: 0.25
@@ -1584,12 +1584,12 @@ Cohesion: 0.7
 Nodes (4): runTests(), testBasicOperations(), testClusterInfo(), testConnection()
 
 ### Community 112 - "Community 112"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 113 - "Community 113"
 Cohesion: 0.5
-Nodes (2): createFixtureRepo(), write()
+Nodes (0):
 
 ### Community 114 - "Community 114"
 Cohesion: 0.5
@@ -1604,28 +1604,28 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 117 - "Community 117"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 118 - "Community 118"
 Cohesion: 0.67
 Nodes (2): toDisplayAmount(), toPesewas()
 
-### Community 119 - "Community 119"
+### Community 118 - "Community 118"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 120 - "Community 120"
+### Community 119 - "Community 119"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 121 - "Community 121"
+### Community 120 - "Community 120"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 122 - "Community 122"
+### Community 121 - "Community 121"
 Cohesion: 0.67
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
+
+### Community 122 - "Community 122"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 123 - "Community 123"
 Cohesion: 0.5
@@ -1640,12 +1640,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 126 - "Community 126"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 127 - "Community 127"
 Cohesion: 0.67
 Nodes (2): countGroupedAnalytics(), groupAnalytics()
+
+### Community 127 - "Community 127"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 128 - "Community 128"
 Cohesion: 0.5
@@ -1676,32 +1676,32 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 135 - "Community 135"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 136 - "Community 136"
 Cohesion: 0.67
 Nodes (2): getRiskStyles(), RiskIndicators()
+
+### Community 136 - "Community 136"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 137 - "Community 137"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 138 - "Community 138"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 139 - "Community 139"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 140 - "Community 140"
+### Community 139 - "Community 139"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 141 - "Community 141"
+### Community 140 - "Community 140"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+
+### Community 141 - "Community 141"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 142 - "Community 142"
 Cohesion: 0.5
@@ -1728,28 +1728,28 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 148 - "Community 148"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 149 - "Community 149"
 Cohesion: 0.67
 Nodes (2): clearFilters(), onMobileFiltersCloseClick()
 
-### Community 150 - "Community 150"
+### Community 149 - "Community 149"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 151 - "Community 151"
+### Community 150 - "Community 150"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 152 - "Community 152"
+### Community 151 - "Community 151"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 153 - "Community 153"
+### Community 152 - "Community 152"
 Cohesion: 0.83
 Nodes (3): fileExists(), resolveGraphifyPython(), runGraphifyRebuild()
+
+### Community 153 - "Community 153"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 154 - "Community 154"
 Cohesion: 0.5
@@ -1760,7 +1760,7 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 156 - "Community 156"
-Cohesion: 0.5
+Cohesion: 0.67
 Nodes (0):
 
 ### Community 157 - "Community 157"
@@ -1780,16 +1780,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 161 - "Community 161"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 162 - "Community 162"
 Cohesion: 1.0
 Nodes (2): listBagItems(), loadBagWithItems()
 
-### Community 163 - "Community 163"
+### Community 162 - "Community 162"
 Cohesion: 0.67
 Nodes (1): View()
+
+### Community 163 - "Community 163"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 164 - "Community 164"
 Cohesion: 0.67
@@ -1804,16 +1804,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 167 - "Community 167"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 168 - "Community 168"
 Cohesion: 1.0
 Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
 
-### Community 169 - "Community 169"
+### Community 168 - "Community 168"
 Cohesion: 1.0
 Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+
+### Community 169 - "Community 169"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 170 - "Community 170"
 Cohesion: 0.67
@@ -1825,11 +1825,11 @@ Nodes (0):
 
 ### Community 172 - "Community 172"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 173 - "Community 173"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 174 - "Community 174"
 Cohesion: 0.67
@@ -1837,11 +1837,11 @@ Nodes (0):
 
 ### Community 175 - "Community 175"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 176 - "Community 176"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 177 - "Community 177"
 Cohesion: 0.67
@@ -1885,75 +1885,75 @@ Nodes (0):
 
 ### Community 187 - "Community 187"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): SingleLineError()
 
 ### Community 188 - "Community 188"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (1): ErrorPage()
 
 ### Community 189 - "Community 189"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (1): AppSkeleton()
 
 ### Community 190 - "Community 190"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 191 - "Community 191"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): TableSkeleton()
 
 ### Community 192 - "Community 192"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 193 - "Community 193"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): NotFound()
 
 ### Community 194 - "Community 194"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (0):
 
 ### Community 195 - "Community 195"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): AppContextMenu()
 
 ### Community 196 - "Community 196"
 Cohesion: 0.67
-Nodes (1): AppContextMenu()
+Nodes (1): Badge()
 
 ### Community 197 - "Community 197"
 Cohesion: 0.67
-Nodes (1): Badge()
+Nodes (1): LoadingButton()
 
 ### Community 198 - "Community 198"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (1): onChange()
 
 ### Community 199 - "Community 199"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (1): AlertModal()
 
 ### Community 200 - "Community 200"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): OverlayModal()
 
 ### Community 201 - "Community 201"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): Skeleton()
 
 ### Community 202 - "Community 202"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): Toaster()
 
 ### Community 203 - "Community 203"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): Spinner()
 
 ### Community 204 - "Community 204"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (0):
 
 ### Community 205 - "Community 205"
 Cohesion: 0.67
@@ -1981,11 +1981,11 @@ Nodes (0):
 
 ### Community 211 - "Community 211"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 212 - "Community 212"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 213 - "Community 213"
 Cohesion: 0.67
@@ -2001,59 +2001,59 @@ Nodes (0):
 
 ### Community 216 - "Community 216"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): isInMaintenanceMode()
 
 ### Community 217 - "Community 217"
 Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
+Nodes (1): App()
 
 ### Community 218 - "Community 218"
 Cohesion: 0.67
-Nodes (1): App()
-
-### Community 219 - "Community 219"
-Cohesion: 0.67
 Nodes (0):
 
-### Community 220 - "Community 220"
+### Community 219 - "Community 219"
 Cohesion: 1.0
 Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
-### Community 221 - "Community 221"
+### Community 220 - "Community 220"
 Cohesion: 0.67
 Nodes (1): hashPassword()
 
-### Community 222 - "Community 222"
+### Community 221 - "Community 221"
 Cohesion: 0.67
 Nodes (1): useAppSession()
 
-### Community 223 - "Community 223"
+### Community 222 - "Community 222"
 Cohesion: 0.67
 Nodes (1): createVersionChecker()
 
-### Community 224 - "Community 224"
+### Community 223 - "Community 223"
 Cohesion: 0.67
 Nodes (1): manualChunks()
 
-### Community 225 - "Community 225"
+### Community 224 - "Community 224"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 226 - "Community 226"
+### Community 225 - "Community 225"
 Cohesion: 1.0
 Nodes (2): getAllColors(), getBaseUrl()
 
-### Community 227 - "Community 227"
+### Community 226 - "Community 226"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 228 - "Community 228"
+### Community 227 - "Community 227"
 Cohesion: 1.0
 Nodes (2): getBaseUrl(), getLastViewedProduct()
 
-### Community 229 - "Community 229"
+### Community 228 - "Community 228"
 Cohesion: 1.0
 Nodes (2): getBaseUrl(), getUserOffersEligibility()
+
+### Community 229 - "Community 229"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 230 - "Community 230"
 Cohesion: 0.67
@@ -2064,24 +2064,24 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 232 - "Community 232"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 233 - "Community 233"
 Cohesion: 1.0
 Nodes (2): handleKeyDown(), handleRedeemPromoCode()
+
+### Community 233 - "Community 233"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 234 - "Community 234"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 235 - "Community 235"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 236 - "Community 236"
 Cohesion: 1.0
 Nodes (2): getPromoAlertCopy(), PromoAlert()
+
+### Community 236 - "Community 236"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 237 - "Community 237"
 Cohesion: 0.67
@@ -2152,20 +2152,20 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 254 - "Community 254"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 255 - "Community 255"
 Cohesion: 1.0
 Nodes (2): createFixtureRoot(), write()
 
-### Community 256 - "Community 256"
+### Community 255 - "Community 255"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 257 - "Community 257"
+### Community 256 - "Community 256"
 Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
+
+### Community 257 - "Community 257"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 258 - "Community 258"
 Cohesion: 1.0
@@ -7208,6 +7208,8 @@ _Questions this graph is uniquely positioned to answer:_
 
 - **Should `Community 0` be split into smaller, more focused modules?**
   _Cohesion score 0.09 - nodes in this community are weakly interconnected._
+- **Should `Community 3` be split into smaller, more focused modules?**
+  _Cohesion score 0.13 - nodes in this community are weakly interconnected._
 - **Should `Community 6` be split into smaller, more focused modules?**
   _Cohesion score 0.11 - nodes in this community are weakly interconnected._
 - **Should `Community 10` be split into smaller, more focused modules?**

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -217,7 +217,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_emails_discountcode_tsx",
-      "community": 157
+      "community": 156
     },
     {
       "label": "ProductCard()",
@@ -225,7 +225,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
       "source_location": "L33",
       "id": "discountcode_productcard",
-      "community": 157
+      "community": 156
     },
     {
       "label": "chunkProducts()",
@@ -233,7 +233,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
       "source_location": "L98",
       "id": "discountcode_chunkproducts",
-      "community": 157
+      "community": 156
     },
     {
       "label": "DiscountReminder.tsx",
@@ -241,7 +241,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_emails_discountreminder_tsx",
-      "community": 158
+      "community": 157
     },
     {
       "label": "ProductCard()",
@@ -249,7 +249,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
       "source_location": "L31",
       "id": "discountreminder_productcard",
-      "community": 158
+      "community": 157
     },
     {
       "label": "chunkProducts()",
@@ -257,7 +257,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
       "source_location": "L85",
       "id": "discountreminder_chunkproducts",
-      "community": 158
+      "community": 157
     },
     {
       "label": "FeedbackRequest.tsx",
@@ -433,7 +433,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/checkout.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_checkout_ts",
-      "community": 114
+      "community": 113
     },
     {
       "label": "hasValidCanonicalBagItem()",
@@ -441,7 +441,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/checkout.ts",
       "source_location": "L84",
       "id": "checkout_hasvalidcanonicalbagitem",
-      "community": 114
+      "community": 113
     },
     {
       "label": "hasValidSessionItems()",
@@ -449,7 +449,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/checkout.ts",
       "source_location": "L95",
       "id": "checkout_hasvalidsessionitems",
-      "community": 114
+      "community": 113
     },
     {
       "label": "hasAllVisibileSessionItems()",
@@ -457,7 +457,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/checkout.ts",
       "source_location": "L109",
       "id": "checkout_hasallvisibilesessionitems",
-      "community": 114
+      "community": 113
     },
     {
       "label": "guest.ts",
@@ -641,7 +641,7 @@
       "source_file": "packages/athena-webapp/convex/http/utils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_utils_ts",
-      "community": 159
+      "community": 158
     },
     {
       "label": "getStoreDataFromRequest()",
@@ -649,7 +649,7 @@
       "source_file": "packages/athena-webapp/convex/http/utils.ts",
       "source_location": "L5",
       "id": "utils_getstoredatafromrequest",
-      "community": 159
+      "community": 158
     },
     {
       "label": "getStorefrontUserFromRequest()",
@@ -657,7 +657,7 @@
       "source_file": "packages/athena-webapp/convex/http/utils.ts",
       "source_location": "L12",
       "id": "utils_getstorefrontuserfromrequest",
-      "community": 159
+      "community": 158
     },
     {
       "label": "http.ts",
@@ -753,7 +753,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_expensesessions_ts",
-      "community": 115
+      "community": 114
     },
     {
       "label": "buildNextExpenseSessionNumber()",
@@ -761,7 +761,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
       "source_location": "L33",
       "id": "expensesessions_buildnextexpensesessionnumber",
-      "community": 115
+      "community": 114
     },
     {
       "label": "loadExpenseSessionItems()",
@@ -769,7 +769,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
       "source_location": "L41",
       "id": "expensesessions_loadexpensesessionitems",
-      "community": 115
+      "community": 114
     },
     {
       "label": "listExpenseSessionsByStatusBefore()",
@@ -777,7 +777,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
       "source_location": "L66",
       "id": "expensesessions_listexpensesessionsbystatusbefore",
-      "community": 115
+      "community": 114
     },
     {
       "label": "expenseTransactions.ts",
@@ -801,7 +801,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionExpiration.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionexpiration_ts",
-      "community": 116
+      "community": 115
     },
     {
       "label": "calculateExpenseSessionExpiration()",
@@ -809,7 +809,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionExpiration.ts",
       "source_location": "L21",
       "id": "expensesessionexpiration_calculateexpensesessionexpiration",
-      "community": 116
+      "community": 115
     },
     {
       "label": "getExpenseSessionExpiryDuration()",
@@ -817,7 +817,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionExpiration.ts",
       "source_location": "L35",
       "id": "expensesessionexpiration_getexpensesessionexpiryduration",
-      "community": 116
+      "community": 115
     },
     {
       "label": "getExpenseSessionExpiryDurationMinutes()",
@@ -825,7 +825,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionExpiration.ts",
       "source_location": "L45",
       "id": "expensesessionexpiration_getexpensesessionexpirydurationminutes",
-      "community": 116
+      "community": 115
     },
     {
       "label": "expenseSessionValidation.ts",
@@ -1009,7 +1009,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_helpers_sessionexpiration_ts",
-      "community": 117
+      "community": 116
     },
     {
       "label": "calculateSessionExpiration()",
@@ -1017,7 +1017,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
       "source_location": "L21",
       "id": "sessionexpiration_calculatesessionexpiration",
-      "community": 117
+      "community": 116
     },
     {
       "label": "getSessionExpiryDuration()",
@@ -1025,7 +1025,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
       "source_location": "L35",
       "id": "sessionexpiration_getsessionexpiryduration",
-      "community": 117
+      "community": 116
     },
     {
       "label": "getSessionExpiryDurationMinutes()",
@@ -1033,7 +1033,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
       "source_location": "L45",
       "id": "sessionexpiration_getsessionexpirydurationminutes",
-      "community": 117
+      "community": 116
     },
     {
       "label": "sessionValidation.ts",
@@ -1697,7 +1697,7 @@
       "source_file": "packages/athena-webapp/convex/lib/currency.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_lib_currency_ts",
-      "community": 118
+      "community": 117
     },
     {
       "label": "toPesewas()",
@@ -1705,7 +1705,7 @@
       "source_file": "packages/storefront-webapp/src/lib/currency.ts",
       "source_location": "L1",
       "id": "currency_topesewas",
-      "community": 118
+      "community": 117
     },
     {
       "label": "toDisplayAmount()",
@@ -1713,7 +1713,7 @@
       "source_file": "packages/storefront-webapp/src/lib/currency.ts",
       "source_location": "L5",
       "id": "currency_todisplayamount",
-      "community": 118
+      "community": 117
     },
     {
       "label": "callLlmProvider.ts",
@@ -1785,7 +1785,7 @@
       "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_llm_utils_analyticsutils_ts",
-      "community": 160
+      "community": 159
     },
     {
       "label": "calculateDeviceDistribution()",
@@ -1793,7 +1793,7 @@
       "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
       "source_location": "L11",
       "id": "analyticsutils_calculatedevicedistribution",
-      "community": 160
+      "community": 159
     },
     {
       "label": "calculateActivityTrend()",
@@ -1801,7 +1801,7 @@
       "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
       "source_location": "L43",
       "id": "analyticsutils_calculateactivitytrend",
-      "community": 160
+      "community": 159
     },
     {
       "label": "index.tsx",
@@ -1809,7 +1809,7 @@
       "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_mailersend_index_tsx",
-      "community": 35
+      "community": 34
     },
     {
       "label": "sendVerificationCode()",
@@ -1817,7 +1817,7 @@
       "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L3",
       "id": "index_sendverificationcode",
-      "community": 35
+      "community": 34
     },
     {
       "label": "sendOrderEmail()",
@@ -1825,7 +1825,7 @@
       "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L43",
       "id": "index_sendorderemail",
-      "community": 35
+      "community": 34
     },
     {
       "label": "sendNewOrderEmail()",
@@ -1833,7 +1833,7 @@
       "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L117",
       "id": "index_sendneworderemail",
-      "community": 35
+      "community": 34
     },
     {
       "label": "sendFeedbackRequestEmail()",
@@ -1841,7 +1841,7 @@
       "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L167",
       "id": "index_sendfeedbackrequestemail",
-      "community": 35
+      "community": 34
     },
     {
       "label": "sendDiscountCodeEmail()",
@@ -1849,7 +1849,7 @@
       "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L255",
       "id": "index_senddiscountcodeemail",
-      "community": 35
+      "community": 34
     },
     {
       "label": "sendDiscountReminderEmail()",
@@ -1857,7 +1857,7 @@
       "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L334",
       "id": "index_senddiscountreminderemail",
-      "community": 35
+      "community": 34
     },
     {
       "label": "migrateAmountsToPesewas.ts",
@@ -1937,7 +1937,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_mtn_collections_ts",
-      "community": 119
+      "community": 118
     },
     {
       "label": "getCachedTokenRecord()",
@@ -1945,7 +1945,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
       "source_location": "L26",
       "id": "collections_getcachedtokenrecord",
-      "community": 119
+      "community": 118
     },
     {
       "label": "resolveConfigForStore()",
@@ -1953,7 +1953,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
       "source_location": "L33",
       "id": "collections_resolveconfigforstore",
-      "community": 119
+      "community": 118
     },
     {
       "label": "resolveAccessTokenForStore()",
@@ -1961,7 +1961,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
       "source_location": "L79",
       "id": "collections_resolveaccesstokenforstore",
-      "community": 119
+      "community": 118
     },
     {
       "label": "config.test.ts",
@@ -1977,7 +1977,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_mtn_config_ts",
-      "community": 34
+      "community": 35
     },
     {
       "label": "toEnvSegment()",
@@ -1985,7 +1985,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L29",
       "id": "config_toenvsegment",
-      "community": 34
+      "community": 35
     },
     {
       "label": "buildMtnCollectionsLookupPrefixes()",
@@ -1993,7 +1993,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L43",
       "id": "config_buildmtncollectionslookupprefixes",
-      "community": 34
+      "community": 35
     },
     {
       "label": "readScopedValue()",
@@ -2001,7 +2001,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L56",
       "id": "config_readscopedvalue",
-      "community": 34
+      "community": 35
     },
     {
       "label": "isTargetEnvironment()",
@@ -2009,7 +2009,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L67",
       "id": "config_istargetenvironment",
-      "community": 34
+      "community": 35
     },
     {
       "label": "resolveConfigForPrefix()",
@@ -2017,7 +2017,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L73",
       "id": "config_resolveconfigforprefix",
-      "community": 34
+      "community": 35
     },
     {
       "label": "resolveMtnCollectionsConfigFromEnv()",
@@ -2025,7 +2025,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L108",
       "id": "config_resolvemtncollectionsconfigfromenv",
-      "community": 34
+      "community": 35
     },
     {
       "label": "buildMtnCollectionsCallbackUrl()",
@@ -2033,7 +2033,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L135",
       "id": "config_buildmtncollectionscallbackurl",
-      "community": 34
+      "community": 35
     },
     {
       "label": "foundation.test.ts",
@@ -2065,7 +2065,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_mtn_normalize_ts",
-      "community": 120
+      "community": 119
     },
     {
       "label": "maskMtnPartyId()",
@@ -2073,7 +2073,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
       "source_location": "L10",
       "id": "normalize_maskmtnpartyid",
-      "community": 120
+      "community": 119
     },
     {
       "label": "normalizeCollectionsTransaction()",
@@ -2081,7 +2081,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
       "source_location": "L18",
       "id": "normalize_normalizecollectionstransaction",
-      "community": 120
+      "community": 119
     },
     {
       "label": "parseCollectionsNotificationRequest()",
@@ -2089,7 +2089,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
       "source_location": "L52",
       "id": "normalize_parsecollectionsnotificationrequest",
-      "community": 120
+      "community": 119
     },
     {
       "label": "types.ts",
@@ -2129,7 +2129,7 @@
       "source_file": "packages/athena-webapp/convex/paystack/index.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_paystack_index_ts",
-      "community": 161
+      "community": 160
     },
     {
       "label": "listTransactions()",
@@ -2137,7 +2137,7 @@
       "source_file": "packages/athena-webapp/convex/paystack/index.ts",
       "source_location": "L7",
       "id": "index_listtransactions",
-      "community": 161
+      "community": 160
     },
     {
       "label": "verifyTransaction()",
@@ -2145,7 +2145,7 @@
       "source_file": "packages/athena-webapp/convex/paystack/index.ts",
       "source_location": "L109",
       "id": "index_verifytransaction",
-      "community": 161
+      "community": 160
     },
     {
       "label": "schema.ts",
@@ -2553,7 +2553,7 @@
       "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
-      "community": 35
+      "community": 34
     },
     {
       "label": "orderEmailService.ts",
@@ -2873,7 +2873,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_commercequeryindexes_test_ts",
-      "community": 121
+      "community": 120
     },
     {
       "label": "getTableIndexes()",
@@ -2881,7 +2881,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
       "source_location": "L12",
       "id": "commercequeryindexes_test_gettableindexes",
-      "community": 121
+      "community": 120
     },
     {
       "label": "expectIndex()",
@@ -2889,7 +2889,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
       "source_location": "L19",
       "id": "commercequeryindexes_test_expectindex",
-      "community": 121
+      "community": 120
     },
     {
       "label": "getSource()",
@@ -2897,7 +2897,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
       "source_location": "L26",
       "id": "commercequeryindexes_test_getsource",
-      "community": 121
+      "community": 120
     },
     {
       "label": "customer.ts",
@@ -3033,7 +3033,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/bag.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_helpers_bag_ts",
-      "community": 162
+      "community": 161
     },
     {
       "label": "listBagItems()",
@@ -3041,7 +3041,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/bag.ts",
       "source_location": "L7",
       "id": "bag_listbagitems",
-      "community": 162
+      "community": 161
     },
     {
       "label": "loadBagWithItems()",
@@ -3049,7 +3049,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/bag.ts",
       "source_location": "L14",
       "id": "bag_loadbagwithitems",
-      "community": 162
+      "community": 161
     },
     {
       "label": "onlineOrder.ts",
@@ -3377,7 +3377,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_ts",
-      "community": 122
+      "community": 121
     },
     {
       "label": "getNonEmptyString()",
@@ -3385,7 +3385,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
       "source_location": "L59",
       "id": "storefrontobservabilityreport_getnonemptystring",
-      "community": 122
+      "community": 121
     },
     {
       "label": "normalizeStorefrontObservabilityEvent()",
@@ -3393,7 +3393,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
       "source_location": "L63",
       "id": "storefrontobservabilityreport_normalizestorefrontobservabilityevent",
-      "community": 122
+      "community": 121
     },
     {
       "label": "buildStorefrontObservabilityReport()",
@@ -3401,7 +3401,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
       "source_location": "L95",
       "id": "storefrontobservabilityreport_buildstorefrontobservabilityreport",
-      "community": 122
+      "community": 121
     },
     {
       "label": "supportTicket.ts",
@@ -3785,7 +3785,7 @@
       "source_file": "packages/athena-webapp/src/components/View.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_view_tsx",
-      "community": 163
+      "community": 162
     },
     {
       "label": "View()",
@@ -3793,7 +3793,7 @@
       "source_file": "packages/storefront-webapp/src/components/View.tsx",
       "source_location": "L4",
       "id": "view_view",
-      "community": 163
+      "community": 162
     },
     {
       "label": "AttributesManager.tsx",
@@ -3801,7 +3801,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_attributesmanager_tsx",
-      "community": 123
+      "community": 122
     },
     {
       "label": "Sidebar()",
@@ -3809,7 +3809,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
       "source_location": "L26",
       "id": "attributesmanager_sidebar",
-      "community": 123
+      "community": 122
     },
     {
       "label": "ColorManager()",
@@ -3817,7 +3817,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
       "source_location": "L45",
       "id": "attributesmanager_colormanager",
-      "community": 123
+      "community": 122
     },
     {
       "label": "AttributesManager()",
@@ -3825,7 +3825,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
       "source_location": "L228",
       "id": "attributesmanager_attributesmanager",
-      "community": 123
+      "community": 122
     },
     {
       "label": "AttributesTable.tsx",
@@ -3833,7 +3833,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_attributestable_tsx",
-      "community": 124
+      "community": 123
     },
     {
       "label": "handleChange()",
@@ -3841,7 +3841,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
       "source_location": "L32",
       "id": "attributestable_handlechange",
-      "community": 124
+      "community": 123
     },
     {
       "label": "getProductAttribute()",
@@ -3849,7 +3849,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
       "source_location": "L55",
       "id": "attributestable_getproductattribute",
-      "community": 124
+      "community": 123
     },
     {
       "label": "onSubmit()",
@@ -3857,7 +3857,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
       "source_location": "L210",
       "id": "attributestable_onsubmit",
-      "community": 124
+      "community": 123
     },
     {
       "label": "BarcodeQRViewer.tsx",
@@ -3881,7 +3881,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_categorysubcategorymanager_tsx",
-      "community": 125
+      "community": 124
     },
     {
       "label": "Sidebar()",
@@ -3889,7 +3889,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
       "source_location": "L26",
       "id": "categorysubcategorymanager_sidebar",
-      "community": 125
+      "community": 124
     },
     {
       "label": "CategoryManager()",
@@ -3897,7 +3897,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
       "source_location": "L51",
       "id": "categorysubcategorymanager_categorymanager",
-      "community": 125
+      "community": 124
     },
     {
       "label": "SubcategoryManager()",
@@ -3905,7 +3905,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
       "source_location": "L290",
       "id": "categorysubcategorymanager_subcategorymanager",
-      "community": 125
+      "community": 124
     },
     {
       "label": "DefaultAttributesToggleGroup.tsx",
@@ -3961,7 +3961,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_productavailability_tsx",
-      "community": 164
+      "community": 163
     },
     {
       "label": "ProductAvailabilityView()",
@@ -3969,7 +3969,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
       "source_location": "L5",
       "id": "productavailability_productavailabilityview",
-      "community": 164
+      "community": 163
     },
     {
       "label": "ProductAvailability()",
@@ -3977,7 +3977,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
       "source_location": "L18",
       "id": "productavailability_productavailability",
-      "community": 164
+      "community": 163
     },
     {
       "label": "ProductAvailabilityToggleGroup.tsx",
@@ -4321,7 +4321,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_sheetprovider_tsx",
-      "community": 165
+      "community": 164
     },
     {
       "label": "useSheet()",
@@ -4329,7 +4329,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
       "source_location": "L11",
       "id": "sheetprovider_usesheet",
-      "community": 165
+      "community": 164
     },
     {
       "label": "SheetProvider()",
@@ -4337,7 +4337,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
       "source_location": "L19",
       "id": "sheetprovider_sheetprovider",
-      "community": 165
+      "community": 164
     },
     {
       "label": "WigType.tsx",
@@ -4345,7 +4345,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_wigtype_tsx",
-      "community": 166
+      "community": 165
     },
     {
       "label": "WigTypeView()",
@@ -4353,7 +4353,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
       "source_location": "L8",
       "id": "wigtype_wigtypeview",
-      "community": 166
+      "community": 165
     },
     {
       "label": "WigType()",
@@ -4361,7 +4361,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
       "source_location": "L21",
       "id": "wigtype_wigtype",
-      "community": 166
+      "community": 165
     },
     {
       "label": "CopyImagesProvider.tsx",
@@ -4369,7 +4369,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesprovider_tsx",
-      "community": 167
+      "community": 166
     },
     {
       "label": "useCopyImages()",
@@ -4377,7 +4377,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
       "source_location": "L13",
       "id": "copyimagesprovider_usecopyimages",
-      "community": 167
+      "community": 166
     },
     {
       "label": "CopyImagesProvider()",
@@ -4385,7 +4385,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
       "source_location": "L21",
       "id": "copyimagesprovider_copyimagesprovider",
-      "community": 167
+      "community": 166
     },
     {
       "label": "CopyImagesView.tsx",
@@ -4553,7 +4553,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analyticscombinedusers_tsx",
-      "community": 168
+      "community": 167
     },
     {
       "label": "processAnalyticsToUsers()",
@@ -4561,7 +4561,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
       "source_location": "L10",
       "id": "analyticscombinedusers_processanalyticstousers",
-      "community": 168
+      "community": 167
     },
     {
       "label": "AnalyticsCombinedUsers()",
@@ -4569,7 +4569,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
       "source_location": "L100",
       "id": "analyticscombinedusers_analyticscombinedusers",
-      "community": 168
+      "community": 167
     },
     {
       "label": "AnalyticsItems.tsx",
@@ -4609,7 +4609,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsTopUsers.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analyticstopusers_tsx",
-      "community": 169
+      "community": 168
     },
     {
       "label": "processAnalyticsToUsers()",
@@ -4617,7 +4617,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsTopUsers.tsx",
       "source_location": "L10",
       "id": "analyticstopusers_processanalyticstousers",
-      "community": 169
+      "community": 168
     },
     {
       "label": "AnalyticsTopUsers()",
@@ -4625,7 +4625,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsTopUsers.tsx",
       "source_location": "L100",
       "id": "analyticstopusers_analyticstopusers",
-      "community": 169
+      "community": 168
     },
     {
       "label": "AnalyticsUsers.tsx",
@@ -4649,7 +4649,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analyticsview_tsx",
-      "community": 126
+      "community": 125
     },
     {
       "label": "StoreVisitors()",
@@ -4657,7 +4657,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
       "source_location": "L14",
       "id": "analyticsview_storevisitors",
-      "community": 126
+      "community": 125
     },
     {
       "label": "ActiveCheckoutSessions()",
@@ -4665,7 +4665,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
       "source_location": "L44",
       "id": "analyticsview_activecheckoutsessions",
-      "community": 126
+      "community": 125
     },
     {
       "label": "AnalyticsView()",
@@ -4673,7 +4673,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
       "source_location": "L84",
       "id": "analyticsview_analyticsview",
-      "community": 126
+      "community": 125
     },
     {
       "label": "ConversionFunnelChart.tsx",
@@ -4729,7 +4729,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_storefrontobservabilitypanel_tsx",
-      "community": 170
+      "community": 169
     },
     {
       "label": "formatLabel()",
@@ -4737,7 +4737,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
       "source_location": "L15",
       "id": "storefrontobservabilitypanel_formatlabel",
-      "community": 170
+      "community": 169
     },
     {
       "label": "SummaryCard()",
@@ -4745,7 +4745,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
       "source_location": "L19",
       "id": "storefrontobservabilitypanel_summarycard",
-      "community": 170
+      "community": 169
     },
     {
       "label": "VisitorChart.tsx",
@@ -5113,7 +5113,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_utils_ts",
-      "community": 127
+      "community": 126
     },
     {
       "label": "groupAnalytics()",
@@ -5121,7 +5121,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
       "source_location": "L3",
       "id": "utils_groupanalytics",
-      "community": 127
+      "community": 126
     },
     {
       "label": "countGroupedAnalytics()",
@@ -5129,7 +5129,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
       "source_location": "L52",
       "id": "utils_countgroupedanalytics",
-      "community": 127
+      "community": 126
     },
     {
       "label": "groupProductViewsByDay()",
@@ -5137,7 +5137,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
       "source_location": "L90",
       "id": "utils_groupproductviewsbyday",
-      "community": 127
+      "community": 126
     },
     {
       "label": "LogItems.tsx",
@@ -5257,7 +5257,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_log_items_provider_tsx",
-      "community": 171
+      "community": 170
     },
     {
       "label": "LogItemsProvider()",
@@ -5265,7 +5265,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
       "source_location": "L15",
       "id": "log_items_provider_logitemsprovider",
-      "community": 171
+      "community": 170
     },
     {
       "label": "useLogItems()",
@@ -5273,7 +5273,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
       "source_location": "L39",
       "id": "log_items_provider_uselogitems",
-      "community": 171
+      "community": 170
     },
     {
       "label": "useLoadLogItems.ts",
@@ -5425,7 +5425,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
-      "community": 172
+      "community": 171
     },
     {
       "label": "handlePinChange()",
@@ -5433,7 +5433,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
       "source_location": "L48",
       "id": "inputotp_handlepinchange",
-      "community": 172
+      "community": 171
     },
     {
       "label": "onSubmit()",
@@ -5441,7 +5441,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
       "source_location": "L56",
       "id": "inputotp_onsubmit",
-      "community": 172
+      "community": 171
     },
     {
       "label": "LoginForm.tsx",
@@ -5793,7 +5793,7 @@
       "source_file": "packages/athena-webapp/src/components/common/FadeIn.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_common_fadein_tsx",
-      "community": 173
+      "community": 172
     },
     {
       "label": "FadeIn()",
@@ -5801,7 +5801,7 @@
       "source_file": "packages/storefront-webapp/src/components/common/FadeIn.tsx",
       "source_location": "L3",
       "id": "fadein_fadein",
-      "community": 173
+      "community": 172
     },
     {
       "label": "PageHeader.tsx",
@@ -6001,7 +6001,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_bestsellers_tsx",
-      "community": 174
+      "community": 173
     },
     {
       "label": "handleRemoveBestSeller()",
@@ -6009,7 +6009,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
       "source_location": "L53",
       "id": "bestsellers_handleremovebestseller",
-      "community": 174
+      "community": 173
     },
     {
       "label": "onDragEnd()",
@@ -6017,7 +6017,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
       "source_location": "L65",
       "id": "bestsellers_ondragend",
-      "community": 174
+      "community": 173
     },
     {
       "label": "BestSellersDialog.tsx",
@@ -6041,7 +6041,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_featuredsection_tsx",
-      "community": 175
+      "community": 174
     },
     {
       "label": "handleHighlightedItem()",
@@ -6049,7 +6049,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
       "source_location": "L47",
       "id": "featuredsection_handlehighlighteditem",
-      "community": 175
+      "community": 174
     },
     {
       "label": "onDragEnd()",
@@ -6057,7 +6057,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
       "source_location": "L53",
       "id": "featuredsection_ondragend",
-      "community": 175
+      "community": 174
     },
     {
       "label": "FeaturedSectionDialog.tsx",
@@ -6233,7 +6233,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_maintenancemessageeditor_tsx",
-      "community": 128
+      "community": 127
     },
     {
       "label": "handleSave()",
@@ -6241,7 +6241,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
       "source_location": "L52",
       "id": "maintenancemessageeditor_handlesave",
-      "community": 128
+      "community": 127
     },
     {
       "label": "handleCountdownChange()",
@@ -6249,7 +6249,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
       "source_location": "L76",
       "id": "maintenancemessageeditor_handlecountdownchange",
-      "community": 128
+      "community": 127
     },
     {
       "label": "getCountdownStatus()",
@@ -6257,7 +6257,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
       "source_location": "L86",
       "id": "maintenancemessageeditor_getcountdownstatus",
-      "community": 128
+      "community": 127
     },
     {
       "label": "ReelUploader.tsx",
@@ -6305,7 +6305,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_shoplook_tsx",
-      "community": 129
+      "community": 128
     },
     {
       "label": "handleHighlightedItem()",
@@ -6313,7 +6313,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
       "source_location": "L67",
       "id": "shoplook_handlehighlighteditem",
-      "community": 129
+      "community": 128
     },
     {
       "label": "onDragEnd()",
@@ -6321,7 +6321,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
       "source_location": "L73",
       "id": "shoplook_ondragend",
-      "community": 129
+      "community": 128
     },
     {
       "label": "handleImageUpdate()",
@@ -6329,7 +6329,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
       "source_location": "L90",
       "id": "shoplook_handleimageupdate",
-      "community": 129
+      "community": 128
     },
     {
       "label": "ShopLookDialog.tsx",
@@ -6369,7 +6369,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/VideoPlayer.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_videoplayer_tsx",
-      "community": 176
+      "community": 175
     },
     {
       "label": "VideoPlayer()",
@@ -6377,7 +6377,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
       "source_location": "L9",
       "id": "videoplayer_videoplayer",
-      "community": 176
+      "community": 175
     },
     {
       "label": "index.tsx",
@@ -6585,7 +6585,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_orderview_tsx",
-      "community": 177
+      "community": 176
     },
     {
       "label": "handleRefundOrder()",
@@ -6593,7 +6593,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderView.tsx",
       "source_location": "L67",
       "id": "orderview_handlerefundorder",
-      "community": 177
+      "community": 176
     },
     {
       "label": "handleVerifyPayment()",
@@ -6601,7 +6601,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderView.tsx",
       "source_location": "L423",
       "id": "orderview_handleverifypayment",
-      "community": 177
+      "community": 176
     },
     {
       "label": "Orders.tsx",
@@ -6633,7 +6633,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/PickupDetailsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_pickupdetailsview_tsx",
-      "community": 178
+      "community": 177
     },
     {
       "label": "PickupDetailsView()",
@@ -6641,7 +6641,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/PickupDetailsView.tsx",
       "source_location": "L9",
       "id": "pickupdetailsview_pickupdetailsview",
-      "community": 178
+      "community": 177
     },
     {
       "label": "DeliveryDetails()",
@@ -6649,7 +6649,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/PickupDetailsView.tsx",
       "source_location": "L67",
       "id": "pickupdetailsview_deliverydetails",
-      "community": 178
+      "community": 177
     },
     {
       "label": "RefundsView.tsx",
@@ -7057,7 +7057,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-switcher.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_switcher_tsx",
-      "community": 179
+      "community": 178
     },
     {
       "label": "onOrganizationSelect()",
@@ -7065,7 +7065,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-switcher.tsx",
       "source_location": "L94",
       "id": "organization_switcher_onorganizationselect",
-      "community": 179
+      "community": 178
     },
     {
       "label": "handleSignOut()",
@@ -7073,7 +7073,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-switcher.tsx",
       "source_location": "L99",
       "id": "organization_switcher_handlesignout",
-      "community": 179
+      "community": 178
     },
     {
       "label": "CartItems.tsx",
@@ -7185,7 +7185,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
-      "community": 130
+      "community": 129
     },
     {
       "label": "Navigation()",
@@ -7193,7 +7193,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
       "source_location": "L22",
       "id": "newtransactionview_navigation",
-      "community": 130
+      "community": 129
     },
     {
       "label": "handleStartTransaction()",
@@ -7201,7 +7201,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
       "source_location": "L68",
       "id": "newtransactionview_handlestarttransaction",
-      "community": 130
+      "community": 129
     },
     {
       "label": "handleQuickStart()",
@@ -7209,7 +7209,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
       "source_location": "L91",
       "id": "newtransactionview_handlequickstart",
-      "community": 130
+      "community": 129
     },
     {
       "label": "NoResultsMessage.tsx",
@@ -7233,7 +7233,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
-      "community": 131
+      "community": 130
     },
     {
       "label": "handleCompleteTransaction()",
@@ -7241,7 +7241,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
       "source_location": "L128",
       "id": "ordersummary_handlecompletetransaction",
-      "community": 131
+      "community": 130
     },
     {
       "label": "handleSelectedPaymentMethod()",
@@ -7249,7 +7249,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
       "source_location": "L150",
       "id": "ordersummary_handleselectedpaymentmethod",
-      "community": 131
+      "community": 130
     },
     {
       "label": "handleNewTransaction()",
@@ -7257,7 +7257,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
       "source_location": "L162",
       "id": "ordersummary_handlenewtransaction",
-      "community": 131
+      "community": 130
     },
     {
       "label": "POSRegisterView.tsx",
@@ -7657,7 +7657,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_tsx",
-      "community": 180
+      "community": 179
     },
     {
       "label": "hasExpired()",
@@ -7665,7 +7665,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx",
       "source_location": "L54",
       "id": "heldsessionslist_hasexpired",
-      "community": 180
+      "community": 179
     },
     {
       "label": "getSessionCartItemsCount()",
@@ -7673,7 +7673,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx",
       "source_location": "L58",
       "id": "heldsessionslist_getsessioncartitemscount",
-      "community": 180
+      "community": 179
     },
     {
       "label": "HoldSessionDialog.tsx",
@@ -7713,7 +7713,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_tsx",
-      "community": 132
+      "community": 131
     },
     {
       "label": "loadFingerprint()",
@@ -7721,7 +7721,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
       "source_location": "L166",
       "id": "possettingsview_loadfingerprint",
-      "community": 132
+      "community": 131
     },
     {
       "label": "handleRegisterTerminal()",
@@ -7729,7 +7729,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
       "source_location": "L247",
       "id": "possettingsview_handleregisterterminal",
-      "community": 132
+      "community": 131
     },
     {
       "label": "handleUpdateExistingTerminal()",
@@ -7737,7 +7737,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
       "source_location": "L284",
       "id": "possettingsview_handleupdateexistingterminal",
-      "community": 132
+      "community": 131
     },
     {
       "label": "TransactionView.tsx",
@@ -7753,7 +7753,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
-      "community": 181
+      "community": 180
     },
     {
       "label": "formatPaymentMethod()",
@@ -7761,7 +7761,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
       "source_location": "L19",
       "id": "transactionsview_formatpaymentmethod",
-      "community": 181
+      "community": 180
     },
     {
       "label": "isToday()",
@@ -7769,7 +7769,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
       "source_location": "L25",
       "id": "transactionsview_istoday",
-      "community": 181
+      "community": 180
     },
     {
       "label": "transactionColumns.tsx",
@@ -7889,7 +7889,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_product_productstock_tsx",
-      "community": 133
+      "community": 132
     },
     {
       "label": "ProductStockStatus()",
@@ -7897,7 +7897,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
       "source_location": "L4",
       "id": "productstock_productstockstatus",
-      "community": 133
+      "community": 132
     },
     {
       "label": "OutOfStockStatus()",
@@ -7905,7 +7905,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
       "source_location": "L38",
       "id": "productstock_outofstockstatus",
-      "community": 133
+      "community": 132
     },
     {
       "label": "LowStockStatus()",
@@ -7913,7 +7913,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
       "source_location": "L47",
       "id": "productstock_lowstockstatus",
-      "community": 133
+      "community": 132
     },
     {
       "label": "SKUSelector.tsx",
@@ -7977,7 +7977,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsListView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_productslistview_tsx",
-      "community": 182
+      "community": 181
     },
     {
       "label": "ProductActionsToggleGroup()",
@@ -7985,7 +7985,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsListView.tsx",
       "source_location": "L20",
       "id": "productslistview_productactionstogglegroup",
-      "community": 182
+      "community": 181
     },
     {
       "label": "handleClearCache()",
@@ -7993,7 +7993,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsListView.tsx",
       "source_location": "L65",
       "id": "productslistview_handleclearcache",
-      "community": 182
+      "community": 181
     },
     {
       "label": "ProductsTableContext.tsx",
@@ -8001,7 +8001,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsTableContext.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_productstablecontext_tsx",
-      "community": 183
+      "community": 182
     },
     {
       "label": "ProductsTableProvider()",
@@ -8009,7 +8009,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsTableContext.tsx",
       "source_location": "L16",
       "id": "productstablecontext_productstableprovider",
-      "community": 183
+      "community": 182
     },
     {
       "label": "useProductsTableState()",
@@ -8017,7 +8017,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsTableContext.tsx",
       "source_location": "L60",
       "id": "productstablecontext_useproductstablestate",
-      "community": 183
+      "community": 182
     },
     {
       "label": "ProductsView.tsx",
@@ -8049,7 +8049,7 @@
       "source_file": "packages/athena-webapp/src/components/products/StoreProductsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_storeproductsview_tsx",
-      "community": 184
+      "community": 183
     },
     {
       "label": "ProductActionsToggleGroup()",
@@ -8057,7 +8057,7 @@
       "source_file": "packages/athena-webapp/src/components/products/StoreProductsView.tsx",
       "source_location": "L19",
       "id": "storeproductsview_productactionstogglegroup",
-      "community": 184
+      "community": 183
     },
     {
       "label": "Navigation()",
@@ -8065,7 +8065,7 @@
       "source_file": "packages/athena-webapp/src/components/products/StoreProductsView.tsx",
       "source_location": "L45",
       "id": "storeproductsview_navigation",
-      "community": 184
+      "community": 183
     },
     {
       "label": "UnresolvedProducts.tsx",
@@ -8081,7 +8081,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/AddComplimentaryProduct.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_complimentary_addcomplimentaryproduct_tsx",
-      "community": 185
+      "community": 184
     },
     {
       "label": "handleAddComplimentaryProducts()",
@@ -8089,7 +8089,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/AddComplimentaryProduct.tsx",
       "source_location": "L40",
       "id": "addcomplimentaryproduct_handleaddcomplimentaryproducts",
-      "community": 185
+      "community": 184
     },
     {
       "label": "AddComplimentaryProduct()",
@@ -8097,7 +8097,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/AddComplimentaryProduct.tsx",
       "source_location": "L128",
       "id": "addcomplimentaryproduct_addcomplimentaryproduct",
-      "community": 185
+      "community": 184
     },
     {
       "label": "ComplimentaryProducts.tsx",
@@ -8113,7 +8113,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
-      "community": 134
+      "community": 133
     },
     {
       "label": "Navigation()",
@@ -8121,7 +8121,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
       "source_location": "L6",
       "id": "complimentaryproductsview_navigation",
-      "community": 134
+      "community": 133
     },
     {
       "label": "Body()",
@@ -8129,7 +8129,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
       "source_location": "L16",
       "id": "complimentaryproductsview_body",
-      "community": 134
+      "community": 133
     },
     {
       "label": "ComplimentaryProductsView()",
@@ -8137,7 +8137,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
       "source_location": "L35",
       "id": "complimentaryproductsview_complimentaryproductsview",
-      "community": 134
+      "community": 133
     },
     {
       "label": "complimentaryProductsColumn.tsx",
@@ -8441,7 +8441,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_color_picker_tsx",
-      "community": 186
+      "community": 185
     },
     {
       "label": "handleInputChange()",
@@ -8449,7 +8449,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
       "source_location": "L20",
       "id": "color_picker_handleinputchange",
-      "community": 186
+      "community": 185
     },
     {
       "label": "handleBlur()",
@@ -8457,7 +8457,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
       "source_location": "L24",
       "id": "color_picker_handleblur",
-      "community": 186
+      "community": 185
     },
     {
       "label": "promo-code-modal.tsx",
@@ -8713,7 +8713,7 @@
       "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_providers_currency_provider_tsx",
-      "community": 187
+      "community": 186
     },
     {
       "label": "useStoreCurrency()",
@@ -8721,7 +8721,7 @@
       "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
       "source_location": "L17",
       "id": "currency_provider_usestorecurrency",
-      "community": 187
+      "community": 186
     },
     {
       "label": "CurrencyProvider()",
@@ -8729,7 +8729,7 @@
       "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
       "source_location": "L25",
       "id": "currency_provider_currencyprovider",
-      "community": 187
+      "community": 186
     },
     {
       "label": "RatingStars.tsx",
@@ -8841,7 +8841,7 @@
       "source_file": "packages/athena-webapp/src/components/states/error/SingleLineError.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_states_error_singlelineerror_tsx",
-      "community": 188
+      "community": 187
     },
     {
       "label": "SingleLineError()",
@@ -8849,7 +8849,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/error/SingleLineError.tsx",
       "source_location": "L3",
       "id": "singlelineerror_singlelineerror",
-      "community": 188
+      "community": 187
     },
     {
       "label": "index.tsx",
@@ -8857,7 +8857,7 @@
       "source_file": "packages/athena-webapp/src/components/states/error/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_states_error_index_tsx",
-      "community": 189
+      "community": 188
     },
     {
       "label": "ErrorPage()",
@@ -8865,7 +8865,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/error/index.tsx",
       "source_location": "L9",
       "id": "index_errorpage",
-      "community": 189
+      "community": 188
     },
     {
       "label": "app-skeleton.tsx",
@@ -8873,7 +8873,7 @@
       "source_file": "packages/athena-webapp/src/components/states/loading/app-skeleton.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_states_loading_app_skeleton_tsx",
-      "community": 190
+      "community": 189
     },
     {
       "label": "AppSkeleton()",
@@ -8881,7 +8881,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/app-skeleton.tsx",
       "source_location": "L3",
       "id": "app_skeleton_appskeleton",
-      "community": 190
+      "community": 189
     },
     {
       "label": "dashboard-skeleton.tsx",
@@ -8889,7 +8889,7 @@
       "source_file": "packages/athena-webapp/src/components/states/loading/dashboard-skeleton.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_states_loading_dashboard_skeleton_tsx",
-      "community": 191
+      "community": 190
     },
     {
       "label": "DashboardSkeleton()",
@@ -8897,7 +8897,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/dashboard-skeleton.tsx",
       "source_location": "L3",
       "id": "dashboard_skeleton_dashboardskeleton",
-      "community": 191
+      "community": 190
     },
     {
       "label": "table-skeleton.tsx",
@@ -8905,7 +8905,7 @@
       "source_file": "packages/athena-webapp/src/components/states/loading/table-skeleton.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_states_loading_table_skeleton_tsx",
-      "community": 192
+      "community": 191
     },
     {
       "label": "TableSkeleton()",
@@ -8913,7 +8913,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/table-skeleton.tsx",
       "source_location": "L3",
       "id": "table_skeleton_tableskeleton",
-      "community": 192
+      "community": 191
     },
     {
       "label": "transactions-skeleton.tsx",
@@ -8921,7 +8921,7 @@
       "source_file": "packages/athena-webapp/src/components/states/loading/transactions-skeleton.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_states_loading_transactions_skeleton_tsx",
-      "community": 193
+      "community": 192
     },
     {
       "label": "TransactionsSkeleton()",
@@ -8929,7 +8929,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/transactions-skeleton.tsx",
       "source_location": "L3",
       "id": "transactions_skeleton_transactionsskeleton",
-      "community": 193
+      "community": 192
     },
     {
       "label": "NoPermission.tsx",
@@ -8969,7 +8969,7 @@
       "source_file": "packages/athena-webapp/src/components/states/not-found/NotFound.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_states_not_found_notfound_tsx",
-      "community": 194
+      "community": 193
     },
     {
       "label": "NotFound()",
@@ -8977,7 +8977,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/not-found/NotFound.tsx",
       "source_location": "L4",
       "id": "notfound_notfound",
-      "community": 194
+      "community": 193
     },
     {
       "label": "NotFoundView.tsx",
@@ -9017,7 +9017,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FeesView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_store_configuration_components_feesview_tsx",
-      "community": 195
+      "community": 194
     },
     {
       "label": "handleUpdateFees()",
@@ -9025,7 +9025,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FeesView.tsx",
       "source_location": "L36",
       "id": "feesview_handleupdatefees",
-      "community": 195
+      "community": 194
     },
     {
       "label": "handleToggleAllFees()",
@@ -9033,7 +9033,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FeesView.tsx",
       "source_location": "L104",
       "id": "feesview_handletoggleallfees",
-      "community": 195
+      "community": 194
     },
     {
       "label": "FulfillmentView.tsx",
@@ -9329,7 +9329,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/app-context-menu.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_app_context_menu_tsx",
-      "community": 196
+      "community": 195
     },
     {
       "label": "AppContextMenu()",
@@ -9337,7 +9337,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/app-context-menu.tsx",
       "source_location": "L20",
       "id": "app_context_menu_appcontextmenu",
-      "community": 196
+      "community": 195
     },
     {
       "label": "badge.tsx",
@@ -9345,7 +9345,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/badge.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_badge_tsx",
-      "community": 197
+      "community": 196
     },
     {
       "label": "Badge()",
@@ -9353,7 +9353,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/badge.tsx",
       "source_location": "L30",
       "id": "badge_badge",
-      "community": 197
+      "community": 196
     },
     {
       "label": "button.test.tsx",
@@ -9601,7 +9601,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/loading-button.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_loading_button_tsx",
-      "community": 198
+      "community": 197
     },
     {
       "label": "LoadingButton()",
@@ -9609,7 +9609,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/loading-button.tsx",
       "source_location": "L9",
       "id": "loading_button_loadingbutton",
-      "community": 198
+      "community": 197
     },
     {
       "label": "modal.tsx",
@@ -9617,7 +9617,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modal.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_modal_tsx",
-      "community": 199
+      "community": 198
     },
     {
       "label": "onChange()",
@@ -9625,7 +9625,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modal.tsx",
       "source_location": "L38",
       "id": "modal_onchange",
-      "community": 199
+      "community": 198
     },
     {
       "label": "action-modal.tsx",
@@ -9641,7 +9641,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/alert-modal.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_modals_alert_modal_tsx",
-      "community": 200
+      "community": 199
     },
     {
       "label": "AlertModal()",
@@ -9649,7 +9649,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/alert-modal.tsx",
       "source_location": "L20",
       "id": "alert_modal_alertmodal",
-      "community": 200
+      "community": 199
     },
     {
       "label": "custom-modal-example.tsx",
@@ -9729,7 +9729,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/overlay-modal.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_modals_overlay_modal_tsx",
-      "community": 201
+      "community": 200
     },
     {
       "label": "OverlayModal()",
@@ -9737,7 +9737,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/overlay-modal.tsx",
       "source_location": "L12",
       "id": "overlay_modal_overlaymodal",
-      "community": 201
+      "community": 200
     },
     {
       "label": "store-modal.tsx",
@@ -9905,7 +9905,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/skeleton.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_skeleton_tsx",
-      "community": 202
+      "community": 201
     },
     {
       "label": "Skeleton()",
@@ -9913,7 +9913,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/skeleton.tsx",
       "source_location": "L3",
       "id": "skeleton_skeleton",
-      "community": 202
+      "community": 201
     },
     {
       "label": "sonner.tsx",
@@ -9921,7 +9921,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sonner.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_sonner_tsx",
-      "community": 203
+      "community": 202
     },
     {
       "label": "Toaster()",
@@ -9929,7 +9929,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/sonner.tsx",
       "source_location": "L6",
       "id": "sonner_toaster",
-      "community": 203
+      "community": 202
     },
     {
       "label": "spinner.tsx",
@@ -9937,7 +9937,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/spinner.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_spinner_tsx",
-      "community": 204
+      "community": 203
     },
     {
       "label": "Spinner()",
@@ -9945,7 +9945,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/spinner.tsx",
       "source_location": "L3",
       "id": "spinner_spinner",
-      "community": 204
+      "community": 203
     },
     {
       "label": "switch.tsx",
@@ -10273,7 +10273,7 @@
       "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_activitysummarycards_tsx",
-      "community": 205
+      "community": 204
     },
     {
       "label": "SummaryCard()",
@@ -10281,7 +10281,7 @@
       "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
       "source_location": "L19",
       "id": "activitysummarycards_summarycard",
-      "community": 205
+      "community": 204
     },
     {
       "label": "ActivitySummaryCards()",
@@ -10289,7 +10289,7 @@
       "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
       "source_location": "L44",
       "id": "activitysummarycards_activitysummarycards",
-      "community": 205
+      "community": 204
     },
     {
       "label": "CustomerBehaviorTimeline.tsx",
@@ -10329,7 +10329,7 @@
       "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_tsx",
-      "community": 206
+      "community": 205
     },
     {
       "label": "formatObservabilityLabel()",
@@ -10337,7 +10337,7 @@
       "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
       "source_location": "L139",
       "id": "timelineeventcard_formatobservabilitylabel",
-      "community": 206
+      "community": 205
     },
     {
       "label": "loadMore()",
@@ -10345,7 +10345,7 @@
       "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
       "source_location": "L175",
       "id": "timelineeventcard_loadmore",
-      "community": 206
+      "community": 205
     },
     {
       "label": "UserActivity.tsx",
@@ -10353,7 +10353,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_useractivity_tsx",
-      "community": 207
+      "community": 206
     },
     {
       "label": "ActivityHeader()",
@@ -10361,7 +10361,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
       "source_location": "L22",
       "id": "useractivity_activityheader",
-      "community": 207
+      "community": 206
     },
     {
       "label": "UserActivity()",
@@ -10369,7 +10369,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
       "source_location": "L45",
       "id": "useractivity_useractivity",
-      "community": 207
+      "community": 206
     },
     {
       "label": "UserAnalyticsName.tsx",
@@ -10489,7 +10489,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_engagementmetrics_tsx",
-      "community": 135
+      "community": 134
     },
     {
       "label": "formatLastActivity()",
@@ -10497,7 +10497,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
       "source_location": "L75",
       "id": "engagementmetrics_formatlastactivity",
-      "community": 135
+      "community": 134
     },
     {
       "label": "getDeviceIcon()",
@@ -10505,7 +10505,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
       "source_location": "L82",
       "id": "engagementmetrics_getdeviceicon",
-      "community": 135
+      "community": 134
     },
     {
       "label": "getDeviceLabel()",
@@ -10513,7 +10513,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
       "source_location": "L93",
       "id": "engagementmetrics_getdevicelabel",
-      "community": 135
+      "community": 134
     },
     {
       "label": "RiskIndicators.tsx",
@@ -10521,7 +10521,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
-      "community": 136
+      "community": 135
     },
     {
       "label": "getRiskIcon()",
@@ -10529,7 +10529,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
       "source_location": "L15",
       "id": "riskindicators_getriskicon",
-      "community": 136
+      "community": 135
     },
     {
       "label": "getRiskStyles()",
@@ -10537,7 +10537,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
       "source_location": "L28",
       "id": "riskindicators_getriskstyles",
-      "community": 136
+      "community": 135
     },
     {
       "label": "RiskIndicators()",
@@ -10545,7 +10545,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
       "source_location": "L54",
       "id": "riskindicators_riskindicators",
-      "community": 136
+      "community": 135
     },
     {
       "label": "UserBehaviorInsights.tsx",
@@ -10577,7 +10577,7 @@
       "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_contexts_onlineordercontext_tsx",
-      "community": 208
+      "community": 207
     },
     {
       "label": "OnlineOrderProvider()",
@@ -10585,7 +10585,7 @@
       "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
       "source_location": "L24",
       "id": "onlineordercontext_onlineorderprovider",
-      "community": 208
+      "community": 207
     },
     {
       "label": "useOnlineOrder()",
@@ -10593,7 +10593,7 @@
       "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
       "source_location": "L38",
       "id": "onlineordercontext_useonlineorder",
-      "community": 208
+      "community": 207
     },
     {
       "label": "PermissionsContext.tsx",
@@ -10601,7 +10601,7 @@
       "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_contexts_permissionscontext_tsx",
-      "community": 209
+      "community": 208
     },
     {
       "label": "PermissionsProvider()",
@@ -10609,7 +10609,7 @@
       "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
       "source_location": "L23",
       "id": "permissionscontext_permissionsprovider",
-      "community": 209
+      "community": 208
     },
     {
       "label": "usePermissionsContext()",
@@ -10617,7 +10617,7 @@
       "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
       "source_location": "L51",
       "id": "permissionscontext_usepermissionscontext",
-      "community": 209
+      "community": 208
     },
     {
       "label": "ProductContext.tsx",
@@ -10625,7 +10625,7 @@
       "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_contexts_productcontext_tsx",
-      "community": 210
+      "community": 209
     },
     {
       "label": "ProductProvider()",
@@ -10633,7 +10633,7 @@
       "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
       "source_location": "L54",
       "id": "productcontext_productprovider",
-      "community": 210
+      "community": 209
     },
     {
       "label": "useProduct()",
@@ -10641,7 +10641,7 @@
       "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
       "source_location": "L282",
       "id": "productcontext_useproduct",
-      "community": 210
+      "community": 209
     },
     {
       "label": "ThemeContext.tsx",
@@ -10657,7 +10657,7 @@
       "source_file": "packages/athena-webapp/src/contexts/UserContext.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_contexts_usercontext_tsx",
-      "community": 211
+      "community": 210
     },
     {
       "label": "UserProvider()",
@@ -10665,7 +10665,7 @@
       "source_file": "packages/athena-webapp/src/contexts/UserContext.tsx",
       "source_location": "L12",
       "id": "usercontext_userprovider",
-      "community": 211
+      "community": 210
     },
     {
       "label": "useUserContext()",
@@ -10673,7 +10673,7 @@
       "source_file": "packages/athena-webapp/src/contexts/UserContext.tsx",
       "source_location": "L37",
       "id": "usercontext_useusercontext",
-      "community": 211
+      "community": 210
     },
     {
       "label": "use-image-upload.ts",
@@ -10785,7 +10785,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useAuth.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_useauth_ts",
-      "community": 212
+      "community": 211
     },
     {
       "label": "useAuth()",
@@ -10793,7 +10793,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useAuth.ts",
       "source_location": "L4",
       "id": "useauth_useauth",
-      "community": 212
+      "community": 211
     },
     {
       "label": "useBulkOperations.test.ts",
@@ -11025,7 +11025,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetActiveStore.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usegetactivestore_ts",
-      "community": 213
+      "community": 212
     },
     {
       "label": "useGetActiveStore()",
@@ -11033,7 +11033,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetActiveStore.ts",
       "source_location": "L9",
       "id": "usegetactivestore_usegetactivestore",
-      "community": 213
+      "community": 212
     },
     {
       "label": "useGetStores()",
@@ -11041,7 +11041,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetActiveStore.ts",
       "source_location": "L50",
       "id": "usegetactivestore_usegetstores",
-      "community": 213
+      "community": 212
     },
     {
       "label": "useGetAuthedUser.ts",
@@ -11113,7 +11113,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usegetorganizations_ts",
-      "community": 214
+      "community": 213
     },
     {
       "label": "useGetActiveOrganization()",
@@ -11121,7 +11121,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
       "source_location": "L6",
       "id": "usegetorganizations_usegetactiveorganization",
-      "community": 214
+      "community": 213
     },
     {
       "label": "useGetOrganizations()",
@@ -11129,7 +11129,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
       "source_location": "L31",
       "id": "usegetorganizations_usegetorganizations",
-      "community": 214
+      "community": 213
     },
     {
       "label": "useGetProducts.ts",
@@ -11137,7 +11137,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usegetproducts_ts",
-      "community": 215
+      "community": 214
     },
     {
       "label": "useGetProducts()",
@@ -11145,7 +11145,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
       "source_location": "L5",
       "id": "usegetproducts_usegetproducts",
-      "community": 215
+      "community": 214
     },
     {
       "label": "useGetUnresolvedProducts()",
@@ -11153,7 +11153,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
       "source_location": "L31",
       "id": "usegetproducts_usegetunresolvedproducts",
-      "community": 215
+      "community": 214
     },
     {
       "label": "useGetSubcategories.ts",
@@ -11265,7 +11265,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSOperations.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_useposoperations_ts",
-      "community": 216
+      "community": 215
     },
     {
       "label": "usePOSOperations()",
@@ -11273,7 +11273,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSOperations.ts",
       "source_location": "L30",
       "id": "useposoperations_useposoperations",
-      "community": 216
+      "community": 215
     },
     {
       "label": "usePOSState()",
@@ -11281,7 +11281,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSOperations.ts",
       "source_location": "L580",
       "id": "useposoperations_useposstate",
-      "community": 216
+      "community": 215
     },
     {
       "label": "usePOSProducts.ts",
@@ -11689,7 +11689,7 @@
       "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_customerobservabilitytimeline_ts",
-      "community": 137
+      "community": 136
     },
     {
       "label": "formatObservabilityLabel()",
@@ -11697,7 +11697,7 @@
       "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
       "source_location": "L59",
       "id": "customerobservabilitytimeline_formatobservabilitylabel",
-      "community": 137
+      "community": 136
     },
     {
       "label": "getObservabilityStatusStyles()",
@@ -11705,7 +11705,7 @@
       "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
       "source_location": "L67",
       "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
-      "community": 137
+      "community": 136
     },
     {
       "label": "getDeviceIcon()",
@@ -11713,7 +11713,7 @@
       "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
       "source_location": "L114",
       "id": "customerobservabilitytimeline_getdeviceicon",
-      "community": 137
+      "community": 136
     },
     {
       "label": "ghana.ts",
@@ -11889,7 +11889,7 @@
       "source_file": "packages/athena-webapp/src/lib/maintenanceUtils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_maintenanceutils_ts",
-      "community": 217
+      "community": 216
     },
     {
       "label": "isInMaintenanceMode()",
@@ -11897,7 +11897,7 @@
       "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.ts",
       "source_location": "L7",
       "id": "maintenanceutils_isinmaintenancemode",
-      "community": 217
+      "community": 216
     },
     {
       "label": "navigationUtils.ts",
@@ -11921,7 +11921,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_pos_barcodeutils_ts",
-      "community": 138
+      "community": 137
     },
     {
       "label": "isValidConvexId()",
@@ -11929,7 +11929,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
       "source_location": "L16",
       "id": "barcodeutils_isvalidconvexid",
-      "community": 138
+      "community": 137
     },
     {
       "label": "extractBarcodeFromInput()",
@@ -11937,7 +11937,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
       "source_location": "L51",
       "id": "barcodeutils_extractbarcodefrominput",
-      "community": 138
+      "community": 137
     },
     {
       "label": "isUrlOrBarcode()",
@@ -11945,7 +11945,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
       "source_location": "L92",
       "id": "barcodeutils_isurlorbarcode",
-      "community": 138
+      "community": 137
     },
     {
       "label": "calculations.ts",
@@ -12321,7 +12321,7 @@
       "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_storeconfig_ts",
-      "community": 4
+      "community": 5
     },
     {
       "label": "asRecord()",
@@ -12329,7 +12329,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L103",
       "id": "storeconfig_asrecord",
-      "community": 4
+      "community": 5
     },
     {
       "label": "asString()",
@@ -12337,7 +12337,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L111",
       "id": "storeconfig_asstring",
-      "community": 4
+      "community": 5
     },
     {
       "label": "asNumber()",
@@ -12345,7 +12345,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L114",
       "id": "storeconfig_asnumber",
-      "community": 4
+      "community": 5
     },
     {
       "label": "asBoolean()",
@@ -12353,7 +12353,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L117",
       "id": "storeconfig_asboolean",
-      "community": 4
+      "community": 5
     },
     {
       "label": "asOptionalArray()",
@@ -12361,7 +12361,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L132",
       "id": "storeconfig_asoptionalarray",
-      "community": 4
+      "community": 5
     },
     {
       "label": "firstDefined()",
@@ -12369,7 +12369,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L120",
       "id": "storeconfig_firstdefined",
-      "community": 4
+      "community": 5
     },
     {
       "label": "cleanUndefined()",
@@ -12377,7 +12377,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L143",
       "id": "storeconfig_cleanundefined",
-      "community": 4
+      "community": 5
     },
     {
       "label": "asMtnMomoSetupStatus()",
@@ -12385,7 +12385,7 @@
       "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L80",
       "id": "storeconfig_asmtnmomosetupstatus",
-      "community": 4
+      "community": 5
     },
     {
       "label": "hasMtnMomoReceivingAccountDetails()",
@@ -12393,7 +12393,7 @@
       "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L93",
       "id": "storeconfig_hasmtnmomoreceivingaccountdetails",
-      "community": 4
+      "community": 5
     },
     {
       "label": "mapMtnMomoReceivingAccount()",
@@ -12401,7 +12401,7 @@
       "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L106",
       "id": "storeconfig_mapmtnmomoreceivingaccount",
-      "community": 4
+      "community": 5
     },
     {
       "label": "normalizeMtnMomoReceivingAccounts()",
@@ -12409,7 +12409,7 @@
       "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L126",
       "id": "storeconfig_normalizemtnmomoreceivingaccounts",
-      "community": 4
+      "community": 5
     },
     {
       "label": "getRawConfig()",
@@ -12417,7 +12417,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L196",
       "id": "storeconfig_getrawconfig",
-      "community": 4
+      "community": 5
     },
     {
       "label": "mapStreamReel()",
@@ -12425,7 +12425,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L155",
       "id": "storeconfig_mapstreamreel",
-      "community": 4
+      "community": 5
     },
     {
       "label": "mapPromotion()",
@@ -12433,7 +12433,7 @@
       "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L172",
       "id": "storeconfig_mappromotion",
-      "community": 4
+      "community": 5
     },
     {
       "label": "normalizeWaiveDeliveryFees()",
@@ -12441,7 +12441,7 @@
       "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L177",
       "id": "storeconfig_normalizewaivedeliveryfees",
-      "community": 4
+      "community": 5
     },
     {
       "label": "getStoreConfigV2()",
@@ -12449,7 +12449,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L208",
       "id": "storeconfig_getstoreconfigv2",
-      "community": 4
+      "community": 5
     },
     {
       "label": "timelineUtils.ts",
@@ -12577,7 +12577,7 @@
       "source_file": "packages/athena-webapp/src/main.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_main_tsx",
-      "community": 218
+      "community": 217
     },
     {
       "label": "App()",
@@ -12585,7 +12585,7 @@
       "source_file": "packages/storefront-webapp/src/main.tsx",
       "source_location": "L38",
       "id": "main_app",
-      "community": 218
+      "community": 217
     },
     {
       "label": "routeTree.gen.ts",
@@ -13017,7 +13017,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_tsx",
-      "community": 219
+      "community": 218
     },
     {
       "label": "AuthedComponent()",
@@ -13025,7 +13025,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed.tsx",
       "source_location": "L18",
       "id": "authed_authedcomponent",
-      "community": 219
+      "community": 218
     },
     {
       "label": "Layout()",
@@ -13033,7 +13033,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed.tsx",
       "source_location": "L38",
       "id": "authed_layout",
-      "community": 219
+      "community": 218
     },
     {
       "label": "index.tsx",
@@ -13321,7 +13321,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/inventoryValidationLogic.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_tests_pos_inventoryvalidationlogic_test_ts",
-      "community": 220
+      "community": 219
     },
     {
       "label": "validateInventoryForTransaction()",
@@ -13329,7 +13329,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/inventoryValidationLogic.test.ts",
       "source_location": "L20",
       "id": "inventoryvalidationlogic_test_validateinventoryfortransaction",
-      "community": 220
+      "community": 219
     },
     {
       "label": "mockGetSku()",
@@ -13337,7 +13337,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/inventoryValidationLogic.test.ts",
       "source_location": "L66",
       "id": "inventoryvalidationlogic_test_mockgetsku",
-      "community": 220
+      "community": 219
     },
     {
       "label": "simple.test.ts",
@@ -13449,7 +13449,7 @@
       "source_file": "packages/athena-webapp/src/utils/index.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_utils_index_ts",
-      "community": 221
+      "community": 220
     },
     {
       "label": "hashPassword()",
@@ -13457,7 +13457,7 @@
       "source_file": "packages/storefront-webapp/src/utils/index.ts",
       "source_location": "L1",
       "id": "index_hashpassword",
-      "community": 221
+      "community": 220
     },
     {
       "label": "session.ts",
@@ -13465,7 +13465,7 @@
       "source_file": "packages/athena-webapp/src/utils/session.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_utils_session_ts",
-      "community": 222
+      "community": 221
     },
     {
       "label": "useAppSession()",
@@ -13473,7 +13473,7 @@
       "source_file": "packages/storefront-webapp/src/utils/session.ts",
       "source_location": "L8",
       "id": "session_useappsession",
-      "community": 222
+      "community": 221
     },
     {
       "label": "versionChecker.ts",
@@ -13481,7 +13481,7 @@
       "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_utils_versionchecker_ts",
-      "community": 223
+      "community": 222
     },
     {
       "label": "createVersionChecker()",
@@ -13489,7 +13489,7 @@
       "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
       "source_location": "L16",
       "id": "versionchecker_createversionchecker",
-      "community": 223
+      "community": 222
     },
     {
       "label": "tailwind.config.js",
@@ -13513,7 +13513,7 @@
       "source_file": "packages/athena-webapp/vite.config.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_vite_config_ts",
-      "community": 224
+      "community": 223
     },
     {
       "label": "manualChunks()",
@@ -13521,7 +13521,7 @@
       "source_file": "packages/storefront-webapp/vite.config.ts",
       "source_location": "L19",
       "id": "vite_config_manualchunks",
-      "community": 224
+      "community": 223
     },
     {
       "label": "vitest.config.ts",
@@ -13609,7 +13609,7 @@
       "source_file": "packages/storefront-webapp/src/api/auth.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_auth_ts",
-      "community": 225
+      "community": 224
     },
     {
       "label": "verifyUserAccount()",
@@ -13617,7 +13617,7 @@
       "source_file": "packages/storefront-webapp/src/api/auth.ts",
       "source_location": "L3",
       "id": "auth_verifyuseraccount",
-      "community": 225
+      "community": 224
     },
     {
       "label": "logout()",
@@ -13625,7 +13625,7 @@
       "source_file": "packages/storefront-webapp/src/api/auth.ts",
       "source_location": "L32",
       "id": "auth_logout",
-      "community": 225
+      "community": 224
     },
     {
       "label": "bag.ts",
@@ -13897,7 +13897,7 @@
       "source_file": "packages/storefront-webapp/src/api/color.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_color_ts",
-      "community": 226
+      "community": 225
     },
     {
       "label": "getBaseUrl()",
@@ -13905,7 +13905,7 @@
       "source_file": "packages/storefront-webapp/src/api/color.ts",
       "source_location": "L5",
       "id": "color_getbaseurl",
-      "community": 226
+      "community": 225
     },
     {
       "label": "getAllColors()",
@@ -13913,7 +13913,7 @@
       "source_file": "packages/storefront-webapp/src/api/color.ts",
       "source_location": "L7",
       "id": "color_getallcolors",
-      "community": 226
+      "community": 225
     },
     {
       "label": "guest.ts",
@@ -13937,7 +13937,7 @@
       "source_file": "packages/storefront-webapp/src/api/offers.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_offers_ts",
-      "community": 139
+      "community": 138
     },
     {
       "label": "getBaseUrl()",
@@ -13945,7 +13945,7 @@
       "source_file": "packages/storefront-webapp/src/api/offers.ts",
       "source_location": "L13",
       "id": "offers_getbaseurl",
-      "community": 139
+      "community": 138
     },
     {
       "label": "submitOffer()",
@@ -13953,7 +13953,7 @@
       "source_file": "packages/storefront-webapp/src/api/offers.ts",
       "source_location": "L21",
       "id": "offers_submitoffer",
-      "community": 139
+      "community": 138
     },
     {
       "label": "getUserRedeemedOffers()",
@@ -13961,7 +13961,7 @@
       "source_file": "packages/storefront-webapp/src/api/offers.ts",
       "source_location": "L46",
       "id": "offers_getuserredeemedoffers",
-      "community": 139
+      "community": 138
     },
     {
       "label": "onlineOrder.ts",
@@ -14009,7 +14009,7 @@
       "source_file": "packages/storefront-webapp/src/api/organization.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_organization_ts",
-      "community": 227
+      "community": 226
     },
     {
       "label": "getAllOrganizations()",
@@ -14017,7 +14017,7 @@
       "source_file": "packages/storefront-webapp/src/api/organization.ts",
       "source_location": "L6",
       "id": "organization_getallorganizations",
-      "community": 227
+      "community": 226
     },
     {
       "label": "getOrganization()",
@@ -14025,7 +14025,7 @@
       "source_file": "packages/storefront-webapp/src/api/organization.ts",
       "source_location": "L18",
       "id": "organization_getorganization",
-      "community": 227
+      "community": 226
     },
     {
       "label": "product.ts",
@@ -14441,7 +14441,7 @@
       "source_file": "packages/storefront-webapp/src/api/stores.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_stores_ts",
-      "community": 140
+      "community": 139
     },
     {
       "label": "getBaseUrl()",
@@ -14449,7 +14449,7 @@
       "source_file": "packages/storefront-webapp/src/api/stores.ts",
       "source_location": "L5",
       "id": "stores_getbaseurl",
-      "community": 140
+      "community": 139
     },
     {
       "label": "getAllStores()",
@@ -14457,7 +14457,7 @@
       "source_file": "packages/storefront-webapp/src/api/stores.ts",
       "source_location": "L8",
       "id": "stores_getallstores",
-      "community": 140
+      "community": 139
     },
     {
       "label": "getStore()",
@@ -14465,7 +14465,7 @@
       "source_file": "packages/storefront-webapp/src/api/stores.ts",
       "source_location": "L20",
       "id": "stores_getstore",
-      "community": 140
+      "community": 139
     },
     {
       "label": "subcategory.ts",
@@ -14473,7 +14473,7 @@
       "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_subcategory_ts",
-      "community": 141
+      "community": 140
     },
     {
       "label": "getBaseUrl()",
@@ -14481,7 +14481,7 @@
       "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
       "source_location": "L9",
       "id": "subcategory_getbaseurl",
-      "community": 141
+      "community": 140
     },
     {
       "label": "getAllSubcategories()",
@@ -14489,7 +14489,7 @@
       "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
       "source_location": "L11",
       "id": "subcategory_getallsubcategories",
-      "community": 141
+      "community": 140
     },
     {
       "label": "getSubategory()",
@@ -14497,7 +14497,7 @@
       "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
       "source_location": "L25",
       "id": "subcategory_getsubategory",
-      "community": 141
+      "community": 140
     },
     {
       "label": "types.ts",
@@ -14513,7 +14513,7 @@
       "source_file": "packages/storefront-webapp/src/api/upsells.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_upsells_ts",
-      "community": 228
+      "community": 227
     },
     {
       "label": "getBaseUrl()",
@@ -14521,7 +14521,7 @@
       "source_file": "packages/storefront-webapp/src/api/upsells.ts",
       "source_location": "L3",
       "id": "upsells_getbaseurl",
-      "community": 228
+      "community": 227
     },
     {
       "label": "getLastViewedProduct()",
@@ -14529,7 +14529,7 @@
       "source_file": "packages/storefront-webapp/src/api/upsells.ts",
       "source_location": "L5",
       "id": "upsells_getlastviewedproduct",
-      "community": 228
+      "community": 227
     },
     {
       "label": "userOffers.ts",
@@ -14537,7 +14537,7 @@
       "source_file": "packages/storefront-webapp/src/api/userOffers.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_useroffers_ts",
-      "community": 229
+      "community": 228
     },
     {
       "label": "getBaseUrl()",
@@ -14545,7 +14545,7 @@
       "source_file": "packages/storefront-webapp/src/api/userOffers.ts",
       "source_location": "L18",
       "id": "useroffers_getbaseurl",
-      "community": 229
+      "community": 228
     },
     {
       "label": "getUserOffersEligibility()",
@@ -14553,7 +14553,7 @@
       "source_file": "packages/storefront-webapp/src/api/userOffers.ts",
       "source_location": "L23",
       "id": "useroffers_getuserofferseligibility",
-      "community": 229
+      "community": 228
     },
     {
       "label": "HeartIconFilled.tsx",
@@ -14601,7 +14601,7 @@
       "source_file": "packages/storefront-webapp/src/components/HomePage.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_homepage_tsx",
-      "community": 142
+      "community": 141
     },
     {
       "label": "handleScroll()",
@@ -14609,7 +14609,7 @@
       "source_file": "packages/storefront-webapp/src/components/HomePage.tsx",
       "source_location": "L106",
       "id": "homepage_handlescroll",
-      "community": 142
+      "community": 141
     },
     {
       "label": "handleClickOnDiscountCode()",
@@ -14617,7 +14617,7 @@
       "source_file": "packages/storefront-webapp/src/components/HomePage.tsx",
       "source_location": "L155",
       "id": "homepage_handleclickondiscountcode",
-      "community": 142
+      "community": 141
     },
     {
       "label": "handleClickOnLeaveReviewButton()",
@@ -14625,7 +14625,7 @@
       "source_file": "packages/storefront-webapp/src/components/HomePage.tsx",
       "source_location": "L167",
       "id": "homepage_handleclickonleavereviewbutton",
-      "community": 142
+      "community": 141
     },
     {
       "label": "ProductActionBar.tsx",
@@ -14633,7 +14633,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_productactionbar_tsx",
-      "community": 143
+      "community": 142
     },
     {
       "label": "checkScroll()",
@@ -14641,7 +14641,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
       "source_location": "L50",
       "id": "productactionbar_checkscroll",
-      "community": 143
+      "community": 142
     },
     {
       "label": "handleDismiss()",
@@ -14649,7 +14649,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
       "source_location": "L74",
       "id": "productactionbar_handledismiss",
-      "community": 143
+      "community": 142
     },
     {
       "label": "handleAction()",
@@ -14657,7 +14657,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
       "source_location": "L92",
       "id": "productactionbar_handleaction",
-      "community": 143
+      "community": 142
     },
     {
       "label": "ProductCard.tsx",
@@ -14673,7 +14673,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_productreminderbar_tsx",
-      "community": 144
+      "community": 143
     },
     {
       "label": "checkScroll()",
@@ -14681,7 +14681,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
       "source_location": "L62",
       "id": "productreminderbar_checkscroll",
-      "community": 144
+      "community": 143
     },
     {
       "label": "handleAddToBag()",
@@ -14689,7 +14689,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
       "source_location": "L109",
       "id": "productreminderbar_handleaddtobag",
-      "community": 144
+      "community": 143
     },
     {
       "label": "handleDismiss()",
@@ -14697,7 +14697,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
       "source_location": "L177",
       "id": "productreminderbar_handledismiss",
-      "community": 144
+      "community": 143
     },
     {
       "label": "ProductsPage.tsx",
@@ -14729,7 +14729,7 @@
       "source_file": "packages/storefront-webapp/src/components/View.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_view_tsx",
-      "community": 163
+      "community": 162
     },
     {
       "label": "Auth.tsx",
@@ -14817,7 +14817,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetailssection_tsx",
-      "community": 145
+      "community": 144
     },
     {
       "label": "clearForm()",
@@ -14825,7 +14825,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
       "source_location": "L18",
       "id": "billingdetailssection_clearform",
-      "community": 145
+      "community": 144
     },
     {
       "label": "handleUseBillingAddressOnFile()",
@@ -14833,7 +14833,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
       "source_location": "L52",
       "id": "billingdetailssection_handleusebillingaddressonfile",
-      "community": 145
+      "community": 144
     },
     {
       "label": "toggleSameAsDelivery()",
@@ -14841,7 +14841,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
       "source_location": "L68",
       "id": "billingdetailssection_togglesameasdelivery",
-      "community": 145
+      "community": 144
     },
     {
       "label": "Checkout.tsx",
@@ -14889,7 +14889,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/CustomerDetails.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_customerdetails_tsx",
-      "community": 230
+      "community": 229
     },
     {
       "label": "EnteredCustomerDetails()",
@@ -14897,7 +14897,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/CustomerDetails.tsx",
       "source_location": "L22",
       "id": "customerdetails_enteredcustomerdetails",
-      "community": 230
+      "community": 229
     },
     {
       "label": "onSubmit()",
@@ -14905,7 +14905,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/CustomerDetails.tsx",
       "source_location": "L55",
       "id": "customerdetails_onsubmit",
-      "community": 230
+      "community": 229
     },
     {
       "label": "CustomerInfoSection.tsx",
@@ -14921,7 +14921,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliveryoptionsselector_tsx",
-      "community": 231
+      "community": 230
     },
     {
       "label": "StoreSelector()",
@@ -14929,7 +14929,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
       "source_location": "L11",
       "id": "deliveryoptionsselector_storeselector",
-      "community": 231
+      "community": 230
     },
     {
       "label": "handleChange()",
@@ -14937,7 +14937,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
       "source_location": "L77",
       "id": "deliveryoptionsselector_handlechange",
-      "community": 231
+      "community": 230
     },
     {
       "label": "DeliverySection.tsx",
@@ -14945,7 +14945,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliverysection_tsx",
-      "community": 232
+      "community": 231
     },
     {
       "label": "DeliveryDetails()",
@@ -14953,7 +14953,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
       "source_location": "L11",
       "id": "deliverysection_deliverydetails",
-      "community": 232
+      "community": 231
     },
     {
       "label": "DeliveryOptions()",
@@ -14961,7 +14961,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
       "source_location": "L22",
       "id": "deliverysection_deliveryoptions",
-      "community": 232
+      "community": 231
     },
     {
       "label": "PickupOptions.tsx",
@@ -15017,7 +15017,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_mobilebagsummary_tsx",
-      "community": 233
+      "community": 232
     },
     {
       "label": "handleRedeemPromoCode()",
@@ -15025,7 +15025,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
       "source_location": "L89",
       "id": "mobilebagsummary_handleredeempromocode",
-      "community": 233
+      "community": 232
     },
     {
       "label": "handleKeyDown()",
@@ -15033,7 +15033,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
       "source_location": "L110",
       "id": "mobilebagsummary_handlekeydown",
-      "community": 233
+      "community": 232
     },
     {
       "label": "OrderSummary.tsx",
@@ -15113,7 +15113,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_ts",
-      "community": 234
+      "community": 233
     },
     {
       "label": "loadCheckoutState()",
@@ -15121,7 +15121,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
       "source_location": "L4",
       "id": "checkoutstorage_loadcheckoutstate",
-      "community": 234
+      "community": 233
     },
     {
       "label": "saveCheckoutState()",
@@ -15129,7 +15129,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
       "source_location": "L24",
       "id": "checkoutstorage_savecheckoutstate",
-      "community": 234
+      "community": 233
     },
     {
       "label": "deliveryFees.test.ts",
@@ -15289,7 +15289,7 @@
       "source_file": "packages/storefront-webapp/src/components/common/FadeIn.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_common_fadein_tsx",
-      "community": 173
+      "community": 172
     },
     {
       "label": "CustomerDetailsForm.tsx",
@@ -15433,7 +15433,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_home_featuredproductssection_tsx",
-      "community": 235
+      "community": 234
     },
     {
       "label": "FeaturedProductsSection()",
@@ -15441,7 +15441,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
       "source_location": "L20",
       "id": "featuredproductssection_featuredproductssection",
-      "community": 235
+      "community": 234
     },
     {
       "label": "FeaturedSection()",
@@ -15449,7 +15449,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
       "source_location": "L46",
       "id": "featuredproductssection_featuredsection",
-      "community": 235
+      "community": 234
     },
     {
       "label": "HomeHero.tsx",
@@ -15473,7 +15473,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_home_promoalert_tsx",
-      "community": 236
+      "community": 235
     },
     {
       "label": "getPromoAlertCopy()",
@@ -15481,7 +15481,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
       "source_location": "L20",
       "id": "promoalert_getpromoalertcopy",
-      "community": 236
+      "community": 235
     },
     {
       "label": "PromoAlert()",
@@ -15489,7 +15489,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
       "source_location": "L59",
       "id": "promoalert_promoalert",
-      "community": 236
+      "community": 235
     },
     {
       "label": "RewardsAlert.tsx",
@@ -15497,7 +15497,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_home_rewardsalert_tsx",
-      "community": 237
+      "community": 236
     },
     {
       "label": "onRewardsAlertClose()",
@@ -15505,7 +15505,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
       "source_location": "L20",
       "id": "rewardsalert_onrewardsalertclose",
-      "community": 237
+      "community": 236
     },
     {
       "label": "handleShopNow()",
@@ -15513,7 +15513,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
       "source_location": "L25",
       "id": "rewardsalert_handleshopnow",
-      "community": 237
+      "community": 236
     },
     {
       "label": "VideoPlayer.tsx",
@@ -15521,7 +15521,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_home_videoplayer_tsx",
-      "community": 176
+      "community": 175
     },
     {
       "label": "hooks.ts",
@@ -15529,7 +15529,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
-      "community": 146
+      "community": 145
     },
     {
       "label": "useGetStoreSubcategories()",
@@ -15537,7 +15537,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
       "source_location": "L10",
       "id": "hooks_usegetstoresubcategories",
-      "community": 146
+      "community": 145
     },
     {
       "label": "useGetStoreCategories()",
@@ -15545,7 +15545,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
       "source_location": "L21",
       "id": "hooks_usegetstorecategories",
-      "community": 146
+      "community": 145
     },
     {
       "label": "useGetShopSearchParams()",
@@ -15553,7 +15553,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
       "source_location": "L55",
       "id": "hooks_usegetshopsearchparams",
-      "community": 146
+      "community": 145
     },
     {
       "label": "BagMenu.tsx",
@@ -15889,7 +15889,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
-      "community": 238
+      "community": 237
     },
     {
       "label": "findSize()",
@@ -15897,7 +15897,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
       "source_location": "L61",
       "id": "productattribute_findsize",
-      "community": 238
+      "community": 237
     },
     {
       "label": "handleClick()",
@@ -15905,7 +15905,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
       "source_location": "L65",
       "id": "productattribute_handleclick",
-      "community": 238
+      "community": 237
     },
     {
       "label": "ProductAttributes.tsx",
@@ -15929,7 +15929,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_page_productdetails_tsx",
-      "community": 147
+      "community": 146
     },
     {
       "label": "PickupDetails()",
@@ -15937,7 +15937,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
       "source_location": "L13",
       "id": "productdetails_pickupdetails",
-      "community": 147
+      "community": 146
     },
     {
       "label": "BagProduct()",
@@ -15945,7 +15945,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
       "source_location": "L43",
       "id": "productdetails_bagproduct",
-      "community": 147
+      "community": 146
     },
     {
       "label": "ShippingPolicy()",
@@ -15953,7 +15953,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
       "source_location": "L88",
       "id": "productdetails_shippingpolicy",
-      "community": 147
+      "community": 146
     },
     {
       "label": "ProductInfo.tsx",
@@ -16081,7 +16081,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_reviews_revieweditor_tsx",
-      "community": 239
+      "community": 238
     },
     {
       "label": "handleFormDataChange()",
@@ -16089,7 +16089,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
       "source_location": "L150",
       "id": "revieweditor_handleformdatachange",
-      "community": 239
+      "community": 238
     },
     {
       "label": "handleSubmit()",
@@ -16097,7 +16097,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
       "source_location": "L157",
       "id": "revieweditor_handlesubmit",
-      "community": 239
+      "community": 238
     },
     {
       "label": "ReviewForm.tsx",
@@ -16377,7 +16377,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/error/SingleLineError.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_states_error_singlelineerror_tsx",
-      "community": 188
+      "community": 187
     },
     {
       "label": "index.tsx",
@@ -16385,7 +16385,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/error/index.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_states_error_index_tsx",
-      "community": 189
+      "community": 188
     },
     {
       "label": "app-skeleton.tsx",
@@ -16393,7 +16393,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/app-skeleton.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_states_loading_app_skeleton_tsx",
-      "community": 190
+      "community": 189
     },
     {
       "label": "dashboard-skeleton.tsx",
@@ -16401,7 +16401,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/dashboard-skeleton.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_states_loading_dashboard_skeleton_tsx",
-      "community": 191
+      "community": 190
     },
     {
       "label": "table-skeleton.tsx",
@@ -16409,7 +16409,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/table-skeleton.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_states_loading_table_skeleton_tsx",
-      "community": 192
+      "community": 191
     },
     {
       "label": "transactions-skeleton.tsx",
@@ -16417,7 +16417,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/transactions-skeleton.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_states_loading_transactions_skeleton_tsx",
-      "community": 193
+      "community": 192
     },
     {
       "label": "Maintenance.tsx",
@@ -16433,7 +16433,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/not-found/NotFound.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_states_not_found_notfound_tsx",
-      "community": 194
+      "community": 193
     },
     {
       "label": "AnimatedCard.tsx",
@@ -16481,7 +16481,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/app-context-menu.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_app_context_menu_tsx",
-      "community": 196
+      "community": 195
     },
     {
       "label": "badge.tsx",
@@ -16489,7 +16489,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/badge.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_badge_tsx",
-      "community": 197
+      "community": 196
     },
     {
       "label": "breadcrumb.tsx",
@@ -16673,7 +16673,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/loading-button.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_loading_button_tsx",
-      "community": 198
+      "community": 197
     },
     {
       "label": "modal.tsx",
@@ -16681,7 +16681,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modal.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modal_tsx",
-      "community": 199
+      "community": 198
     },
     {
       "label": "LeaveAReviewModal.tsx",
@@ -16713,7 +16713,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
-      "community": 148
+      "community": 147
     },
     {
       "label": "handleScroll()",
@@ -16721,7 +16721,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
       "source_location": "L66",
       "id": "upsellmodal_handlescroll",
-      "community": 148
+      "community": 147
     },
     {
       "label": "handleClose()",
@@ -16729,7 +16729,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
       "source_location": "L111",
       "id": "upsellmodal_handleclose",
-      "community": 148
+      "community": 147
     },
     {
       "label": "handleSuccess()",
@@ -16737,7 +16737,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
       "source_location": "L127",
       "id": "upsellmodal_handlesuccess",
-      "community": 148
+      "community": 147
     },
     {
       "label": "UpsellModalForm.tsx",
@@ -16745,7 +16745,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalform_tsx",
-      "community": 240
+      "community": 239
     },
     {
       "label": "handleSubmit()",
@@ -16753,7 +16753,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
       "source_location": "L48",
       "id": "upsellmodalform_handlesubmit",
-      "community": 240
+      "community": 239
     },
     {
       "label": "handleInputChange()",
@@ -16761,7 +16761,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
       "source_location": "L63",
       "id": "upsellmodalform_handleinputchange",
-      "community": 240
+      "community": 239
     },
     {
       "label": "UpsellModalSuccess.tsx",
@@ -16785,7 +16785,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodal_tsx",
-      "community": 241
+      "community": 240
     },
     {
       "label": "handleClose()",
@@ -16793,7 +16793,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
       "source_location": "L63",
       "id": "welcomebackmodal_handleclose",
-      "community": 241
+      "community": 240
     },
     {
       "label": "handleSuccess()",
@@ -16801,7 +16801,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
       "source_location": "L76",
       "id": "welcomebackmodal_handlesuccess",
-      "community": 241
+      "community": 240
     },
     {
       "label": "WelcomeBackModalForm.tsx",
@@ -16809,7 +16809,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalform_tsx",
-      "community": 242
+      "community": 241
     },
     {
       "label": "handleSubmit()",
@@ -16817,7 +16817,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
       "source_location": "L36",
       "id": "welcomebackmodalform_handlesubmit",
-      "community": 242
+      "community": 241
     },
     {
       "label": "handleInputChange()",
@@ -16825,7 +16825,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
       "source_location": "L51",
       "id": "welcomebackmodalform_handleinputchange",
-      "community": 242
+      "community": 241
     },
     {
       "label": "WelcomeBackModalSuccess.tsx",
@@ -16857,7 +16857,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/alert-modal.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_alert_modal_tsx",
-      "community": 200
+      "community": 199
     },
     {
       "label": "welcomeBackModalAnimations.ts",
@@ -16913,7 +16913,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/overlay-modal.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_overlay_modal_tsx",
-      "community": 201
+      "community": 200
     },
     {
       "label": "types.ts",
@@ -16985,7 +16985,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/skeleton.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_skeleton_tsx",
-      "community": 202
+      "community": 201
     },
     {
       "label": "sonner.tsx",
@@ -16993,7 +16993,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/sonner.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_sonner_tsx",
-      "community": 203
+      "community": 202
     },
     {
       "label": "spinner.tsx",
@@ -17001,7 +17001,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/spinner.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_spinner_tsx",
-      "community": 204
+      "community": 203
     },
     {
       "label": "table.tsx",
@@ -17097,7 +17097,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_contexts_navigationbarprovider_tsx",
-      "community": 243
+      "community": 242
     },
     {
       "label": "NavigationBarProvider()",
@@ -17105,7 +17105,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
       "source_location": "L16",
       "id": "navigationbarprovider_navigationbarprovider",
-      "community": 243
+      "community": 242
     },
     {
       "label": "useNavigationBarContext()",
@@ -17113,7 +17113,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
       "source_location": "L39",
       "id": "navigationbarprovider_usenavigationbarcontext",
-      "community": 243
+      "community": 242
     },
     {
       "label": "StoreContext.tsx",
@@ -17121,7 +17121,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
-      "community": 244
+      "community": 243
     },
     {
       "label": "StoreProvider()",
@@ -17129,7 +17129,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
       "source_location": "L25",
       "id": "storecontext_storeprovider",
-      "community": 244
+      "community": 243
     },
     {
       "label": "useStoreContext()",
@@ -17137,7 +17137,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
       "source_location": "L82",
       "id": "storecontext_usestorecontext",
-      "community": 244
+      "community": 243
     },
     {
       "label": "StorefrontObservabilityProvider.tsx",
@@ -17145,7 +17145,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_tsx",
-      "community": 245
+      "community": 244
     },
     {
       "label": "StorefrontObservabilityProvider()",
@@ -17153,7 +17153,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
       "source_location": "L20",
       "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
-      "community": 245
+      "community": 244
     },
     {
       "label": "useStorefrontObservability()",
@@ -17161,7 +17161,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
       "source_location": "L55",
       "id": "storefrontobservabilityprovider_usestorefrontobservability",
-      "community": 245
+      "community": 244
     },
     {
       "label": "use-store-modal.tsx",
@@ -17177,7 +17177,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useAuth.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_useauth_ts",
-      "community": 212
+      "community": 211
     },
     {
       "label": "useCheckout.ts",
@@ -17385,7 +17385,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_useproductdiscount_ts",
-      "community": 246
+      "community": 245
     },
     {
       "label": "useProductDiscounts()",
@@ -17393,7 +17393,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
       "source_location": "L25",
       "id": "useproductdiscount_useproductdiscounts",
-      "community": 246
+      "community": 245
     },
     {
       "label": "useProductDiscount()",
@@ -17401,7 +17401,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
       "source_location": "L107",
       "id": "useproductdiscount_useproductdiscount",
-      "community": 246
+      "community": 245
     },
     {
       "label": "useProductPageLogic.ts",
@@ -17505,7 +17505,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_useshoppingbag_ts",
-      "community": 247
+      "community": 246
     },
     {
       "label": "useShoppingBag()",
@@ -17513,7 +17513,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
       "source_location": "L52",
       "id": "useshoppingbag_useshoppingbag",
-      "community": 247
+      "community": 246
     },
     {
       "label": "isUnavailableProductList()",
@@ -17521,7 +17521,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
       "source_location": "L540",
       "id": "useshoppingbag_isunavailableproductlist",
-      "community": 247
+      "community": 246
     },
     {
       "label": "useStorefrontObservability.ts",
@@ -17601,7 +17601,7 @@
       "source_file": "packages/storefront-webapp/src/lib/currency.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_currency_ts",
-      "community": 118
+      "community": 117
     },
     {
       "label": "feeUtils.test.ts",
@@ -17689,7 +17689,7 @@
       "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_ts",
-      "community": 217
+      "community": 216
     },
     {
       "label": "analytics.ts",
@@ -18041,7 +18041,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_storeconfig_ts",
-      "community": 4
+      "community": 5
     },
     {
       "label": "mapPromo()",
@@ -18049,7 +18049,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L172",
       "id": "storeconfig_mappromo",
-      "community": 4
+      "community": 5
     },
     {
       "label": "isStoreReadOnlyMode()",
@@ -18057,7 +18057,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L461",
       "id": "storeconfig_isstorereadonlymode",
-      "community": 4
+      "community": 5
     },
     {
       "label": "isStoreMaintenanceMode()",
@@ -18065,7 +18065,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L465",
       "id": "storeconfig_isstoremaintenancemode",
-      "community": 4
+      "community": 5
     },
     {
       "label": "getStoreFallbackImageUrl()",
@@ -18073,7 +18073,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L479",
       "id": "storeconfig_getstorefallbackimageurl",
-      "community": 4
+      "community": 5
     },
     {
       "label": "storefrontFailureObservability.test.ts",
@@ -18609,7 +18609,7 @@
       "source_file": "packages/storefront-webapp/src/main.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_main_tsx",
-      "community": 218
+      "community": 217
     },
     {
       "label": "routeTree.gen.ts",
@@ -18657,7 +18657,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_index_tsx",
-      "community": 248
+      "community": 247
     },
     {
       "label": "getPaymentText()",
@@ -18665,7 +18665,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
       "source_location": "L102",
       "id": "index_getpaymenttext",
-      "community": 248
+      "community": 247
     },
     {
       "label": "getOrderMessage()",
@@ -18673,7 +18673,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
       "source_location": "L429",
       "id": "index_getordermessage",
-      "community": 248
+      "community": 247
     },
     {
       "label": "review.tsx",
@@ -18681,7 +18681,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_review_tsx",
-      "community": 249
+      "community": 248
     },
     {
       "label": "OrderNavigation()",
@@ -18689,7 +18689,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
       "source_location": "L46",
       "id": "review_ordernavigation",
-      "community": 249
+      "community": 248
     },
     {
       "label": "getOrderMessage()",
@@ -18697,7 +18697,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
       "source_location": "L250",
       "id": "review_getordermessage",
-      "community": 249
+      "community": 248
     },
     {
       "label": "index.tsx",
@@ -18745,7 +18745,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_tsx",
-      "community": 149
+      "community": 148
     },
     {
       "label": "onClickOnMobileFilters()",
@@ -18753,7 +18753,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
       "source_location": "L105",
       "id": "shoplayout_onclickonmobilefilters",
-      "community": 149
+      "community": 148
     },
     {
       "label": "onMobileFiltersCloseClick()",
@@ -18761,7 +18761,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
       "source_location": "L110",
       "id": "shoplayout_onmobilefilterscloseclick",
-      "community": 149
+      "community": 148
     },
     {
       "label": "clearFilters()",
@@ -18769,7 +18769,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
       "source_location": "L115",
       "id": "shoplayout_clearfilters",
-      "community": 149
+      "community": 148
     },
     {
       "label": "account.tsx",
@@ -18777,7 +18777,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_layout_account_tsx",
-      "community": 250
+      "community": 249
     },
     {
       "label": "accountBeforeLoad()",
@@ -18785,7 +18785,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
       "source_location": "L17",
       "id": "account_accountbeforeload",
-      "community": 250
+      "community": 249
     },
     {
       "label": "handleOnSubmitForm()",
@@ -18793,7 +18793,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
       "source_location": "L63",
       "id": "account_handleonsubmitform",
-      "community": 250
+      "community": 249
     },
     {
       "label": "contact-us.tsx",
@@ -18969,7 +18969,7 @@
       "source_file": "packages/storefront-webapp/src/routes/login.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_login_tsx",
-      "community": 251
+      "community": 250
     },
     {
       "label": "loginBeforeLoad()",
@@ -18977,7 +18977,7 @@
       "source_file": "packages/storefront-webapp/src/routes/login.tsx",
       "source_location": "L47",
       "id": "login_loginbeforeload",
-      "community": 251
+      "community": 250
     },
     {
       "label": "onSubmit()",
@@ -18985,7 +18985,7 @@
       "source_file": "packages/storefront-webapp/src/routes/login.tsx",
       "source_location": "L141",
       "id": "login_onsubmit",
-      "community": 251
+      "community": 250
     },
     {
       "label": "bag.index.tsx",
@@ -19033,7 +19033,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_index_tsx",
-      "community": 150
+      "community": 149
     },
     {
       "label": "getErrorMessage()",
@@ -19041,7 +19041,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
       "source_location": "L26",
       "id": "index_geterrormessage",
-      "community": 150
+      "community": 149
     },
     {
       "label": "placeOrder()",
@@ -19049,7 +19049,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
       "source_location": "L71",
       "id": "index_placeorder",
-      "community": 150
+      "community": 149
     },
     {
       "label": "cancelOrder()",
@@ -19057,7 +19057,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
       "source_location": "L121",
       "id": "index_cancelorder",
-      "community": 150
+      "community": 149
     },
     {
       "label": "complete.index.tsx",
@@ -19113,7 +19113,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_verify_index_tsx",
-      "community": 252
+      "community": 251
     },
     {
       "label": "Verify()",
@@ -19121,7 +19121,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
       "source_location": "L21",
       "id": "verify_index_verify",
-      "community": 252
+      "community": 251
     },
     {
       "label": "VerifyCheckoutSessionPayment()",
@@ -19129,7 +19129,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
       "source_location": "L107",
       "id": "verify_index_verifycheckoutsessionpayment",
-      "community": 252
+      "community": 251
     },
     {
       "label": "signup.tsx",
@@ -19137,7 +19137,7 @@
       "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_signup_tsx",
-      "community": 253
+      "community": 252
     },
     {
       "label": "signupBeforeLoad()",
@@ -19145,7 +19145,7 @@
       "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
       "source_location": "L66",
       "id": "signup_signupbeforeload",
-      "community": 253
+      "community": 252
     },
     {
       "label": "onSubmit()",
@@ -19153,7 +19153,7 @@
       "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
       "source_location": "L161",
       "id": "signup_onsubmit",
-      "community": 253
+      "community": 252
     },
     {
       "label": "ssr.tsx",
@@ -19169,7 +19169,7 @@
       "source_file": "packages/storefront-webapp/src/utils/index.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_utils_index_ts",
-      "community": 221
+      "community": 220
     },
     {
       "label": "session.ts",
@@ -19177,7 +19177,7 @@
       "source_file": "packages/storefront-webapp/src/utils/session.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_utils_session_ts",
-      "community": 222
+      "community": 221
     },
     {
       "label": "versionChecker.ts",
@@ -19185,7 +19185,7 @@
       "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
-      "community": 223
+      "community": 222
     },
     {
       "label": "tailwind.config.js",
@@ -19201,7 +19201,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_tests_e2e_helpers_bootstrap_ts",
-      "community": 151
+      "community": 150
     },
     {
       "label": "createMarker()",
@@ -19209,7 +19209,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
       "source_location": "L20",
       "id": "bootstrap_createmarker",
-      "community": 151
+      "community": 150
     },
     {
       "label": "createBootstrapToken()",
@@ -19217,7 +19217,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
       "source_location": "L24",
       "id": "bootstrap_createbootstraptoken",
-      "community": 151
+      "community": 150
     },
     {
       "label": "bootstrapCheckout()",
@@ -19225,7 +19225,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
       "source_location": "L46",
       "id": "bootstrap_bootstrapcheckout",
-      "community": 151
+      "community": 150
     },
     {
       "label": "env.ts",
@@ -19233,7 +19233,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_tests_e2e_helpers_env_ts",
-      "community": 254
+      "community": 253
     },
     {
       "label": "requireEnv()",
@@ -19241,7 +19241,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
       "source_location": "L1",
       "id": "env_requireenv",
-      "community": 254
+      "community": 253
     },
     {
       "label": "optionalNumberEnv()",
@@ -19249,7 +19249,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
       "source_location": "L11",
       "id": "env_optionalnumberenv",
-      "community": 254
+      "community": 253
     },
     {
       "label": "vite.config.ts",
@@ -19257,7 +19257,7 @@
       "source_file": "packages/storefront-webapp/vite.config.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_vite_config_ts",
-      "community": 224
+      "community": 223
     },
     {
       "label": "vitest.config.ts",
@@ -19361,7 +19361,7 @@
       "source_file": "scripts/graphify-check.test.ts",
       "source_location": "L1",
       "id": "scripts_graphify_check_test_ts",
-      "community": 255
+      "community": 254
     },
     {
       "label": "write()",
@@ -19369,7 +19369,7 @@
       "source_file": "scripts/graphify-check.test.ts",
       "source_location": "L10",
       "id": "graphify_check_test_write",
-      "community": 255
+      "community": 254
     },
     {
       "label": "createFixtureRoot()",
@@ -19377,7 +19377,7 @@
       "source_file": "scripts/graphify-check.test.ts",
       "source_location": "L16",
       "id": "graphify_check_test_createfixtureroot",
-      "community": 255
+      "community": 254
     },
     {
       "label": "graphify-check.ts",
@@ -19433,7 +19433,7 @@
       "source_file": "scripts/graphify-rebuild.test.ts",
       "source_location": "L1",
       "id": "scripts_graphify_rebuild_test_ts",
-      "community": 152
+      "community": 151
     },
     {
       "label": "write()",
@@ -19441,7 +19441,7 @@
       "source_file": "scripts/graphify-rebuild.test.ts",
       "source_location": "L10",
       "id": "graphify_rebuild_test_write",
-      "community": 152
+      "community": 151
     },
     {
       "label": "createFixtureRoot()",
@@ -19449,7 +19449,7 @@
       "source_file": "scripts/graphify-rebuild.test.ts",
       "source_location": "L16",
       "id": "graphify_rebuild_test_createfixtureroot",
-      "community": 152
+      "community": 151
     },
     {
       "label": "spawn()",
@@ -19457,7 +19457,7 @@
       "source_file": "scripts/graphify-rebuild.test.ts",
       "source_location": "L57",
       "id": "graphify_rebuild_test_spawn",
-      "community": 152
+      "community": 151
     },
     {
       "label": "graphify-rebuild.ts",
@@ -19465,7 +19465,7 @@
       "source_file": "scripts/graphify-rebuild.ts",
       "source_location": "L1",
       "id": "scripts_graphify_rebuild_ts",
-      "community": 153
+      "community": 152
     },
     {
       "label": "fileExists()",
@@ -19473,7 +19473,7 @@
       "source_file": "scripts/graphify-rebuild.ts",
       "source_location": "L78",
       "id": "graphify_rebuild_fileexists",
-      "community": 153
+      "community": 152
     },
     {
       "label": "resolveGraphifyPython()",
@@ -19481,7 +19481,7 @@
       "source_file": "scripts/graphify-rebuild.ts",
       "source_location": "L87",
       "id": "graphify_rebuild_resolvegraphifypython",
-      "community": 153
+      "community": 152
     },
     {
       "label": "runGraphifyRebuild()",
@@ -19489,7 +19489,7 @@
       "source_file": "scripts/graphify-rebuild.ts",
       "source_location": "L114",
       "id": "graphify_rebuild_rungraphifyrebuild",
-      "community": 153
+      "community": 152
     },
     {
       "label": "harness-app-registry.ts",
@@ -19497,7 +19497,7 @@
       "source_file": "scripts/harness-app-registry.ts",
       "source_location": "L1",
       "id": "scripts_harness_app_registry_ts",
-      "community": 256
+      "community": 255
     },
     {
       "label": "buildHarnessDocPaths()",
@@ -19505,7 +19505,7 @@
       "source_file": "scripts/harness-app-registry.ts",
       "source_location": "L104",
       "id": "harness_app_registry_buildharnessdocpaths",
-      "community": 256
+      "community": 255
     },
     {
       "label": "getHarnessPackageRegistration()",
@@ -19513,7 +19513,7 @@
       "source_file": "scripts/harness-app-registry.ts",
       "source_location": "L387",
       "id": "harness_app_registry_getharnesspackageregistration",
-      "community": 256
+      "community": 255
     },
     {
       "label": "harness-audit.test.ts",
@@ -19521,7 +19521,7 @@
       "source_file": "scripts/harness-audit.test.ts",
       "source_location": "L1",
       "id": "scripts_harness_audit_test_ts",
-      "community": 257
+      "community": 256
     },
     {
       "label": "write()",
@@ -19529,7 +19529,7 @@
       "source_file": "scripts/harness-audit.test.ts",
       "source_location": "L11",
       "id": "harness_audit_test_write",
-      "community": 257
+      "community": 256
     },
     {
       "label": "createFixtureRepo()",
@@ -19537,7 +19537,7 @@
       "source_file": "scripts/harness-audit.test.ts",
       "source_location": "L17",
       "id": "harness_audit_test_createfixturerepo",
-      "community": 257
+      "community": 256
     },
     {
       "label": "harness-audit.ts",
@@ -19753,31 +19753,31 @@
       "source_file": "scripts/harness-behavior-scenarios.ts",
       "source_location": "L1",
       "id": "scripts_harness_behavior_scenarios_ts",
-      "community": 154
+      "community": 153
     },
     {
       "label": "createAthenaRuntimeProcess()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L63",
+      "source_location": "L105",
       "id": "harness_behavior_scenarios_createathenaruntimeprocess",
-      "community": 154
+      "community": 153
     },
     {
       "label": "buildAthenaRuntimeUrl()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L75",
+      "source_location": "L117",
       "id": "harness_behavior_scenarios_buildathenaruntimeurl",
-      "community": 154
+      "community": 153
     },
     {
       "label": "createStorefrontRuntimeProcesses()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L79",
+      "source_location": "L121",
       "id": "harness_behavior_scenarios_createstorefrontruntimeprocesses",
-      "community": 154
+      "community": 153
     },
     {
       "label": "harness-behavior.test.ts",
@@ -19785,7 +19785,7 @@
       "source_file": "scripts/harness-behavior.test.ts",
       "source_location": "L1",
       "id": "scripts_harness_behavior_test_ts",
-      "community": 112
+      "community": 257
     },
     {
       "label": "write()",
@@ -19793,7 +19793,7 @@
       "source_file": "scripts/harness-behavior.test.ts",
       "source_location": "L15",
       "id": "harness_behavior_test_write",
-      "community": 112
+      "community": 257
     },
     {
       "label": "createFixtureRoot()",
@@ -19801,23 +19801,7 @@
       "source_file": "scripts/harness-behavior.test.ts",
       "source_location": "L21",
       "id": "harness_behavior_test_createfixtureroot",
-      "community": 112
-    },
-    {
-      "label": "log()",
-      "file_type": "code",
-      "source_file": "scripts/harness-behavior.test.ts",
-      "source_location": "L113",
-      "id": "harness_behavior_test_log",
-      "community": 112
-    },
-    {
-      "label": "error()",
-      "file_type": "code",
-      "source_file": "scripts/harness-behavior.test.ts",
-      "source_location": "L116",
-      "id": "harness_behavior_test_error",
-      "community": 112
+      "community": 257
     },
     {
       "label": "harness-behavior.ts",
@@ -19825,175 +19809,207 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L1",
       "id": "scripts_harness_behavior_ts",
-      "community": 5
+      "community": 3
     },
     {
       "label": "HarnessBehaviorPhaseError",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L151",
+      "source_location": "L222",
       "id": "harness_behavior_harnessbehaviorphaseerror",
-      "community": 5
+      "community": 3
     },
     {
       "label": ".constructor()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L155",
+      "source_location": "L227",
       "id": "harness_behavior_harnessbehaviorphaseerror_constructor",
-      "community": 5
+      "community": 3
     },
     {
       "label": "logPhase()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L207",
+      "source_location": "L281",
       "id": "harness_behavior_logphase",
-      "community": 5
+      "community": 3
     },
     {
       "label": "sleep()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L215",
+      "source_location": "L289",
       "id": "harness_behavior_sleep",
-      "community": 5
+      "community": 3
     },
     {
       "label": "asRegExp()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L221",
+      "source_location": "L295",
       "id": "harness_behavior_asregexp",
-      "community": 5
+      "community": 3
     },
     {
       "label": "escapeRegExp()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L229",
+      "source_location": "L303",
       "id": "harness_behavior_escaperegexp",
-      "community": 5
+      "community": 3
     },
     {
       "label": "formatError()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L233",
+      "source_location": "L307",
       "id": "harness_behavior_formaterror",
-      "community": 5
+      "community": 3
     },
     {
       "label": "getLinesForSource()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L241",
+      "source_location": "L315",
       "id": "harness_behavior_getlinesforsource",
-      "community": 5
+      "community": 3
     },
     {
       "label": "consumeLines()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L254",
+      "source_location": "L328",
       "id": "harness_behavior_consumelines",
-      "community": 5
+      "community": 3
     },
     {
       "label": "stopProcess()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L320",
+      "source_location": "L394",
       "id": "harness_behavior_stopprocess",
-      "community": 5
+      "community": 3
     },
     {
       "label": "startProcess()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L342",
+      "source_location": "L416",
       "id": "harness_behavior_startprocess",
-      "community": 5
+      "community": 3
     },
     {
       "label": "spawnCommand()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L476",
+      "source_location": "L550",
       "id": "harness_behavior_spawncommand",
-      "community": 5
+      "community": 3
     },
     {
       "label": "resolveHarnessBehaviorShell()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L530",
+      "source_location": "L604",
       "id": "harness_behavior_resolveharnessbehaviorshell",
-      "community": 5
+      "community": 3
     },
     {
       "label": "runHttpReadinessCheck()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L557",
+      "source_location": "L631",
       "id": "harness_behavior_runhttpreadinesscheck",
-      "community": 5
+      "community": 3
     },
     {
       "label": "collectRuntimeSignalMatches()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L589",
+      "source_location": "L663",
       "id": "harness_behavior_collectruntimesignalmatches",
-      "community": 5
+      "community": 3
+    },
+    {
+      "label": "collectRuntimeSignalDiagnostics()",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L720",
+      "id": "harness_behavior_collectruntimesignaldiagnostics",
+      "community": 3
+    },
+    {
+      "label": "collectLatencyDiagnostics()",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L753",
+      "id": "harness_behavior_collectlatencydiagnostics",
+      "community": 3
+    },
+    {
+      "label": "formatAssertionDiagnostics()",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L801",
+      "id": "harness_behavior_formatassertiondiagnostics",
+      "community": 3
     },
     {
       "label": "runPlaywrightFlow()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L689",
+      "source_location": "L853",
       "id": "harness_behavior_runplaywrightflow",
-      "community": 5
+      "community": 3
     },
     {
       "label": "wrapPhaseError()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L793",
+      "source_location": "L957",
       "id": "harness_behavior_wrapphaseerror",
-      "community": 5
+      "community": 3
+    },
+    {
+      "label": "runPhaseWithDuration()",
+      "file_type": "code",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L968",
+      "id": "harness_behavior_runphasewithduration",
+      "community": 3
     },
     {
       "label": "runHarnessBehaviorScenario()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L804",
+      "source_location": "L981",
       "id": "harness_behavior_runharnessbehaviorscenario",
-      "community": 5
+      "community": 3
     },
     {
       "label": "parseHarnessBehaviorArgs()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L956",
+      "source_location": "L1215",
       "id": "harness_behavior_parseharnessbehaviorargs",
-      "community": 5
+      "community": 3
     },
     {
       "label": "printHarnessBehaviorUsage()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L1028",
+      "source_location": "L1287",
       "id": "harness_behavior_printharnessbehaviorusage",
-      "community": 5
+      "community": 3
     },
     {
       "label": "runHarnessBehaviorCli()",
       "file_type": "code",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L1036",
+      "source_location": "L1295",
       "id": "harness_behavior_runharnessbehaviorcli",
-      "community": 5
+      "community": 3
     },
     {
       "label": "harness-check.test.ts",
@@ -20417,7 +20433,7 @@
       "source_file": "scripts/harness-review.test.ts",
       "source_location": "L1",
       "id": "scripts_harness_review_test_ts",
-      "community": 113
+      "community": 112
     },
     {
       "label": "write()",
@@ -20425,7 +20441,7 @@
       "source_file": "scripts/harness-review.test.ts",
       "source_location": "L10",
       "id": "harness_review_test_write",
-      "community": 113
+      "community": 112
     },
     {
       "label": "createFixtureRepo()",
@@ -20433,7 +20449,7 @@
       "source_file": "scripts/harness-review.test.ts",
       "source_location": "L16",
       "id": "harness_review_test_createfixturerepo",
-      "community": 113
+      "community": 112
     },
     {
       "label": "log()",
@@ -20441,7 +20457,7 @@
       "source_file": "scripts/harness-review.test.ts",
       "source_location": "L167",
       "id": "harness_review_test_log",
-      "community": 113
+      "community": 112
     },
     {
       "label": "error()",
@@ -20449,7 +20465,7 @@
       "source_file": "scripts/harness-review.test.ts",
       "source_location": "L168",
       "id": "harness_review_test_error",
-      "community": 113
+      "community": 112
     },
     {
       "label": "harness-review.ts",
@@ -20601,7 +20617,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L1",
       "id": "scripts_harness_self_review_ts",
-      "community": 3
+      "community": 4
     },
     {
       "label": "normalizeRepoPath()",
@@ -20609,7 +20625,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L92",
       "id": "harness_self_review_normalizerepopath",
-      "community": 3
+      "community": 4
     },
     {
       "label": "sortUniquePaths()",
@@ -20617,7 +20633,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L96",
       "id": "harness_self_review_sortuniquepaths",
-      "community": 3
+      "community": 4
     },
     {
       "label": "matchesPathPrefix()",
@@ -20625,7 +20641,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L102",
       "id": "harness_self_review_matchespathprefix",
-      "community": 3
+      "community": 4
     },
     {
       "label": "normalizeValidationCommand()",
@@ -20633,7 +20649,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L116",
       "id": "harness_self_review_normalizevalidationcommand",
-      "community": 3
+      "community": 4
     },
     {
       "label": "normalizeBehaviorScenarioName()",
@@ -20641,7 +20657,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L124",
       "id": "harness_self_review_normalizebehaviorscenarioname",
-      "community": 3
+      "community": 4
     },
     {
       "label": "formatValidationCommand()",
@@ -20649,7 +20665,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L128",
       "id": "harness_self_review_formatvalidationcommand",
-      "community": 3
+      "community": 4
     },
     {
       "label": "quoteCode()",
@@ -20657,7 +20673,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L136",
       "id": "harness_self_review_quotecode",
-      "community": 3
+      "community": 4
     },
     {
       "label": "fileExists()",
@@ -20665,7 +20681,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L140",
       "id": "harness_self_review_fileexists",
-      "community": 3
+      "community": 4
     },
     {
       "label": "readJsonFile()",
@@ -20673,7 +20689,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L149",
       "id": "harness_self_review_readjsonfile",
-      "community": 3
+      "community": 4
     },
     {
       "label": "runCommand()",
@@ -20681,7 +20697,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L153",
       "id": "harness_self_review_runcommand",
-      "community": 3
+      "community": 4
     },
     {
       "label": "getChangedFilesFromGit()",
@@ -20689,7 +20705,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L173",
       "id": "harness_self_review_getchangedfilesfromgit",
-      "community": 3
+      "community": 4
     },
     {
       "label": "parseRuntimeScenarios()",
@@ -20697,7 +20713,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L237",
       "id": "harness_self_review_parseruntimescenarios",
-      "community": 3
+      "community": 4
     },
     {
       "label": "loadSelfReviewTarget()",
@@ -20705,7 +20721,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L243",
       "id": "harness_self_review_loadselfreviewtarget",
-      "community": 3
+      "community": 4
     },
     {
       "label": "loadSelfReviewTargets()",
@@ -20713,7 +20729,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L375",
       "id": "harness_self_review_loadselfreviewtargets",
-      "community": 3
+      "community": 4
     },
     {
       "label": "collectCoverage()",
@@ -20721,7 +20737,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L394",
       "id": "harness_self_review_collectcoverage",
-      "community": 3
+      "community": 4
     },
     {
       "label": "isLikelyCodeOrConfig()",
@@ -20729,7 +20745,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L472",
       "id": "harness_self_review_islikelycodeorconfig",
-      "community": 3
+      "community": 4
     },
     {
       "label": "evaluateGraphifyFreshness()",
@@ -20737,7 +20753,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L493",
       "id": "harness_self_review_evaluategraphifyfreshness",
-      "community": 3
+      "community": 4
     },
     {
       "label": "runQuietHarnessCheck()",
@@ -20745,7 +20761,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L557",
       "id": "harness_self_review_runquietharnesscheck",
-      "community": 3
+      "community": 4
     },
     {
       "label": "appendListSection()",
@@ -20753,7 +20769,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L566",
       "id": "harness_self_review_appendlistsection",
-      "community": 3
+      "community": 4
     },
     {
       "label": "buildMarkdownBundle()",
@@ -20761,7 +20777,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L585",
       "id": "harness_self_review_buildmarkdownbundle",
-      "community": 3
+      "community": 4
     },
     {
       "label": "parseCliArguments()",
@@ -20769,7 +20785,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L742",
       "id": "harness_self_review_parsecliarguments",
-      "community": 3
+      "community": 4
     },
     {
       "label": "runHarnessSelfReview()",
@@ -20777,7 +20793,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L791",
       "id": "harness_self_review_runharnessselfreview",
-      "community": 3
+      "community": 4
     },
     {
       "label": "pre-push-review.test.ts",
@@ -20785,7 +20801,7 @@
       "source_file": "scripts/pre-push-review.test.ts",
       "source_location": "L1",
       "id": "scripts_pre_push_review_test_ts",
-      "community": 155
+      "community": 154
     },
     {
       "label": "log()",
@@ -20793,7 +20809,7 @@
       "source_file": "scripts/pre-push-review.test.ts",
       "source_location": "L81",
       "id": "pre_push_review_test_log",
-      "community": 155
+      "community": 154
     },
     {
       "label": "warn()",
@@ -20801,7 +20817,7 @@
       "source_file": "scripts/pre-push-review.test.ts",
       "source_location": "L82",
       "id": "pre_push_review_test_warn",
-      "community": 155
+      "community": 154
     },
     {
       "label": "error()",
@@ -20809,7 +20825,7 @@
       "source_file": "scripts/pre-push-review.test.ts",
       "source_location": "L83",
       "id": "pre_push_review_test_error",
-      "community": 155
+      "community": 154
     },
     {
       "label": "pre-push-review.ts",
@@ -20817,7 +20833,7 @@
       "source_file": "scripts/pre-push-review.ts",
       "source_location": "L1",
       "id": "scripts_pre_push_review_ts",
-      "community": 156
+      "community": 155
     },
     {
       "label": "getChangedFilesVsOriginMain()",
@@ -20825,7 +20841,7 @@
       "source_file": "scripts/pre-push-review.ts",
       "source_location": "L24",
       "id": "pre_push_review_getchangedfilesvsoriginmain",
-      "community": 156
+      "community": 155
     },
     {
       "label": "runArchitectureCheck()",
@@ -20833,7 +20849,7 @@
       "source_file": "scripts/pre-push-review.ts",
       "source_location": "L65",
       "id": "pre_push_review_runarchitecturecheck",
-      "community": 156
+      "community": 155
     },
     {
       "label": "runPrePushReview()",
@@ -20841,7 +20857,7 @@
       "source_file": "scripts/pre-push-review.ts",
       "source_location": "L77",
       "id": "pre_push_review_runprepushreview",
-      "community": 156
+      "community": 155
     }
   ],
   "links": [
@@ -42077,7 +42093,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L63",
+      "source_location": "L105",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_scenarios_ts",
       "_tgt": "harness_behavior_scenarios_createathenaruntimeprocess",
@@ -42089,7 +42105,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L75",
+      "source_location": "L117",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_scenarios_ts",
       "_tgt": "harness_behavior_scenarios_buildathenaruntimeurl",
@@ -42101,7 +42117,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L79",
+      "source_location": "L121",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_scenarios_ts",
       "_tgt": "harness_behavior_scenarios_createstorefrontruntimeprocesses",
@@ -42136,32 +42152,8 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "scripts/harness-behavior.test.ts",
-      "source_location": "L113",
-      "weight": 1.0,
-      "_src": "scripts_harness_behavior_test_ts",
-      "_tgt": "harness_behavior_test_log",
-      "source": "scripts_harness_behavior_test_ts",
-      "target": "harness_behavior_test_log",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
-      "source_file": "scripts/harness-behavior.test.ts",
-      "source_location": "L116",
-      "weight": 1.0,
-      "_src": "scripts_harness_behavior_test_ts",
-      "_tgt": "harness_behavior_test_error",
-      "source": "scripts_harness_behavior_test_ts",
-      "target": "harness_behavior_test_error",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "contains",
-      "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L151",
+      "source_location": "L222",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_ts",
       "_tgt": "harness_behavior_harnessbehaviorphaseerror",
@@ -42173,7 +42165,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L207",
+      "source_location": "L281",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_ts",
       "_tgt": "harness_behavior_logphase",
@@ -42185,7 +42177,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L215",
+      "source_location": "L289",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_ts",
       "_tgt": "harness_behavior_sleep",
@@ -42197,7 +42189,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L221",
+      "source_location": "L295",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_ts",
       "_tgt": "harness_behavior_asregexp",
@@ -42209,7 +42201,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L229",
+      "source_location": "L303",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_ts",
       "_tgt": "harness_behavior_escaperegexp",
@@ -42221,7 +42213,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L233",
+      "source_location": "L307",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_ts",
       "_tgt": "harness_behavior_formaterror",
@@ -42233,7 +42225,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L241",
+      "source_location": "L315",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_ts",
       "_tgt": "harness_behavior_getlinesforsource",
@@ -42245,7 +42237,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L254",
+      "source_location": "L328",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_ts",
       "_tgt": "harness_behavior_consumelines",
@@ -42257,7 +42249,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L320",
+      "source_location": "L394",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_ts",
       "_tgt": "harness_behavior_stopprocess",
@@ -42269,7 +42261,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L342",
+      "source_location": "L416",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_ts",
       "_tgt": "harness_behavior_startprocess",
@@ -42281,7 +42273,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L476",
+      "source_location": "L550",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_ts",
       "_tgt": "harness_behavior_spawncommand",
@@ -42293,7 +42285,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L530",
+      "source_location": "L604",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_ts",
       "_tgt": "harness_behavior_resolveharnessbehaviorshell",
@@ -42305,7 +42297,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L557",
+      "source_location": "L631",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_ts",
       "_tgt": "harness_behavior_runhttpreadinesscheck",
@@ -42317,7 +42309,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L589",
+      "source_location": "L663",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_ts",
       "_tgt": "harness_behavior_collectruntimesignalmatches",
@@ -42329,7 +42321,43 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L689",
+      "source_location": "L720",
+      "weight": 1.0,
+      "_src": "scripts_harness_behavior_ts",
+      "_tgt": "harness_behavior_collectruntimesignaldiagnostics",
+      "source": "scripts_harness_behavior_ts",
+      "target": "harness_behavior_collectruntimesignaldiagnostics",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L753",
+      "weight": 1.0,
+      "_src": "scripts_harness_behavior_ts",
+      "_tgt": "harness_behavior_collectlatencydiagnostics",
+      "source": "scripts_harness_behavior_ts",
+      "target": "harness_behavior_collectlatencydiagnostics",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L801",
+      "weight": 1.0,
+      "_src": "scripts_harness_behavior_ts",
+      "_tgt": "harness_behavior_formatassertiondiagnostics",
+      "source": "scripts_harness_behavior_ts",
+      "target": "harness_behavior_formatassertiondiagnostics",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L853",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_ts",
       "_tgt": "harness_behavior_runplaywrightflow",
@@ -42341,7 +42369,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L793",
+      "source_location": "L957",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_ts",
       "_tgt": "harness_behavior_wrapphaseerror",
@@ -42353,7 +42381,19 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L804",
+      "source_location": "L968",
+      "weight": 1.0,
+      "_src": "scripts_harness_behavior_ts",
+      "_tgt": "harness_behavior_runphasewithduration",
+      "source": "scripts_harness_behavior_ts",
+      "target": "harness_behavior_runphasewithduration",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L981",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_ts",
       "_tgt": "harness_behavior_runharnessbehaviorscenario",
@@ -42365,7 +42405,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L956",
+      "source_location": "L1215",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_ts",
       "_tgt": "harness_behavior_parseharnessbehaviorargs",
@@ -42377,7 +42417,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L1028",
+      "source_location": "L1287",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_ts",
       "_tgt": "harness_behavior_printharnessbehaviorusage",
@@ -42389,7 +42429,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L1036",
+      "source_location": "L1295",
       "weight": 1.0,
       "_src": "scripts_harness_behavior_ts",
       "_tgt": "harness_behavior_runharnessbehaviorcli",
@@ -42401,7 +42441,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L155",
+      "source_location": "L227",
       "weight": 1.0,
       "_src": "harness_behavior_harnessbehaviorphaseerror",
       "_tgt": "harness_behavior_harnessbehaviorphaseerror_constructor",
@@ -42413,7 +42453,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L353",
+      "source_location": "L427",
       "weight": 1.0,
       "_src": "harness_behavior_startprocess",
       "_tgt": "harness_behavior_logphase",
@@ -42425,19 +42465,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L842",
-      "weight": 1.0,
-      "_src": "harness_behavior_runharnessbehaviorscenario",
-      "_tgt": "harness_behavior_logphase",
-      "source": "harness_behavior_logphase",
-      "target": "harness_behavior_runharnessbehaviorscenario",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L331",
+      "source_location": "L405",
       "weight": 1.0,
       "_src": "harness_behavior_stopprocess",
       "_tgt": "harness_behavior_sleep",
@@ -42449,7 +42477,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L226",
+      "source_location": "L300",
       "weight": 1.0,
       "_src": "harness_behavior_asregexp",
       "_tgt": "harness_behavior_escaperegexp",
@@ -42461,7 +42489,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L448",
+      "source_location": "L522",
       "weight": 1.0,
       "_src": "harness_behavior_startprocess",
       "_tgt": "harness_behavior_asregexp",
@@ -42473,7 +42501,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L597",
+      "source_location": "L671",
       "weight": 1.0,
       "_src": "harness_behavior_collectruntimesignalmatches",
       "_tgt": "harness_behavior_asregexp",
@@ -42485,7 +42513,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L576",
+      "source_location": "L650",
       "weight": 1.0,
       "_src": "harness_behavior_runhttpreadinesscheck",
       "_tgt": "harness_behavior_formaterror",
@@ -42497,7 +42525,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L769",
+      "source_location": "L933",
       "weight": 1.0,
       "_src": "harness_behavior_runplaywrightflow",
       "_tgt": "harness_behavior_formaterror",
@@ -42509,7 +42537,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L801",
+      "source_location": "L965",
       "weight": 1.0,
       "_src": "harness_behavior_wrapphaseerror",
       "_tgt": "harness_behavior_formaterror",
@@ -42521,7 +42549,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L378",
+      "source_location": "L452",
       "weight": 1.0,
       "_src": "harness_behavior_startprocess",
       "_tgt": "harness_behavior_consumelines",
@@ -42533,7 +42561,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L355",
+      "source_location": "L429",
       "weight": 1.0,
       "_src": "harness_behavior_startprocess",
       "_tgt": "harness_behavior_spawncommand",
@@ -42545,19 +42573,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L844",
-      "weight": 1.0,
-      "_src": "harness_behavior_runharnessbehaviorscenario",
-      "_tgt": "harness_behavior_startprocess",
-      "source": "harness_behavior_startprocess",
-      "target": "harness_behavior_runharnessbehaviorscenario",
-      "confidence_score": 1.0
-    },
-    {
-      "relation": "calls",
-      "confidence": "EXTRACTED",
-      "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L481",
+      "source_location": "L555",
       "weight": 1.0,
       "_src": "harness_behavior_spawncommand",
       "_tgt": "harness_behavior_resolveharnessbehaviorshell",
@@ -42569,11 +42585,11 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L857",
+      "source_location": "L1149",
       "weight": 1.0,
       "_src": "harness_behavior_runharnessbehaviorscenario",
-      "_tgt": "harness_behavior_runhttpreadinesscheck",
-      "source": "harness_behavior_runhttpreadinesscheck",
+      "_tgt": "harness_behavior_collectruntimesignaldiagnostics",
+      "source": "harness_behavior_collectruntimesignaldiagnostics",
       "target": "harness_behavior_runharnessbehaviorscenario",
       "confidence_score": 1.0
     },
@@ -42581,11 +42597,11 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L893",
+      "source_location": "L1153",
       "weight": 1.0,
       "_src": "harness_behavior_runharnessbehaviorscenario",
-      "_tgt": "harness_behavior_collectruntimesignalmatches",
-      "source": "harness_behavior_collectruntimesignalmatches",
+      "_tgt": "harness_behavior_collectlatencydiagnostics",
+      "source": "harness_behavior_collectlatencydiagnostics",
       "target": "harness_behavior_runharnessbehaviorscenario",
       "confidence_score": 1.0
     },
@@ -42593,7 +42609,19 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L914",
+      "source_location": "L1163",
+      "weight": 1.0,
+      "_src": "harness_behavior_runharnessbehaviorscenario",
+      "_tgt": "harness_behavior_formatassertiondiagnostics",
+      "source": "harness_behavior_formatassertiondiagnostics",
+      "target": "harness_behavior_runharnessbehaviorscenario",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-behavior.ts",
+      "source_location": "L1113",
       "weight": 1.0,
       "_src": "harness_behavior_runharnessbehaviorscenario",
       "_tgt": "harness_behavior_wrapphaseerror",
@@ -42605,7 +42633,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L1118",
+      "source_location": "L1377",
       "weight": 1.0,
       "_src": "harness_behavior_runharnessbehaviorcli",
       "_tgt": "harness_behavior_runharnessbehaviorscenario",
@@ -42617,7 +42645,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L1046",
+      "source_location": "L1305",
       "weight": 1.0,
       "_src": "harness_behavior_runharnessbehaviorcli",
       "_tgt": "harness_behavior_parseharnessbehaviorargs",
@@ -42629,7 +42657,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-behavior.ts",
-      "source_location": "L1049",
+      "source_location": "L1308",
       "weight": 1.0,
       "_src": "harness_behavior_runharnessbehaviorcli",
       "_tgt": "harness_behavior_printharnessbehaviorusage",

--- a/packages/athena-webapp/docs/agent/testing.md
+++ b/packages/athena-webapp/docs/agent/testing.md
@@ -8,6 +8,8 @@ Use the repo-root harness commands together:
 - `bun run harness:behavior --scenario <name>` runs shared runtime behavior scenarios that boot app processes, wait for readiness, drive browser interactions, assert runtime signals, and clean up automatically.
 - `bun run harness:behavior --scenario <name> --record-video` captures browser-flow evidence for handoff under `artifacts/harness-behavior/videos/<scenario>/<run-stamp>/`.
 
+Behavior runs emit `[harness:behavior:report]` JSON with per-phase latency and runtime-signal diagnostics. Thresholds are configured per scenario through `runtimeSignals[].minMatches` / `runtimeSignals[].maxMatches` and `thresholds.latency` in [scripts/harness-behavior-scenarios.ts](../../../../scripts/harness-behavior-scenarios.ts).
+
 - [Test index](./test-index.md)
 - [Validation guide](./validation-guide.md)
 

--- a/packages/storefront-webapp/docs/agent/testing.md
+++ b/packages/storefront-webapp/docs/agent/testing.md
@@ -8,6 +8,8 @@ Use the repo-root harness commands together:
 - `bun run harness:behavior --scenario <name>` runs shared runtime behavior scenarios that boot app processes, wait for readiness, drive browser interactions, assert runtime signals, and clean up automatically.
 - `bun run harness:behavior --scenario <name> --record-video` captures browser-flow evidence for handoff under `artifacts/harness-behavior/videos/<scenario>/<run-stamp>/`.
 
+Behavior runs emit `[harness:behavior:report]` JSON with per-phase latency and runtime-signal diagnostics. Thresholds are configured per scenario through `runtimeSignals[].minMatches` / `runtimeSignals[].maxMatches` and `thresholds.latency` in [scripts/harness-behavior-scenarios.ts](../../../../scripts/harness-behavior-scenarios.ts).
+
 - [Test index](./test-index.md)
 - [Validation guide](./validation-guide.md)
 

--- a/scripts/harness-behavior-scenarios.test.ts
+++ b/scripts/harness-behavior-scenarios.test.ts
@@ -33,5 +33,20 @@ describe("HARNESS_BEHAVIOR_SCENARIOS", () => {
     expect(recoveryScenario?.runtimeSignals?.map((signal) => signal.name)).toContain(
       "storefront-payment-verification-requested"
     );
+    expect(
+      bootstrapScenario?.runtimeSignals?.find(
+        (signal) => signal.name === "storefront-runtime-api-errors"
+      )
+    ).toMatchObject({
+      minMatches: 0,
+      maxMatches: 0,
+    });
+  });
+
+  it("applies latency thresholds to every registered scenario", () => {
+    for (const scenario of HARNESS_BEHAVIOR_SCENARIOS) {
+      expect(scenario.thresholds?.latency?.maxTotalDurationMs).toBeDefined();
+      expect(scenario.thresholds?.latency?.maxPhaseDurationMs).toBeDefined();
+    }
   });
 });

--- a/scripts/harness-behavior-scenarios.ts
+++ b/scripts/harness-behavior-scenarios.ts
@@ -28,6 +28,48 @@ const STOREFRONT_CHECKOUT_VALIDATION_BLOCKER_PATH =
   "/shop/checkout/not-a-real-session";
 const STOREFRONT_CHECKOUT_RECOVERY_PATH = "/shop/checkout?origin=paystack";
 
+const SAMPLE_RUNTIME_LATENCY_THRESHOLDS = {
+  latency: {
+    maxTotalDurationMs: 30_000,
+    maxPhaseDurationMs: {
+      boot: 20_000,
+      readiness: 20_000,
+      browser: 10_000,
+      runtime: 5_000,
+      assertion: 5_000,
+      cleanup: 10_000,
+    },
+  },
+} satisfies HarnessBehaviorScenario["thresholds"];
+
+const ATHENA_RUNTIME_LATENCY_THRESHOLDS = {
+  latency: {
+    maxTotalDurationMs: 90_000,
+    maxPhaseDurationMs: {
+      boot: 25_000,
+      readiness: 25_000,
+      browser: 30_000,
+      runtime: 5_000,
+      assertion: 5_000,
+      cleanup: 10_000,
+    },
+  },
+} satisfies HarnessBehaviorScenario["thresholds"];
+
+const STOREFRONT_RUNTIME_LATENCY_THRESHOLDS = {
+  latency: {
+    maxTotalDurationMs: 220_000,
+    maxPhaseDurationMs: {
+      boot: 140_000,
+      readiness: 140_000,
+      browser: 45_000,
+      runtime: 5_000,
+      assertion: 5_000,
+      cleanup: 15_000,
+    },
+  },
+} satisfies HarnessBehaviorScenario["thresholds"];
+
 type StorefrontBehaviorMode =
   | "checkout-bootstrap"
   | "validation-blocker"
@@ -176,7 +218,16 @@ export const SAMPLE_RUNTIME_SMOKE_SCENARIO: HarnessBehaviorScenario<SampleScenar
         pattern: "RUNTIME_SIGNAL:browser-clicked",
         minMatches: 1,
       },
+      {
+        name: "sample-app-runtime-errors",
+        processId: "sample-app",
+        source: "combined",
+        pattern: "signal request failed",
+        minMatches: 0,
+        maxMatches: 0,
+      },
     ],
+    thresholds: SAMPLE_RUNTIME_LATENCY_THRESHOLDS,
     assert: async ({ browserResult, runtimeSignals }) => {
       if (browserResult.signalStatus !== "signal-recorded") {
         throw new Error(
@@ -243,7 +294,16 @@ export const ATHENA_ADMIN_SHELL_BOOT_SCENARIO: HarnessBehaviorScenario<AthenaAdm
         pattern: "RUNTIME_SIGNAL:athena-admin-shell-boot",
         minMatches: 1,
       },
+      {
+        name: "athena-runtime-errors",
+        processId: "athena-runtime-app",
+        source: "combined",
+        pattern: /(admin shell runtime signal failed|storefront request failed)/,
+        minMatches: 0,
+        maxMatches: 0,
+      },
     ],
+    thresholds: ATHENA_RUNTIME_LATENCY_THRESHOLDS,
     assert: async ({ browserResult, runtimeSignals }) => {
       if (browserResult.authState !== "authed") {
         throw new Error(
@@ -349,7 +409,16 @@ export const ATHENA_CONVEX_COMPOSITION_SCENARIO: HarnessBehaviorScenario<AthenaC
         pattern: "RUNTIME_SIGNAL:convex-storefront-query",
         minMatches: 1,
       },
+      {
+        name: "athena-runtime-errors",
+        processId: "athena-runtime-app",
+        source: "combined",
+        pattern: /(admin shell runtime signal failed|storefront request failed)/,
+        minMatches: 0,
+        maxMatches: 0,
+      },
     ],
+    thresholds: ATHENA_RUNTIME_LATENCY_THRESHOLDS,
     assert: async ({ browserResult, runtimeSignals }) => {
       if (browserResult.authState !== "authed") {
         throw new Error(
@@ -458,7 +527,16 @@ export const ATHENA_CONVEX_FAILURE_VISIBILITY_SCENARIO: HarnessBehaviorScenario<
         pattern: "RUNTIME_SIGNAL:convex-storefront-route-hit",
         minMatches: 1,
       },
+      {
+        name: "athena-runtime-errors",
+        processId: "athena-runtime-app",
+        source: "combined",
+        pattern: /(admin shell runtime signal failed|storefront request failed)/,
+        minMatches: 0,
+        maxMatches: 0,
+      },
     ],
+    thresholds: ATHENA_RUNTIME_LATENCY_THRESHOLDS,
     assert: async ({ browserResult, runtimeSignals }) => {
       if (browserResult.authState !== "authed") {
         throw new Error(
@@ -521,7 +599,16 @@ export const STOREFRONT_CHECKOUT_BOOTSTRAP_SCENARIO: HarnessBehaviorScenario<Sto
         pattern: "RUNTIME_SIGNAL:storefront-checkout-bootstrap-loaded",
         minMatches: 1,
       },
+      {
+        name: "storefront-runtime-api-errors",
+        processId: "storefront-api",
+        source: "combined",
+        pattern: "Unhandled fixture route",
+        minMatches: 0,
+        maxMatches: 0,
+      },
     ],
+    thresholds: STOREFRONT_RUNTIME_LATENCY_THRESHOLDS,
     assert: async ({ browserResult, runtimeSignals }) => {
       if (browserResult.observedText !== "Checkout") {
         throw new Error(
@@ -573,7 +660,16 @@ export const STOREFRONT_CHECKOUT_VALIDATION_BLOCKER_SCENARIO: HarnessBehaviorSce
         pattern: "RUNTIME_SIGNAL:storefront-checkout-session-missing",
         minMatches: 1,
       },
+      {
+        name: "storefront-runtime-api-errors",
+        processId: "storefront-api",
+        source: "combined",
+        pattern: "Unhandled fixture route",
+        minMatches: 0,
+        maxMatches: 0,
+      },
     ],
+    thresholds: STOREFRONT_RUNTIME_LATENCY_THRESHOLDS,
     assert: async ({ browserResult, runtimeSignals }) => {
       if (
         !browserResult.observedText.includes("This checkout session does not exist")
@@ -629,7 +725,16 @@ export const STOREFRONT_CHECKOUT_VERIFICATION_RECOVERY_SCENARIO: HarnessBehavior
         pattern: "RUNTIME_SIGNAL:storefront-payment-verification-requested",
         minMatches: 1,
       },
+      {
+        name: "storefront-runtime-api-errors",
+        processId: "storefront-api",
+        source: "combined",
+        pattern: "Unhandled fixture route",
+        minMatches: 0,
+        maxMatches: 0,
+      },
     ],
+    thresholds: STOREFRONT_RUNTIME_LATENCY_THRESHOLDS,
     assert: async ({ browserResult, runtimeSignals }) => {
       if (!browserResult.observedText.includes("Get excited, Ada!")) {
         throw new Error(

--- a/scripts/harness-behavior.test.ts
+++ b/scripts/harness-behavior.test.ts
@@ -60,7 +60,7 @@ describe("runHarnessBehaviorScenario", () => {
     const executionOrder: string[] = [];
     const logs: string[] = [];
 
-    await runHarnessBehaviorScenario(
+    const report = await runHarnessBehaviorScenario(
       rootDir,
       {
         name: "unit-happy-path",
@@ -131,6 +131,18 @@ describe("runHarnessBehaviorScenario", () => {
     expect(logs.some((line) => line.includes("[browser]"))).toBe(true);
     expect(logs.some((line) => line.includes("[runtime]"))).toBe(true);
     expect(logs.some((line) => line.includes("[assertion]"))).toBe(true);
+    expect(logs.some((line) => line.includes("[harness:behavior:report]"))).toBe(
+      true
+    );
+    expect(report.status).toBe("passed");
+    expect(report.diagnostics).toEqual([]);
+    expect(report.runtimeSignals).toEqual([
+      expect.objectContaining({
+        name: "heartbeat-signal",
+        minMatches: 1,
+        maxMatches: null,
+      }),
+    ]);
     expect(await readFile(stopFile, "utf8")).toBe("stopped");
   });
 
@@ -246,6 +258,117 @@ describe("runHarnessBehaviorScenario", () => {
     } satisfies Partial<HarnessBehaviorPhaseError>);
 
     expect(await readFile(stopFile, "utf8")).toBe("stopped");
+  });
+
+  it("fails deterministically when runtime signal max threshold is breached", async () => {
+    const rootDir = await createFixtureRoot("athena-harness-runtime-threshold-");
+    const stopFile = path.join(rootDir, "stop.log");
+    const appScriptPath = path.join(rootDir, "fixtures", "runtime-app.ts");
+
+    await write(
+      "fixtures/runtime-app.ts",
+      [
+        'console.log("APP_READY");',
+        'console.error("RUNTIME_ERROR:boom");',
+        "const stopFile = process.env.STOP_FILE;",
+        "setInterval(() => {}, 50);",
+        "process.on(\"SIGTERM\", async () => {",
+        "  if (stopFile) {",
+        '    await Bun.write(stopFile, "stopped");',
+        "  }",
+        "  process.exit(0);",
+        "});",
+      ].join("\n"),
+      rootDir
+    );
+
+    let thrown: HarnessBehaviorPhaseError | null = null;
+
+    await expect(
+      runHarnessBehaviorScenario(rootDir, {
+        name: "unit-runtime-threshold-failure",
+        processes: [
+          {
+            id: "runtime-app",
+            command: `bun ${appScriptPath}`,
+            env: {
+              STOP_FILE: stopFile,
+            },
+            readyPattern: "APP_READY",
+            readyTimeoutMs: 2_000,
+          },
+        ],
+        readiness: [],
+        browser: async () => ({ ok: true }),
+        runtimeSignals: [
+          {
+            name: "runtime-error-signal",
+            processId: "runtime-app",
+            source: "combined",
+            pattern: "RUNTIME_ERROR:",
+            minMatches: 0,
+            maxMatches: 0,
+          },
+        ],
+        assert: async () => {},
+      }).catch((error: unknown) => {
+        thrown = error as HarnessBehaviorPhaseError;
+        throw error;
+      })
+    ).rejects.toMatchObject({
+      phase: "assertion",
+    } satisfies Partial<HarnessBehaviorPhaseError>);
+
+    expect(thrown?.report?.status).toBe("failed");
+    expect(thrown?.report?.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "runtime-signal-above-maximum",
+          signalName: "runtime-error-signal",
+        }),
+      ])
+    );
+    expect(await readFile(stopFile, "utf8")).toBe("stopped");
+  });
+
+  it("fails deterministically when latency thresholds are exceeded", async () => {
+    await expect(
+      runHarnessBehaviorScenario("/tmp", {
+        name: "unit-latency-threshold-failure",
+        processes: [],
+        readiness: [],
+        browser: async () => {
+          await new Promise<void>((resolve) => {
+            setTimeout(resolve, 25);
+          });
+          return { ok: true };
+        },
+        runtimeSignals: [],
+        thresholds: {
+          latency: {
+            maxTotalDurationMs: 10,
+            maxPhaseDurationMs: {
+              browser: 10,
+            },
+          },
+        },
+        assert: async () => {},
+      })
+    ).rejects.toMatchObject({
+      phase: "assertion",
+      report: {
+        status: "failed",
+        diagnostics: expect.arrayContaining([
+          expect.objectContaining({
+            type: "latency-total-threshold-breached",
+          }),
+          expect.objectContaining({
+            type: "latency-phase-threshold-breached",
+            phase: "browser",
+          }),
+        ]),
+      },
+    });
   });
 });
 

--- a/scripts/harness-behavior.ts
+++ b/scripts/harness-behavior.ts
@@ -60,6 +60,7 @@ export type HarnessBehaviorRuntimeSignalExpectation = {
   processId?: string;
   source?: HarnessBehaviorSignalSource;
   minMatches?: number;
+  maxMatches?: number;
 };
 
 export type HarnessBehaviorRuntimeSignalResult = {
@@ -67,6 +68,8 @@ export type HarnessBehaviorRuntimeSignalResult = {
   processId: string | null;
   source: HarnessBehaviorSignalSource;
   pattern: RegExp;
+  minMatches: number;
+  maxMatches: number | null;
   matchCount: number;
   matchedLines: string[];
 };
@@ -123,6 +126,15 @@ export type HarnessBehaviorAssertionContext<TBrowserResult> =
 export type HarnessBehaviorCleanupContext<TBrowserResult> =
   HarnessBehaviorAssertionContext<TBrowserResult>;
 
+export type HarnessBehaviorLatencyThresholds = {
+  maxTotalDurationMs?: number;
+  maxPhaseDurationMs?: Partial<Record<HarnessBehaviorPhase, number>>;
+};
+
+export type HarnessBehaviorThresholds = {
+  latency?: HarnessBehaviorLatencyThresholds;
+};
+
 export type HarnessBehaviorScenario<TBrowserResult = unknown> = {
   name: string;
   description?: string;
@@ -135,6 +147,7 @@ export type HarnessBehaviorScenario<TBrowserResult = unknown> = {
   assert: (
     context: HarnessBehaviorAssertionContext<TBrowserResult>
   ) => Promise<void>;
+  thresholds?: HarnessBehaviorThresholds;
   cleanup?: (
     context: HarnessBehaviorCleanupContext<TBrowserResult>
   ) => Promise<void>;
@@ -148,14 +161,74 @@ export type HarnessBehaviorPhase =
   | "assertion"
   | "cleanup";
 
+export type HarnessBehaviorPhaseDuration = {
+  phase: HarnessBehaviorPhase;
+  durationMs: number;
+};
+
+export type HarnessBehaviorRuntimeSignalSummary = {
+  name: string;
+  processId: string | null;
+  source: HarnessBehaviorSignalSource;
+  pattern: string;
+  minMatches: number;
+  maxMatches: number | null;
+  matchCount: number;
+  sampleMatches: string[];
+};
+
+export type HarnessBehaviorAssertionDiagnostic =
+  | {
+      type: "runtime-signal-below-minimum";
+      message: string;
+      signalName: string;
+      observedMatches: number;
+      minMatches: number;
+    }
+  | {
+      type: "runtime-signal-above-maximum";
+      message: string;
+      signalName: string;
+      observedMatches: number;
+      maxMatches: number;
+    }
+  | {
+      type: "latency-phase-threshold-breached";
+      message: string;
+      phase: HarnessBehaviorPhase;
+      observedDurationMs: number;
+      maxDurationMs: number;
+    }
+  | {
+      type: "latency-total-threshold-breached";
+      message: string;
+      observedDurationMs: number;
+      maxDurationMs: number;
+    };
+
+export type HarnessBehaviorScenarioReport = {
+  scenarioName: string;
+  status: "passed" | "failed";
+  totalDurationMs: number;
+  phaseDurations: HarnessBehaviorPhaseDuration[];
+  runtimeSignals: HarnessBehaviorRuntimeSignalSummary[];
+  diagnostics: HarnessBehaviorAssertionDiagnostic[];
+  failure?: {
+    phase: HarnessBehaviorPhase;
+    details: string;
+  };
+};
+
 export class HarnessBehaviorPhaseError extends Error {
   phase: HarnessBehaviorPhase;
   details: string;
+  report?: HarnessBehaviorScenarioReport;
 
   constructor(
     phase: HarnessBehaviorPhase,
     details: string,
-    cause?: unknown
+    cause?: unknown,
+    report?: HarnessBehaviorScenarioReport
   ) {
     const formattedDetails = details.trim();
     super(
@@ -167,6 +240,7 @@ export class HarnessBehaviorPhaseError extends Error {
     this.name = "HarnessBehaviorPhaseError";
     this.phase = phase;
     this.details = formattedDetails;
+    this.report = report;
   }
 }
 
@@ -621,9 +695,10 @@ function collectRuntimeSignalMatches(
     }
 
     const minMatches = expectation.minMatches ?? 1;
-    if (matchedLines.length < minMatches) {
+    const maxMatches = expectation.maxMatches ?? null;
+    if (maxMatches !== null && maxMatches < minMatches) {
       throw new Error(
-        `Runtime signal "${expectation.name}" expected at least ${minMatches} match(es) for ${regex}, found ${matchedLines.length}.`
+        `Runtime signal "${expectation.name}" has invalid thresholds: maxMatches (${maxMatches}) must be >= minMatches (${minMatches}).`
       );
     }
 
@@ -632,12 +707,101 @@ function collectRuntimeSignalMatches(
       processId: expectation.processId ?? null,
       source,
       pattern: regex,
+      minMatches,
+      maxMatches,
       matchCount: matchedLines.length,
       matchedLines,
     };
   }
 
   return results;
+}
+
+function collectRuntimeSignalDiagnostics(
+  runtimeSignals: Record<string, HarnessBehaviorRuntimeSignalResult>
+) {
+  const diagnostics: HarnessBehaviorAssertionDiagnostic[] = [];
+
+  for (const runtimeSignal of Object.values(runtimeSignals)) {
+    if (runtimeSignal.matchCount < runtimeSignal.minMatches) {
+      diagnostics.push({
+        type: "runtime-signal-below-minimum",
+        signalName: runtimeSignal.name,
+        observedMatches: runtimeSignal.matchCount,
+        minMatches: runtimeSignal.minMatches,
+        message: `Runtime signal "${runtimeSignal.name}" expected at least ${runtimeSignal.minMatches} match(es), found ${runtimeSignal.matchCount}.`,
+      });
+    }
+
+    if (
+      runtimeSignal.maxMatches !== null &&
+      runtimeSignal.matchCount > runtimeSignal.maxMatches
+    ) {
+      diagnostics.push({
+        type: "runtime-signal-above-maximum",
+        signalName: runtimeSignal.name,
+        observedMatches: runtimeSignal.matchCount,
+        maxMatches: runtimeSignal.maxMatches,
+        message: `Runtime signal "${runtimeSignal.name}" expected at most ${runtimeSignal.maxMatches} match(es), found ${runtimeSignal.matchCount}.`,
+      });
+    }
+  }
+
+  return diagnostics;
+}
+
+function collectLatencyDiagnostics(
+  thresholds: HarnessBehaviorLatencyThresholds | undefined,
+  phaseDurations: Partial<Record<HarnessBehaviorPhase, number>>,
+  totalDurationMs: number
+) {
+  if (!thresholds) {
+    return [] satisfies HarnessBehaviorAssertionDiagnostic[];
+  }
+
+  const diagnostics: HarnessBehaviorAssertionDiagnostic[] = [];
+  if (thresholds.maxTotalDurationMs !== undefined) {
+    if (totalDurationMs > thresholds.maxTotalDurationMs) {
+      diagnostics.push({
+        type: "latency-total-threshold-breached",
+        observedDurationMs: totalDurationMs,
+        maxDurationMs: thresholds.maxTotalDurationMs,
+        message: `Total scenario duration ${totalDurationMs}ms exceeded threshold ${thresholds.maxTotalDurationMs}ms.`,
+      });
+    }
+  }
+
+  for (const [phaseName, maxDurationMs] of Object.entries(
+    thresholds.maxPhaseDurationMs ?? {}
+  )) {
+    if (maxDurationMs === undefined) {
+      continue;
+    }
+
+    const phase = phaseName as HarnessBehaviorPhase;
+    const observedDurationMs = phaseDurations[phase];
+    if (observedDurationMs === undefined) {
+      continue;
+    }
+
+    if (observedDurationMs > maxDurationMs) {
+      diagnostics.push({
+        type: "latency-phase-threshold-breached",
+        phase,
+        observedDurationMs,
+        maxDurationMs,
+        message: `Phase "${phase}" duration ${observedDurationMs}ms exceeded threshold ${maxDurationMs}ms.`,
+      });
+    }
+  }
+
+  return diagnostics;
+}
+
+function formatAssertionDiagnostics(
+  diagnostics: HarnessBehaviorAssertionDiagnostic[]
+) {
+  return diagnostics.map((diagnostic) => diagnostic.message).join(" ");
 }
 
 type HarnessBehaviorPlaywrightBrowser = {
@@ -801,16 +965,32 @@ function wrapPhaseError(
   return new HarnessBehaviorPhaseError(phase, formatError(error), error);
 }
 
+async function runPhaseWithDuration<T>(
+  phase: HarnessBehaviorPhase,
+  phaseDurations: Partial<Record<HarnessBehaviorPhase, number>>,
+  action: () => Promise<T>
+) {
+  const startedAt = Date.now();
+  try {
+    return await action();
+  } finally {
+    phaseDurations[phase] = Date.now() - startedAt;
+  }
+}
+
 export async function runHarnessBehaviorScenario<TBrowserResult>(
   rootDir: string,
   scenario: HarnessBehaviorScenario<TBrowserResult>,
   options: RunHarnessBehaviorOptions = {}
 ) {
+  const scenarioStartedAt = Date.now();
   const logger = options.logger ?? console;
   const fetchImpl = options.fetchImpl ?? fetch;
   const sleepImpl = options.sleep ?? sleep;
   const runPlaywrightImpl = options.runPlaywrightFlow ?? runPlaywrightFlow;
   const runningProcesses = new Map<string, RunningProcess>();
+  const phaseDurations: Partial<Record<HarnessBehaviorPhase, number>> = {};
+  const assertionDiagnostics: HarnessBehaviorAssertionDiagnostic[] = [];
   let browserResult: TBrowserResult | undefined;
   let runtimeSignals: Record<string, HarnessBehaviorRuntimeSignalResult> = {};
   let pendingError: HarnessBehaviorPhaseError | null = null;
@@ -837,103 +1017,123 @@ export async function runHarnessBehaviorScenario<TBrowserResult>(
     logger.log(`[harness:behavior] ${scenario.description}`);
   }
 
+  const runPhase = <T>(
+    phase: HarnessBehaviorPhase,
+    action: () => Promise<T>
+  ) => {
+    currentPhase = phase;
+    return runPhaseWithDuration(phase, phaseDurations, action);
+  };
+
   try {
-    currentPhase = "boot";
-    logPhase(logger, "boot", "booting scenario processes");
-    for (const processDefinition of scenario.processes) {
-      const runningProcess = await startProcess(rootDir, processDefinition, logger);
-      runningProcesses.set(processDefinition.id, runningProcess);
-    }
-
-    currentPhase = "readiness";
-    logPhase(logger, "readiness", "running readiness checks");
-    for (const check of scenario.readiness) {
-      if (check.kind === "http") {
-        logPhase(
-          logger,
-          "readiness",
-          `check "${check.name}" -> ${check.url} (expect ${check.expectedStatus ?? 200})`
-        );
-        await runHttpReadinessCheck(check, fetchImpl, sleepImpl);
-        continue;
+    await runPhase("boot", async () => {
+      logPhase(logger, "boot", "booting scenario processes");
+      for (const processDefinition of scenario.processes) {
+        const runningProcess = await startProcess(rootDir, processDefinition, logger);
+        runningProcesses.set(processDefinition.id, runningProcess);
       }
-
-      if (check.kind === "log") {
-        const processHandle = processHandles()[check.processId];
-        if (!processHandle) {
-          throw new Error(
-            `Readiness check "${check.name}" references unknown process "${check.processId}".`
-          );
-        }
-        logPhase(
-          logger,
-          "readiness",
-          `check "${check.name}" waiting for ${check.processId} output`
-        );
-        await processHandle.waitForOutput(check.pattern, {
-          source: check.source ?? "combined",
-          timeoutMs: check.timeoutMs ?? DEFAULT_READY_TIMEOUT_MS,
-        });
-        continue;
-      }
-
-      logPhase(logger, "readiness", `check "${check.name}" (custom)`);
-      await check.check(baseContext());
-    }
-
-    currentPhase = "browser";
-    logPhase(logger, "browser", "running browser flow");
-    browserResult = await scenario.browser({
-      ...baseContext(),
-      runPlaywrightFlow: runPlaywrightImpl,
     });
 
-    currentPhase = "runtime";
-    logPhase(logger, "runtime", "collecting runtime signals");
-    runtimeSignals = collectRuntimeSignalMatches(
-      scenario.runtimeSignals ?? [],
-      processHandles()
-    );
+    await runPhase("readiness", async () => {
+      logPhase(logger, "readiness", "running readiness checks");
+      for (const check of scenario.readiness) {
+        if (check.kind === "http") {
+          logPhase(
+            logger,
+            "readiness",
+            `check "${check.name}" -> ${check.url} (expect ${check.expectedStatus ?? 200})`
+          );
+          await runHttpReadinessCheck(check, fetchImpl, sleepImpl);
+          continue;
+        }
 
-    for (const runtimeSignal of Object.values(runtimeSignals)) {
-      logPhase(
-        logger,
-        "runtime",
-        `${runtimeSignal.name}: matched ${runtimeSignal.matchCount} line(s)`
+        if (check.kind === "log") {
+          const processHandle = processHandles()[check.processId];
+          if (!processHandle) {
+            throw new Error(
+              `Readiness check "${check.name}" references unknown process "${check.processId}".`
+            );
+          }
+          logPhase(
+            logger,
+            "readiness",
+            `check "${check.name}" waiting for ${check.processId} output`
+          );
+          await processHandle.waitForOutput(check.pattern, {
+            source: check.source ?? "combined",
+            timeoutMs: check.timeoutMs ?? DEFAULT_READY_TIMEOUT_MS,
+          });
+          continue;
+        }
+
+        logPhase(logger, "readiness", `check "${check.name}" (custom)`);
+        await check.check(baseContext());
+      }
+    });
+
+    browserResult = await runPhase("browser", async () => {
+      logPhase(logger, "browser", "running browser flow");
+      return scenario.browser({
+        ...baseContext(),
+        runPlaywrightFlow: runPlaywrightImpl,
+      });
+    });
+
+    runtimeSignals = await runPhase("runtime", async () => {
+      logPhase(logger, "runtime", "collecting runtime signals");
+      const collectedSignals = collectRuntimeSignalMatches(
+        scenario.runtimeSignals ?? [],
+        processHandles()
       );
-    }
 
-    currentPhase = "assertion";
-    logPhase(logger, "assertion", "running scenario assertions");
-    await scenario.assert({
-      ...baseContext(),
-      browserResult: browserResult as TBrowserResult,
-      runtimeSignals,
+      for (const runtimeSignal of Object.values(collectedSignals)) {
+        const maxMatchesSuffix =
+          runtimeSignal.maxMatches === null
+            ? ""
+            : `, max ${runtimeSignal.maxMatches}`;
+        logPhase(
+          logger,
+          "runtime",
+          `${runtimeSignal.name}: matched ${runtimeSignal.matchCount} line(s) [min ${runtimeSignal.minMatches}${maxMatchesSuffix}]`
+        );
+      }
+
+      return collectedSignals;
+    });
+
+    await runPhase("assertion", async () => {
+      logPhase(logger, "assertion", "running scenario assertions");
+      await scenario.assert({
+        ...baseContext(),
+        browserResult: browserResult as TBrowserResult,
+        runtimeSignals,
+      });
     });
   } catch (error) {
     pendingError = wrapPhaseError(currentPhase, error);
   } finally {
     try {
-      currentPhase = "cleanup";
-      logPhase(logger, "cleanup", "tearing down scenario resources");
+      await runPhase("cleanup", async () => {
+        logPhase(logger, "cleanup", "tearing down scenario resources");
 
-      if (scenario.cleanup && browserResult !== undefined) {
-        await scenario.cleanup({
-          ...baseContext(),
-          browserResult,
-          runtimeSignals,
-        });
-      } else if (scenario.cleanup) {
-        await scenario.cleanup({
-          ...baseContext(),
-          browserResult: undefined as TBrowserResult,
-          runtimeSignals,
-        });
-      }
+        if (scenario.cleanup && browserResult !== undefined) {
+          await scenario.cleanup({
+            ...baseContext(),
+            browserResult,
+            runtimeSignals,
+          });
+        } else if (scenario.cleanup) {
+          await scenario.cleanup({
+            ...baseContext(),
+            browserResult: undefined as TBrowserResult,
+            runtimeSignals,
+          });
+        }
 
-      for (const runningProcess of [...runningProcesses.values()].reverse()) {
-        await runningProcess.stop();
-      }
+        for (const runningProcess of [...runningProcesses.values()].reverse()) {
+          await runningProcess.stop();
+        }
+      });
     } catch (cleanupError) {
       const wrappedCleanupError = wrapPhaseError("cleanup", cleanupError);
       if (pendingError) {
@@ -946,11 +1146,70 @@ export async function runHarnessBehaviorScenario<TBrowserResult>(
     }
   }
 
+  assertionDiagnostics.push(...collectRuntimeSignalDiagnostics(runtimeSignals));
+
+  const totalDurationMs = Date.now() - scenarioStartedAt;
+  assertionDiagnostics.push(
+    ...collectLatencyDiagnostics(
+      scenario.thresholds?.latency,
+      phaseDurations,
+      totalDurationMs
+    )
+  );
+
+  if (!pendingError && assertionDiagnostics.length > 0) {
+    pendingError = new HarnessBehaviorPhaseError(
+      "assertion",
+      formatAssertionDiagnostics(assertionDiagnostics)
+    );
+  }
+
+  const orderedPhases: HarnessBehaviorPhase[] = [
+    "boot",
+    "readiness",
+    "browser",
+    "runtime",
+    "assertion",
+    "cleanup",
+  ];
+  const report: HarnessBehaviorScenarioReport = {
+    scenarioName: scenario.name,
+    status: pendingError ? "failed" : "passed",
+    totalDurationMs,
+    phaseDurations: orderedPhases
+      .filter((phase) => phaseDurations[phase] !== undefined)
+      .map((phase) => ({
+        phase,
+        durationMs: phaseDurations[phase] as number,
+      })),
+    runtimeSignals: Object.values(runtimeSignals).map((runtimeSignal) => ({
+      name: runtimeSignal.name,
+      processId: runtimeSignal.processId,
+      source: runtimeSignal.source,
+      pattern: runtimeSignal.pattern.source,
+      minMatches: runtimeSignal.minMatches,
+      maxMatches: runtimeSignal.maxMatches,
+      matchCount: runtimeSignal.matchCount,
+      sampleMatches: runtimeSignal.matchedLines.slice(0, 5),
+    })),
+    diagnostics: assertionDiagnostics,
+    failure: pendingError
+      ? {
+          phase: pendingError.phase,
+          details: pendingError.details,
+        }
+      : undefined,
+  };
+
+  logger.log(`[harness:behavior:report] ${JSON.stringify(report)}`);
+
   if (pendingError) {
+    pendingError.report = report;
     throw pendingError;
   }
 
   logger.log(`[harness:behavior] Scenario ${scenario.name} passed.`);
+  return report;
 }
 
 export function parseHarnessBehaviorArgs(


### PR DESCRIPTION
## Summary
- add first-class behavior-harness threshold assertions for runtime signals and latency budgets
- emit machine-parseable `[harness:behavior:report]` JSON including phase durations, runtime-signal summaries, and structured diagnostics
- apply threshold configs to all core athena/storefront behavior scenarios and add focused regression tests/docs updates

## Why
- ticket V26-207 requires deterministic failure semantics when latency or runtime-signal quality regresses
- structured per-scenario diagnostics make threshold breaches actionable and consumable by harness tooling
- centralizing threshold logic in the harness runtime keeps scenario behavior consistent and reduces duplicated assertion code

## Validation
- `bun test scripts/harness-behavior.test.ts scripts/harness-behavior-scenarios.test.ts`
- `bun run harness:behavior --scenario sample-runtime-smoke`
- `bun run harness:behavior --scenario athena-admin-shell-boot`
- `bun run harness:behavior --scenario athena-convex-storefront-composition`
- `bun run harness:behavior --scenario athena-convex-storefront-failure-visibility`
- `bun run harness:behavior --scenario storefront-checkout-bootstrap`
- `bun run harness:behavior --scenario storefront-checkout-validation-blocker`
- `bun run harness:behavior --scenario storefront-checkout-verification-recovery`
- `bun run harness:behavior --scenario athena-convex-storefront-failure-visibility --record-video`
- `bun run harness:review`
- `bun run pr:athena`
- `git diff --check`
- `bun run graphify:rebuild`

https://linear.app/v26-labs/issue/V26-207/add-performance-and-runtime-signal-quality-assertions-to-behavior
