### PR TITLE
[V26-221]: Generate Graphify wiki navigation pages from graph and harness metadata

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1193 files · ~0 words
+- 1195 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 2716 nodes · 2191 edges · 1108 communities detected
+- 2738 nodes · 2229 edges · 1110 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1118,6 +1118,8 @@
 - [[_COMMUNITY_Community 1105|Community 1105]]
 - [[_COMMUNITY_Community 1106|Community 1106]]
 - [[_COMMUNITY_Community 1107|Community 1107]]
+- [[_COMMUNITY_Community 1108|Community 1108]]
+- [[_COMMUNITY_Community 1109|Community 1109]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -1194,152 +1196,152 @@ Cohesion: 0.16
 Nodes (9): checkIfItemsHaveChanged(), createOnlineOrder(), findBestValuePromoCode(), handleExistingSession(), handleOrderCreation(), handlePlaceOrder(), listSessionItems(), updateExistingSession() (+1 more)
 
 ### Community 12 - "Community 12"
+Cohesion: 0.22
+Nodes (16): buildDegreeIndex(), buildHotspotLines(), buildPackagePage(), buildRootIndexPage(), collectRepoCodeFiles(), compareHotspots(), countCommunities(), fileExists() (+8 more)
+
+### Community 13 - "Community 13"
 Cohesion: 0.12
 Nodes (1): DataTableViewOptions()
 
-### Community 13 - "Community 13"
+### Community 14 - "Community 14"
 Cohesion: 0.19
 Nodes (13): compareSnapshots(), fileExists(), formatArtifactList(), formatDetailLines(), formatError(), formatHarnessJanitorReport(), readUtf8OrNull(), runCheckStep() (+5 more)
 
-### Community 14 - "Community 14"
+### Community 15 - "Community 15"
 Cohesion: 0.21
 Nodes (14): CheckoutSessionError, createCheckoutSession(), defaultCheckoutActionMessage(), getActiveCheckoutSession(), getBaseUrl(), getCheckoutActionErrorMessage(), getCheckoutErrorMessageFromPayload(), getCheckoutSession() (+6 more)
 
-### Community 15 - "Community 15"
+### Community 16 - "Community 16"
 Cohesion: 0.13
 Nodes (1): DataTableColumnHeader()
 
-### Community 16 - "Community 16"
+### Community 17 - "Community 17"
 Cohesion: 0.2
 Nodes (8): collectCommandsForChangedFiles(), fileExists(), loadReviewTarget(), loadReviewTargets(), matchesPathPrefix(), normalizeBehaviorScenarioName(), normalizeRepoPath(), runHarnessReview()
 
-### Community 17 - "Community 17"
+### Community 18 - "Community 18"
 Cohesion: 0.24
 Nodes (13): buildNumericTrendStats(), buildRegressionWarnings(), buildRuntimeTrendOutput(), buildScenarioTrend(), collectHarnessRuntimeTrends(), formatMs(), formatPercent(), parseHarnessBehaviorReportLines() (+5 more)
 
-### Community 18 - "Community 18"
+### Community 19 - "Community 19"
 Cohesion: 0.18
 Nodes (5): handleSave(), hasReceivingAccountDetails(), normalizePrimaryAccounts(), toPatchReceivingAccounts(), trimToUndefined()
 
-### Community 19 - "Community 19"
+### Community 20 - "Community 20"
 Cohesion: 0.29
 Nodes (11): addGroupedError(), collectLiveSurfaceEntries(), fileExists(), formatGroupedErrors(), inferGroupFromError(), loadAuditTarget(), matchesPathPrefix(), normalizeBehaviorScenarioName() (+3 more)
 
-### Community 20 - "Community 20"
+### Community 21 - "Community 21"
 Cohesion: 0.18
 Nodes (3): isValidEmail(), isValidPhone(), validateCustomer()
 
-### Community 21 - "Community 21"
+### Community 22 - "Community 22"
 Cohesion: 0.29
 Nodes (12): createReview(), deleteReview(), getBaseUrl(), getReviewByOrderItem(), getReviewsByProductId(), getReviewsByProductSkuId(), getUserReviews(), getUserReviewsForProduct() (+4 more)
 
-### Community 22 - "Community 22"
+### Community 23 - "Community 23"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 23 - "Community 23"
+### Community 24 - "Community 24"
 Cohesion: 0.33
 Nodes (9): usePOSActiveSession(), usePOSSessionComplete(), usePOSSessionCreate(), usePOSSessionHold(), usePOSSessionManager(), usePOSSessionResume(), usePOSSessionUpdate(), usePOSSessionVoid() (+1 more)
-
-### Community 24 - "Community 24"
-Cohesion: 0.18
-Nodes (0):
 
 ### Community 25 - "Community 25"
 Cohesion: 0.18
 Nodes (0):
 
 ### Community 26 - "Community 26"
+Cohesion: 0.18
+Nodes (0):
+
+### Community 27 - "Community 27"
 Cohesion: 0.31
 Nodes (6): expenseItemSuccess(), expenseSessionSuccess(), itemSuccess(), operationSuccess(), sessionSuccess(), success()
 
-### Community 27 - "Community 27"
+### Community 28 - "Community 28"
 Cohesion: 0.22
 Nodes (2): isValidEmail(), validateCustomerInfo()
 
-### Community 28 - "Community 28"
+### Community 29 - "Community 29"
 Cohesion: 0.36
 Nodes (8): collectAllPages(), createTransactionFromSessionHandler(), listCompletedTransactionsForDay(), listProductSkusByProductId(), listSessionItems(), listStoreProducts(), listStoreSkus(), listTransactionItems()
 
-### Community 29 - "Community 29"
+### Community 30 - "Community 30"
 Cohesion: 0.31
 Nodes (5): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getPotentialPoints()
 
-### Community 30 - "Community 30"
+### Community 31 - "Community 31"
 Cohesion: 0.29
 Nodes (6): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile()
 
-### Community 31 - "Community 31"
+### Community 32 - "Community 32"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 32 - "Community 32"
+### Community 33 - "Community 33"
 Cohesion: 0.38
 Nodes (9): awardPointsForGuestOrders(), awardPointsForPastOrder(), getBaseUrl(), getEligiblePastOrders(), getOrderRewardPoints(), getPointHistory(), getRewardTiers(), getUserPoints() (+1 more)
 
-### Community 33 - "Community 33"
+### Community 34 - "Community 34"
 Cohesion: 0.28
 Nodes (3): modifyProduct(), onSubmit(), saveProduct()
 
-### Community 34 - "Community 34"
+### Community 35 - "Community 35"
 Cohesion: 0.25
 Nodes (2): handleNewSession(), resetAutoSessionInitialized()
 
-### Community 35 - "Community 35"
+### Community 36 - "Community 36"
 Cohesion: 0.39
 Nodes (7): calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock(), validateRefund()
 
-### Community 36 - "Community 36"
+### Community 37 - "Community 37"
 Cohesion: 0.39
 Nodes (6): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction()
 
-### Community 37 - "Community 37"
+### Community 38 - "Community 38"
 Cohesion: 0.44
 Nodes (1): Logger
-
-### Community 38 - "Community 38"
-Cohesion: 0.43
-Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
 ### Community 39 - "Community 39"
 Cohesion: 0.43
 Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 40 - "Community 40"
+Cohesion: 0.43
+Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
+
+### Community 41 - "Community 41"
 Cohesion: 0.25
 Nodes (1): DataTableRowActions()
 
-### Community 41 - "Community 41"
+### Community 42 - "Community 42"
 Cohesion: 0.29
 Nodes (2): handleNewSession(), resetAutoSessionInitialized()
 
-### Community 42 - "Community 42"
+### Community 43 - "Community 43"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 43 - "Community 43"
+### Community 44 - "Community 44"
 Cohesion: 0.46
 Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
 
-### Community 44 - "Community 44"
+### Community 45 - "Community 45"
 Cohesion: 0.43
 Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
 
-### Community 45 - "Community 45"
+### Community 46 - "Community 46"
 Cohesion: 0.52
 Nodes (5): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventoryHold(), releaseInventoryHold(), validateInventoryAvailability()
 
-### Community 46 - "Community 46"
+### Community 47 - "Community 47"
 Cohesion: 0.57
 Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
 
-### Community 47 - "Community 47"
+### Community 48 - "Community 48"
 Cohesion: 0.57
 Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
-
-### Community 48 - "Community 48"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 49 - "Community 49"
 Cohesion: 0.29
@@ -1350,60 +1352,60 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 51 - "Community 51"
-Cohesion: 0.52
-Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
-
-### Community 52 - "Community 52"
 Cohesion: 0.29
 Nodes (0):
 
+### Community 52 - "Community 52"
+Cohesion: 0.52
+Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
+
 ### Community 53 - "Community 53"
+Cohesion: 0.29
+Nodes (0):
+
+### Community 54 - "Community 54"
 Cohesion: 0.33
 Nodes (2): getProductName(), sortProduct()
 
-### Community 54 - "Community 54"
+### Community 55 - "Community 55"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 55 - "Community 55"
+### Community 56 - "Community 56"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 56 - "Community 56"
+### Community 57 - "Community 57"
 Cohesion: 0.33
 Nodes (1): ValkeyClient
 
-### Community 57 - "Community 57"
+### Community 58 - "Community 58"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 58 - "Community 58"
+### Community 59 - "Community 59"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
-### Community 59 - "Community 59"
+### Community 60 - "Community 60"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 60 - "Community 60"
+### Community 61 - "Community 61"
 Cohesion: 0.47
 Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
 
-### Community 61 - "Community 61"
+### Community 62 - "Community 62"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 62 - "Community 62"
+### Community 63 - "Community 63"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
-### Community 63 - "Community 63"
+### Community 64 - "Community 64"
 Cohesion: 0.4
 Nodes (2): buildUsername(), normalizeNameSegment()
-
-### Community 64 - "Community 64"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 65 - "Community 65"
 Cohesion: 0.33
@@ -1418,16 +1420,16 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 68 - "Community 68"
-Cohesion: 0.4
-Nodes (2): useBulkOperations(), validateOperationValue()
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 69 - "Community 69"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 70 - "Community 70"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): useBulkOperations(), validateOperationValue()
 
 ### Community 71 - "Community 71"
 Cohesion: 0.33
@@ -1438,44 +1440,44 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 73 - "Community 73"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 74 - "Community 74"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 75 - "Community 75"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
-### Community 75 - "Community 75"
+### Community 76 - "Community 76"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
+
+### Community 77 - "Community 77"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
-### Community 76 - "Community 76"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 77 - "Community 77"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 78 - "Community 78"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 79 - "Community 79"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 80 - "Community 80"
 Cohesion: 0.53
 Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
-### Community 80 - "Community 80"
+### Community 81 - "Community 81"
 Cohesion: 0.47
 Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
-### Community 81 - "Community 81"
+### Community 82 - "Community 82"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
-
-### Community 82 - "Community 82"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 83 - "Community 83"
 Cohesion: 0.4
@@ -1490,24 +1492,24 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 86 - "Community 86"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 87 - "Community 87"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 87 - "Community 87"
+### Community 88 - "Community 88"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 88 - "Community 88"
-Cohesion: 0.6
-Nodes (3): getNonEmptyString(), isFailureStatus(), normalizeEvent()
 
 ### Community 89 - "Community 89"
 Cohesion: 0.6
-Nodes (3): createOffer(), isDuplicate(), updateStoreFrontActorEmail()
+Nodes (3): getNonEmptyString(), isFailureStatus(), normalizeEvent()
 
 ### Community 90 - "Community 90"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (3): createOffer(), isDuplicate(), updateStoreFrontActorEmail()
 
 ### Community 91 - "Community 91"
 Cohesion: 0.4
@@ -1515,23 +1517,23 @@ Nodes (0):
 
 ### Community 92 - "Community 92"
 Cohesion: 0.4
-Nodes (1): Header()
+Nodes (0):
 
 ### Community 93 - "Community 93"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): Header()
 
 ### Community 94 - "Community 94"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 95 - "Community 95"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
-
-### Community 96 - "Community 96"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 96 - "Community 96"
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 97 - "Community 97"
 Cohesion: 0.4
@@ -1562,16 +1564,16 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 104 - "Community 104"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 105 - "Community 105"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 105 - "Community 105"
-Cohesion: 0.4
-Nodes (1): MockImage
-
 ### Community 106 - "Community 106"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): MockImage
 
 ### Community 107 - "Community 107"
 Cohesion: 0.4
@@ -1586,43 +1588,43 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 110 - "Community 110"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 111 - "Community 111"
 Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 112 - "Community 112"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 113 - "Community 113"
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+
+### Community 114 - "Community 114"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 114 - "Community 114"
+### Community 115 - "Community 115"
 Cohesion: 0.7
 Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
-### Community 115 - "Community 115"
+### Community 116 - "Community 116"
 Cohesion: 0.6
 Nodes (4): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), trackStorefrontEvent()
 
-### Community 116 - "Community 116"
+### Community 117 - "Community 117"
 Cohesion: 0.7
 Nodes (4): runTests(), testBasicOperations(), testClusterInfo(), testConnection()
 
-### Community 117 - "Community 117"
+### Community 118 - "Community 118"
 Cohesion: 0.5
 Nodes (2): createFixtureRepo(), write()
 
-### Community 118 - "Community 118"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 119 - "Community 119"
-Cohesion: 0.5
+Cohesion: 0.4
 Nodes (0):
 
 ### Community 120 - "Community 120"
@@ -1638,28 +1640,28 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 123 - "Community 123"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 124 - "Community 124"
 Cohesion: 0.67
 Nodes (2): toDisplayAmount(), toPesewas()
 
-### Community 124 - "Community 124"
+### Community 125 - "Community 125"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 125 - "Community 125"
+### Community 126 - "Community 126"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 126 - "Community 126"
+### Community 127 - "Community 127"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 127 - "Community 127"
+### Community 128 - "Community 128"
 Cohesion: 0.67
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
-
-### Community 128 - "Community 128"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 129 - "Community 129"
 Cohesion: 0.5
@@ -1674,12 +1676,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 132 - "Community 132"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
-
-### Community 133 - "Community 133"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 133 - "Community 133"
+Cohesion: 0.67
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 134 - "Community 134"
 Cohesion: 0.5
@@ -1710,32 +1712,32 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 141 - "Community 141"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
-
-### Community 142 - "Community 142"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 142 - "Community 142"
+Cohesion: 0.67
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 143 - "Community 143"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 144 - "Community 144"
-Cohesion: 0.83
-Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 145 - "Community 145"
 Cohesion: 0.83
-Nodes (3): getAllStores(), getBaseUrl(), getStore()
+Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 146 - "Community 146"
 Cohesion: 0.83
-Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
 ### Community 147 - "Community 147"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
 
 ### Community 148 - "Community 148"
 Cohesion: 0.5
@@ -1762,32 +1764,32 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 154 - "Community 154"
-Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
-
-### Community 155 - "Community 155"
-Cohesion: 0.83
-Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
-
-### Community 156 - "Community 156"
-Cohesion: 0.83
-Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
-
-### Community 157 - "Community 157"
 Cohesion: 0.5
 Nodes (0):
 
+### Community 155 - "Community 155"
+Cohesion: 0.67
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+
+### Community 156 - "Community 156"
+Cohesion: 0.83
+Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
+
+### Community 157 - "Community 157"
+Cohesion: 0.83
+Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
+
 ### Community 158 - "Community 158"
 Cohesion: 0.83
-Nodes (3): fileExists(), resolveGraphifyPython(), runGraphifyRebuild()
+Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
 ### Community 159 - "Community 159"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 160 - "Community 160"
-Cohesion: 0.67
-Nodes (2): collectHarnessTestTargets(), runHarnessTest()
+Cohesion: 0.83
+Nodes (3): fileExists(), resolveGraphifyPython(), runGraphifyRebuild()
 
 ### Community 161 - "Community 161"
 Cohesion: 0.5
@@ -1795,10 +1797,10 @@ Nodes (0):
 
 ### Community 162 - "Community 162"
 Cohesion: 0.67
-Nodes (0):
+Nodes (2): collectHarnessTestTargets(), runHarnessTest()
 
 ### Community 163 - "Community 163"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 164 - "Community 164"
@@ -1814,20 +1816,20 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 167 - "Community 167"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 168 - "Community 168"
 Cohesion: 0.67
-Nodes (1): View()
+Nodes (0):
 
 ### Community 169 - "Community 169"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 170 - "Community 170"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 171 - "Community 171"
 Cohesion: 0.67
@@ -1838,20 +1840,20 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 173 - "Community 173"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 174 - "Community 174"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 175 - "Community 175"
 Cohesion: 1.0
 Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
 
-### Community 174 - "Community 174"
+### Community 176 - "Community 176"
 Cohesion: 1.0
 Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
-
-### Community 175 - "Community 175"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 176 - "Community 176"
-Cohesion: 0.67
-Nodes (0):
 
 ### Community 177 - "Community 177"
 Cohesion: 0.67
@@ -1859,7 +1861,7 @@ Nodes (0):
 
 ### Community 178 - "Community 178"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 179 - "Community 179"
 Cohesion: 0.67
@@ -1867,11 +1869,11 @@ Nodes (0):
 
 ### Community 180 - "Community 180"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 181 - "Community 181"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 182 - "Community 182"
 Cohesion: 0.67
@@ -1879,7 +1881,7 @@ Nodes (0):
 
 ### Community 183 - "Community 183"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 184 - "Community 184"
 Cohesion: 0.67
@@ -1919,79 +1921,79 @@ Nodes (0):
 
 ### Community 193 - "Community 193"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 194 - "Community 194"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (0):
 
 ### Community 195 - "Community 195"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): SingleLineError()
 
 ### Community 196 - "Community 196"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 197 - "Community 197"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 198 - "Community 198"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 199 - "Community 199"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TableSkeleton()
 
 ### Community 200 - "Community 200"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): TransactionsSkeleton()
 
 ### Community 201 - "Community 201"
 Cohesion: 0.67
-Nodes (1): AppContextMenu()
+Nodes (1): NotFound()
 
 ### Community 202 - "Community 202"
 Cohesion: 0.67
-Nodes (1): Badge()
+Nodes (0):
 
 ### Community 203 - "Community 203"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (1): AppContextMenu()
 
 ### Community 204 - "Community 204"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (1): Badge()
 
 ### Community 205 - "Community 205"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): LoadingButton()
 
 ### Community 206 - "Community 206"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): onChange()
 
 ### Community 207 - "Community 207"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): AlertModal()
 
 ### Community 208 - "Community 208"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): OverlayModal()
 
 ### Community 209 - "Community 209"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Skeleton()
 
 ### Community 210 - "Community 210"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Toaster()
 
 ### Community 211 - "Community 211"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 212 - "Community 212"
 Cohesion: 0.67
@@ -2015,7 +2017,7 @@ Nodes (0):
 
 ### Community 217 - "Community 217"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 218 - "Community 218"
 Cohesion: 0.67
@@ -2023,7 +2025,7 @@ Nodes (0):
 
 ### Community 219 - "Community 219"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 220 - "Community 220"
 Cohesion: 0.67
@@ -2035,43 +2037,43 @@ Nodes (0):
 
 ### Community 222 - "Community 222"
 Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
+Nodes (0):
 
 ### Community 223 - "Community 223"
 Cohesion: 0.67
-Nodes (1): App()
+Nodes (0):
 
 ### Community 224 - "Community 224"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): isInMaintenanceMode()
 
 ### Community 225 - "Community 225"
-Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Cohesion: 0.67
+Nodes (1): App()
 
 ### Community 226 - "Community 226"
 Cohesion: 0.67
-Nodes (1): hashPassword()
+Nodes (0):
 
 ### Community 227 - "Community 227"
-Cohesion: 0.67
-Nodes (1): useAppSession()
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 228 - "Community 228"
 Cohesion: 0.67
-Nodes (1): createVersionChecker()
+Nodes (1): hashPassword()
 
 ### Community 229 - "Community 229"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (1): useAppSession()
 
 ### Community 230 - "Community 230"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): createVersionChecker()
 
 ### Community 231 - "Community 231"
-Cohesion: 1.0
-Nodes (2): getAllColors(), getBaseUrl()
+Cohesion: 0.67
+Nodes (1): manualChunks()
 
 ### Community 232 - "Community 232"
 Cohesion: 0.67
@@ -2079,47 +2081,47 @@ Nodes (0):
 
 ### Community 233 - "Community 233"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
+Nodes (2): getAllColors(), getBaseUrl()
 
 ### Community 234 - "Community 234"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 235 - "Community 235"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 236 - "Community 236"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 237 - "Community 237"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 238 - "Community 238"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 239 - "Community 239"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 240 - "Community 240"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 241 - "Community 241"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 242 - "Community 242"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 243 - "Community 243"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 244 - "Community 244"
 Cohesion: 0.67
@@ -2186,16 +2188,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 260 - "Community 260"
-Cohesion: 1.0
-Nodes (2): createFixtureRoot(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 261 - "Community 261"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 262 - "Community 262"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 263 - "Community 263"
 Cohesion: 0.67
@@ -2206,8 +2208,8 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 265 - "Community 265"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 266 - "Community 266"
 Cohesion: 1.0
@@ -2222,15 +2224,15 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 269 - "Community 269"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 270 - "Community 270"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 271 - "Community 271"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0):
 
 ### Community 272 - "Community 272"
@@ -5577,1682 +5579,1690 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1108 - "Community 1108"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1109 - "Community 1109"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
-- **Thin community `Community 270`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 272`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 271`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 273`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 272`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 274`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 273`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 275`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 274`** (2 nodes): `authenticateHandler()`, `cashier.ts`
+- **Thin community `Community 276`** (2 nodes): `authenticateHandler()`, `cashier.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 275`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 277`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 276`** (2 nodes): `sessionQueryIndexes.test.ts`, `readProjectFile()`
+- **Thin community `Community 278`** (2 nodes): `sessionQueryIndexes.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 277`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 279`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 278`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 280`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 279`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 281`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 280`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 282`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 281`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 283`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 282`** (2 nodes): `VerificationCodeEmail.tsx`, `VerificationCodeEmail()`
+- **Thin community `Community 284`** (2 nodes): `VerificationCodeEmail.tsx`, `VerificationCodeEmail()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 283`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 285`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 284`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 286`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 285`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 287`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 286`** (2 nodes): `listOrderItems()`, `onlineOrder.ts`
+- **Thin community `Community 288`** (2 nodes): `listOrderItems()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 287`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 289`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 288`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 290`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 289`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 291`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 290`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 292`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 291`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 293`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 292`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 294`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 293`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 295`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 294`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 296`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 295`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 297`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 296`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 298`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 297`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 299`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 298`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 300`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 299`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 301`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 300`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 302`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 301`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 303`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 302`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 304`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 303`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 305`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 304`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 306`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 305`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
+- **Thin community `Community 307`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 306`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 308`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 307`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 309`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 308`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 310`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 309`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 311`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 310`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 312`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 311`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 313`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 312`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 314`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 313`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 315`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 314`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 316`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 315`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 317`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 316`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 318`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 317`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 319`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 318`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 320`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 319`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 321`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 320`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 322`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 321`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 323`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 322`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 324`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 323`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 325`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 324`** (2 nodes): `Login()`, `index.tsx`
+- **Thin community `Community 326`** (2 nodes): `Login()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 325`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 327`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 326`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 328`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 327`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 329`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 328`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 330`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 329`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 331`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 330`** (2 nodes): `PageHeader.tsx`, `PageHeader()`
+- **Thin community `Community 332`** (2 nodes): `PageHeader.tsx`, `PageHeader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 331`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 333`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 332`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 334`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 333`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 335`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 334`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 336`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 335`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 337`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 336`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 338`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 337`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 339`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 338`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 340`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 339`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 341`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 340`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 342`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 341`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 343`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 342`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 344`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 343`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 345`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 344`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 346`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 345`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 347`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 346`** (2 nodes): `handleSignOut()`, `CashierView.tsx`
+- **Thin community `Community 348`** (2 nodes): `handleSignOut()`, `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 347`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 349`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 348`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 350`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 349`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 351`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 350`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
+- **Thin community `Community 352`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 351`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 353`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 352`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
+- **Thin community `Community 354`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 353`** (2 nodes): `ProductEntry.tsx`, `handleClearSearch()`
+- **Thin community `Community 355`** (2 nodes): `ProductEntry.tsx`, `handleClearSearch()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 354`** (2 nodes): `QuickActionsBar.tsx`, `QuickActionsBar()`
+- **Thin community `Community 356`** (2 nodes): `QuickActionsBar.tsx`, `QuickActionsBar()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 355`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 357`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 356`** (2 nodes): `TotalsDisplay.tsx`, `TotalsDisplay()`
+- **Thin community `Community 358`** (2 nodes): `TotalsDisplay.tsx`, `TotalsDisplay()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 357`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
+- **Thin community `Community 359`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 358`** (2 nodes): `usePOSCashier()`, `hooks.ts`
+- **Thin community `Community 360`** (2 nodes): `usePOSCashier()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 359`** (2 nodes): `HoldSessionDialog()`, `HoldSessionDialog.tsx`
+- **Thin community `Community 361`** (2 nodes): `HoldSessionDialog()`, `HoldSessionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 360`** (2 nodes): `VoidSessionDialog.tsx`, `VoidSessionDialog()`
+- **Thin community `Community 362`** (2 nodes): `VoidSessionDialog.tsx`, `VoidSessionDialog()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 361`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 363`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 362`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 364`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 363`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 365`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 364`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 366`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 365`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 367`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 366`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
+- **Thin community `Community 368`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 367`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 369`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 368`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 370`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 369`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 371`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 370`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 372`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 371`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 373`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 372`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 374`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 373`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 375`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 374`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 376`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 375`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 377`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 376`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 378`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 377`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 379`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 378`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 380`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 379`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 381`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 380`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 382`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 381`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 383`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 382`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 384`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 383`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 385`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 384`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 386`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 385`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 387`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 386`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 388`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 387`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 389`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 388`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 390`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 389`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 391`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 390`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 392`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 391`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 393`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 392`** (2 nodes): `DateTimePicker()`, `date-time-picker.tsx`
+- **Thin community `Community 394`** (2 nodes): `DateTimePicker()`, `date-time-picker.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 393`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 395`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 394`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 396`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 395`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 397`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 396`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 398`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 397`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 399`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 398`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 400`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 399`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 401`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 400`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 402`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 401`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 403`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 402`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 404`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 403`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 405`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 404`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 406`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 405`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 407`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 406`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 408`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 407`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 409`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 408`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 410`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 409`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 411`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 410`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 412`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 411`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 413`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 412`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 414`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 413`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 415`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 414`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 416`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 415`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 417`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 416`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 418`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 417`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 419`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 418`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 420`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 419`** (2 nodes): `useCartOperations.ts`, `useCartOperations()`
+- **Thin community `Community 421`** (2 nodes): `useCartOperations.ts`, `useCartOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 420`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 422`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 421`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 423`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 422`** (2 nodes): `useCustomerOperations.ts`, `useCustomerOperations()`
+- **Thin community `Community 424`** (2 nodes): `useCustomerOperations.ts`, `useCustomerOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 423`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 425`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 424`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
+- **Thin community `Community 426`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 425`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 427`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 426`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 428`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 427`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 429`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 428`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 430`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 429`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 431`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 430`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 432`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 431`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 433`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 432`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 434`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 433`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 435`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 434`** (2 nodes): `usePrint.ts`, `usePrint()`
+- **Thin community `Community 436`** (2 nodes): `usePrint.ts`, `usePrint()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 435`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 437`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 436`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 438`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 437`** (2 nodes): `useSessionManagement.ts`, `useSessionManagement()`
+- **Thin community `Community 439`** (2 nodes): `useSessionManagement.ts`, `useSessionManagement()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 438`** (2 nodes): `useSessionManagementExpense.ts`, `useSessionManagementExpense()`
+- **Thin community `Community 440`** (2 nodes): `useSessionManagementExpense.ts`, `useSessionManagementExpense()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 439`** (2 nodes): `useSessionManagerOperations.ts`, `useSessionManagerOperations()`
+- **Thin community `Community 441`** (2 nodes): `useSessionManagerOperations.ts`, `useSessionManagerOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 440`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 442`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 441`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 443`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 442`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 444`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 443`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 445`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 444`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 446`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 445`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 447`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 446`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 448`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 447`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 449`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 448`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 450`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 449`** (2 nodes): `LoginLayout()`, `_layout.tsx`
+- **Thin community `Community 451`** (2 nodes): `LoginLayout()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 450`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 452`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 451`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 453`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 452`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 454`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 453`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 455`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 454`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 456`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 455`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 457`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 456`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 458`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 457`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 459`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 458`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 460`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 459`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 461`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 460`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 462`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 461`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 463`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 462`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
+- **Thin community `Community 464`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 463`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 465`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 464`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 466`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 465`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 467`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 466`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 468`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 467`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 469`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 468`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 470`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 469`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 471`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 470`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 472`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 471`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 473`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 472`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 474`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 473`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 475`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 474`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 476`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 475`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 477`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 476`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 478`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 477`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 479`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 478`** (2 nodes): `LinkGroup()`, `Footer.tsx`
+- **Thin community `Community 480`** (2 nodes): `LinkGroup()`, `Footer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 479`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 481`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 480`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 482`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 481`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 483`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 482`** (2 nodes): `StoreCategoriesSubmenu()`, `NavigationBar.tsx`
+- **Thin community `Community 484`** (2 nodes): `StoreCategoriesSubmenu()`, `NavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 483`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 485`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 484`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 486`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 485`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 487`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 486`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 488`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 487`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 489`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 488`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 490`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 489`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 491`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 490`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 492`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 491`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 493`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 492`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 494`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 493`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 495`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 494`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 496`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 495`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 497`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 496`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 498`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 497`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 499`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 498`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 500`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 499`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 501`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 500`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 502`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 501`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 503`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 502`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 504`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 503`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 505`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 504`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 506`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 505`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 507`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 506`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 508`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 507`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 509`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 508`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 510`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 509`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 511`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 510`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 512`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 511`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 513`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 512`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 514`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 513`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 515`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 514`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 516`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 515`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 517`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 516`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 518`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 517`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 519`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 518`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 520`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 519`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 521`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 520`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 522`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 521`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 523`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 522`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 524`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 523`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 525`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 524`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 526`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 525`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 527`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 526`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 528`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 527`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 529`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 528`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 530`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 529`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 531`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 530`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 532`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 531`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 533`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 532`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 534`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 533`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 535`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 534`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 536`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 535`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 537`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 536`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 538`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 537`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 539`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 538`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 540`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 539`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 541`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 540`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 542`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 541`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 543`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 542`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 544`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 543`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 545`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 544`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 546`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 545`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 547`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 546`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 548`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 547`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 549`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 548`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 550`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 551`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 552`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 553`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 554`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 555`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 556`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 557`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 558`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 559`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 560`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 561`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 562`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 563`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 564`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 565`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 566`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 567`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 568`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (1 nodes): `api.d.ts`
+- **Thin community `Community 569`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (1 nodes): `api.js`
+- **Thin community `Community 570`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 571`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (1 nodes): `server.d.ts`
+- **Thin community `Community 572`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (1 nodes): `server.js`
+- **Thin community `Community 573`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (1 nodes): `app.ts`
+- **Thin community `Community 574`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (1 nodes): `auth.config.js`
+- **Thin community `Community 575`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (1 nodes): `auth.ts`
+- **Thin community `Community 576`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (1 nodes): `countries.ts`
+- **Thin community `Community 577`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (1 nodes): `email.ts`
+- **Thin community `Community 578`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (1 nodes): `ghana.ts`
+- **Thin community `Community 579`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (1 nodes): `payment.ts`
+- **Thin community `Community 580`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (1 nodes): `crons.ts`
+- **Thin community `Community 581`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 582`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 583`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 584`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 585`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (1 nodes): `env.ts`
+- **Thin community `Community 586`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (1 nodes): `analytics.ts`
+- **Thin community `Community 587`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (1 nodes): `auth.ts`
+- **Thin community `Community 588`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 589`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (1 nodes): `categories.ts`
+- **Thin community `Community 590`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (1 nodes): `colors.ts`
+- **Thin community `Community 591`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (1 nodes): `index.ts`
+- **Thin community `Community 592`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (1 nodes): `organizations.ts`
+- **Thin community `Community 593`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (1 nodes): `products.ts`
+- **Thin community `Community 594`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (1 nodes): `stores.ts`
+- **Thin community `Community 595`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 596`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (1 nodes): `index.ts`
+- **Thin community `Community 597`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (1 nodes): `bag.ts`
+- **Thin community `Community 598`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (1 nodes): `guest.ts`
+- **Thin community `Community 599`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (1 nodes): `index.ts`
+- **Thin community `Community 600`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (1 nodes): `me.ts`
+- **Thin community `Community 601`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (1 nodes): `offers.ts`
+- **Thin community `Community 602`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 603`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (1 nodes): `paystack.ts`
+- **Thin community `Community 604`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (1 nodes): `reviews.ts`
+- **Thin community `Community 605`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (1 nodes): `rewards.ts`
+- **Thin community `Community 606`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 607`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (1 nodes): `security.test.ts`
+- **Thin community `Community 608`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (1 nodes): `storefront.ts`
+- **Thin community `Community 609`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (1 nodes): `upsells.ts`
+- **Thin community `Community 610`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (1 nodes): `user.ts`
+- **Thin community `Community 611`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 612`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (1 nodes): `http.ts`
+- **Thin community `Community 613`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 614`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (1 nodes): `auth.ts`
+- **Thin community `Community 615`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 616`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 617`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (1 nodes): `categories.ts`
+- **Thin community `Community 618`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (1 nodes): `colors.ts`
+- **Thin community `Community 619`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 620`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (1 nodes): `expenseSessionItems.ts`
+- **Thin community `Community 621`** (1 nodes): `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (1 nodes): `expenseTransactions.ts`
+- **Thin community `Community 622`** (1 nodes): `expenseTransactions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 623`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 624`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 625`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (1 nodes): `organizations.ts`
+- **Thin community `Community 626`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 627`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (1 nodes): `posSessionItems.ts`
+- **Thin community `Community 628`** (1 nodes): `posSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 629`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (1 nodes): `productSku.ts`
+- **Thin community `Community 630`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (1 nodes): `productUtil.ts`
+- **Thin community `Community 631`** (1 nodes): `productUtil.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 632`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 633`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 634`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 635`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 636`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 637`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 638`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 639`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (1 nodes): `client.test.ts`
+- **Thin community `Community 640`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (1 nodes): `config.test.ts`
+- **Thin community `Community 641`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 642`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (1 nodes): `types.ts`
+- **Thin community `Community 643`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (1 nodes): `ResendOTP.ts`
+- **Thin community `Community 644`** (1 nodes): `ResendOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (1 nodes): `schema.ts`
+- **Thin community `Community 645`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 646`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 647`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 648`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 649`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (1 nodes): `cashier.ts`
+- **Thin community `Community 650`** (1 nodes): `cashier.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (1 nodes): `category.ts`
+- **Thin community `Community 651`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (1 nodes): `color.ts`
+- **Thin community `Community 652`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 653`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 654`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (1 nodes): `index.ts`
+- **Thin community `Community 655`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 656`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (1 nodes): `organization.ts`
+- **Thin community `Community 657`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 658`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (1 nodes): `product.ts`
+- **Thin community `Community 659`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 660`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 661`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (1 nodes): `store.ts`
+- **Thin community `Community 662`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 663`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 664`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (1 nodes): `customer.ts`
+- **Thin community `Community 665`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 666`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 667`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 668`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 669`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (1 nodes): `index.ts`
+- **Thin community `Community 670`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (1 nodes): `posSession.ts`
+- **Thin community `Community 671`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 672`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 673`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 674`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 675`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (1 nodes): `analytics.ts`
+- **Thin community `Community 676`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (1 nodes): `bag.ts`
+- **Thin community `Community 677`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 678`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 679`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 680`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (1 nodes): `customer.ts`
+- **Thin community `Community 681`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (1 nodes): `guest.ts`
+- **Thin community `Community 682`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (1 nodes): `index.ts`
+- **Thin community `Community 683`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (1 nodes): `offer.ts`
+- **Thin community `Community 684`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 685`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 686`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (1 nodes): `review.ts`
+- **Thin community `Community 687`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (1 nodes): `rewards.ts`
+- **Thin community `Community 688`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 689`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 690`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 691`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 692`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 693`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 694`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (1 nodes): `bag.ts`
+- **Thin community `Community 695`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 696`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (1 nodes): `customer.ts`
+- **Thin community `Community 697`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (1 nodes): `guest.ts`
+- **Thin community `Community 698`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 699`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (1 nodes): `payment.ts`
+- **Thin community `Community 700`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 701`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (1 nodes): `rewards.ts`
+- **Thin community `Community 702`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 703`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 704`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (1 nodes): `users.ts`
+- **Thin community `Community 705`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (1 nodes): `payment.ts`
+- **Thin community `Community 706`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 707`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (1 nodes): `index.ts`
+- **Thin community `Community 708`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 709`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 710`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 711`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 712`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 713`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 714`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 715`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (1 nodes): `constants.ts`
+- **Thin community `Community 716`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 717`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 718`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 719`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (1 nodes): `types.ts`
+- **Thin community `Community 720`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 721`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 722`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 723`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 724`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 725`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 726`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 727`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 728`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (1 nodes): `columns.tsx`
+- **Thin community `Community 729`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 730`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 731`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 732`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 733`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (1 nodes): `columns.tsx`
+- **Thin community `Community 734`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 735`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 736`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (1 nodes): `chart.tsx`
+- **Thin community `Community 737`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (1 nodes): `columns.tsx`
+- **Thin community `Community 738`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 739`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 740`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (1 nodes): `columns.tsx`
+- **Thin community `Community 741`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (1 nodes): `constants.ts`
+- **Thin community `Community 742`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 743`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 744`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 745`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (1 nodes): `data.ts`
+- **Thin community `Community 746`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (1 nodes): `columns.tsx`
+- **Thin community `Community 747`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 748`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 749`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (1 nodes): `columns.tsx`
+- **Thin community `Community 750`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 751`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 752`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 753`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 754`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 755`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (1 nodes): `app-sidebar.tsx`
+- **Thin community `Community 756`** (1 nodes): `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 757`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (1 nodes): `constants.ts`
+- **Thin community `Community 758`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 759`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 760`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 761`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (1 nodes): `data.ts`
+- **Thin community `Community 762`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 763`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 764`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (1 nodes): `columns.tsx`
+- **Thin community `Community 765`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 766`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 767`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 768`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 769`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 770`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (1 nodes): `columns.tsx`
+- **Thin community `Community 771`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (1 nodes): `constants.ts`
+- **Thin community `Community 772`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 773`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 774`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 775`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 776`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (1 nodes): `index.tsx`
+- **Thin community `Community 777`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (1 nodes): `columns.tsx`
+- **Thin community `Community 778`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 779`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 780`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 781`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (1 nodes): `ExpenseCompletion.tsx`
+- **Thin community `Community 782`** (1 nodes): `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 783`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 784`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 785`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (1 nodes): `constants.ts`
+- **Thin community `Community 786`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 787`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 788`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 789`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (1 nodes): `data.ts`
+- **Thin community `Community 790`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (1 nodes): `constants.ts`
+- **Thin community `Community 791`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 792`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 793`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 794`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 795`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (1 nodes): `data.ts`
+- **Thin community `Community 796`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 797`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (1 nodes): `constants.ts`
+- **Thin community `Community 798`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 799`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 800`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 801`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 802`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (1 nodes): `data.ts`
+- **Thin community `Community 803`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 804`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (1 nodes): `CartItems.tsx`
+- **Thin community `Community 805`** (1 nodes): `CartItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (1 nodes): `CashierAuthDialog.tsx`
+- **Thin community `Community 806`** (1 nodes): `CashierAuthDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 807`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 808`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (1 nodes): `SearchResultsSection.tsx`
+- **Thin community `Community 809`** (1 nodes): `SearchResultsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (1 nodes): `ExpenseReportView.tsx`
+- **Thin community `Community 810`** (1 nodes): `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 811`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (1 nodes): `TransactionView.tsx`
+- **Thin community `Community 812`** (1 nodes): `TransactionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (1 nodes): `types.ts`
+- **Thin community `Community 813`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 814`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 815`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 816`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (1 nodes): `ProductDetailView.tsx`
+- **Thin community `Community 817`** (1 nodes): `ProductDetailView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (1 nodes): `ProductStatus.tsx`
+- **Thin community `Community 818`** (1 nodes): `ProductStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (1 nodes): `CategoryListView.tsx`
+- **Thin community `Community 819`** (1 nodes): `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 820`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (1 nodes): `Products.tsx`
+- **Thin community `Community 821`** (1 nodes): `Products.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 822`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 823`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 824`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 825`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 826`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 827`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 828`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 829`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 830`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (1 nodes): `data.ts`
+- **Thin community `Community 831`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 832`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (1 nodes): `PromoCodePreview.tsx`
+- **Thin community `Community 833`** (1 nodes): `PromoCodePreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 834`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 835`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 836`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (1 nodes): `columns.tsx`
+- **Thin community `Community 837`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 838`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 839`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 840`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 841`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 842`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (1 nodes): `columns.tsx`
+- **Thin community `Community 843`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (1 nodes): `constants.ts`
+- **Thin community `Community 844`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 845`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 846`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 847`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (1 nodes): `data.ts`
+- **Thin community `Community 848`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (1 nodes): `types.ts`
+- **Thin community `Community 849`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 850`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 851`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 852`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 853`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 854`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (1 nodes): `index.tsx`
+- **Thin community `Community 855`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 856`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 857`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (1 nodes): `button.tsx`
+- **Thin community `Community 858`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 859`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (1 nodes): `calendar.tsx`
+- **Thin community `Community 860`** (1 nodes): `calendar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (1 nodes): `card.tsx`
+- **Thin community `Community 861`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 862`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 863`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (1 nodes): `command.tsx`
+- **Thin community `Community 864`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 865`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 866`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 867`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (1 nodes): `form.tsx`
+- **Thin community `Community 868`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (1 nodes): `icons.tsx`
+- **Thin community `Community 869`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 870`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (1 nodes): `input.tsx`
+- **Thin community `Community 871`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 872`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (1 nodes): `popover.tsx`
+- **Thin community `Community 873`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 874`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 875`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (1 nodes): `select.tsx`
+- **Thin community `Community 876`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (1 nodes): `separator.tsx`
+- **Thin community `Community 877`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 878`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (1 nodes): `switch.tsx`
+- **Thin community `Community 879`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (1 nodes): `table.tsx`
+- **Thin community `Community 880`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 881`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 882`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 883`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 884`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 885`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 886`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 887`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (1 nodes): `columns.tsx`
+- **Thin community `Community 888`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (1 nodes): `constants.ts`
+- **Thin community `Community 889`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 890`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 891`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 892`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (1 nodes): `data.ts`
+- **Thin community `Community 893`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 894`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 895`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (1 nodes): `columns.tsx`
+- **Thin community `Community 896`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 897`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 898`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 899`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 900`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 901`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 902`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 903`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 904`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 905`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (1 nodes): `UserBehaviorInsights.tsx`
+- **Thin community `Community 906`** (1 nodes): `UserBehaviorInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (1 nodes): `index.ts`
+- **Thin community `Community 907`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (1 nodes): `config.ts`
+- **Thin community `Community 908`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 909`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 910`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 911`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (1 nodes): `aws.ts`
+- **Thin community `Community 912`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (1 nodes): `constants.ts`
+- **Thin community `Community 913`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (1 nodes): `countries.ts`
+- **Thin community `Community 914`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (1 nodes): `ghana.ts`
+- **Thin community `Community 915`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 916`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (1 nodes): `constants.ts`
+- **Thin community `Community 917`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 918`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (1 nodes): `category.ts`
+- **Thin community `Community 919`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (1 nodes): `product.ts`
+- **Thin community `Community 920`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (1 nodes): `store.ts`
+- **Thin community `Community 921`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 922`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (1 nodes): `user.ts`
+- **Thin community `Community 923`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 924`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 925`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 926`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (1 nodes): `__root.tsx`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (1 nodes): `index.tsx`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (1 nodes): `index.tsx`
+- **Thin community `Community 927`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 928`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 929`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 930`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 931`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 932`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 933`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (1 nodes): `index.tsx`
+- **Thin community `Community 934`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 935`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 936`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 937`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `home.tsx`
+- **Thin community `Community 938`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 939`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 940`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 941`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `index.tsx`
+- **Thin community `Community 942`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 943`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 944`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 945`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `index.tsx`
+- **Thin community `Community 946`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 947`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 948`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 949`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 950`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 951`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 952`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `expense.index.tsx`
+- **Thin community `Community 953`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `index.tsx`
+- **Thin community `Community 954`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 955`** (1 nodes): `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 956`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 957`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 958`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `edit.tsx`
+- **Thin community `Community 959`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `index.tsx`
+- **Thin community `Community 960`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `index.tsx`
+- **Thin community `Community 961`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `new.tsx`
+- **Thin community `Community 962`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 963`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 964`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 965`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 966`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `index.tsx`
+- **Thin community `Community 967`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `new.tsx`
+- **Thin community `Community 968`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 969`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 970`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 971`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `index.tsx`
+- **Thin community `Community 972`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 973`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `_layout.index.tsx`
+- **Thin community `Community 974`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 975`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 976`** (1 nodes): `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `posStore.ts`
+- **Thin community `Community 977`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `setup.ts`
+- **Thin community `Community 978`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `usePrint.test.ts`
+- **Thin community `Community 979`** (1 nodes): `posStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 980`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `types.ts`
+- **Thin community `Community 981`** (1 nodes): `usePrint.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 982`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 983`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 984`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `global.d.ts`
+- **Thin community `Community 985`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 986`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `types.ts`
+- **Thin community `Community 987`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 988`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (1 nodes): `client.tsx`
+- **Thin community `Community 989`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 990`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 991`** (1 nodes): `client.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 992`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 993`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 994`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `schema.ts`
+- **Thin community `Community 995`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 996`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 997`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 998`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 999`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1000`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1001`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1002`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1003`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1004`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `types.ts`
+- **Thin community `Community 1005`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1006`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1007`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1008`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1009`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1010`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `constants.ts`
+- **Thin community `Community 1011`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1012`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `About.tsx`
+- **Thin community `Community 1013`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1014`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1015`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1016`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1017`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1018`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1019`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1020`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1021`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `types.ts`
+- **Thin community `Community 1022`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1023`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1024`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1025`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1026`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1027`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1028`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1029`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1030`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1031`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `button.tsx`
+- **Thin community `Community 1032`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `card.tsx`
+- **Thin community `Community 1033`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1034`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `command.tsx`
+- **Thin community `Community 1035`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1036`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1037`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1038`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `form.tsx`
+- **Thin community `Community 1039`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1040`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1041`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1042`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1043`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `input.tsx`
+- **Thin community `Community 1044`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `label.tsx`
+- **Thin community `Community 1045`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1046`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1047`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1048`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `index.ts`
+- **Thin community `Community 1049`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `types.ts`
+- **Thin community `Community 1050`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1051`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1052`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1053`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1054`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `select.tsx`
+- **Thin community `Community 1055`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1056`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1057`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `table.tsx`
+- **Thin community `Community 1058`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1059`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1060`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1061`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1062`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1063`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `config.ts`
+- **Thin community `Community 1064`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1065`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1066`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1067`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `constants.ts`
+- **Thin community `Community 1068`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `countries.ts`
+- **Thin community `Community 1069`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1070`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1071`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1072`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1073`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `index.ts`
+- **Thin community `Community 1074`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `store.ts`
+- **Thin community `Community 1075`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `bag.ts`
+- **Thin community `Community 1076`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1077`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `category.ts`
+- **Thin community `Community 1078`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `organization.ts`
+- **Thin community `Community 1079`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `product.ts`
+- **Thin community `Community 1080`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `store.ts`
+- **Thin community `Community 1081`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1082`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `user.ts`
+- **Thin community `Community 1083`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `states.ts`
+- **Thin community `Community 1084`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1085`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1086`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1087`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1088`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1089`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1090`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `index.tsx`
+- **Thin community `Community 1091`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1092`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1093`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1094`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1095`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `index.tsx`
+- **Thin community `Community 1096`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1097`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1098`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1099`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `index.tsx`
+- **Thin community `Community 1100`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1101`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `ssr.tsx`
+- **Thin community `Community 1102`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1103`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1104`** (1 nodes): `ssr.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1105`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `index.js`
+- **Thin community `Community 1106`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1107`** (1 nodes): `vitest.setup.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1108`** (1 nodes): `index.js`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1109`** (1 nodes): `harness-behavior-scenarios.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
@@ -7264,7 +7274,7 @@ _Questions this graph is uniquely positioned to answer:_
   _Cohesion score 0.13 - nodes in this community are weakly interconnected._
 - **Should `Community 8` be split into smaller, more focused modules?**
   _Cohesion score 0.11 - nodes in this community are weakly interconnected._
-- **Should `Community 12` be split into smaller, more focused modules?**
+- **Should `Community 13` be split into smaller, more focused modules?**
   _Cohesion score 0.12 - nodes in this community are weakly interconnected._
-- **Should `Community 15` be split into smaller, more focused modules?**
+- **Should `Community 16` be split into smaller, more focused modules?**
   _Cohesion score 0.13 - nodes in this community are weakly interconnected._

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -9,7 +9,7 @@
       "source_file": "packages/athena-webapp/convex/_generated/api.d.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_generated_api_d_ts",
-      "community": 567
+      "community": 569
     },
     {
       "label": "api.js",
@@ -17,7 +17,7 @@
       "source_file": "packages/athena-webapp/convex/_generated/api.js",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_generated_api_js",
-      "community": 568
+      "community": 570
     },
     {
       "label": "dataModel.d.ts",
@@ -25,7 +25,7 @@
       "source_file": "packages/athena-webapp/convex/_generated/dataModel.d.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_generated_datamodel_d_ts",
-      "community": 569
+      "community": 571
     },
     {
       "label": "server.d.ts",
@@ -33,7 +33,7 @@
       "source_file": "packages/athena-webapp/convex/_generated/server.d.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_generated_server_d_ts",
-      "community": 570
+      "community": 572
     },
     {
       "label": "server.js",
@@ -41,7 +41,7 @@
       "source_file": "packages/athena-webapp/convex/_generated/server.js",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_generated_server_js",
-      "community": 571
+      "community": 573
     },
     {
       "label": "app.ts",
@@ -49,7 +49,7 @@
       "source_file": "packages/athena-webapp/convex/app.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_app_ts",
-      "community": 572
+      "community": 574
     },
     {
       "label": "auth.config.js",
@@ -57,7 +57,7 @@
       "source_file": "packages/athena-webapp/convex/auth.config.js",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_auth_config_js",
-      "community": 573
+      "community": 575
     },
     {
       "label": "auth.ts",
@@ -65,7 +65,7 @@
       "source_file": "packages/athena-webapp/convex/auth.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_auth_ts",
-      "community": 574
+      "community": 576
     },
     {
       "label": "index.ts",
@@ -73,7 +73,7 @@
       "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_cache_index_ts",
-      "community": 56
+      "community": 57
     },
     {
       "label": "ValkeyClient",
@@ -81,7 +81,7 @@
       "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L4",
       "id": "index_valkeyclient",
-      "community": 56
+      "community": 57
     },
     {
       "label": ".constructor()",
@@ -89,7 +89,7 @@
       "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L11",
       "id": "index_valkeyclient_constructor",
-      "community": 56
+      "community": 57
     },
     {
       "label": ".get()",
@@ -97,7 +97,7 @@
       "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L20",
       "id": "index_valkeyclient_get",
-      "community": 56
+      "community": 57
     },
     {
       "label": ".set()",
@@ -105,7 +105,7 @@
       "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L48",
       "id": "index_valkeyclient_set",
-      "community": 56
+      "community": 57
     },
     {
       "label": ".invalidate()",
@@ -113,7 +113,7 @@
       "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L75",
       "id": "index_valkeyclient_invalidate",
-      "community": 56
+      "community": 57
     },
     {
       "label": "r2.ts",
@@ -121,7 +121,7 @@
       "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_cloudflare_r2_ts",
-      "community": 82
+      "community": 83
     },
     {
       "label": "uploadFileToR2()",
@@ -129,7 +129,7 @@
       "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
       "source_location": "L21",
       "id": "r2_uploadfiletor2",
-      "community": 82
+      "community": 83
     },
     {
       "label": "deleteFileInR2()",
@@ -137,7 +137,7 @@
       "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
       "source_location": "L40",
       "id": "r2_deletefileinr2",
-      "community": 82
+      "community": 83
     },
     {
       "label": "deleteDirectoryInR2()",
@@ -145,7 +145,7 @@
       "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
       "source_location": "L62",
       "id": "r2_deletedirectoryinr2",
-      "community": 82
+      "community": 83
     },
     {
       "label": "listItemsInR2Directory()",
@@ -153,7 +153,7 @@
       "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
       "source_location": "L106",
       "id": "r2_listitemsinr2directory",
-      "community": 82
+      "community": 83
     },
     {
       "label": "stream.ts",
@@ -161,7 +161,7 @@
       "source_file": "packages/athena-webapp/convex/cloudflare/stream.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_cloudflare_stream_ts",
-      "community": 270
+      "community": 272
     },
     {
       "label": "getCloudflareConfig()",
@@ -169,7 +169,7 @@
       "source_file": "packages/athena-webapp/convex/cloudflare/stream.ts",
       "source_location": "L8",
       "id": "stream_getcloudflareconfig",
-      "community": 270
+      "community": 272
     },
     {
       "label": "countries.ts",
@@ -177,7 +177,7 @@
       "source_file": "packages/athena-webapp/convex/constants/countries.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_constants_countries_ts",
-      "community": 575
+      "community": 577
     },
     {
       "label": "email.ts",
@@ -185,7 +185,7 @@
       "source_file": "packages/athena-webapp/convex/constants/email.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_constants_email_ts",
-      "community": 576
+      "community": 578
     },
     {
       "label": "ghana.ts",
@@ -193,7 +193,7 @@
       "source_file": "packages/athena-webapp/convex/constants/ghana.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_constants_ghana_ts",
-      "community": 577
+      "community": 579
     },
     {
       "label": "payment.ts",
@@ -201,7 +201,7 @@
       "source_file": "packages/athena-webapp/convex/constants/payment.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_constants_payment_ts",
-      "community": 578
+      "community": 580
     },
     {
       "label": "crons.ts",
@@ -209,7 +209,7 @@
       "source_file": "packages/athena-webapp/convex/crons.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_crons_ts",
-      "community": 579
+      "community": 581
     },
     {
       "label": "DiscountCode.tsx",
@@ -217,7 +217,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_emails_discountcode_tsx",
-      "community": 162
+      "community": 164
     },
     {
       "label": "ProductCard()",
@@ -225,7 +225,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
       "source_location": "L33",
       "id": "discountcode_productcard",
-      "community": 162
+      "community": 164
     },
     {
       "label": "chunkProducts()",
@@ -233,7 +233,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
       "source_location": "L98",
       "id": "discountcode_chunkproducts",
-      "community": 162
+      "community": 164
     },
     {
       "label": "DiscountReminder.tsx",
@@ -241,7 +241,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_emails_discountreminder_tsx",
-      "community": 163
+      "community": 165
     },
     {
       "label": "ProductCard()",
@@ -249,7 +249,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
       "source_location": "L31",
       "id": "discountreminder_productcard",
-      "community": 163
+      "community": 165
     },
     {
       "label": "chunkProducts()",
@@ -257,7 +257,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
       "source_location": "L85",
       "id": "discountreminder_chunkproducts",
-      "community": 163
+      "community": 165
     },
     {
       "label": "FeedbackRequest.tsx",
@@ -265,7 +265,7 @@
       "source_file": "packages/athena-webapp/convex/emails/FeedbackRequest.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_emails_feedbackrequest_tsx",
-      "community": 580
+      "community": 582
     },
     {
       "label": "NewOrderAdmin.tsx",
@@ -273,7 +273,7 @@
       "source_file": "packages/athena-webapp/convex/emails/NewOrderAdmin.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_emails_neworderadmin_tsx",
-      "community": 581
+      "community": 583
     },
     {
       "label": "OrderEmail.tsx",
@@ -281,7 +281,7 @@
       "source_file": "packages/athena-webapp/convex/emails/OrderEmail.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_emails_orderemail_tsx",
-      "community": 582
+      "community": 584
     },
     {
       "label": "PosReceiptEmail.tsx",
@@ -289,7 +289,7 @@
       "source_file": "packages/athena-webapp/convex/emails/PosReceiptEmail.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_emails_posreceiptemail_tsx",
-      "community": 583
+      "community": 585
     },
     {
       "label": "VerificationCode.tsx",
@@ -297,7 +297,7 @@
       "source_file": "packages/athena-webapp/convex/emails/VerificationCode.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_emails_verificationcode_tsx",
-      "community": 271
+      "community": 273
     },
     {
       "label": "VerificationCode()",
@@ -305,7 +305,7 @@
       "source_file": "packages/athena-webapp/convex/emails/VerificationCode.tsx",
       "source_location": "L18",
       "id": "verificationcode_verificationcode",
-      "community": 271
+      "community": 273
     },
     {
       "label": "env.ts",
@@ -313,7 +313,7 @@
       "source_file": "packages/athena-webapp/convex/env.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_env_ts",
-      "community": 584
+      "community": 586
     },
     {
       "label": "analytics.ts",
@@ -321,7 +321,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/analytics.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_analytics_ts",
-      "community": 585
+      "community": 587
     },
     {
       "label": "auth.ts",
@@ -329,7 +329,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/auth.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_auth_ts",
-      "community": 586
+      "community": 588
     },
     {
       "label": "bannerMessage.ts",
@@ -337,7 +337,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/bannerMessage.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_bannermessage_ts",
-      "community": 587
+      "community": 589
     },
     {
       "label": "categories.ts",
@@ -345,7 +345,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/categories.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_categories_ts",
-      "community": 588
+      "community": 590
     },
     {
       "label": "colors.ts",
@@ -353,7 +353,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/colors.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_colors_ts",
-      "community": 589
+      "community": 591
     },
     {
       "label": "index.ts",
@@ -361,7 +361,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/index.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_index_ts",
-      "community": 590
+      "community": 592
     },
     {
       "label": "organizations.ts",
@@ -369,7 +369,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/organizations.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_organizations_ts",
-      "community": 591
+      "community": 593
     },
     {
       "label": "products.ts",
@@ -377,7 +377,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/products.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_products_ts",
-      "community": 592
+      "community": 594
     },
     {
       "label": "stores.ts",
@@ -385,7 +385,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/stores.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_stores_ts",
-      "community": 593
+      "community": 595
     },
     {
       "label": "subcategories.ts",
@@ -393,7 +393,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/subcategories.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_subcategories_ts",
-      "community": 594
+      "community": 596
     },
     {
       "label": "index.ts",
@@ -401,7 +401,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/index.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_payments_routes_index_ts",
-      "community": 595
+      "community": 597
     },
     {
       "label": "mtnMomo.ts",
@@ -409,7 +409,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/mtnMomo.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_payments_routes_mtnmomo_ts",
-      "community": 272
+      "community": 274
     },
     {
       "label": "handleCollectionNotification()",
@@ -417,7 +417,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/mtnMomo.ts",
       "source_location": "L10",
       "id": "mtnmomo_handlecollectionnotification",
-      "community": 272
+      "community": 274
     },
     {
       "label": "bag.ts",
@@ -425,7 +425,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/bag.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_bag_ts",
-      "community": 596
+      "community": 598
     },
     {
       "label": "checkout.ts",
@@ -433,7 +433,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/checkout.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_checkout_ts",
-      "community": 119
+      "community": 120
     },
     {
       "label": "hasValidCanonicalBagItem()",
@@ -441,7 +441,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/checkout.ts",
       "source_location": "L84",
       "id": "checkout_hasvalidcanonicalbagitem",
-      "community": 119
+      "community": 120
     },
     {
       "label": "hasValidSessionItems()",
@@ -449,7 +449,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/checkout.ts",
       "source_location": "L95",
       "id": "checkout_hasvalidsessionitems",
-      "community": 119
+      "community": 120
     },
     {
       "label": "hasAllVisibileSessionItems()",
@@ -457,7 +457,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/checkout.ts",
       "source_location": "L109",
       "id": "checkout_hasallvisibilesessionitems",
-      "community": 119
+      "community": 120
     },
     {
       "label": "guest.ts",
@@ -465,7 +465,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/guest.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_guest_ts",
-      "community": 597
+      "community": 599
     },
     {
       "label": "index.ts",
@@ -473,7 +473,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/index.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_index_ts",
-      "community": 598
+      "community": 600
     },
     {
       "label": "me.ts",
@@ -481,7 +481,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/me.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_me_ts",
-      "community": 599
+      "community": 601
     },
     {
       "label": "offers.ts",
@@ -489,7 +489,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/offers.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_offers_ts",
-      "community": 600
+      "community": 602
     },
     {
       "label": "onlineOrder.ts",
@@ -497,7 +497,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/onlineOrder.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_onlineorder_ts",
-      "community": 601
+      "community": 603
     },
     {
       "label": "paystack.ts",
@@ -505,7 +505,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/paystack.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_paystack_ts",
-      "community": 602
+      "community": 604
     },
     {
       "label": "reviews.ts",
@@ -513,7 +513,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/reviews.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_reviews_ts",
-      "community": 603
+      "community": 605
     },
     {
       "label": "rewards.ts",
@@ -521,7 +521,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/rewards.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_rewards_ts",
-      "community": 604
+      "community": 606
     },
     {
       "label": "savedBag.ts",
@@ -529,7 +529,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/savedBag.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_savedbag_ts",
-      "community": 605
+      "community": 607
     },
     {
       "label": "security.test.ts",
@@ -537,7 +537,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_test_ts",
-      "community": 606
+      "community": 608
     },
     {
       "label": "security.ts",
@@ -545,7 +545,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_ts",
-      "community": 57
+      "community": 58
     },
     {
       "label": "hasValidPositiveQuantity()",
@@ -553,7 +553,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
       "source_location": "L27",
       "id": "security_hasvalidpositivequantity",
-      "community": 57
+      "community": 58
     },
     {
       "label": "isAuthorizedResourceOwner()",
@@ -561,7 +561,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
       "source_location": "L31",
       "id": "security_isauthorizedresourceowner",
-      "community": 57
+      "community": 58
     },
     {
       "label": "buildCanonicalCheckoutProducts()",
@@ -569,7 +569,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
       "source_location": "L42",
       "id": "security_buildcanonicalcheckoutproducts",
-      "community": 57
+      "community": 58
     },
     {
       "label": "isAmountTampered()",
@@ -577,7 +577,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
       "source_location": "L65",
       "id": "security_isamounttampered",
-      "community": 57
+      "community": 58
     },
     {
       "label": "isDuplicateChargeSuccess()",
@@ -585,7 +585,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
       "source_location": "L76",
       "id": "security_isduplicatechargesuccess",
-      "community": 57
+      "community": 58
     },
     {
       "label": "storefront.ts",
@@ -593,7 +593,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/storefront.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_storefront_ts",
-      "community": 607
+      "community": 609
     },
     {
       "label": "upsells.ts",
@@ -601,7 +601,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/upsells.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_upsells_ts",
-      "community": 608
+      "community": 610
     },
     {
       "label": "user.ts",
@@ -609,7 +609,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/user.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_user_ts",
-      "community": 609
+      "community": 611
     },
     {
       "label": "userOffers.ts",
@@ -617,7 +617,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/userOffers.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_useroffers_ts",
-      "community": 610
+      "community": 612
     },
     {
       "label": "routerComposition.test.ts",
@@ -625,7 +625,7 @@
       "source_file": "packages/athena-webapp/convex/http/routerComposition.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_routercomposition_test_ts",
-      "community": 273
+      "community": 275
     },
     {
       "label": "readProjectFile()",
@@ -633,7 +633,7 @@
       "source_file": "packages/athena-webapp/convex/http/routerComposition.test.ts",
       "source_location": "L6",
       "id": "routercomposition_test_readprojectfile",
-      "community": 273
+      "community": 275
     },
     {
       "label": "utils.ts",
@@ -641,7 +641,7 @@
       "source_file": "packages/athena-webapp/convex/http/utils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_utils_ts",
-      "community": 164
+      "community": 166
     },
     {
       "label": "getStoreDataFromRequest()",
@@ -649,7 +649,7 @@
       "source_file": "packages/athena-webapp/convex/http/utils.ts",
       "source_location": "L5",
       "id": "utils_getstoredatafromrequest",
-      "community": 164
+      "community": 166
     },
     {
       "label": "getStorefrontUserFromRequest()",
@@ -657,7 +657,7 @@
       "source_file": "packages/athena-webapp/convex/http/utils.ts",
       "source_location": "L12",
       "id": "utils_getstorefrontuserfromrequest",
-      "community": 164
+      "community": 166
     },
     {
       "label": "http.ts",
@@ -665,7 +665,7 @@
       "source_file": "packages/athena-webapp/convex/http.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_ts",
-      "community": 611
+      "community": 613
     },
     {
       "label": "athenaUser.ts",
@@ -673,7 +673,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/athenaUser.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_athenauser_ts",
-      "community": 612
+      "community": 614
     },
     {
       "label": "auth.ts",
@@ -681,7 +681,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/auth.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_auth_ts",
-      "community": 613
+      "community": 615
     },
     {
       "label": "bannerMessage.ts",
@@ -689,7 +689,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/bannerMessage.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_bannermessage_ts",
-      "community": 614
+      "community": 616
     },
     {
       "label": "bestSeller.ts",
@@ -697,7 +697,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/bestSeller.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_bestseller_ts",
-      "community": 615
+      "community": 617
     },
     {
       "label": "cashier.ts",
@@ -705,7 +705,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/cashier.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_cashier_ts",
-      "community": 274
+      "community": 276
     },
     {
       "label": "authenticateHandler()",
@@ -713,7 +713,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/cashier.ts",
       "source_location": "L239",
       "id": "cashier_authenticatehandler",
-      "community": 274
+      "community": 276
     },
     {
       "label": "categories.ts",
@@ -721,7 +721,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/categories.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_categories_ts",
-      "community": 616
+      "community": 618
     },
     {
       "label": "colors.ts",
@@ -729,7 +729,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/colors.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_colors_ts",
-      "community": 617
+      "community": 619
     },
     {
       "label": "complimentaryProduct.ts",
@@ -737,7 +737,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/complimentaryProduct.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_complimentaryproduct_ts",
-      "community": 618
+      "community": 620
     },
     {
       "label": "expenseSessionItems.ts",
@@ -745,7 +745,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessionItems.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_expensesessionitems_ts",
-      "community": 619
+      "community": 621
     },
     {
       "label": "expenseSessions.ts",
@@ -753,7 +753,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_expensesessions_ts",
-      "community": 120
+      "community": 121
     },
     {
       "label": "buildNextExpenseSessionNumber()",
@@ -761,7 +761,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
       "source_location": "L33",
       "id": "expensesessions_buildnextexpensesessionnumber",
-      "community": 120
+      "community": 121
     },
     {
       "label": "loadExpenseSessionItems()",
@@ -769,7 +769,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
       "source_location": "L41",
       "id": "expensesessions_loadexpensesessionitems",
-      "community": 120
+      "community": 121
     },
     {
       "label": "listExpenseSessionsByStatusBefore()",
@@ -777,7 +777,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.ts",
       "source_location": "L66",
       "id": "expensesessions_listexpensesessionsbystatusbefore",
-      "community": 120
+      "community": 121
     },
     {
       "label": "expenseTransactions.ts",
@@ -785,7 +785,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_expensetransactions_ts",
-      "community": 620
+      "community": 622
     },
     {
       "label": "featuredItem.ts",
@@ -793,7 +793,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/featuredItem.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_featureditem_ts",
-      "community": 621
+      "community": 623
     },
     {
       "label": "expenseSessionExpiration.ts",
@@ -801,7 +801,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionExpiration.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionexpiration_ts",
-      "community": 121
+      "community": 122
     },
     {
       "label": "calculateExpenseSessionExpiration()",
@@ -809,7 +809,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionExpiration.ts",
       "source_location": "L21",
       "id": "expensesessionexpiration_calculateexpensesessionexpiration",
-      "community": 121
+      "community": 122
     },
     {
       "label": "getExpenseSessionExpiryDuration()",
@@ -817,7 +817,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionExpiration.ts",
       "source_location": "L35",
       "id": "expensesessionexpiration_getexpensesessionexpiryduration",
-      "community": 121
+      "community": 122
     },
     {
       "label": "getExpenseSessionExpiryDurationMinutes()",
@@ -825,7 +825,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionExpiration.ts",
       "source_location": "L45",
       "id": "expensesessionexpiration_getexpensesessionexpirydurationminutes",
-      "community": 121
+      "community": 122
     },
     {
       "label": "expenseSessionValidation.ts",
@@ -833,7 +833,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionvalidation_ts",
-      "community": 83
+      "community": 84
     },
     {
       "label": "validateExpenseSessionExists()",
@@ -841,7 +841,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
       "source_location": "L19",
       "id": "expensesessionvalidation_validateexpensesessionexists",
-      "community": 83
+      "community": 84
     },
     {
       "label": "validateExpenseSessionActive()",
@@ -849,7 +849,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
       "source_location": "L39",
       "id": "expensesessionvalidation_validateexpensesessionactive",
-      "community": 83
+      "community": 84
     },
     {
       "label": "validateExpenseSessionModifiable()",
@@ -857,7 +857,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
       "source_location": "L92",
       "id": "expensesessionvalidation_validateexpensesessionmodifiable",
-      "community": 83
+      "community": 84
     },
     {
       "label": "validateExpenseItemBelongsToSession()",
@@ -865,7 +865,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
       "source_location": "L135",
       "id": "expensesessionvalidation_validateexpenseitembelongstosession",
-      "community": 83
+      "community": 84
     },
     {
       "label": "inventoryHolds.ts",
@@ -873,7 +873,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_helpers_inventoryholds_ts",
-      "community": 45
+      "community": 46
     },
     {
       "label": "validateInventoryAvailability()",
@@ -881,7 +881,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
       "source_location": "L20",
       "id": "inventoryholds_validateinventoryavailability",
-      "community": 45
+      "community": 46
     },
     {
       "label": "acquireInventoryHold()",
@@ -889,7 +889,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
       "source_location": "L76",
       "id": "inventoryholds_acquireinventoryhold",
-      "community": 45
+      "community": 46
     },
     {
       "label": "releaseInventoryHold()",
@@ -897,7 +897,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
       "source_location": "L114",
       "id": "inventoryholds_releaseinventoryhold",
-      "community": 45
+      "community": 46
     },
     {
       "label": "adjustInventoryHold()",
@@ -905,7 +905,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
       "source_location": "L161",
       "id": "inventoryholds_adjustinventoryhold",
-      "community": 45
+      "community": 46
     },
     {
       "label": "acquireInventoryHoldsBatch()",
@@ -913,7 +913,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
       "source_location": "L190",
       "id": "inventoryholds_acquireinventoryholdsbatch",
-      "community": 45
+      "community": 46
     },
     {
       "label": "releaseInventoryHoldsBatch()",
@@ -921,7 +921,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/inventoryHolds.ts",
       "source_location": "L239",
       "id": "inventoryholds_releaseinventoryholdsbatch",
-      "community": 45
+      "community": 46
     },
     {
       "label": "resultTypes.ts",
@@ -929,7 +929,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_helpers_resulttypes_ts",
-      "community": 26
+      "community": 27
     },
     {
       "label": "success()",
@@ -937,7 +937,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L21",
       "id": "resulttypes_success",
-      "community": 26
+      "community": 27
     },
     {
       "label": "error()",
@@ -945,7 +945,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L28",
       "id": "resulttypes_error",
-      "community": 26
+      "community": 27
     },
     {
       "label": "itemSuccess()",
@@ -953,7 +953,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L140",
       "id": "resulttypes_itemsuccess",
-      "community": 26
+      "community": 27
     },
     {
       "label": "operationSuccess()",
@@ -961,7 +961,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L150",
       "id": "resulttypes_operationsuccess",
-      "community": 26
+      "community": 27
     },
     {
       "label": "sessionSuccess()",
@@ -969,7 +969,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L157",
       "id": "resulttypes_sessionsuccess",
-      "community": 26
+      "community": 27
     },
     {
       "label": "isSuccess()",
@@ -977,7 +977,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L167",
       "id": "resulttypes_issuccess",
-      "community": 26
+      "community": 27
     },
     {
       "label": "isError()",
@@ -985,7 +985,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L176",
       "id": "resulttypes_iserror",
-      "community": 26
+      "community": 27
     },
     {
       "label": "expenseItemSuccess()",
@@ -993,7 +993,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L276",
       "id": "resulttypes_expenseitemsuccess",
-      "community": 26
+      "community": 27
     },
     {
       "label": "expenseSessionSuccess()",
@@ -1001,7 +1001,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L286",
       "id": "resulttypes_expensesessionsuccess",
-      "community": 26
+      "community": 27
     },
     {
       "label": "sessionExpiration.ts",
@@ -1009,7 +1009,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_helpers_sessionexpiration_ts",
-      "community": 122
+      "community": 123
     },
     {
       "label": "calculateSessionExpiration()",
@@ -1017,7 +1017,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
       "source_location": "L21",
       "id": "sessionexpiration_calculatesessionexpiration",
-      "community": 122
+      "community": 123
     },
     {
       "label": "getSessionExpiryDuration()",
@@ -1025,7 +1025,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
       "source_location": "L35",
       "id": "sessionexpiration_getsessionexpiryduration",
-      "community": 122
+      "community": 123
     },
     {
       "label": "getSessionExpiryDurationMinutes()",
@@ -1033,7 +1033,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionExpiration.ts",
       "source_location": "L45",
       "id": "sessionexpiration_getsessionexpirydurationminutes",
-      "community": 122
+      "community": 123
     },
     {
       "label": "sessionValidation.ts",
@@ -1041,7 +1041,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_helpers_sessionvalidation_ts",
-      "community": 27
+      "community": 28
     },
     {
       "label": "validateSessionExists()",
@@ -1049,7 +1049,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L19",
       "id": "sessionvalidation_validatesessionexists",
-      "community": 27
+      "community": 28
     },
     {
       "label": "validateSessionActive()",
@@ -1057,7 +1057,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L39",
       "id": "sessionvalidation_validatesessionactive",
-      "community": 27
+      "community": 28
     },
     {
       "label": "validateSessionModifiable()",
@@ -1065,7 +1065,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L95",
       "id": "sessionvalidation_validatesessionmodifiable",
-      "community": 27
+      "community": 28
     },
     {
       "label": "validateSessionOwnership()",
@@ -1073,7 +1073,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L140",
       "id": "sessionvalidation_validatesessionownership",
-      "community": 27
+      "community": 28
     },
     {
       "label": "validateCartItems()",
@@ -1081,7 +1081,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L188",
       "id": "sessionvalidation_validatecartitems",
-      "community": 27
+      "community": 28
     },
     {
       "label": "validateItemBelongsToSession()",
@@ -1089,7 +1089,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L245",
       "id": "sessionvalidation_validateitembelongstosession",
-      "community": 27
+      "community": 28
     },
     {
       "label": "validateCustomerInfo()",
@@ -1097,7 +1097,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L272",
       "id": "sessionvalidation_validatecustomerinfo",
-      "community": 27
+      "community": 28
     },
     {
       "label": "isValidEmail()",
@@ -1105,7 +1105,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L300",
       "id": "sessionvalidation_isvalidemail",
-      "community": 27
+      "community": 28
     },
     {
       "label": "validatePaymentDetails()",
@@ -1113,7 +1113,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L308",
       "id": "sessionvalidation_validatepaymentdetails",
-      "community": 27
+      "community": 28
     },
     {
       "label": "inviteCode.ts",
@@ -1121,7 +1121,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/inviteCode.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_invitecode_ts",
-      "community": 622
+      "community": 624
     },
     {
       "label": "organizationMembers.ts",
@@ -1129,7 +1129,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/organizationMembers.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_organizationmembers_ts",
-      "community": 623
+      "community": 625
     },
     {
       "label": "organizations.ts",
@@ -1137,7 +1137,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/organizations.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_organizations_ts",
-      "community": 624
+      "community": 626
     },
     {
       "label": "pos.ts",
@@ -1145,7 +1145,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_pos_ts",
-      "community": 28
+      "community": 29
     },
     {
       "label": "isConvexProductId()",
@@ -1153,7 +1153,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L15",
       "id": "pos_isconvexproductid",
-      "community": 28
+      "community": 29
     },
     {
       "label": "collectAllPages()",
@@ -1161,7 +1161,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L19",
       "id": "pos_collectallpages",
-      "community": 28
+      "community": 29
     },
     {
       "label": "listProductSkusByProductId()",
@@ -1169,7 +1169,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L41",
       "id": "pos_listproductskusbyproductid",
-      "community": 28
+      "community": 29
     },
     {
       "label": "listStoreProducts()",
@@ -1177,7 +1177,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L53",
       "id": "pos_liststoreproducts",
-      "community": 28
+      "community": 29
     },
     {
       "label": "listStoreSkus()",
@@ -1185,7 +1185,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L62",
       "id": "pos_liststoreskus",
-      "community": 28
+      "community": 29
     },
     {
       "label": "listTransactionItems()",
@@ -1193,7 +1193,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L71",
       "id": "pos_listtransactionitems",
-      "community": 28
+      "community": 29
     },
     {
       "label": "listSessionItems()",
@@ -1201,7 +1201,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L83",
       "id": "pos_listsessionitems",
-      "community": 28
+      "community": 29
     },
     {
       "label": "listCompletedTransactionsForDay()",
@@ -1209,7 +1209,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L92",
       "id": "pos_listcompletedtransactionsforday",
-      "community": 28
+      "community": 29
     },
     {
       "label": "createTransactionFromSessionHandler()",
@@ -1217,7 +1217,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L939",
       "id": "pos_createtransactionfromsessionhandler",
-      "community": 28
+      "community": 29
     },
     {
       "label": "posCustomers.ts",
@@ -1225,7 +1225,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posCustomers.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_poscustomers_ts",
-      "community": 625
+      "community": 627
     },
     {
       "label": "posQueryCleanup.test.ts",
@@ -1233,7 +1233,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posQueryCleanup.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_posquerycleanup_test_ts",
-      "community": 275
+      "community": 277
     },
     {
       "label": "readProjectFile()",
@@ -1241,7 +1241,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posQueryCleanup.test.ts",
       "source_location": "L8",
       "id": "posquerycleanup_test_readprojectfile",
-      "community": 275
+      "community": 277
     },
     {
       "label": "posSessionItems.ts",
@@ -1249,7 +1249,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posSessionItems.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_possessionitems_ts",
-      "community": 626
+      "community": 628
     },
     {
       "label": "posSessions.ts",
@@ -1257,7 +1257,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_possessions_ts",
-      "community": 84
+      "community": 85
     },
     {
       "label": "buildNextSessionNumber()",
@@ -1265,7 +1265,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
       "source_location": "L34",
       "id": "possessions_buildnextsessionnumber",
-      "community": 84
+      "community": 85
     },
     {
       "label": "loadPosSessionItems()",
@@ -1273,7 +1273,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
       "source_location": "L45",
       "id": "possessions_loadpossessionitems",
-      "community": 84
+      "community": 85
     },
     {
       "label": "listPosSessionsByStatusBefore()",
@@ -1281,7 +1281,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
       "source_location": "L67",
       "id": "possessions_listpossessionsbystatusbefore",
-      "community": 84
+      "community": 85
     },
     {
       "label": "listPosSessionsForStoreStatus()",
@@ -1289,7 +1289,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
       "source_location": "L93",
       "id": "possessions_listpossessionsforstorestatus",
-      "community": 84
+      "community": 85
     },
     {
       "label": "posTerminal.ts",
@@ -1297,7 +1297,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posTerminal.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_posterminal_ts",
-      "community": 627
+      "community": 629
     },
     {
       "label": "productSku.ts",
@@ -1305,7 +1305,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/productSku.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_productsku_ts",
-      "community": 628
+      "community": 630
     },
     {
       "label": "productUtil.ts",
@@ -1313,7 +1313,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/productUtil.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_productutil_ts",
-      "community": 629
+      "community": 631
     },
     {
       "label": "products.ts",
@@ -1321,7 +1321,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/products.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_products_ts",
-      "community": 85
+      "community": 86
     },
     {
       "label": "generateSKU()",
@@ -1329,7 +1329,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/products.ts",
       "source_location": "L18",
       "id": "products_generatesku",
-      "community": 85
+      "community": 86
     },
     {
       "label": "generateBarcode()",
@@ -1337,7 +1337,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/products.ts",
       "source_location": "L42",
       "id": "products_generatebarcode",
-      "community": 85
+      "community": 86
     },
     {
       "label": "calculateTotalInventoryCount()",
@@ -1345,7 +1345,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/products.ts",
       "source_location": "L65",
       "id": "products_calculatetotalinventorycount",
-      "community": 85
+      "community": 86
     },
     {
       "label": "calculateTotalAvailableCount()",
@@ -1353,7 +1353,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/products.ts",
       "source_location": "L70",
       "id": "products_calculatetotalavailablecount",
-      "community": 85
+      "community": 86
     },
     {
       "label": "promoCode.ts",
@@ -1361,7 +1361,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/promoCode.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_promocode_ts",
-      "community": 630
+      "community": 632
     },
     {
       "label": "sessionQueryIndexes.test.ts",
@@ -1369,7 +1369,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/sessionQueryIndexes.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_sessionqueryindexes_test_ts",
-      "community": 276
+      "community": 278
     },
     {
       "label": "readProjectFile()",
@@ -1377,7 +1377,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/sessionQueryIndexes.test.ts",
       "source_location": "L6",
       "id": "sessionqueryindexes_test_readprojectfile",
-      "community": 276
+      "community": 278
     },
     {
       "label": "stockValidation.ts",
@@ -1385,7 +1385,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/stockValidation.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_stockvalidation_ts",
-      "community": 631
+      "community": 633
     },
     {
       "label": "storeConfigV2.test.ts",
@@ -1393,7 +1393,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_storeconfigv2_test_ts",
-      "community": 632
+      "community": 634
     },
     {
       "label": "storeConfigV2.ts",
@@ -1625,7 +1625,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/stores.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_stores_ts",
-      "community": 277
+      "community": 279
     },
     {
       "label": "toV2OnlyConfig()",
@@ -1633,7 +1633,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/stores.ts",
       "source_location": "L27",
       "id": "stores_tov2onlyconfig",
-      "community": 277
+      "community": 279
     },
     {
       "label": "subcategories.ts",
@@ -1641,7 +1641,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/subcategories.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_subcategories_ts",
-      "community": 633
+      "community": 635
     },
     {
       "label": "utils.ts",
@@ -1649,7 +1649,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_utils_ts",
-      "community": 29
+      "community": 30
     },
     {
       "label": "getDiscountValue()",
@@ -1657,7 +1657,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L17",
       "id": "utils_getdiscountvalue",
-      "community": 29
+      "community": 30
     },
     {
       "label": "getProductDiscountValue()",
@@ -1665,7 +1665,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
       "source_location": "L75",
       "id": "utils_getproductdiscountvalue",
-      "community": 29
+      "community": 30
     },
     {
       "label": "getOrderAmount()",
@@ -1673,7 +1673,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L51",
       "id": "utils_getorderamount",
-      "community": 29
+      "community": 30
     },
     {
       "label": "formatDeliveryAddress()",
@@ -1681,7 +1681,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L74",
       "id": "utils_formatdeliveryaddress",
-      "community": 29
+      "community": 30
     },
     {
       "label": "currency.test.ts",
@@ -1689,7 +1689,7 @@
       "source_file": "packages/athena-webapp/convex/lib/currency.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_lib_currency_test_ts",
-      "community": 634
+      "community": 636
     },
     {
       "label": "currency.ts",
@@ -1697,7 +1697,7 @@
       "source_file": "packages/athena-webapp/convex/lib/currency.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_lib_currency_ts",
-      "community": 123
+      "community": 124
     },
     {
       "label": "toPesewas()",
@@ -1705,7 +1705,7 @@
       "source_file": "packages/storefront-webapp/src/lib/currency.ts",
       "source_location": "L1",
       "id": "currency_topesewas",
-      "community": 123
+      "community": 124
     },
     {
       "label": "toDisplayAmount()",
@@ -1713,7 +1713,7 @@
       "source_file": "packages/storefront-webapp/src/lib/currency.ts",
       "source_location": "L5",
       "id": "currency_todisplayamount",
-      "community": 123
+      "community": 124
     },
     {
       "label": "callLlmProvider.ts",
@@ -1721,7 +1721,7 @@
       "source_file": "packages/athena-webapp/convex/llm/callLlmProvider.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_llm_callllmprovider_ts",
-      "community": 278
+      "community": 280
     },
     {
       "label": "callLlmProvider()",
@@ -1729,7 +1729,7 @@
       "source_file": "packages/athena-webapp/convex/llm/callLlmProvider.ts",
       "source_location": "L4",
       "id": "callllmprovider_callllmprovider",
-      "community": 278
+      "community": 280
     },
     {
       "label": "anthropic.ts",
@@ -1737,7 +1737,7 @@
       "source_file": "packages/athena-webapp/convex/llm/providers/anthropic.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_llm_providers_anthropic_ts",
-      "community": 279
+      "community": 281
     },
     {
       "label": "callAnthropic()",
@@ -1745,7 +1745,7 @@
       "source_file": "packages/athena-webapp/convex/llm/providers/anthropic.ts",
       "source_location": "L3",
       "id": "anthropic_callanthropic",
-      "community": 279
+      "community": 281
     },
     {
       "label": "openai.ts",
@@ -1753,7 +1753,7 @@
       "source_file": "packages/athena-webapp/convex/llm/providers/openai.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_llm_providers_openai_ts",
-      "community": 280
+      "community": 282
     },
     {
       "label": "callOpenAi()",
@@ -1761,7 +1761,7 @@
       "source_file": "packages/athena-webapp/convex/llm/providers/openai.ts",
       "source_location": "L3",
       "id": "openai_callopenai",
-      "community": 280
+      "community": 282
     },
     {
       "label": "storeInsights.ts",
@@ -1769,7 +1769,7 @@
       "source_file": "packages/athena-webapp/convex/llm/storeInsights.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_llm_storeinsights_ts",
-      "community": 635
+      "community": 637
     },
     {
       "label": "userInsights.ts",
@@ -1777,7 +1777,7 @@
       "source_file": "packages/athena-webapp/convex/llm/userInsights.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_llm_userinsights_ts",
-      "community": 636
+      "community": 638
     },
     {
       "label": "analyticsUtils.ts",
@@ -1785,7 +1785,7 @@
       "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_llm_utils_analyticsutils_ts",
-      "community": 165
+      "community": 167
     },
     {
       "label": "calculateDeviceDistribution()",
@@ -1793,7 +1793,7 @@
       "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
       "source_location": "L11",
       "id": "analyticsutils_calculatedevicedistribution",
-      "community": 165
+      "community": 167
     },
     {
       "label": "calculateActivityTrend()",
@@ -1801,7 +1801,7 @@
       "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
       "source_location": "L43",
       "id": "analyticsutils_calculateactivitytrend",
-      "community": 165
+      "community": 167
     },
     {
       "label": "index.tsx",
@@ -1865,7 +1865,7 @@
       "source_file": "packages/athena-webapp/convex/migrations/migrateAmountsToPesewas.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_migrations_migrateamountstopesewas_ts",
-      "community": 637
+      "community": 639
     },
     {
       "label": "client.test.ts",
@@ -1873,7 +1873,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_mtn_client_test_ts",
-      "community": 638
+      "community": 640
     },
     {
       "label": "client.ts",
@@ -1881,7 +1881,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_mtn_client_ts",
-      "community": 46
+      "community": 47
     },
     {
       "label": "encodeBasicAuth()",
@@ -1889,7 +1889,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L9",
       "id": "client_encodebasicauth",
-      "community": 46
+      "community": 47
     },
     {
       "label": "toError()",
@@ -1897,7 +1897,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L13",
       "id": "client_toerror",
-      "community": 46
+      "community": 47
     },
     {
       "label": "buildHeaders()",
@@ -1905,7 +1905,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L20",
       "id": "client_buildheaders",
-      "community": 46
+      "community": 47
     },
     {
       "label": "createCollectionsAccessToken()",
@@ -1913,7 +1913,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L30",
       "id": "client_createcollectionsaccesstoken",
-      "community": 46
+      "community": 47
     },
     {
       "label": "requestToPay()",
@@ -1921,7 +1921,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L65",
       "id": "client_requesttopay",
-      "community": 46
+      "community": 47
     },
     {
       "label": "getRequestToPayStatus()",
@@ -1929,7 +1929,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/client.ts",
       "source_location": "L115",
       "id": "client_getrequesttopaystatus",
-      "community": 46
+      "community": 47
     },
     {
       "label": "collections.ts",
@@ -1937,7 +1937,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_mtn_collections_ts",
-      "community": 124
+      "community": 125
     },
     {
       "label": "getCachedTokenRecord()",
@@ -1945,7 +1945,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
       "source_location": "L26",
       "id": "collections_getcachedtokenrecord",
-      "community": 124
+      "community": 125
     },
     {
       "label": "resolveConfigForStore()",
@@ -1953,7 +1953,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
       "source_location": "L33",
       "id": "collections_resolveconfigforstore",
-      "community": 124
+      "community": 125
     },
     {
       "label": "resolveAccessTokenForStore()",
@@ -1961,7 +1961,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
       "source_location": "L79",
       "id": "collections_resolveaccesstokenforstore",
-      "community": 124
+      "community": 125
     },
     {
       "label": "config.test.ts",
@@ -1969,7 +1969,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_mtn_config_test_ts",
-      "community": 639
+      "community": 641
     },
     {
       "label": "config.ts",
@@ -1977,7 +1977,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_mtn_config_ts",
-      "community": 38
+      "community": 40
     },
     {
       "label": "toEnvSegment()",
@@ -1985,7 +1985,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L29",
       "id": "config_toenvsegment",
-      "community": 38
+      "community": 40
     },
     {
       "label": "buildMtnCollectionsLookupPrefixes()",
@@ -1993,7 +1993,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L43",
       "id": "config_buildmtncollectionslookupprefixes",
-      "community": 38
+      "community": 40
     },
     {
       "label": "readScopedValue()",
@@ -2001,7 +2001,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L56",
       "id": "config_readscopedvalue",
-      "community": 38
+      "community": 40
     },
     {
       "label": "isTargetEnvironment()",
@@ -2009,7 +2009,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L67",
       "id": "config_istargetenvironment",
-      "community": 38
+      "community": 40
     },
     {
       "label": "resolveConfigForPrefix()",
@@ -2017,7 +2017,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L73",
       "id": "config_resolveconfigforprefix",
-      "community": 38
+      "community": 40
     },
     {
       "label": "resolveMtnCollectionsConfigFromEnv()",
@@ -2025,7 +2025,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L108",
       "id": "config_resolvemtncollectionsconfigfromenv",
-      "community": 38
+      "community": 40
     },
     {
       "label": "buildMtnCollectionsCallbackUrl()",
@@ -2033,7 +2033,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L135",
       "id": "config_buildmtncollectionscallbackurl",
-      "community": 38
+      "community": 40
     },
     {
       "label": "foundation.test.ts",
@@ -2041,7 +2041,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/foundation.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_mtn_foundation_test_ts",
-      "community": 281
+      "community": 283
     },
     {
       "label": "readProjectFile()",
@@ -2049,7 +2049,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/foundation.test.ts",
       "source_location": "L6",
       "id": "foundation_test_readprojectfile",
-      "community": 281
+      "community": 283
     },
     {
       "label": "normalize.test.ts",
@@ -2057,7 +2057,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/normalize.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_mtn_normalize_test_ts",
-      "community": 640
+      "community": 642
     },
     {
       "label": "normalize.ts",
@@ -2065,7 +2065,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_mtn_normalize_ts",
-      "community": 125
+      "community": 126
     },
     {
       "label": "maskMtnPartyId()",
@@ -2073,7 +2073,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
       "source_location": "L10",
       "id": "normalize_maskmtnpartyid",
-      "community": 125
+      "community": 126
     },
     {
       "label": "normalizeCollectionsTransaction()",
@@ -2081,7 +2081,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
       "source_location": "L18",
       "id": "normalize_normalizecollectionstransaction",
-      "community": 125
+      "community": 126
     },
     {
       "label": "parseCollectionsNotificationRequest()",
@@ -2089,7 +2089,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
       "source_location": "L52",
       "id": "normalize_parsecollectionsnotificationrequest",
-      "community": 125
+      "community": 126
     },
     {
       "label": "types.ts",
@@ -2097,7 +2097,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/types.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_mtn_types_ts",
-      "community": 641
+      "community": 643
     },
     {
       "label": "ResendOTP.ts",
@@ -2105,7 +2105,7 @@
       "source_file": "packages/athena-webapp/convex/otp/ResendOTP.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_otp_resendotp_ts",
-      "community": 642
+      "community": 644
     },
     {
       "label": "VerificationCodeEmail.tsx",
@@ -2113,7 +2113,7 @@
       "source_file": "packages/athena-webapp/convex/otp/VerificationCodeEmail.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_otp_verificationcodeemail_tsx",
-      "community": 282
+      "community": 284
     },
     {
       "label": "VerificationCodeEmail()",
@@ -2121,7 +2121,7 @@
       "source_file": "packages/athena-webapp/convex/otp/VerificationCodeEmail.tsx",
       "source_location": "L11",
       "id": "verificationcodeemail_verificationcodeemail",
-      "community": 282
+      "community": 284
     },
     {
       "label": "index.ts",
@@ -2129,7 +2129,7 @@
       "source_file": "packages/athena-webapp/convex/paystack/index.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_paystack_index_ts",
-      "community": 166
+      "community": 168
     },
     {
       "label": "listTransactions()",
@@ -2137,7 +2137,7 @@
       "source_file": "packages/athena-webapp/convex/paystack/index.ts",
       "source_location": "L7",
       "id": "index_listtransactions",
-      "community": 166
+      "community": 168
     },
     {
       "label": "verifyTransaction()",
@@ -2145,7 +2145,7 @@
       "source_file": "packages/athena-webapp/convex/paystack/index.ts",
       "source_location": "L109",
       "id": "index_verifytransaction",
-      "community": 166
+      "community": 168
     },
     {
       "label": "schema.ts",
@@ -2153,7 +2153,7 @@
       "source_file": "packages/athena-webapp/convex/schema.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schema_ts",
-      "community": 643
+      "community": 645
     },
     {
       "label": "appVerificationCode.ts",
@@ -2161,7 +2161,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/appVerificationCode.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_inventory_appverificationcode_ts",
-      "community": 644
+      "community": 646
     },
     {
       "label": "athenaUser.ts",
@@ -2169,7 +2169,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/athenaUser.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_inventory_athenauser_ts",
-      "community": 645
+      "community": 647
     },
     {
       "label": "bannerMessage.ts",
@@ -2177,7 +2177,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/bannerMessage.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_inventory_bannermessage_ts",
-      "community": 646
+      "community": 648
     },
     {
       "label": "bestSeller.ts",
@@ -2185,7 +2185,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/bestSeller.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_inventory_bestseller_ts",
-      "community": 647
+      "community": 649
     },
     {
       "label": "cashier.ts",
@@ -2193,7 +2193,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/cashier.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_inventory_cashier_ts",
-      "community": 648
+      "community": 650
     },
     {
       "label": "category.ts",
@@ -2201,7 +2201,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/category.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_inventory_category_ts",
-      "community": 649
+      "community": 651
     },
     {
       "label": "color.ts",
@@ -2209,7 +2209,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/color.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_inventory_color_ts",
-      "community": 650
+      "community": 652
     },
     {
       "label": "complimentaryProduct.ts",
@@ -2217,7 +2217,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/complimentaryProduct.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_inventory_complimentaryproduct_ts",
-      "community": 651
+      "community": 653
     },
     {
       "label": "featuredItem.ts",
@@ -2225,7 +2225,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/featuredItem.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_inventory_featureditem_ts",
-      "community": 652
+      "community": 654
     },
     {
       "label": "index.ts",
@@ -2233,7 +2233,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/index.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_inventory_index_ts",
-      "community": 653
+      "community": 655
     },
     {
       "label": "inviteCode.ts",
@@ -2241,7 +2241,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/inviteCode.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_inventory_invitecode_ts",
-      "community": 654
+      "community": 656
     },
     {
       "label": "organization.ts",
@@ -2249,7 +2249,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/organization.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_inventory_organization_ts",
-      "community": 655
+      "community": 657
     },
     {
       "label": "organizationMember.ts",
@@ -2257,7 +2257,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/organizationMember.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_inventory_organizationmember_ts",
-      "community": 656
+      "community": 658
     },
     {
       "label": "product.ts",
@@ -2265,7 +2265,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/product.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_inventory_product_ts",
-      "community": 657
+      "community": 659
     },
     {
       "label": "promoCode.ts",
@@ -2273,7 +2273,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/promoCode.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_inventory_promocode_ts",
-      "community": 658
+      "community": 660
     },
     {
       "label": "redeemedPromoCode.ts",
@@ -2281,7 +2281,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/redeemedPromoCode.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_inventory_redeemedpromocode_ts",
-      "community": 659
+      "community": 661
     },
     {
       "label": "store.ts",
@@ -2289,7 +2289,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/store.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_inventory_store_ts",
-      "community": 660
+      "community": 662
     },
     {
       "label": "subcategory.ts",
@@ -2297,7 +2297,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/inventory/subcategory.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_inventory_subcategory_ts",
-      "community": 661
+      "community": 663
     },
     {
       "label": "mtnCollections.ts",
@@ -2305,7 +2305,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/payments/mtnCollections.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_payments_mtncollections_ts",
-      "community": 662
+      "community": 664
     },
     {
       "label": "customer.ts",
@@ -2313,7 +2313,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/pos/customer.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_pos_customer_ts",
-      "community": 663
+      "community": 665
     },
     {
       "label": "expenseSession.ts",
@@ -2321,7 +2321,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/pos/expenseSession.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesession_ts",
-      "community": 664
+      "community": 666
     },
     {
       "label": "expenseSessionItem.ts",
@@ -2329,7 +2329,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/pos/expenseSessionItem.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesessionitem_ts",
-      "community": 665
+      "community": 667
     },
     {
       "label": "expenseTransaction.ts",
@@ -2337,7 +2337,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/pos/expenseTransaction.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransaction_ts",
-      "community": 666
+      "community": 668
     },
     {
       "label": "expenseTransactionItem.ts",
@@ -2345,7 +2345,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/pos/expenseTransactionItem.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransactionitem_ts",
-      "community": 667
+      "community": 669
     },
     {
       "label": "index.ts",
@@ -2353,7 +2353,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/pos/index.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_pos_index_ts",
-      "community": 668
+      "community": 670
     },
     {
       "label": "posSession.ts",
@@ -2361,7 +2361,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/pos/posSession.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_pos_possession_ts",
-      "community": 669
+      "community": 671
     },
     {
       "label": "posSessionItem.ts",
@@ -2369,7 +2369,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/pos/posSessionItem.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_pos_possessionitem_ts",
-      "community": 670
+      "community": 672
     },
     {
       "label": "posTerminal.ts",
@@ -2377,7 +2377,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/pos/posTerminal.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_pos_posterminal_ts",
-      "community": 671
+      "community": 673
     },
     {
       "label": "posTransaction.ts",
@@ -2385,7 +2385,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/pos/posTransaction.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_pos_postransaction_ts",
-      "community": 672
+      "community": 674
     },
     {
       "label": "posTransactionItem.ts",
@@ -2393,7 +2393,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/pos/posTransactionItem.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_pos_postransactionitem_ts",
-      "community": 673
+      "community": 675
     },
     {
       "label": "analytics.ts",
@@ -2401,7 +2401,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/analytics.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_storefront_analytics_ts",
-      "community": 674
+      "community": 676
     },
     {
       "label": "bag.ts",
@@ -2409,7 +2409,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/bag.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_storefront_bag_ts",
-      "community": 675
+      "community": 677
     },
     {
       "label": "bagItem.ts",
@@ -2417,7 +2417,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/bagItem.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_storefront_bagitem_ts",
-      "community": 676
+      "community": 678
     },
     {
       "label": "checkoutSession.ts",
@@ -2425,7 +2425,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/checkoutSession.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsession_ts",
-      "community": 677
+      "community": 679
     },
     {
       "label": "checkoutSessionItem.ts",
@@ -2433,7 +2433,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/checkoutSessionItem.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsessionitem_ts",
-      "community": 678
+      "community": 680
     },
     {
       "label": "customer.ts",
@@ -2441,7 +2441,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/customer.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_storefront_customer_ts",
-      "community": 679
+      "community": 681
     },
     {
       "label": "guest.ts",
@@ -2449,7 +2449,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/guest.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_storefront_guest_ts",
-      "community": 680
+      "community": 682
     },
     {
       "label": "index.ts",
@@ -2457,7 +2457,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/index.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_storefront_index_ts",
-      "community": 681
+      "community": 683
     },
     {
       "label": "offer.ts",
@@ -2465,7 +2465,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/offer.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_storefront_offer_ts",
-      "community": 682
+      "community": 684
     },
     {
       "label": "onlineOrder.ts",
@@ -2473,7 +2473,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/onlineOrder/onlineOrder.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorder_ts",
-      "community": 683
+      "community": 685
     },
     {
       "label": "onlineOrderItem.ts",
@@ -2481,7 +2481,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/onlineOrder/onlineOrderItem.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorderitem_ts",
-      "community": 684
+      "community": 686
     },
     {
       "label": "review.ts",
@@ -2489,7 +2489,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/review.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_storefront_review_ts",
-      "community": 685
+      "community": 687
     },
     {
       "label": "rewards.ts",
@@ -2497,7 +2497,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/rewards.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_storefront_rewards_ts",
-      "community": 686
+      "community": 688
     },
     {
       "label": "savedBag.ts",
@@ -2505,7 +2505,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/savedBag.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbag_ts",
-      "community": 687
+      "community": 689
     },
     {
       "label": "savedBagItem.ts",
@@ -2513,7 +2513,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/savedBagItem.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbagitem_ts",
-      "community": 688
+      "community": 690
     },
     {
       "label": "storeFrontSession.ts",
@@ -2521,7 +2521,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontSession.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontsession_ts",
-      "community": 689
+      "community": 691
     },
     {
       "label": "storeFrontUser.ts",
@@ -2529,7 +2529,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontUser.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontuser_ts",
-      "community": 690
+      "community": 692
     },
     {
       "label": "storeFrontVerificationCode.ts",
@@ -2537,7 +2537,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontVerificationCode.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontverificationcode_ts",
-      "community": 691
+      "community": 693
     },
     {
       "label": "supportTicket.ts",
@@ -2545,7 +2545,7 @@
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/supportTicket.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_schemas_storefront_supportticket_ts",
-      "community": 692
+      "community": 694
     },
     {
       "label": "index.tsx",
@@ -2561,7 +2561,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_services_orderemailservice_ts",
-      "community": 58
+      "community": 59
     },
     {
       "label": "shouldSendToAdmins()",
@@ -2569,7 +2569,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L42",
       "id": "orderemailservice_shouldsendtoadmins",
-      "community": 58
+      "community": 59
     },
     {
       "label": "buildOrderStatusMessage()",
@@ -2577,7 +2577,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L49",
       "id": "orderemailservice_buildorderstatusmessage",
-      "community": 58
+      "community": 59
     },
     {
       "label": "buildPickupDetails()",
@@ -2585,7 +2585,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L77",
       "id": "orderemailservice_buildpickupdetails",
-      "community": 58
+      "community": 59
     },
     {
       "label": "sendPODOrderEmails()",
@@ -2593,7 +2593,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L96",
       "id": "orderemailservice_sendpodorderemails",
-      "community": 58
+      "community": 59
     },
     {
       "label": "sendPaymentVerificationEmails()",
@@ -2601,7 +2601,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L217",
       "id": "orderemailservice_sendpaymentverificationemails",
-      "community": 58
+      "community": 59
     },
     {
       "label": "paystackService.ts",
@@ -2609,7 +2609,7 @@
       "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_services_paystackservice_ts",
-      "community": 86
+      "community": 87
     },
     {
       "label": "getPaystackHeaders()",
@@ -2617,7 +2617,7 @@
       "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
       "source_location": "L11",
       "id": "paystackservice_getpaystackheaders",
-      "community": 86
+      "community": 87
     },
     {
       "label": "initializeTransaction()",
@@ -2625,7 +2625,7 @@
       "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
       "source_location": "L21",
       "id": "paystackservice_initializetransaction",
-      "community": 86
+      "community": 87
     },
     {
       "label": "verifyTransaction()",
@@ -2633,7 +2633,7 @@
       "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
       "source_location": "L65",
       "id": "paystackservice_verifytransaction",
-      "community": 86
+      "community": 87
     },
     {
       "label": "initiateRefund()",
@@ -2641,7 +2641,7 @@
       "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
       "source_location": "L87",
       "id": "paystackservice_initiaterefund",
-      "community": 86
+      "community": 87
     },
     {
       "label": "analytics.ts",
@@ -2649,7 +2649,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_analytics_ts",
-      "community": 59
+      "community": 60
     },
     {
       "label": "extractPromoCodeId()",
@@ -2657,7 +2657,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L18",
       "id": "analytics_extractpromocodeid",
-      "community": 59
+      "community": 60
     },
     {
       "label": "getAnalyticsByStoreQuery()",
@@ -2665,7 +2665,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L28",
       "id": "analytics_getanalyticsbystorequery",
-      "community": 59
+      "community": 60
     },
     {
       "label": "getCompletedOrdersQuery()",
@@ -2673,7 +2673,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L59",
       "id": "analytics_getcompletedordersquery",
-      "community": 59
+      "community": 60
     },
     {
       "label": "getAnalyticsByStoreAndActionQuery()",
@@ -2681,7 +2681,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L97",
       "id": "analytics_getanalyticsbystoreandactionquery",
-      "community": 59
+      "community": 60
     },
     {
       "label": "getSkuMapForProducts()",
@@ -2689,7 +2689,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L132",
       "id": "analytics_getskumapforproducts",
-      "community": 59
+      "community": 60
     },
     {
       "label": "auth.ts",
@@ -2697,7 +2697,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/auth.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_auth_ts",
-      "community": 283
+      "community": 285
     },
     {
       "label": "getStoreFrontActorById()",
@@ -2705,7 +2705,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/auth.ts",
       "source_location": "L15",
       "id": "auth_getstorefrontactorbyid",
-      "community": 283
+      "community": 285
     },
     {
       "label": "bag.ts",
@@ -2713,7 +2713,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/bag.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_bag_ts",
-      "community": 693
+      "community": 695
     },
     {
       "label": "bagItem.ts",
@@ -2721,7 +2721,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/bagItem.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_bagitem_ts",
-      "community": 694
+      "community": 696
     },
     {
       "label": "checkoutSession.ts",
@@ -2873,7 +2873,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_commercequeryindexes_test_ts",
-      "community": 126
+      "community": 127
     },
     {
       "label": "getTableIndexes()",
@@ -2881,7 +2881,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
       "source_location": "L12",
       "id": "commercequeryindexes_test_gettableindexes",
-      "community": 126
+      "community": 127
     },
     {
       "label": "expectIndex()",
@@ -2889,7 +2889,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
       "source_location": "L19",
       "id": "commercequeryindexes_test_expectindex",
-      "community": 126
+      "community": 127
     },
     {
       "label": "getSource()",
@@ -2897,7 +2897,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts",
       "source_location": "L26",
       "id": "commercequeryindexes_test_getsource",
-      "community": 126
+      "community": 127
     },
     {
       "label": "customer.ts",
@@ -2905,7 +2905,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customer.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_customer_ts",
-      "community": 695
+      "community": 697
     },
     {
       "label": "customerBehaviorTimeline.ts",
@@ -2913,7 +2913,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_ts",
-      "community": 87
+      "community": 88
     },
     {
       "label": "getTimeFilterForRange()",
@@ -2921,7 +2921,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
       "source_location": "L11",
       "id": "customerbehaviortimeline_gettimefilterforrange",
-      "community": 87
+      "community": 88
     },
     {
       "label": "getCustomerAnalyticsQuery()",
@@ -2929,7 +2929,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
       "source_location": "L26",
       "id": "customerbehaviortimeline_getcustomeranalyticsquery",
-      "community": 87
+      "community": 88
     },
     {
       "label": "getTimelineUserData()",
@@ -2937,7 +2937,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
       "source_location": "L42",
       "id": "customerbehaviortimeline_gettimelineuserdata",
-      "community": 87
+      "community": 88
     },
     {
       "label": "getProductInfoMaps()",
@@ -2945,7 +2945,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
       "source_location": "L66",
       "id": "customerbehaviortimeline_getproductinfomaps",
-      "community": 87
+      "community": 88
     },
     {
       "label": "customerObservabilityTimeline.test.ts",
@@ -2953,7 +2953,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimeline.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_customerobservabilitytimeline_test_ts",
-      "community": 284
+      "community": 286
     },
     {
       "label": "createAnalyticsEvent()",
@@ -2961,7 +2961,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimeline.test.ts",
       "source_location": "L17",
       "id": "customerobservabilitytimeline_test_createanalyticsevent",
-      "community": 284
+      "community": 286
     },
     {
       "label": "customerObservabilityTimelineData.ts",
@@ -2969,7 +2969,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_customerobservabilitytimelinedata_ts",
-      "community": 88
+      "community": 89
     },
     {
       "label": "getNonEmptyString()",
@@ -2977,7 +2977,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L64",
       "id": "customerobservabilitytimelinedata_getnonemptystring",
-      "community": 88
+      "community": 89
     },
     {
       "label": "isFailureStatus()",
@@ -2985,7 +2985,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L68",
       "id": "customerobservabilitytimelinedata_isfailurestatus",
-      "community": 88
+      "community": 89
     },
     {
       "label": "normalizeEvent()",
@@ -2993,7 +2993,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L72",
       "id": "customerobservabilitytimelinedata_normalizeevent",
-      "community": 88
+      "community": 89
     },
     {
       "label": "buildCustomerObservabilityTimeline()",
@@ -3001,7 +3001,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L118",
       "id": "customerobservabilitytimelinedata_buildcustomerobservabilitytimeline",
-      "community": 88
+      "community": 89
     },
     {
       "label": "guest.ts",
@@ -3009,7 +3009,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/guest.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_guest_ts",
-      "community": 696
+      "community": 698
     },
     {
       "label": "helperOrchestration.test.ts",
@@ -3017,7 +3017,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helperOrchestration.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_helperorchestration_test_ts",
-      "community": 285
+      "community": 287
     },
     {
       "label": "readProjectFile()",
@@ -3025,7 +3025,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helperOrchestration.test.ts",
       "source_location": "L6",
       "id": "helperorchestration_test_readprojectfile",
-      "community": 285
+      "community": 287
     },
     {
       "label": "bag.ts",
@@ -3033,7 +3033,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/bag.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_helpers_bag_ts",
-      "community": 167
+      "community": 169
     },
     {
       "label": "listBagItems()",
@@ -3041,7 +3041,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/bag.ts",
       "source_location": "L7",
       "id": "bag_listbagitems",
-      "community": 167
+      "community": 169
     },
     {
       "label": "loadBagWithItems()",
@@ -3049,7 +3049,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/bag.ts",
       "source_location": "L14",
       "id": "bag_loadbagwithitems",
-      "community": 167
+      "community": 169
     },
     {
       "label": "onlineOrder.ts",
@@ -3057,7 +3057,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_helpers_onlineorder_ts",
-      "community": 60
+      "community": 61
     },
     {
       "label": "generateOrderNumber()",
@@ -3065,7 +3065,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
       "source_location": "L8",
       "id": "onlineorder_generateordernumber",
-      "community": 60
+      "community": 61
     },
     {
       "label": "findOrderByExternalReference()",
@@ -3073,7 +3073,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
       "source_location": "L15",
       "id": "onlineorder_findorderbyexternalreference",
-      "community": 60
+      "community": 61
     },
     {
       "label": "clearBagItems()",
@@ -3081,7 +3081,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
       "source_location": "L27",
       "id": "onlineorder_clearbagitems",
-      "community": 60
+      "community": 61
     },
     {
       "label": "returnOrderItemsToStock()",
@@ -3089,7 +3089,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
       "source_location": "L39",
       "id": "onlineorder_returnorderitemstostock",
-      "community": 60
+      "community": 61
     },
     {
       "label": "createOrderFromCheckoutSession()",
@@ -3097,7 +3097,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
       "source_location": "L75",
       "id": "onlineorder_createorderfromcheckoutsession",
-      "community": 60
+      "community": 61
     },
     {
       "label": "orderUpdateEmails.ts",
@@ -3105,7 +3105,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_helpers_orderupdateemails_ts",
-      "community": 47
+      "community": 48
     },
     {
       "label": "getPickupLocation()",
@@ -3113,7 +3113,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L52",
       "id": "orderupdateemails_getpickuplocation",
-      "community": 47
+      "community": 48
     },
     {
       "label": "getDeliveryAddress()",
@@ -3121,7 +3121,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L55",
       "id": "orderupdateemails_getdeliveryaddress",
-      "community": 47
+      "community": 48
     },
     {
       "label": "getLocationDetails()",
@@ -3129,7 +3129,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L58",
       "id": "orderupdateemails_getlocationdetails",
-      "community": 47
+      "community": 48
     },
     {
       "label": "formatOrderItems()",
@@ -3137,7 +3137,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L64",
       "id": "orderupdateemails_formatorderitems",
-      "community": 47
+      "community": 48
     },
     {
       "label": "handleOrderStatusUpdate()",
@@ -3145,7 +3145,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L118",
       "id": "orderupdateemails_handleorderstatusupdate",
-      "community": 47
+      "community": 48
     },
     {
       "label": "processOrderUpdateEmail()",
@@ -3153,7 +3153,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/orderUpdateEmails.ts",
       "source_location": "L293",
       "id": "orderupdateemails_processorderupdateemail",
-      "community": 47
+      "community": 48
     },
     {
       "label": "paymentHelpers.ts",
@@ -3161,7 +3161,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_helpers_paymenthelpers_ts",
-      "community": 48
+      "community": 49
     },
     {
       "label": "generatePODReference()",
@@ -3169,7 +3169,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
       "source_location": "L9",
       "id": "paymenthelpers_generatepodreference",
-      "community": 48
+      "community": 49
     },
     {
       "label": "extractOrderItems()",
@@ -3177,7 +3177,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
       "source_location": "L18",
       "id": "paymenthelpers_extractorderitems",
-      "community": 48
+      "community": 49
     },
     {
       "label": "calculateOrderAmount()",
@@ -3185,7 +3185,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
       "source_location": "L35",
       "id": "paymenthelpers_calculateorderamount",
-      "community": 48
+      "community": 49
     },
     {
       "label": "calculateRewardPoints()",
@@ -3193,7 +3193,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
       "source_location": "L53",
       "id": "paymenthelpers_calculaterewardpoints",
-      "community": 48
+      "community": 49
     },
     {
       "label": "validatePaymentAmount()",
@@ -3201,7 +3201,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
       "source_location": "L61",
       "id": "paymenthelpers_validatepaymentamount",
-      "community": 48
+      "community": 49
     },
     {
       "label": "getOrderDiscountValue()",
@@ -3209,7 +3209,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
       "source_location": "L75",
       "id": "paymenthelpers_getorderdiscountvalue",
-      "community": 48
+      "community": 49
     },
     {
       "label": "offers.ts",
@@ -3217,7 +3217,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_offers_ts",
-      "community": 89
+      "community": 90
     },
     {
       "label": "isDuplicate()",
@@ -3225,7 +3225,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
       "source_location": "L36",
       "id": "offers_isduplicate",
-      "community": 89
+      "community": 90
     },
     {
       "label": "updateStoreFrontActorEmail()",
@@ -3233,7 +3233,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
       "source_location": "L59",
       "id": "offers_updatestorefrontactoremail",
-      "community": 89
+      "community": 90
     },
     {
       "label": "createOffer()",
@@ -3241,7 +3241,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
       "source_location": "L88",
       "id": "offers_createoffer",
-      "community": 89
+      "community": 90
     },
     {
       "label": "getUpsellProducts()",
@@ -3249,7 +3249,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
       "source_location": "L685",
       "id": "offers_getupsellproducts",
-      "community": 89
+      "community": 90
     },
     {
       "label": "onlineOrder.ts",
@@ -3257,7 +3257,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_onlineorder_ts",
-      "community": 286
+      "community": 288
     },
     {
       "label": "listOrderItems()",
@@ -3265,7 +3265,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
       "source_location": "L27",
       "id": "onlineorder_listorderitems",
-      "community": 286
+      "community": 288
     },
     {
       "label": "onlineOrderItem.ts",
@@ -3273,7 +3273,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderItem.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_onlineorderitem_ts",
-      "community": 287
+      "community": 289
     },
     {
       "label": "updateOnlineOrderItem()",
@@ -3281,7 +3281,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderItem.ts",
       "source_location": "L21",
       "id": "onlineorderitem_updateonlineorderitem",
-      "community": 287
+      "community": 289
     },
     {
       "label": "onlineOrderUtilFns.ts",
@@ -3289,7 +3289,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderUtilFns.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_onlineorderutilfns_ts",
-      "community": 697
+      "community": 699
     },
     {
       "label": "payment.ts",
@@ -3297,7 +3297,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/payment.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_payment_ts",
-      "community": 698
+      "community": 700
     },
     {
       "label": "paystackActions.ts",
@@ -3305,7 +3305,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/paystackActions.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_paystackactions_ts",
-      "community": 699
+      "community": 701
     },
     {
       "label": "reviews.ts",
@@ -3313,7 +3313,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/reviews.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_reviews_ts",
-      "community": 288
+      "community": 290
     },
     {
       "label": "getStoreFrontActorById()",
@@ -3321,7 +3321,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/reviews.ts",
       "source_location": "L17",
       "id": "reviews_getstorefrontactorbyid",
-      "community": 288
+      "community": 290
     },
     {
       "label": "rewards.ts",
@@ -3329,7 +3329,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/rewards.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_rewards_ts",
-      "community": 700
+      "community": 702
     },
     {
       "label": "savedBag.ts",
@@ -3337,7 +3337,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/savedBag.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_savedbag_ts",
-      "community": 289
+      "community": 291
     },
     {
       "label": "listSavedBagItems()",
@@ -3345,7 +3345,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/savedBag.ts",
       "source_location": "L14",
       "id": "savedbag_listsavedbagitems",
-      "community": 289
+      "community": 291
     },
     {
       "label": "savedBagItem.ts",
@@ -3353,7 +3353,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/savedBagItem.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_savedbagitem_ts",
-      "community": 701
+      "community": 703
     },
     {
       "label": "storefrontObservabilityReport.test.ts",
@@ -3361,7 +3361,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_test_ts",
-      "community": 290
+      "community": 292
     },
     {
       "label": "createAnalyticsEvent()",
@@ -3369,7 +3369,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.test.ts",
       "source_location": "L7",
       "id": "storefrontobservabilityreport_test_createanalyticsevent",
-      "community": 290
+      "community": 292
     },
     {
       "label": "storefrontObservabilityReport.ts",
@@ -3377,7 +3377,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_ts",
-      "community": 127
+      "community": 128
     },
     {
       "label": "getNonEmptyString()",
@@ -3385,7 +3385,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
       "source_location": "L59",
       "id": "storefrontobservabilityreport_getnonemptystring",
-      "community": 127
+      "community": 128
     },
     {
       "label": "normalizeStorefrontObservabilityEvent()",
@@ -3393,7 +3393,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
       "source_location": "L63",
       "id": "storefrontobservabilityreport_normalizestorefrontobservabilityevent",
-      "community": 127
+      "community": 128
     },
     {
       "label": "buildStorefrontObservabilityReport()",
@@ -3401,7 +3401,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/storefrontObservabilityReport.ts",
       "source_location": "L95",
       "id": "storefrontobservabilityreport_buildstorefrontobservabilityreport",
-      "community": 127
+      "community": 128
     },
     {
       "label": "supportTicket.ts",
@@ -3409,7 +3409,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/supportTicket.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_supportticket_ts",
-      "community": 702
+      "community": 704
     },
     {
       "label": "timeQueryRefactors.test.ts",
@@ -3417,7 +3417,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/timeQueryRefactors.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_timequeryrefactors_test_ts",
-      "community": 291
+      "community": 293
     },
     {
       "label": "readSource()",
@@ -3425,7 +3425,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/timeQueryRefactors.test.ts",
       "source_location": "L5",
       "id": "timequeryrefactors_test_readsource",
-      "community": 291
+      "community": 293
     },
     {
       "label": "user.ts",
@@ -3433,7 +3433,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/user.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_user_ts",
-      "community": 292
+      "community": 294
     },
     {
       "label": "getStoreFrontActorById()",
@@ -3441,7 +3441,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/user.ts",
       "source_location": "L15",
       "id": "user_getstorefrontactorbyid",
-      "community": 292
+      "community": 294
     },
     {
       "label": "userOffers.ts",
@@ -3449,7 +3449,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/userOffers.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_useroffers_ts",
-      "community": 293
+      "community": 295
     },
     {
       "label": "determineOfferEligibility()",
@@ -3457,7 +3457,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/userOffers.ts",
       "source_location": "L30",
       "id": "useroffers_determineoffereligibility",
-      "community": 293
+      "community": 295
     },
     {
       "label": "users.ts",
@@ -3465,7 +3465,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/users.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_users_ts",
-      "community": 703
+      "community": 705
     },
     {
       "label": "payment.ts",
@@ -3473,7 +3473,7 @@
       "source_file": "packages/athena-webapp/convex/types/payment.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_types_payment_ts",
-      "community": 704
+      "community": 706
     },
     {
       "label": "utils.ts",
@@ -3545,7 +3545,7 @@
       "source_file": "packages/athena-webapp/eslint.config.js",
       "source_location": "L1",
       "id": "packages_athena_webapp_eslint_config_js",
-      "community": 705
+      "community": 707
     },
     {
       "label": "index.ts",
@@ -3553,7 +3553,7 @@
       "source_file": "packages/athena-webapp/index.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_index_ts",
-      "community": 706
+      "community": 708
     },
     {
       "label": "postcss.config.js",
@@ -3561,7 +3561,7 @@
       "source_file": "packages/athena-webapp/postcss.config.js",
       "source_location": "L1",
       "id": "packages_athena_webapp_postcss_config_js",
-      "community": 707
+      "community": 709
     },
     {
       "label": "GenericComboBox.tsx",
@@ -3569,7 +3569,7 @@
       "source_file": "packages/athena-webapp/src/components/GenericComboBox.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_genericcombobox_tsx",
-      "community": 708
+      "community": 710
     },
     {
       "label": "Navbar.tsx",
@@ -3577,7 +3577,7 @@
       "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_navbar_tsx",
-      "community": 90
+      "community": 91
     },
     {
       "label": "SettingsHeader()",
@@ -3585,7 +3585,7 @@
       "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
       "source_location": "L20",
       "id": "navbar_settingsheader",
-      "community": 90
+      "community": 91
     },
     {
       "label": "AppHeader()",
@@ -3593,7 +3593,7 @@
       "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
       "source_location": "L61",
       "id": "navbar_appheader",
-      "community": 90
+      "community": 91
     },
     {
       "label": "Header()",
@@ -3601,7 +3601,7 @@
       "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
       "source_location": "L75",
       "id": "navbar_header",
-      "community": 90
+      "community": 91
     },
     {
       "label": "Navbar()",
@@ -3609,7 +3609,7 @@
       "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
       "source_location": "L116",
       "id": "navbar_navbar",
-      "community": 90
+      "community": 91
     },
     {
       "label": "OrganizationView.tsx",
@@ -3617,7 +3617,7 @@
       "source_file": "packages/athena-webapp/src/components/OrganizationView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organizationview_tsx",
-      "community": 294
+      "community": 296
     },
     {
       "label": "Navigation()",
@@ -3625,7 +3625,7 @@
       "source_file": "packages/athena-webapp/src/components/OrganizationView.tsx",
       "source_location": "L7",
       "id": "organizationview_navigation",
-      "community": 294
+      "community": 296
     },
     {
       "label": "OrganizationsView.tsx",
@@ -3633,7 +3633,7 @@
       "source_file": "packages/athena-webapp/src/components/OrganizationsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organizationsview_tsx",
-      "community": 295
+      "community": 297
     },
     {
       "label": "Navigation()",
@@ -3641,7 +3641,7 @@
       "source_file": "packages/athena-webapp/src/components/OrganizationsView.tsx",
       "source_location": "L12",
       "id": "organizationsview_navigation",
-      "community": 295
+      "community": 297
     },
     {
       "label": "PermissionGate.tsx",
@@ -3649,7 +3649,7 @@
       "source_file": "packages/athena-webapp/src/components/PermissionGate.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_permissiongate_tsx",
-      "community": 296
+      "community": 298
     },
     {
       "label": "PermissionGate()",
@@ -3657,7 +3657,7 @@
       "source_file": "packages/athena-webapp/src/components/PermissionGate.tsx",
       "source_location": "L11",
       "id": "permissiongate_permissiongate",
-      "community": 296
+      "community": 298
     },
     {
       "label": "ProtectedRoute.tsx",
@@ -3665,7 +3665,7 @@
       "source_file": "packages/athena-webapp/src/components/ProtectedRoute.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_protectedroute_tsx",
-      "community": 297
+      "community": 299
     },
     {
       "label": "ProtectedRoute()",
@@ -3673,7 +3673,7 @@
       "source_file": "packages/athena-webapp/src/components/ProtectedRoute.tsx",
       "source_location": "L11",
       "id": "protectedroute_protectedroute",
-      "community": 297
+      "community": 299
     },
     {
       "label": "SettingsView.tsx",
@@ -3681,7 +3681,7 @@
       "source_file": "packages/athena-webapp/src/components/SettingsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_settingsview_tsx",
-      "community": 298
+      "community": 300
     },
     {
       "label": "SettingsView()",
@@ -3689,7 +3689,7 @@
       "source_file": "packages/athena-webapp/src/components/SettingsView.tsx",
       "source_location": "L3",
       "id": "settingsview_settingsview",
-      "community": 298
+      "community": 300
     },
     {
       "label": "StoreAccordion.tsx",
@@ -3697,7 +3697,7 @@
       "source_file": "packages/athena-webapp/src/components/StoreAccordion.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_storeaccordion_tsx",
-      "community": 709
+      "community": 711
     },
     {
       "label": "StoreActions.tsx",
@@ -3705,7 +3705,7 @@
       "source_file": "packages/athena-webapp/src/components/StoreActions.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_storeactions_tsx",
-      "community": 299
+      "community": 301
     },
     {
       "label": "StoreActions()",
@@ -3713,7 +3713,7 @@
       "source_file": "packages/athena-webapp/src/components/StoreActions.tsx",
       "source_location": "L12",
       "id": "storeactions_storeactions",
-      "community": 299
+      "community": 301
     },
     {
       "label": "StoreDropdown.tsx",
@@ -3721,7 +3721,7 @@
       "source_file": "packages/athena-webapp/src/components/StoreDropdown.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_storedropdown_tsx",
-      "community": 300
+      "community": 302
     },
     {
       "label": "StoreDropdown()",
@@ -3729,7 +3729,7 @@
       "source_file": "packages/athena-webapp/src/components/StoreDropdown.tsx",
       "source_location": "L42",
       "id": "storedropdown_storedropdown",
-      "community": 300
+      "community": 302
     },
     {
       "label": "StoreView.tsx",
@@ -3737,7 +3737,7 @@
       "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_storeview_tsx",
-      "community": 301
+      "community": 303
     },
     {
       "label": "Navigation()",
@@ -3745,7 +3745,7 @@
       "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
       "source_location": "L13",
       "id": "storeview_navigation",
-      "community": 301
+      "community": 303
     },
     {
       "label": "StoresAccordion.tsx",
@@ -3753,7 +3753,7 @@
       "source_file": "packages/athena-webapp/src/components/StoresAccordion.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_storesaccordion_tsx",
-      "community": 710
+      "community": 712
     },
     {
       "label": "StoresDropdown.tsx",
@@ -3761,7 +3761,7 @@
       "source_file": "packages/athena-webapp/src/components/StoresDropdown.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_storesdropdown_tsx",
-      "community": 302
+      "community": 304
     },
     {
       "label": "StoresDropdown()",
@@ -3769,7 +3769,7 @@
       "source_file": "packages/athena-webapp/src/components/StoresDropdown.tsx",
       "source_location": "L42",
       "id": "storesdropdown_storesdropdown",
-      "community": 302
+      "community": 304
     },
     {
       "label": "ThemeToggle.tsx",
@@ -3777,7 +3777,7 @@
       "source_file": "packages/athena-webapp/src/components/ThemeToggle.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_themetoggle_tsx",
-      "community": 711
+      "community": 713
     },
     {
       "label": "View.tsx",
@@ -3785,7 +3785,7 @@
       "source_file": "packages/athena-webapp/src/components/View.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_view_tsx",
-      "community": 168
+      "community": 170
     },
     {
       "label": "View()",
@@ -3793,7 +3793,7 @@
       "source_file": "packages/storefront-webapp/src/components/View.tsx",
       "source_location": "L4",
       "id": "view_view",
-      "community": 168
+      "community": 170
     },
     {
       "label": "AttributesManager.tsx",
@@ -3801,7 +3801,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_attributesmanager_tsx",
-      "community": 128
+      "community": 129
     },
     {
       "label": "Sidebar()",
@@ -3809,7 +3809,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
       "source_location": "L26",
       "id": "attributesmanager_sidebar",
-      "community": 128
+      "community": 129
     },
     {
       "label": "ColorManager()",
@@ -3817,7 +3817,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
       "source_location": "L45",
       "id": "attributesmanager_colormanager",
-      "community": 128
+      "community": 129
     },
     {
       "label": "AttributesManager()",
@@ -3825,7 +3825,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
       "source_location": "L228",
       "id": "attributesmanager_attributesmanager",
-      "community": 128
+      "community": 129
     },
     {
       "label": "AttributesTable.tsx",
@@ -3833,7 +3833,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_attributestable_tsx",
-      "community": 129
+      "community": 130
     },
     {
       "label": "handleChange()",
@@ -3841,7 +3841,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
       "source_location": "L32",
       "id": "attributestable_handlechange",
-      "community": 129
+      "community": 130
     },
     {
       "label": "getProductAttribute()",
@@ -3849,7 +3849,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
       "source_location": "L55",
       "id": "attributestable_getproductattribute",
-      "community": 129
+      "community": 130
     },
     {
       "label": "onSubmit()",
@@ -3857,7 +3857,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/AttributesTable.tsx",
       "source_location": "L210",
       "id": "attributestable_onsubmit",
-      "community": 129
+      "community": 130
     },
     {
       "label": "BarcodeQRViewer.tsx",
@@ -3865,7 +3865,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/BarcodeQRViewer.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_barcodeqrviewer_tsx",
-      "community": 303
+      "community": 305
     },
     {
       "label": "handlePrint()",
@@ -3873,7 +3873,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/BarcodeQRViewer.tsx",
       "source_location": "L31",
       "id": "barcodeqrviewer_handleprint",
-      "community": 303
+      "community": 305
     },
     {
       "label": "CategorySubcategoryManager.tsx",
@@ -3881,7 +3881,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_categorysubcategorymanager_tsx",
-      "community": 130
+      "community": 131
     },
     {
       "label": "Sidebar()",
@@ -3889,7 +3889,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
       "source_location": "L26",
       "id": "categorysubcategorymanager_sidebar",
-      "community": 130
+      "community": 131
     },
     {
       "label": "CategoryManager()",
@@ -3897,7 +3897,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
       "source_location": "L51",
       "id": "categorysubcategorymanager_categorymanager",
-      "community": 130
+      "community": 131
     },
     {
       "label": "SubcategoryManager()",
@@ -3905,7 +3905,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx",
       "source_location": "L290",
       "id": "categorysubcategorymanager_subcategorymanager",
-      "community": 130
+      "community": 131
     },
     {
       "label": "DefaultAttributesToggleGroup.tsx",
@@ -3913,7 +3913,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/DefaultAttributesToggleGroup.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_defaultattributestogglegroup_tsx",
-      "community": 712
+      "community": 714
     },
     {
       "label": "ProcessingFees.tsx",
@@ -3921,7 +3921,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProcessingFees.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_processingfees_tsx",
-      "community": 304
+      "community": 306
     },
     {
       "label": "ProcessingFeesView()",
@@ -3929,7 +3929,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProcessingFees.tsx",
       "source_location": "L10",
       "id": "processingfees_processingfeesview",
-      "community": 304
+      "community": 306
     },
     {
       "label": "ProductAttributes.tsx",
@@ -3937,7 +3937,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAttributes.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_productattributes_tsx",
-      "community": 305
+      "community": 307
     },
     {
       "label": "isAllowedAttribute()",
@@ -3945,7 +3945,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAttributes.tsx",
       "source_location": "L14",
       "id": "productattributes_isallowedattribute",
-      "community": 305
+      "community": 307
     },
     {
       "label": "ProductAttributesView.tsx",
@@ -3953,7 +3953,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAttributesView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_productattributesview_tsx",
-      "community": 713
+      "community": 715
     },
     {
       "label": "ProductAvailability.tsx",
@@ -3961,7 +3961,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_productavailability_tsx",
-      "community": 169
+      "community": 171
     },
     {
       "label": "ProductAvailabilityView()",
@@ -3969,7 +3969,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
       "source_location": "L5",
       "id": "productavailability_productavailabilityview",
-      "community": 169
+      "community": 171
     },
     {
       "label": "ProductAvailability()",
@@ -3977,7 +3977,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
       "source_location": "L18",
       "id": "productavailability_productavailability",
-      "community": 169
+      "community": 171
     },
     {
       "label": "ProductAvailabilityToggleGroup.tsx",
@@ -3985,7 +3985,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailabilityToggleGroup.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_productavailabilitytogglegroup_tsx",
-      "community": 306
+      "community": 308
     },
     {
       "label": "ProductAvailabilityToggleGroup()",
@@ -3993,7 +3993,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailabilityToggleGroup.tsx",
       "source_location": "L5",
       "id": "productavailabilitytogglegroup_productavailabilitytogglegroup",
-      "community": 306
+      "community": 308
     },
     {
       "label": "ProductCategorization.tsx",
@@ -4001,7 +4001,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_productcategorization_tsx",
-      "community": 91
+      "community": 92
     },
     {
       "label": "handleClose()",
@@ -4009,7 +4009,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
       "source_location": "L203",
       "id": "productcategorization_handleclose",
-      "community": 91
+      "community": 92
     },
     {
       "label": "setInitialSelectedOption()",
@@ -4017,7 +4017,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
       "source_location": "L230",
       "id": "productcategorization_setinitialselectedoption",
-      "community": 91
+      "community": 92
     },
     {
       "label": "handleProductVisibility()",
@@ -4025,7 +4025,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
       "source_location": "L243",
       "id": "productcategorization_handleproductvisibility",
-      "community": 91
+      "community": 92
     },
     {
       "label": "getProductName()",
@@ -4033,7 +4033,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
       "source_location": "L286",
       "id": "productcategorization_getproductname",
-      "community": 91
+      "community": 92
     },
     {
       "label": "ProductDetails.tsx",
@@ -4041,7 +4041,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductDetails.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_productdetails_tsx",
-      "community": 307
+      "community": 309
     },
     {
       "label": "handleNameChange()",
@@ -4049,7 +4049,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductDetails.tsx",
       "source_location": "L10",
       "id": "productdetails_handlenamechange",
-      "community": 307
+      "community": 309
     },
     {
       "label": "ProductImages.tsx",
@@ -4057,7 +4057,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductImages.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_productimages_tsx",
-      "community": 308
+      "community": 310
     },
     {
       "label": "Header()",
@@ -4065,7 +4065,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductImages.tsx",
       "source_location": "L15",
       "id": "productimages_header",
-      "community": 308
+      "community": 310
     },
     {
       "label": "ProductPage.tsx",
@@ -4073,7 +4073,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductPage.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_productpage_tsx",
-      "community": 309
+      "community": 311
     },
     {
       "label": "ProductPage()",
@@ -4081,7 +4081,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductPage.tsx",
       "source_location": "L13",
       "id": "productpage_productpage",
-      "community": 309
+      "community": 311
     },
     {
       "label": "ProductStock.tsx",
@@ -4249,7 +4249,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_productview_tsx",
-      "community": 33
+      "community": 34
     },
     {
       "label": "deleteActiveProduct()",
@@ -4257,7 +4257,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L82",
       "id": "productview_deleteactiveproduct",
-      "community": 33
+      "community": 34
     },
     {
       "label": "saveProduct()",
@@ -4265,7 +4265,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L115",
       "id": "productview_saveproduct",
-      "community": 33
+      "community": 34
     },
     {
       "label": "modifyProduct()",
@@ -4273,7 +4273,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L170",
       "id": "productview_modifyproduct",
-      "community": 33
+      "community": 34
     },
     {
       "label": "createVariantSku()",
@@ -4281,7 +4281,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L245",
       "id": "productview_createvariantsku",
-      "community": 33
+      "community": 34
     },
     {
       "label": "updateVariantSku()",
@@ -4289,7 +4289,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L300",
       "id": "productview_updatevariantsku",
-      "community": 33
+      "community": 34
     },
     {
       "label": "onSubmit()",
@@ -4297,7 +4297,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L369",
       "id": "productview_onsubmit",
-      "community": 33
+      "community": 34
     },
     {
       "label": "handleKeyDown()",
@@ -4305,7 +4305,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L380",
       "id": "productview_handlekeydown",
-      "community": 33
+      "community": 34
     },
     {
       "label": "updateProductVisibility()",
@@ -4313,7 +4313,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L431",
       "id": "productview_updateproductvisibility",
-      "community": 33
+      "community": 34
     },
     {
       "label": "SheetProvider.tsx",
@@ -4321,7 +4321,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_sheetprovider_tsx",
-      "community": 170
+      "community": 172
     },
     {
       "label": "useSheet()",
@@ -4329,7 +4329,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
       "source_location": "L11",
       "id": "sheetprovider_usesheet",
-      "community": 170
+      "community": 172
     },
     {
       "label": "SheetProvider()",
@@ -4337,7 +4337,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
       "source_location": "L19",
       "id": "sheetprovider_sheetprovider",
-      "community": 170
+      "community": 172
     },
     {
       "label": "WigType.tsx",
@@ -4345,7 +4345,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_wigtype_tsx",
-      "community": 171
+      "community": 173
     },
     {
       "label": "WigTypeView()",
@@ -4353,7 +4353,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
       "source_location": "L8",
       "id": "wigtype_wigtypeview",
-      "community": 171
+      "community": 173
     },
     {
       "label": "WigType()",
@@ -4361,7 +4361,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
       "source_location": "L21",
       "id": "wigtype_wigtype",
-      "community": 171
+      "community": 173
     },
     {
       "label": "CopyImagesProvider.tsx",
@@ -4369,7 +4369,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesprovider_tsx",
-      "community": 172
+      "community": 174
     },
     {
       "label": "useCopyImages()",
@@ -4377,7 +4377,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
       "source_location": "L13",
       "id": "copyimagesprovider_usecopyimages",
-      "community": 172
+      "community": 174
     },
     {
       "label": "CopyImagesProvider()",
@@ -4385,7 +4385,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
       "source_location": "L21",
       "id": "copyimagesprovider_copyimagesprovider",
-      "community": 172
+      "community": 174
     },
     {
       "label": "CopyImagesView.tsx",
@@ -4393,7 +4393,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesview_tsx",
-      "community": 310
+      "community": 312
     },
     {
       "label": "setIsUpdatingSku()",
@@ -4401,7 +4401,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesView.tsx",
       "source_location": "L116",
       "id": "copyimagesview_setisupdatingsku",
-      "community": 310
+      "community": 312
     },
     {
       "label": "constants.ts",
@@ -4409,7 +4409,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/constants.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_constants_ts",
-      "community": 714
+      "community": 716
     },
     {
       "label": "data-table-column-header.tsx",
@@ -4417,7 +4417,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_column_header_tsx",
-      "community": 15
+      "community": 16
     },
     {
       "label": "DataTableColumnHeader()",
@@ -4425,7 +4425,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-column-header.tsx",
       "source_location": "L20",
       "id": "data_table_column_header_datatablecolumnheader",
-      "community": 15
+      "community": 16
     },
     {
       "label": "data-table-faceted-filter.tsx",
@@ -4433,7 +4433,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-faceted-filter.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_faceted_filter_tsx",
-      "community": 715
+      "community": 717
     },
     {
       "label": "data-table-pagination.tsx",
@@ -4441,7 +4441,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_pagination_tsx",
-      "community": 716
+      "community": 718
     },
     {
       "label": "data-table-toolbar-provider.tsx",
@@ -4449,7 +4449,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar-provider.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_provider_tsx",
-      "community": 22
+      "community": 23
     },
     {
       "label": "OrdersTableToolbarProvider()",
@@ -4457,7 +4457,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
       "source_location": "L16",
       "id": "data_table_toolbar_provider_orderstabletoolbarprovider",
-      "community": 22
+      "community": 23
     },
     {
       "label": "useOrdersTableToolbar()",
@@ -4465,7 +4465,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
       "source_location": "L46",
       "id": "data_table_toolbar_provider_useorderstabletoolbar",
-      "community": 22
+      "community": 23
     },
     {
       "label": "data-table-toolbar.tsx",
@@ -4473,7 +4473,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_tsx",
-      "community": 61
+      "community": 62
     },
     {
       "label": "DataTableToolbar()",
@@ -4481,7 +4481,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
       "source_location": "L23",
       "id": "data_table_toolbar_datatabletoolbar",
-      "community": 61
+      "community": 62
     },
     {
       "label": "data-table-view-options.tsx",
@@ -4489,7 +4489,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-view-options.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_view_options_tsx",
-      "community": 12
+      "community": 13
     },
     {
       "label": "DataTableViewOptions()",
@@ -4497,7 +4497,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
       "source_location": "L18",
       "id": "data_table_view_options_datatableviewoptions",
-      "community": 12
+      "community": 13
     },
     {
       "label": "data-table.tsx",
@@ -4505,7 +4505,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_tsx",
-      "community": 717
+      "community": 719
     },
     {
       "label": "product-variant-columns.tsx",
@@ -4513,7 +4513,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_product_variant_columns_tsx",
-      "community": 311
+      "community": 313
     },
     {
       "label": "setSourceVariant()",
@@ -4521,7 +4521,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
       "source_location": "L47",
       "id": "product_variant_columns_setsourcevariant",
-      "community": 311
+      "community": 313
     },
     {
       "label": "types.ts",
@@ -4529,7 +4529,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/types.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_types_ts",
-      "community": 718
+      "community": 720
     },
     {
       "label": "ActivityTimeline.tsx",
@@ -4537,7 +4537,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/ActivityTimeline.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_activitytimeline_tsx",
-      "community": 312
+      "community": 314
     },
     {
       "label": "capitalizeFirstLetter()",
@@ -4545,7 +4545,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/ActivityTimeline.tsx",
       "source_location": "L151",
       "id": "activitytimeline_capitalizefirstletter",
-      "community": 312
+      "community": 314
     },
     {
       "label": "AnalyticsCombinedUsers.tsx",
@@ -4553,7 +4553,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analyticscombinedusers_tsx",
-      "community": 173
+      "community": 175
     },
     {
       "label": "processAnalyticsToUsers()",
@@ -4561,7 +4561,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
       "source_location": "L10",
       "id": "analyticscombinedusers_processanalyticstousers",
-      "community": 173
+      "community": 175
     },
     {
       "label": "AnalyticsCombinedUsers()",
@@ -4569,7 +4569,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
       "source_location": "L100",
       "id": "analyticscombinedusers_analyticscombinedusers",
-      "community": 173
+      "community": 175
     },
     {
       "label": "AnalyticsItems.tsx",
@@ -4577,7 +4577,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsItems.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analyticsitems_tsx",
-      "community": 313
+      "community": 315
     },
     {
       "label": "AnalyticsItems()",
@@ -4585,7 +4585,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsItems.tsx",
       "source_location": "L6",
       "id": "analyticsitems_analyticsitems",
-      "community": 313
+      "community": 315
     },
     {
       "label": "AnalyticsProducts.tsx",
@@ -4593,7 +4593,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsProducts.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analyticsproducts_tsx",
-      "community": 314
+      "community": 316
     },
     {
       "label": "AnalyticsProducts()",
@@ -4601,7 +4601,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsProducts.tsx",
       "source_location": "L19",
       "id": "analyticsproducts_analyticsproducts",
-      "community": 314
+      "community": 316
     },
     {
       "label": "AnalyticsTopUsers.tsx",
@@ -4609,7 +4609,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsTopUsers.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analyticstopusers_tsx",
-      "community": 174
+      "community": 176
     },
     {
       "label": "processAnalyticsToUsers()",
@@ -4617,7 +4617,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsTopUsers.tsx",
       "source_location": "L10",
       "id": "analyticstopusers_processanalyticstousers",
-      "community": 174
+      "community": 176
     },
     {
       "label": "AnalyticsTopUsers()",
@@ -4625,7 +4625,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsTopUsers.tsx",
       "source_location": "L100",
       "id": "analyticstopusers_analyticstopusers",
-      "community": 174
+      "community": 176
     },
     {
       "label": "AnalyticsUsers.tsx",
@@ -4633,7 +4633,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsUsers.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analyticsusers_tsx",
-      "community": 315
+      "community": 317
     },
     {
       "label": "AnalyticsUsers()",
@@ -4641,7 +4641,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsUsers.tsx",
       "source_location": "L7",
       "id": "analyticsusers_analyticsusers",
-      "community": 315
+      "community": 317
     },
     {
       "label": "AnalyticsView.tsx",
@@ -4649,7 +4649,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analyticsview_tsx",
-      "community": 131
+      "community": 132
     },
     {
       "label": "StoreVisitors()",
@@ -4657,7 +4657,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
       "source_location": "L14",
       "id": "analyticsview_storevisitors",
-      "community": 131
+      "community": 132
     },
     {
       "label": "ActiveCheckoutSessions()",
@@ -4665,7 +4665,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
       "source_location": "L44",
       "id": "analyticsview_activecheckoutsessions",
-      "community": 131
+      "community": 132
     },
     {
       "label": "AnalyticsView()",
@@ -4673,7 +4673,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
       "source_location": "L84",
       "id": "analyticsview_analyticsview",
-      "community": 131
+      "community": 132
     },
     {
       "label": "ConversionFunnelChart.tsx",
@@ -4681,7 +4681,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/ConversionFunnelChart.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_conversionfunnelchart_tsx",
-      "community": 719
+      "community": 721
     },
     {
       "label": "EnhancedAnalyticsView.tsx",
@@ -4689,7 +4689,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/EnhancedAnalyticsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_enhancedanalyticsview_tsx",
-      "community": 316
+      "community": 318
     },
     {
       "label": "getDateRangeMilliseconds()",
@@ -4697,7 +4697,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/EnhancedAnalyticsView.tsx",
       "source_location": "L42",
       "id": "enhancedanalyticsview_getdaterangemilliseconds",
-      "community": 316
+      "community": 318
     },
     {
       "label": "RevenueChart.tsx",
@@ -4705,7 +4705,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/RevenueChart.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_revenuechart_tsx",
-      "community": 720
+      "community": 722
     },
     {
       "label": "StoreInsights.tsx",
@@ -4713,7 +4713,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/StoreInsights.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_storeinsights_tsx",
-      "community": 317
+      "community": 319
     },
     {
       "label": "getTrendIcon()",
@@ -4721,7 +4721,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/StoreInsights.tsx",
       "source_location": "L66",
       "id": "storeinsights_gettrendicon",
-      "community": 317
+      "community": 319
     },
     {
       "label": "StorefrontObservabilityPanel.tsx",
@@ -4729,7 +4729,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_storefrontobservabilitypanel_tsx",
-      "community": 175
+      "community": 177
     },
     {
       "label": "formatLabel()",
@@ -4737,7 +4737,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
       "source_location": "L15",
       "id": "storefrontobservabilitypanel_formatlabel",
-      "community": 175
+      "community": 177
     },
     {
       "label": "SummaryCard()",
@@ -4745,7 +4745,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
       "source_location": "L19",
       "id": "storefrontobservabilitypanel_summarycard",
-      "community": 175
+      "community": 177
     },
     {
       "label": "VisitorChart.tsx",
@@ -4753,7 +4753,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/VisitorChart.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_visitorchart_tsx",
-      "community": 318
+      "community": 320
     },
     {
       "label": "formatHour()",
@@ -4761,7 +4761,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/VisitorChart.tsx",
       "source_location": "L18",
       "id": "visitorchart_formathour",
-      "community": 318
+      "community": 320
     },
     {
       "label": "analytics-columns.tsx",
@@ -4769,7 +4769,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/analytics-columns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_analytics_columns_tsx",
-      "community": 721
+      "community": 723
     },
     {
       "label": "data-table-column-header.tsx",
@@ -4777,7 +4777,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_column_header_tsx",
-      "community": 722
+      "community": 724
     },
     {
       "label": "data-table-faceted-filter.tsx",
@@ -4785,7 +4785,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-faceted-filter.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_faceted_filter_tsx",
-      "community": 723
+      "community": 725
     },
     {
       "label": "data-table-pagination.tsx",
@@ -4793,7 +4793,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_pagination_tsx",
-      "community": 724
+      "community": 726
     },
     {
       "label": "data-table-row-actions.tsx",
@@ -4801,7 +4801,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-row-actions.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_row_actions_tsx",
-      "community": 40
+      "community": 41
     },
     {
       "label": "DataTableRowActions()",
@@ -4809,7 +4809,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-row-actions.tsx",
       "source_location": "L25",
       "id": "data_table_row_actions_datatablerowactions",
-      "community": 40
+      "community": 41
     },
     {
       "label": "data-table-toolbar.tsx",
@@ -4817,7 +4817,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-toolbar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_toolbar_tsx",
-      "community": 725
+      "community": 727
     },
     {
       "label": "data-table-view-options.tsx",
@@ -4825,7 +4825,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-view-options.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_view_options_tsx",
-      "community": 12
+      "community": 13
     },
     {
       "label": "data-table.tsx",
@@ -4833,7 +4833,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_tsx",
-      "community": 726
+      "community": 728
     },
     {
       "label": "selectable-data-provider.tsx",
@@ -4841,7 +4841,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/selectable-data-provider.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
-      "community": 62
+      "community": 63
     },
     {
       "label": "SelectedProductsProvider()",
@@ -4849,7 +4849,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
       "source_location": "L16",
       "id": "selectable_data_provider_selectedproductsprovider",
-      "community": 62
+      "community": 63
     },
     {
       "label": "useSelectedProducts()",
@@ -4857,7 +4857,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
       "source_location": "L37",
       "id": "selectable_data_provider_useselectedproducts",
-      "community": 62
+      "community": 63
     },
     {
       "label": "columns.tsx",
@@ -4865,7 +4865,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/columns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_columns_tsx",
-      "community": 727
+      "community": 729
     },
     {
       "label": "data-table-column-header.tsx",
@@ -4873,7 +4873,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_column_header_tsx",
-      "community": 15
+      "community": 16
     },
     {
       "label": "data-table-faceted-filter.tsx",
@@ -4881,7 +4881,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-faceted-filter.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_faceted_filter_tsx",
-      "community": 728
+      "community": 730
     },
     {
       "label": "data-table-pagination.tsx",
@@ -4889,7 +4889,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_pagination_tsx",
-      "community": 729
+      "community": 731
     },
     {
       "label": "data-table-row-actions.tsx",
@@ -4897,7 +4897,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-row-actions.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_row_actions_tsx",
-      "community": 40
+      "community": 41
     },
     {
       "label": "data-table-toolbar.tsx",
@@ -4905,7 +4905,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-toolbar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_toolbar_tsx",
-      "community": 730
+      "community": 732
     },
     {
       "label": "data-table-view-options.tsx",
@@ -4913,7 +4913,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-view-options.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_view_options_tsx",
-      "community": 12
+      "community": 13
     },
     {
       "label": "data-table.tsx",
@@ -4921,7 +4921,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_tsx",
-      "community": 731
+      "community": 733
     },
     {
       "label": "columns.tsx",
@@ -4929,7 +4929,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/columns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_columns_tsx",
-      "community": 732
+      "community": 734
     },
     {
       "label": "data-table-column-header.tsx",
@@ -4937,7 +4937,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_column_header_tsx",
-      "community": 15
+      "community": 16
     },
     {
       "label": "data-table-pagination.tsx",
@@ -4945,7 +4945,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_pagination_tsx",
-      "community": 733
+      "community": 735
     },
     {
       "label": "data-table.tsx",
@@ -4953,7 +4953,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/data-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_tsx",
-      "community": 734
+      "community": 736
     },
     {
       "label": "chart.tsx",
@@ -4961,7 +4961,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/chart.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_chart_tsx",
-      "community": 735
+      "community": 737
     },
     {
       "label": "columns.tsx",
@@ -4969,7 +4969,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/columns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_columns_tsx",
-      "community": 736
+      "community": 738
     },
     {
       "label": "data-table-column-header.tsx",
@@ -4977,7 +4977,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_column_header_tsx",
-      "community": 15
+      "community": 16
     },
     {
       "label": "data-table-pagination.tsx",
@@ -4985,7 +4985,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_pagination_tsx",
-      "community": 737
+      "community": 739
     },
     {
       "label": "data-table.tsx",
@@ -4993,7 +4993,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/data-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_tsx",
-      "community": 738
+      "community": 740
     },
     {
       "label": "columns.tsx",
@@ -5001,7 +5001,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/table/columns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_table_columns_tsx",
-      "community": 739
+      "community": 741
     },
     {
       "label": "constants.ts",
@@ -5009,7 +5009,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/table/constants.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_table_constants_ts",
-      "community": 740
+      "community": 742
     },
     {
       "label": "data-table-column-header.tsx",
@@ -5017,7 +5017,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_column_header_tsx",
-      "community": 15
+      "community": 16
     },
     {
       "label": "data-table-faceted-filter.tsx",
@@ -5025,7 +5025,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-faceted-filter.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_faceted_filter_tsx",
-      "community": 741
+      "community": 743
     },
     {
       "label": "data-table-pagination.tsx",
@@ -5033,7 +5033,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_pagination_tsx",
-      "community": 742
+      "community": 744
     },
     {
       "label": "data-table-toolbar-provider.tsx",
@@ -5041,7 +5041,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar-provider.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_provider_tsx",
-      "community": 22
+      "community": 23
     },
     {
       "label": "data-table-toolbar.tsx",
@@ -5049,7 +5049,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_tsx",
-      "community": 61
+      "community": 62
     },
     {
       "label": "data-table-view-options.tsx",
@@ -5057,7 +5057,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-view-options.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_view_options_tsx",
-      "community": 12
+      "community": 13
     },
     {
       "label": "data-table.tsx",
@@ -5065,7 +5065,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/table/data-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_tsx",
-      "community": 743
+      "community": 745
     },
     {
       "label": "data.ts",
@@ -5073,7 +5073,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/table/data.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_table_data_ts",
-      "community": 744
+      "community": 746
     },
     {
       "label": "columns.tsx",
@@ -5081,7 +5081,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/users-table/columns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_users_table_columns_tsx",
-      "community": 745
+      "community": 747
     },
     {
       "label": "data-table-column-header.tsx",
@@ -5089,7 +5089,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/users-table/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_column_header_tsx",
-      "community": 15
+      "community": 16
     },
     {
       "label": "data-table-pagination.tsx",
@@ -5097,7 +5097,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/users-table/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_pagination_tsx",
-      "community": 746
+      "community": 748
     },
     {
       "label": "data-table.tsx",
@@ -5105,7 +5105,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/users-table/data-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_tsx",
-      "community": 747
+      "community": 749
     },
     {
       "label": "utils.ts",
@@ -5113,7 +5113,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_utils_ts",
-      "community": 132
+      "community": 133
     },
     {
       "label": "groupAnalytics()",
@@ -5121,7 +5121,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
       "source_location": "L3",
       "id": "utils_groupanalytics",
-      "community": 132
+      "community": 133
     },
     {
       "label": "countGroupedAnalytics()",
@@ -5129,7 +5129,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
       "source_location": "L52",
       "id": "utils_countgroupedanalytics",
-      "community": 132
+      "community": 133
     },
     {
       "label": "groupProductViewsByDay()",
@@ -5137,7 +5137,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
       "source_location": "L90",
       "id": "utils_groupproductviewsbyday",
-      "community": 132
+      "community": 133
     },
     {
       "label": "LogItems.tsx",
@@ -5145,7 +5145,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/LogItems.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_app_logs_logitems_tsx",
-      "community": 319
+      "community": 321
     },
     {
       "label": "LogItems()",
@@ -5153,7 +5153,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/LogItems.tsx",
       "source_location": "L6",
       "id": "logitems_logitems",
-      "community": 319
+      "community": 321
     },
     {
       "label": "LogView.tsx",
@@ -5161,7 +5161,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/LogView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_app_logs_logview_tsx",
-      "community": 320
+      "community": 322
     },
     {
       "label": "Header()",
@@ -5169,7 +5169,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/LogView.tsx",
       "source_location": "L10",
       "id": "logview_header",
-      "community": 320
+      "community": 322
     },
     {
       "label": "LogsView.tsx",
@@ -5177,7 +5177,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_app_logs_logsview_tsx",
-      "community": 321
+      "community": 323
     },
     {
       "label": "Navigation()",
@@ -5185,7 +5185,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
       "source_location": "L27",
       "id": "logsview_navigation",
-      "community": 321
+      "community": 323
     },
     {
       "label": "columns.tsx",
@@ -5193,7 +5193,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/columns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_columns_tsx",
-      "community": 748
+      "community": 750
     },
     {
       "label": "data-table-column-header.tsx",
@@ -5201,7 +5201,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_column_header_tsx",
-      "community": 749
+      "community": 751
     },
     {
       "label": "data-table-faceted-filter.tsx",
@@ -5209,7 +5209,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-faceted-filter.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_faceted_filter_tsx",
-      "community": 750
+      "community": 752
     },
     {
       "label": "data-table-pagination.tsx",
@@ -5217,7 +5217,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_pagination_tsx",
-      "community": 751
+      "community": 753
     },
     {
       "label": "data-table-row-actions.tsx",
@@ -5225,7 +5225,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-row-actions.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_row_actions_tsx",
-      "community": 40
+      "community": 41
     },
     {
       "label": "data-table-toolbar.tsx",
@@ -5233,7 +5233,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-toolbar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_toolbar_tsx",
-      "community": 752
+      "community": 754
     },
     {
       "label": "data-table-view-options.tsx",
@@ -5241,7 +5241,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-view-options.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_view_options_tsx",
-      "community": 12
+      "community": 13
     },
     {
       "label": "data-table.tsx",
@@ -5249,7 +5249,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_tsx",
-      "community": 753
+      "community": 755
     },
     {
       "label": "log-items-provider.tsx",
@@ -5257,7 +5257,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_log_items_provider_tsx",
-      "community": 176
+      "community": 178
     },
     {
       "label": "LogItemsProvider()",
@@ -5265,7 +5265,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
       "source_location": "L15",
       "id": "log_items_provider_logitemsprovider",
-      "community": 176
+      "community": 178
     },
     {
       "label": "useLogItems()",
@@ -5273,7 +5273,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
       "source_location": "L39",
       "id": "log_items_provider_uselogitems",
-      "community": 176
+      "community": 178
     },
     {
       "label": "useLoadLogItems.ts",
@@ -5281,7 +5281,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/hooks/useLoadLogItems.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_app_logs_hooks_useloadlogitems_ts",
-      "community": 322
+      "community": 324
     },
     {
       "label": "useLoadLogItems()",
@@ -5289,7 +5289,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/hooks/useLoadLogItems.ts",
       "source_location": "L12",
       "id": "useloadlogitems_useloadlogitems",
-      "community": 322
+      "community": 324
     },
     {
       "label": "app-sidebar.tsx",
@@ -5297,7 +5297,7 @@
       "source_file": "packages/athena-webapp/src/components/app-sidebar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_app_sidebar_tsx",
-      "community": 754
+      "community": 756
     },
     {
       "label": "assetsColumns.tsx",
@@ -5305,7 +5305,7 @@
       "source_file": "packages/athena-webapp/src/components/assets/assets-table/assetsColumns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_assets_assets_table_assetscolumns_tsx",
-      "community": 755
+      "community": 757
     },
     {
       "label": "constants.ts",
@@ -5313,7 +5313,7 @@
       "source_file": "packages/athena-webapp/src/components/assets/assets-table/constants.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_assets_assets_table_constants_ts",
-      "community": 756
+      "community": 758
     },
     {
       "label": "data-table-column-header.tsx",
@@ -5321,7 +5321,7 @@
       "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_column_header_tsx",
-      "community": 15
+      "community": 16
     },
     {
       "label": "data-table-faceted-filter.tsx",
@@ -5329,7 +5329,7 @@
       "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-faceted-filter.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_faceted_filter_tsx",
-      "community": 757
+      "community": 759
     },
     {
       "label": "data-table-pagination.tsx",
@@ -5337,7 +5337,7 @@
       "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_pagination_tsx",
-      "community": 758
+      "community": 760
     },
     {
       "label": "data-table-toolbar-provider.tsx",
@@ -5345,7 +5345,7 @@
       "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-toolbar-provider.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_toolbar_provider_tsx",
-      "community": 22
+      "community": 23
     },
     {
       "label": "data-table-view-options.tsx",
@@ -5353,7 +5353,7 @@
       "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-view-options.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_view_options_tsx",
-      "community": 12
+      "community": 13
     },
     {
       "label": "data-table.tsx",
@@ -5361,7 +5361,7 @@
       "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_tsx",
-      "community": 759
+      "community": 761
     },
     {
       "label": "data.ts",
@@ -5369,7 +5369,7 @@
       "source_file": "packages/athena-webapp/src/components/assets/assets-table/data.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_ts",
-      "community": 760
+      "community": 762
     },
     {
       "label": "index.tsx",
@@ -5377,7 +5377,7 @@
       "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_assets_index_tsx",
-      "community": 92
+      "community": 93
     },
     {
       "label": "Header()",
@@ -5385,7 +5385,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
       "source_location": "L42",
       "id": "index_header",
-      "community": 92
+      "community": 93
     },
     {
       "label": "FeesView()",
@@ -5393,7 +5393,7 @@
       "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
       "source_location": "L29",
       "id": "index_feesview",
-      "community": 92
+      "community": 93
     },
     {
       "label": "Auth.tsx",
@@ -5401,7 +5401,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Auth.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_auth_auth_tsx",
-      "community": 323
+      "community": 325
     },
     {
       "label": "Auth()",
@@ -5409,7 +5409,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Auth.tsx",
       "source_location": "L3",
       "id": "auth_auth",
-      "community": 323
+      "community": 325
     },
     {
       "label": "DefaultCatchBoundary.tsx",
@@ -5417,7 +5417,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/DefaultCatchBoundary.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_tsx",
-      "community": 761
+      "community": 763
     },
     {
       "label": "InputOTP.tsx",
@@ -5425,7 +5425,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
-      "community": 177
+      "community": 179
     },
     {
       "label": "handlePinChange()",
@@ -5433,7 +5433,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
       "source_location": "L48",
       "id": "inputotp_handlepinchange",
-      "community": 177
+      "community": 179
     },
     {
       "label": "onSubmit()",
@@ -5441,7 +5441,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
       "source_location": "L56",
       "id": "inputotp_onsubmit",
-      "community": 177
+      "community": 179
     },
     {
       "label": "LoginForm.tsx",
@@ -5449,7 +5449,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Login/LoginForm.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_auth_login_loginform_tsx",
-      "community": 762
+      "community": 764
     },
     {
       "label": "index.tsx",
@@ -5457,7 +5457,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Login/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_auth_login_index_tsx",
-      "community": 324
+      "community": 326
     },
     {
       "label": "Login()",
@@ -5465,7 +5465,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Login/index.tsx",
       "source_location": "L5",
       "id": "index_login",
-      "community": 324
+      "community": 326
     },
     {
       "label": "columns.tsx",
@@ -5473,7 +5473,7 @@
       "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/columns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_columns_tsx",
-      "community": 763
+      "community": 765
     },
     {
       "label": "data-table-column-header.tsx",
@@ -5481,7 +5481,7 @@
       "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_column_header_tsx",
-      "community": 764
+      "community": 766
     },
     {
       "label": "data-table-faceted-filter.tsx",
@@ -5489,7 +5489,7 @@
       "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-faceted-filter.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_faceted_filter_tsx",
-      "community": 765
+      "community": 767
     },
     {
       "label": "data-table-pagination.tsx",
@@ -5497,7 +5497,7 @@
       "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_pagination_tsx",
-      "community": 766
+      "community": 768
     },
     {
       "label": "data-table-row-actions.tsx",
@@ -5505,7 +5505,7 @@
       "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-row-actions.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_row_actions_tsx",
-      "community": 40
+      "community": 41
     },
     {
       "label": "data-table-toolbar.tsx",
@@ -5513,7 +5513,7 @@
       "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-toolbar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_toolbar_tsx",
-      "community": 767
+      "community": 769
     },
     {
       "label": "data-table-view-options.tsx",
@@ -5521,7 +5521,7 @@
       "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-view-options.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_view_options_tsx",
-      "community": 12
+      "community": 13
     },
     {
       "label": "data-table.tsx",
@@ -5529,7 +5529,7 @@
       "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_tsx",
-      "community": 768
+      "community": 770
     },
     {
       "label": "selectable-data-provider.tsx",
@@ -5537,7 +5537,7 @@
       "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/selectable-data-provider.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
-      "community": 62
+      "community": 63
     },
     {
       "label": "columns.tsx",
@@ -5545,7 +5545,7 @@
       "source_file": "packages/athena-webapp/src/components/base/table/columns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_base_table_columns_tsx",
-      "community": 769
+      "community": 771
     },
     {
       "label": "constants.ts",
@@ -5553,7 +5553,7 @@
       "source_file": "packages/athena-webapp/src/components/base/table/constants.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_base_table_constants_ts",
-      "community": 770
+      "community": 772
     },
     {
       "label": "data-table-column-header.tsx",
@@ -5561,7 +5561,7 @@
       "source_file": "packages/athena-webapp/src/components/base/table/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_base_table_data_table_column_header_tsx",
-      "community": 15
+      "community": 16
     },
     {
       "label": "data-table-faceted-filter.tsx",
@@ -5569,7 +5569,7 @@
       "source_file": "packages/athena-webapp/src/components/base/table/data-table-faceted-filter.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_base_table_data_table_faceted_filter_tsx",
-      "community": 771
+      "community": 773
     },
     {
       "label": "data-table-pagination.tsx",
@@ -5577,7 +5577,7 @@
       "source_file": "packages/athena-webapp/src/components/base/table/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_base_table_data_table_pagination_tsx",
-      "community": 772
+      "community": 774
     },
     {
       "label": "data-table-toolbar-provider.tsx",
@@ -5585,7 +5585,7 @@
       "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar-provider.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_provider_tsx",
-      "community": 22
+      "community": 23
     },
     {
       "label": "data-table-toolbar.tsx",
@@ -5593,7 +5593,7 @@
       "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_tsx",
-      "community": 61
+      "community": 62
     },
     {
       "label": "data-table-view-options.tsx",
@@ -5601,7 +5601,7 @@
       "source_file": "packages/athena-webapp/src/components/base/table/data-table-view-options.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_base_table_data_table_view_options_tsx",
-      "community": 12
+      "community": 13
     },
     {
       "label": "data-table.tsx",
@@ -5609,7 +5609,7 @@
       "source_file": "packages/athena-webapp/src/components/base/table/data-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_base_table_data_table_tsx",
-      "community": 773
+      "community": 775
     },
     {
       "label": "BulkOperationsFilters.tsx",
@@ -5617,7 +5617,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsFilters.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationsfilters_tsx",
-      "community": 325
+      "community": 327
     },
     {
       "label": "handleLoadProducts()",
@@ -5625,7 +5625,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsFilters.tsx",
       "source_location": "L49",
       "id": "bulkoperationsfilters_handleloadproducts",
-      "community": 325
+      "community": 327
     },
     {
       "label": "BulkOperationsPage.tsx",
@@ -5633,7 +5633,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPage.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspage_tsx",
-      "community": 774
+      "community": 776
     },
     {
       "label": "BulkOperationsPreview.test.tsx",
@@ -5641,7 +5641,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.test.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_test_tsx",
-      "community": 326
+      "community": 328
     },
     {
       "label": "makeRow()",
@@ -5649,7 +5649,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.test.tsx",
       "source_location": "L23",
       "id": "bulkoperationspreview_test_makerow",
-      "community": 326
+      "community": 328
     },
     {
       "label": "BulkOperationsPreview.tsx",
@@ -5657,7 +5657,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_tsx",
-      "community": 327
+      "community": 329
     },
     {
       "label": "formatPrice()",
@@ -5665,7 +5665,7 @@
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.tsx",
       "source_location": "L50",
       "id": "bulkoperationspreview_formatprice",
-      "community": 327
+      "community": 329
     },
     {
       "label": "CashierManagement.tsx",
@@ -5673,7 +5673,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_cashiers_cashiermanagement_tsx",
-      "community": 63
+      "community": 64
     },
     {
       "label": "normalizeNameSegment()",
@@ -5681,7 +5681,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L42",
       "id": "cashiermanagement_normalizenamesegment",
-      "community": 63
+      "community": 64
     },
     {
       "label": "buildUsername()",
@@ -5689,7 +5689,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L50",
       "id": "cashiermanagement_buildusername",
-      "community": 63
+      "community": 64
     },
     {
       "label": "handleSubmit()",
@@ -5697,7 +5697,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L109",
       "id": "cashiermanagement_handlesubmit",
-      "community": 63
+      "community": 64
     },
     {
       "label": "handlePinKeyDown()",
@@ -5705,7 +5705,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L169",
       "id": "cashiermanagement_handlepinkeydown",
-      "community": 63
+      "community": 64
     },
     {
       "label": "handleDelete()",
@@ -5713,7 +5713,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L320",
       "id": "cashiermanagement_handledelete",
-      "community": 63
+      "community": 64
     },
     {
       "label": "index.tsx",
@@ -5721,7 +5721,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_cashiers_index_tsx",
-      "community": 775
+      "community": 777
     },
     {
       "label": "CheckoutSessionsTable.tsx",
@@ -5729,7 +5729,7 @@
       "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSessionsTable.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsessionstable_tsx",
-      "community": 328
+      "community": 330
     },
     {
       "label": "CheckoutSessionsTable()",
@@ -5737,7 +5737,7 @@
       "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSessionsTable.tsx",
       "source_location": "L13",
       "id": "checkoutsessionstable_checkoutsessionstable",
-      "community": 328
+      "community": 330
     },
     {
       "label": "CheckoutSesssionsView.tsx",
@@ -5745,7 +5745,7 @@
       "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSesssionsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsesssionsview_tsx",
-      "community": 329
+      "community": 331
     },
     {
       "label": "Navigation()",
@@ -5753,7 +5753,7 @@
       "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSesssionsView.tsx",
       "source_location": "L11",
       "id": "checkoutsesssionsview_navigation",
-      "community": 329
+      "community": 331
     },
     {
       "label": "columns.tsx",
@@ -5761,7 +5761,7 @@
       "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/columns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_columns_tsx",
-      "community": 776
+      "community": 778
     },
     {
       "label": "data-table-column-header.tsx",
@@ -5769,7 +5769,7 @@
       "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_column_header_tsx",
-      "community": 15
+      "community": 16
     },
     {
       "label": "data-table-pagination.tsx",
@@ -5777,7 +5777,7 @@
       "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_pagination_tsx",
-      "community": 777
+      "community": 779
     },
     {
       "label": "data-table.tsx",
@@ -5785,7 +5785,7 @@
       "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/data-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_tsx",
-      "community": 778
+      "community": 780
     },
     {
       "label": "FadeIn.tsx",
@@ -5793,7 +5793,7 @@
       "source_file": "packages/athena-webapp/src/components/common/FadeIn.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_common_fadein_tsx",
-      "community": 178
+      "community": 180
     },
     {
       "label": "FadeIn()",
@@ -5801,7 +5801,7 @@
       "source_file": "packages/storefront-webapp/src/components/common/FadeIn.tsx",
       "source_location": "L3",
       "id": "fadein_fadein",
-      "community": 178
+      "community": 180
     },
     {
       "label": "PageHeader.tsx",
@@ -5809,7 +5809,7 @@
       "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
-      "community": 330
+      "community": 332
     },
     {
       "label": "PageHeader()",
@@ -5817,7 +5817,7 @@
       "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
       "source_location": "L7",
       "id": "pageheader_pageheader",
-      "community": 330
+      "community": 332
     },
     {
       "label": "Dashboard.tsx",
@@ -5825,7 +5825,7 @@
       "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
-      "community": 93
+      "community": 94
     },
     {
       "label": "getPeriodRange()",
@@ -5833,7 +5833,7 @@
       "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
       "source_location": "L20",
       "id": "dashboard_getperiodrange",
-      "community": 93
+      "community": 94
     },
     {
       "label": "LoadingSection()",
@@ -5841,7 +5841,7 @@
       "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
       "source_location": "L50",
       "id": "dashboard_loadingsection",
-      "community": 93
+      "community": 94
     },
     {
       "label": "renderSalesSection()",
@@ -5849,7 +5849,7 @@
       "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
       "source_location": "L322",
       "id": "dashboard_rendersalessection",
-      "community": 93
+      "community": 94
     },
     {
       "label": "renderProductsSection()",
@@ -5857,7 +5857,7 @@
       "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
       "source_location": "L342",
       "id": "dashboard_renderproductssection",
-      "community": 93
+      "community": 94
     },
     {
       "label": "MetricCard.tsx",
@@ -5865,7 +5865,7 @@
       "source_file": "packages/athena-webapp/src/components/dashboard/MetricCard.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_dashboard_metriccard_tsx",
-      "community": 779
+      "community": 781
     },
     {
       "label": "ExpenseCompletion.tsx",
@@ -5873,7 +5873,7 @@
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseCompletion.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_expense_expensecompletion_tsx",
-      "community": 780
+      "community": 782
     },
     {
       "label": "ExpenseView.tsx",
@@ -5881,7 +5881,7 @@
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_expense_expenseview_tsx",
-      "community": 34
+      "community": 35
     },
     {
       "label": "handleSessionLoaded()",
@@ -5889,7 +5889,7 @@
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
       "source_location": "L60",
       "id": "expenseview_handlesessionloaded",
-      "community": 34
+      "community": 35
     },
     {
       "label": "resetAutoSessionInitialized()",
@@ -5897,7 +5897,7 @@
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
       "source_location": "L64",
       "id": "expenseview_resetautosessioninitialized",
-      "community": 34
+      "community": 35
     },
     {
       "label": "handleNewSession()",
@@ -5905,7 +5905,7 @@
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
       "source_location": "L68",
       "id": "expenseview_handlenewsession",
-      "community": 34
+      "community": 35
     },
     {
       "label": "handleCashierAuthenticated()",
@@ -5913,7 +5913,7 @@
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
       "source_location": "L86",
       "id": "expenseview_handlecashierauthenticated",
-      "community": 34
+      "community": 35
     },
     {
       "label": "handleBarcodeSubmit()",
@@ -5921,7 +5921,7 @@
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
       "source_location": "L295",
       "id": "expenseview_handlebarcodesubmit",
-      "community": 34
+      "community": 35
     },
     {
       "label": "handleClearCart()",
@@ -5929,7 +5929,7 @@
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
       "source_location": "L322",
       "id": "expenseview_handleclearcart",
-      "community": 34
+      "community": 35
     },
     {
       "label": "handleCompleteExpense()",
@@ -5937,7 +5937,7 @@
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
       "source_location": "L335",
       "id": "expenseview_handlecompleteexpense",
-      "community": 34
+      "community": 35
     },
     {
       "label": "handleNavigateBack()",
@@ -5945,7 +5945,7 @@
       "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
       "source_location": "L383",
       "id": "expenseview_handlenavigateback",
-      "community": 34
+      "community": 35
     },
     {
       "label": "BannerMessageEditor.tsx",
@@ -5953,7 +5953,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_bannermessageeditor_tsx",
-      "community": 64
+      "community": 65
     },
     {
       "label": "handleSave()",
@@ -5961,7 +5961,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L46",
       "id": "bannermessageeditor_handlesave",
-      "community": 64
+      "community": 65
     },
     {
       "label": "handleClear()",
@@ -5969,7 +5969,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L66",
       "id": "bannermessageeditor_handleclear",
-      "community": 64
+      "community": 65
     },
     {
       "label": "handleActiveToggle()",
@@ -5977,7 +5977,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L91",
       "id": "bannermessageeditor_handleactivetoggle",
-      "community": 64
+      "community": 65
     },
     {
       "label": "handleCountdownChange()",
@@ -5985,7 +5985,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L113",
       "id": "bannermessageeditor_handlecountdownchange",
-      "community": 64
+      "community": 65
     },
     {
       "label": "getCountdownStatus()",
@@ -5993,7 +5993,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L123",
       "id": "bannermessageeditor_getcountdownstatus",
-      "community": 64
+      "community": 65
     },
     {
       "label": "BestSellers.tsx",
@@ -6001,7 +6001,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_bestsellers_tsx",
-      "community": 179
+      "community": 181
     },
     {
       "label": "handleRemoveBestSeller()",
@@ -6009,7 +6009,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
       "source_location": "L53",
       "id": "bestsellers_handleremovebestseller",
-      "community": 179
+      "community": 181
     },
     {
       "label": "onDragEnd()",
@@ -6017,7 +6017,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
       "source_location": "L65",
       "id": "bestsellers_ondragend",
-      "community": 179
+      "community": 181
     },
     {
       "label": "BestSellersDialog.tsx",
@@ -6025,7 +6025,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BestSellersDialog.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_bestsellersdialog_tsx",
-      "community": 331
+      "community": 333
     },
     {
       "label": "handleAddBestSeller()",
@@ -6033,7 +6033,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BestSellersDialog.tsx",
       "source_location": "L29",
       "id": "bestsellersdialog_handleaddbestseller",
-      "community": 331
+      "community": 333
     },
     {
       "label": "FeaturedSection.tsx",
@@ -6041,7 +6041,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_featuredsection_tsx",
-      "community": 180
+      "community": 182
     },
     {
       "label": "handleHighlightedItem()",
@@ -6049,7 +6049,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
       "source_location": "L47",
       "id": "featuredsection_handlehighlighteditem",
-      "community": 180
+      "community": 182
     },
     {
       "label": "onDragEnd()",
@@ -6057,7 +6057,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
       "source_location": "L53",
       "id": "featuredsection_ondragend",
-      "community": 180
+      "community": 182
     },
     {
       "label": "FeaturedSectionDialog.tsx",
@@ -6065,7 +6065,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSectionDialog.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_featuredsectiondialog_tsx",
-      "community": 332
+      "community": 334
     },
     {
       "label": "handleAddFeaturedItem()",
@@ -6073,7 +6073,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSectionDialog.tsx",
       "source_location": "L37",
       "id": "featuredsectiondialog_handleaddfeatureditem",
-      "community": 332
+      "community": 334
     },
     {
       "label": "HeroHeaderImageUploader.tsx",
@@ -6081,7 +6081,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_heroheaderimageuploader_tsx",
-      "community": 30
+      "community": 31
     },
     {
       "label": "validateFile()",
@@ -6089,7 +6089,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L50",
       "id": "heroheaderimageuploader_validatefile",
-      "community": 30
+      "community": 31
     },
     {
       "label": "uploadImage()",
@@ -6097,7 +6097,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L67",
       "id": "heroheaderimageuploader_uploadimage",
-      "community": 30
+      "community": 31
     },
     {
       "label": "resetEditState()",
@@ -6105,7 +6105,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L95",
       "id": "heroheaderimageuploader_reseteditstate",
-      "community": 30
+      "community": 31
     },
     {
       "label": "handleEditClick()",
@@ -6113,7 +6113,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L108",
       "id": "heroheaderimageuploader_handleeditclick",
-      "community": 30
+      "community": 31
     },
     {
       "label": "handleFileSelect()",
@@ -6121,7 +6121,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L113",
       "id": "heroheaderimageuploader_handlefileselect",
-      "community": 30
+      "community": 31
     },
     {
       "label": "handleUpload()",
@@ -6129,7 +6129,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L127",
       "id": "heroheaderimageuploader_handleupload",
-      "community": 30
+      "community": 31
     },
     {
       "label": "handleRevert()",
@@ -6137,7 +6137,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L163",
       "id": "heroheaderimageuploader_handlerevert",
-      "community": 30
+      "community": 31
     },
     {
       "label": "EditModeButtons()",
@@ -6145,7 +6145,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L179",
       "id": "heroheaderimageuploader_editmodebuttons",
-      "community": 30
+      "community": 31
     },
     {
       "label": "ViewModeButton()",
@@ -6153,7 +6153,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L205",
       "id": "heroheaderimageuploader_viewmodebutton",
-      "community": 30
+      "community": 31
     },
     {
       "label": "HeroSectionTabs.tsx",
@@ -6161,7 +6161,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
-      "community": 94
+      "community": 95
     },
     {
       "label": "handleImageUpdate()",
@@ -6169,7 +6169,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
       "source_location": "L57",
       "id": "herosectiontabs_handleimageupdate",
-      "community": 94
+      "community": 95
     },
     {
       "label": "handleDisplayTypeChange()",
@@ -6177,7 +6177,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
       "source_location": "L61",
       "id": "herosectiontabs_handledisplaytypechange",
-      "community": 94
+      "community": 95
     },
     {
       "label": "handleOverlayToggle()",
@@ -6185,7 +6185,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
       "source_location": "L98",
       "id": "herosectiontabs_handleoverlaytoggle",
-      "community": 94
+      "community": 95
     },
     {
       "label": "handleTextToggle()",
@@ -6193,7 +6193,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
       "source_location": "L134",
       "id": "herosectiontabs_handletexttoggle",
-      "community": 94
+      "community": 95
     },
     {
       "label": "Home.tsx",
@@ -6201,7 +6201,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/Home.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_home_tsx",
-      "community": 333
+      "community": 335
     },
     {
       "label": "Navigation()",
@@ -6209,7 +6209,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/Home.tsx",
       "source_location": "L25",
       "id": "home_navigation",
-      "community": 333
+      "community": 335
     },
     {
       "label": "LandingPageReelVersion.tsx",
@@ -6217,7 +6217,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/LandingPageReelVersion.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_landingpagereelversion_tsx",
-      "community": 334
+      "community": 336
     },
     {
       "label": "handleUpdateConfig()",
@@ -6225,7 +6225,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/LandingPageReelVersion.tsx",
       "source_location": "L83",
       "id": "landingpagereelversion_handleupdateconfig",
-      "community": 334
+      "community": 336
     },
     {
       "label": "MaintenanceMessageEditor.tsx",
@@ -6233,7 +6233,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_maintenancemessageeditor_tsx",
-      "community": 133
+      "community": 134
     },
     {
       "label": "handleSave()",
@@ -6241,7 +6241,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
       "source_location": "L52",
       "id": "maintenancemessageeditor_handlesave",
-      "community": 133
+      "community": 134
     },
     {
       "label": "handleCountdownChange()",
@@ -6249,7 +6249,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
       "source_location": "L76",
       "id": "maintenancemessageeditor_handlecountdownchange",
-      "community": 133
+      "community": 134
     },
     {
       "label": "getCountdownStatus()",
@@ -6257,7 +6257,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
       "source_location": "L86",
       "id": "maintenancemessageeditor_getcountdownstatus",
-      "community": 133
+      "community": 134
     },
     {
       "label": "ReelUploader.tsx",
@@ -6265,7 +6265,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
-      "community": 95
+      "community": 96
     },
     {
       "label": "formatFileSize()",
@@ -6273,7 +6273,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
       "source_location": "L38",
       "id": "reeluploader_formatfilesize",
-      "community": 95
+      "community": 96
     },
     {
       "label": "validateFile()",
@@ -6281,7 +6281,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
       "source_location": "L43",
       "id": "reeluploader_validatefile",
-      "community": 95
+      "community": 96
     },
     {
       "label": "handleFileSelect()",
@@ -6289,7 +6289,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
       "source_location": "L64",
       "id": "reeluploader_handlefileselect",
-      "community": 95
+      "community": 96
     },
     {
       "label": "handleUpload()",
@@ -6297,7 +6297,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
       "source_location": "L135",
       "id": "reeluploader_handleupload",
-      "community": 95
+      "community": 96
     },
     {
       "label": "ShopLook.tsx",
@@ -6305,7 +6305,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_shoplook_tsx",
-      "community": 134
+      "community": 135
     },
     {
       "label": "handleHighlightedItem()",
@@ -6313,7 +6313,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
       "source_location": "L67",
       "id": "shoplook_handlehighlighteditem",
-      "community": 134
+      "community": 135
     },
     {
       "label": "onDragEnd()",
@@ -6321,7 +6321,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
       "source_location": "L73",
       "id": "shoplook_ondragend",
-      "community": 134
+      "community": 135
     },
     {
       "label": "handleImageUpdate()",
@@ -6329,7 +6329,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
       "source_location": "L90",
       "id": "shoplook_handleimageupdate",
-      "community": 134
+      "community": 135
     },
     {
       "label": "ShopLookDialog.tsx",
@@ -6337,7 +6337,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ShopLookDialog.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_shoplookdialog_tsx",
-      "community": 335
+      "community": 337
     },
     {
       "label": "handleAddFeaturedItem()",
@@ -6345,7 +6345,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ShopLookDialog.tsx",
       "source_location": "L35",
       "id": "shoplookdialog_handleaddfeatureditem",
-      "community": 335
+      "community": 337
     },
     {
       "label": "ShopLookImageUploader.tsx",
@@ -6353,7 +6353,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_shoplookimageuploader_tsx",
-      "community": 336
+      "community": 338
     },
     {
       "label": "ShopLookImageUploader()",
@@ -6361,7 +6361,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
       "source_location": "L28",
       "id": "shoplookimageuploader_shoplookimageuploader",
-      "community": 336
+      "community": 338
     },
     {
       "label": "VideoPlayer.tsx",
@@ -6369,7 +6369,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/VideoPlayer.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_videoplayer_tsx",
-      "community": 181
+      "community": 183
     },
     {
       "label": "VideoPlayer()",
@@ -6377,7 +6377,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
       "source_location": "L9",
       "id": "videoplayer_videoplayer",
-      "community": 181
+      "community": 183
     },
     {
       "label": "index.tsx",
@@ -6385,7 +6385,7 @@
       "source_file": "packages/athena-webapp/src/components/join-team/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_join_team_index_tsx",
-      "community": 337
+      "community": 339
     },
     {
       "label": "JoinTeam()",
@@ -6393,7 +6393,7 @@
       "source_file": "packages/athena-webapp/src/components/join-team/index.tsx",
       "source_location": "L11",
       "id": "index_jointeam",
-      "community": 337
+      "community": 339
     },
     {
       "label": "ActivityView.tsx",
@@ -6401,7 +6401,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
-      "community": 96
+      "community": 97
     },
     {
       "label": "isRefundAction()",
@@ -6409,7 +6409,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
       "source_location": "L50",
       "id": "activityview_isrefundaction",
-      "community": 96
+      "community": 97
     },
     {
       "label": "isTransitionAction()",
@@ -6417,7 +6417,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
       "source_location": "L53",
       "id": "activityview_istransitionaction",
-      "community": 96
+      "community": 97
     },
     {
       "label": "isCreatedAction()",
@@ -6425,7 +6425,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
       "source_location": "L58",
       "id": "activityview_iscreatedaction",
-      "community": 96
+      "community": 97
     },
     {
       "label": "isFeedbackRequestAction()",
@@ -6433,7 +6433,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
       "source_location": "L63",
       "id": "activityview_isfeedbackrequestaction",
-      "community": 96
+      "community": 97
     },
     {
       "label": "CustomerDetailsView.tsx",
@@ -6441,7 +6441,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/CustomerDetailsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_customerdetailsview_tsx",
-      "community": 338
+      "community": 340
     },
     {
       "label": "CustomerDetailsView()",
@@ -6449,7 +6449,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/CustomerDetailsView.tsx",
       "source_location": "L13",
       "id": "customerdetailsview_customerdetailsview",
-      "community": 338
+      "community": 340
     },
     {
       "label": "EmailStatusView.tsx",
@@ -6457,7 +6457,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/EmailStatusView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_emailstatusview_tsx",
-      "community": 339
+      "community": 341
     },
     {
       "label": "handleSendOrderEmail()",
@@ -6465,7 +6465,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/EmailStatusView.tsx",
       "source_location": "L41",
       "id": "emailstatusview_handlesendorderemail",
-      "community": 339
+      "community": 341
     },
     {
       "label": "OrderDetailsView.tsx",
@@ -6473,7 +6473,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
-      "community": 97
+      "community": 98
     },
     {
       "label": "VerifiedBadge()",
@@ -6481,7 +6481,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
       "source_location": "L41",
       "id": "orderdetailsview_verifiedbadge",
-      "community": 97
+      "community": 98
     },
     {
       "label": "fetchTransactions()",
@@ -6489,7 +6489,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
       "source_location": "L136",
       "id": "orderdetailsview_fetchtransactions",
-      "community": 97
+      "community": 98
     },
     {
       "label": "handleMarkAsVerified()",
@@ -6497,7 +6497,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
       "source_location": "L173",
       "id": "orderdetailsview_handlemarkasverified",
-      "community": 97
+      "community": 98
     },
     {
       "label": "handleMarkPaymentCollected()",
@@ -6505,7 +6505,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
       "source_location": "L187",
       "id": "orderdetailsview_handlemarkpaymentcollected",
-      "community": 97
+      "community": 98
     },
     {
       "label": "OrderItemsView.tsx",
@@ -6513,7 +6513,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
-      "community": 98
+      "community": 99
     },
     {
       "label": "handleUpdateOrderItem()",
@@ -6521,7 +6521,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
       "source_location": "L47",
       "id": "orderitemsview_handleupdateorderitem",
-      "community": 98
+      "community": 99
     },
     {
       "label": "handleReturnItemToStock()",
@@ -6529,7 +6529,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
       "source_location": "L61",
       "id": "orderitemsview_handlereturnitemtostock",
-      "community": 98
+      "community": 99
     },
     {
       "label": "handleRequestFeedback()",
@@ -6537,7 +6537,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
       "source_location": "L77",
       "id": "orderitemsview_handlerequestfeedback",
-      "community": 98
+      "community": 99
     },
     {
       "label": "handleRestockAll()",
@@ -6545,7 +6545,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
       "source_location": "L295",
       "id": "orderitemsview_handlerestockall",
-      "community": 98
+      "community": 99
     },
     {
       "label": "OrderMetricsPanel.tsx",
@@ -6553,7 +6553,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_ordermetricspanel_tsx",
-      "community": 340
+      "community": 342
     },
     {
       "label": "handleTimeRangeChange()",
@@ -6561,7 +6561,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
       "source_location": "L33",
       "id": "ordermetricspanel_handletimerangechange",
-      "community": 340
+      "community": 342
     },
     {
       "label": "OrderStatus.tsx",
@@ -6569,7 +6569,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderStatus.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_tsx",
-      "community": 781
+      "community": 783
     },
     {
       "label": "OrderSummary.tsx",
@@ -6577,7 +6577,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderSummary.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_ordersummary_tsx",
-      "community": 782
+      "community": 784
     },
     {
       "label": "OrderView.tsx",
@@ -6585,7 +6585,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_orderview_tsx",
-      "community": 182
+      "community": 184
     },
     {
       "label": "handleRefundOrder()",
@@ -6593,7 +6593,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderView.tsx",
       "source_location": "L67",
       "id": "orderview_handlerefundorder",
-      "community": 182
+      "community": 184
     },
     {
       "label": "handleVerifyPayment()",
@@ -6601,7 +6601,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderView.tsx",
       "source_location": "L423",
       "id": "orderview_handleverifypayment",
-      "community": 182
+      "community": 184
     },
     {
       "label": "Orders.tsx",
@@ -6609,7 +6609,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/Orders.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_orders_tsx",
-      "community": 783
+      "community": 785
     },
     {
       "label": "OrdersView.tsx",
@@ -6617,7 +6617,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_ordersview_tsx",
-      "community": 341
+      "community": 343
     },
     {
       "label": "getTimeFilter()",
@@ -6625,7 +6625,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
       "source_location": "L35",
       "id": "ordersview_gettimefilter",
-      "community": 341
+      "community": 343
     },
     {
       "label": "PickupDetailsView.tsx",
@@ -6633,7 +6633,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/PickupDetailsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_pickupdetailsview_tsx",
-      "community": 183
+      "community": 185
     },
     {
       "label": "PickupDetailsView()",
@@ -6641,7 +6641,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/PickupDetailsView.tsx",
       "source_location": "L9",
       "id": "pickupdetailsview_pickupdetailsview",
-      "community": 183
+      "community": 185
     },
     {
       "label": "DeliveryDetails()",
@@ -6649,7 +6649,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/PickupDetailsView.tsx",
       "source_location": "L67",
       "id": "pickupdetailsview_deliverydetails",
-      "community": 183
+      "community": 185
     },
     {
       "label": "RefundsView.tsx",
@@ -6657,7 +6657,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/RefundsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_refundsview_tsx",
-      "community": 342
+      "community": 344
     },
     {
       "label": "handleRefundOrder()",
@@ -6665,7 +6665,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/RefundsView.tsx",
       "source_location": "L79",
       "id": "refundsview_handlerefundorder",
-      "community": 342
+      "community": 344
     },
     {
       "label": "useGetActiveOnlineOrder.ts",
@@ -6673,7 +6673,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/hooks/useGetActiveOnlineOrder.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_hooks_usegetactiveonlineorder_ts",
-      "community": 343
+      "community": 345
     },
     {
       "label": "useGetActiveOnlineOrder()",
@@ -6681,7 +6681,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/hooks/useGetActiveOnlineOrder.ts",
       "source_location": "L6",
       "id": "usegetactiveonlineorder_usegetactiveonlineorder",
-      "community": 343
+      "community": 345
     },
     {
       "label": "constants.ts",
@@ -6689,7 +6689,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/constants.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_constants_ts",
-      "community": 784
+      "community": 786
     },
     {
       "label": "data-table-column-header.tsx",
@@ -6697,7 +6697,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_column_header_tsx",
-      "community": 15
+      "community": 16
     },
     {
       "label": "data-table-faceted-filter.tsx",
@@ -6705,7 +6705,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-faceted-filter.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_faceted_filter_tsx",
-      "community": 785
+      "community": 787
     },
     {
       "label": "data-table-pagination.tsx",
@@ -6713,7 +6713,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_pagination_tsx",
-      "community": 786
+      "community": 788
     },
     {
       "label": "data-table-toolbar-provider.tsx",
@@ -6721,7 +6721,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar-provider.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_provider_tsx",
-      "community": 22
+      "community": 23
     },
     {
       "label": "data-table-toolbar.tsx",
@@ -6729,7 +6729,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_tsx",
-      "community": 344
+      "community": 346
     },
     {
       "label": "handleClearFilters()",
@@ -6737,7 +6737,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar.tsx",
       "source_location": "L34",
       "id": "data_table_toolbar_handleclearfilters",
-      "community": 344
+      "community": 346
     },
     {
       "label": "data-table-view-options.tsx",
@@ -6745,7 +6745,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-view-options.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_view_options_tsx",
-      "community": 12
+      "community": 13
     },
     {
       "label": "data-table.tsx",
@@ -6753,7 +6753,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_tsx",
-      "community": 787
+      "community": 789
     },
     {
       "label": "data.ts",
@@ -6761,7 +6761,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_ts",
-      "community": 788
+      "community": 790
     },
     {
       "label": "orderColumns.tsx",
@@ -6769,7 +6769,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/orderColumns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_ordercolumns_tsx",
-      "community": 345
+      "community": 347
     },
     {
       "label": "if()",
@@ -6777,7 +6777,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/orderColumns.tsx",
       "source_location": "L89",
       "id": "ordercolumns_if",
-      "community": 345
+      "community": 347
     },
     {
       "label": "refundUtils.ts",
@@ -6785,7 +6785,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_refundutils_ts",
-      "community": 35
+      "community": 36
     },
     {
       "label": "refundReducer()",
@@ -6793,7 +6793,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L31",
       "id": "refundutils_refundreducer",
-      "community": 35
+      "community": 36
     },
     {
       "label": "getAmountRefunded()",
@@ -6801,7 +6801,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L98",
       "id": "refundutils_getamountrefunded",
-      "community": 35
+      "community": 36
     },
     {
       "label": "getNetAmount()",
@@ -6809,7 +6809,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L106",
       "id": "refundutils_getnetamount",
-      "community": 35
+      "community": 36
     },
     {
       "label": "getAvailableItems()",
@@ -6817,7 +6817,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L115",
       "id": "refundutils_getavailableitems",
-      "community": 35
+      "community": 36
     },
     {
       "label": "calculateRefundAmount()",
@@ -6825,7 +6825,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L124",
       "id": "refundutils_calculaterefundamount",
-      "community": 35
+      "community": 36
     },
     {
       "label": "getItemsToRefund()",
@@ -6833,7 +6833,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L174",
       "id": "refundutils_getitemstorefund",
-      "community": 35
+      "community": 36
     },
     {
       "label": "validateRefund()",
@@ -6841,7 +6841,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L199",
       "id": "refundutils_validaterefund",
-      "community": 35
+      "community": 36
     },
     {
       "label": "shouldShowReturnToStock()",
@@ -6849,7 +6849,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/refundUtils.ts",
       "source_location": "L255",
       "id": "refundutils_shouldshowreturntostock",
-      "community": 35
+      "community": 36
     },
     {
       "label": "utils.ts",
@@ -6857,7 +6857,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_utils_ts",
-      "community": 29
+      "community": 30
     },
     {
       "label": "getOrderState()",
@@ -6865,7 +6865,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
       "source_location": "L1",
       "id": "utils_getorderstate",
-      "community": 29
+      "community": 30
     },
     {
       "label": "getAmountPaidForOrder()",
@@ -6873,7 +6873,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
       "source_location": "L108",
       "id": "utils_getamountpaidfororder",
-      "community": 29
+      "community": 30
     },
     {
       "label": "index.tsx",
@@ -6881,7 +6881,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
-      "community": 92
+      "community": 93
     },
     {
       "label": "onSubmit()",
@@ -6889,7 +6889,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
       "source_location": "L105",
       "id": "index_onsubmit",
-      "community": 92
+      "community": 93
     },
     {
       "label": "constants.ts",
@@ -6897,7 +6897,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/constants.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_constants_ts",
-      "community": 789
+      "community": 791
     },
     {
       "label": "data-table-column-header.tsx",
@@ -6905,7 +6905,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_column_header_tsx",
-      "community": 15
+      "community": 16
     },
     {
       "label": "data-table-faceted-filter.tsx",
@@ -6913,7 +6913,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-faceted-filter.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_faceted_filter_tsx",
-      "community": 790
+      "community": 792
     },
     {
       "label": "data-table-pagination.tsx",
@@ -6921,7 +6921,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_pagination_tsx",
-      "community": 791
+      "community": 793
     },
     {
       "label": "data-table-toolbar-provider.tsx",
@@ -6929,7 +6929,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar-provider.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_provider_tsx",
-      "community": 22
+      "community": 23
     },
     {
       "label": "data-table-toolbar.tsx",
@@ -6937,7 +6937,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_tsx",
-      "community": 792
+      "community": 794
     },
     {
       "label": "data-table-view-options.tsx",
@@ -6945,7 +6945,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-view-options.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_view_options_tsx",
-      "community": 12
+      "community": 13
     },
     {
       "label": "data-table.tsx",
@@ -6953,7 +6953,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_tsx",
-      "community": 793
+      "community": 795
     },
     {
       "label": "data.ts",
@@ -6961,7 +6961,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_ts",
-      "community": 794
+      "community": 796
     },
     {
       "label": "inviteColumns.tsx",
@@ -6969,7 +6969,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/inviteColumns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_invitecolumns_tsx",
-      "community": 795
+      "community": 797
     },
     {
       "label": "constants.ts",
@@ -6977,7 +6977,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/constants.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_constants_ts",
-      "community": 796
+      "community": 798
     },
     {
       "label": "data-table-column-header.tsx",
@@ -6985,7 +6985,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_column_header_tsx",
-      "community": 15
+      "community": 16
     },
     {
       "label": "data-table-faceted-filter.tsx",
@@ -6993,7 +6993,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-faceted-filter.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_faceted_filter_tsx",
-      "community": 797
+      "community": 799
     },
     {
       "label": "data-table-pagination.tsx",
@@ -7001,7 +7001,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_pagination_tsx",
-      "community": 798
+      "community": 800
     },
     {
       "label": "data-table-toolbar-provider.tsx",
@@ -7009,7 +7009,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar-provider.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_provider_tsx",
-      "community": 22
+      "community": 23
     },
     {
       "label": "data-table-toolbar.tsx",
@@ -7017,7 +7017,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_tsx",
-      "community": 799
+      "community": 801
     },
     {
       "label": "data-table-view-options.tsx",
@@ -7025,7 +7025,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-view-options.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_view_options_tsx",
-      "community": 12
+      "community": 13
     },
     {
       "label": "data-table.tsx",
@@ -7033,7 +7033,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_tsx",
-      "community": 800
+      "community": 802
     },
     {
       "label": "data.ts",
@@ -7041,7 +7041,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_ts",
-      "community": 801
+      "community": 803
     },
     {
       "label": "membersColumns.tsx",
@@ -7049,7 +7049,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/membersColumns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_memberscolumns_tsx",
-      "community": 802
+      "community": 804
     },
     {
       "label": "organization-switcher.tsx",
@@ -7057,7 +7057,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-switcher.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_switcher_tsx",
-      "community": 184
+      "community": 186
     },
     {
       "label": "onOrganizationSelect()",
@@ -7065,7 +7065,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-switcher.tsx",
       "source_location": "L94",
       "id": "organization_switcher_onorganizationselect",
-      "community": 184
+      "community": 186
     },
     {
       "label": "handleSignOut()",
@@ -7073,7 +7073,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-switcher.tsx",
       "source_location": "L99",
       "id": "organization_switcher_handlesignout",
-      "community": 184
+      "community": 186
     },
     {
       "label": "CartItems.tsx",
@@ -7081,7 +7081,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CartItems.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_cartitems_tsx",
-      "community": 803
+      "community": 805
     },
     {
       "label": "CashierAuthDialog.tsx",
@@ -7089,7 +7089,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_tsx",
-      "community": 804
+      "community": 806
     },
     {
       "label": "CashierView.tsx",
@@ -7097,7 +7097,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CashierView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_cashierview_tsx",
-      "community": 346
+      "community": 348
     },
     {
       "label": "handleSignOut()",
@@ -7105,7 +7105,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CashierView.tsx",
       "source_location": "L63",
       "id": "cashierview_handlesignout",
-      "community": 346
+      "community": 348
     },
     {
       "label": "CustomerInfoPanel.tsx",
@@ -7113,7 +7113,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_customerinfopanel_tsx",
-      "community": 49
+      "community": 50
     },
     {
       "label": "handleSelectCustomer()",
@@ -7121,7 +7121,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
       "source_location": "L59",
       "id": "customerinfopanel_handleselectcustomer",
-      "community": 49
+      "community": 50
     },
     {
       "label": "handleCreateCustomer()",
@@ -7129,7 +7129,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
       "source_location": "L77",
       "id": "customerinfopanel_handlecreatecustomer",
-      "community": 49
+      "community": 50
     },
     {
       "label": "handleStartEdit()",
@@ -7137,7 +7137,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
       "source_location": "L105",
       "id": "customerinfopanel_handlestartedit",
-      "community": 49
+      "community": 50
     },
     {
       "label": "handleSaveEdit()",
@@ -7145,7 +7145,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
       "source_location": "L115",
       "id": "customerinfopanel_handlesaveedit",
-      "community": 49
+      "community": 50
     },
     {
       "label": "handleCancelEdit()",
@@ -7153,7 +7153,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
       "source_location": "L146",
       "id": "customerinfopanel_handlecanceledit",
-      "community": 49
+      "community": 50
     },
     {
       "label": "clearCustomer()",
@@ -7161,7 +7161,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
       "source_location": "L155",
       "id": "customerinfopanel_clearcustomer",
-      "community": 49
+      "community": 50
     },
     {
       "label": "DebugProducts.tsx",
@@ -7169,7 +7169,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/DebugProducts.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_debugproducts_tsx",
-      "community": 347
+      "community": 349
     },
     {
       "label": "DebugProducts()",
@@ -7177,7 +7177,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/DebugProducts.tsx",
       "source_location": "L5",
       "id": "debugproducts_debugproducts",
-      "community": 347
+      "community": 349
     },
     {
       "label": "NewTransactionView.tsx",
@@ -7185,7 +7185,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
-      "community": 135
+      "community": 136
     },
     {
       "label": "Navigation()",
@@ -7193,7 +7193,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
       "source_location": "L22",
       "id": "newtransactionview_navigation",
-      "community": 135
+      "community": 136
     },
     {
       "label": "handleStartTransaction()",
@@ -7201,7 +7201,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
       "source_location": "L68",
       "id": "newtransactionview_handlestarttransaction",
-      "community": 135
+      "community": 136
     },
     {
       "label": "handleQuickStart()",
@@ -7209,7 +7209,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
       "source_location": "L91",
       "id": "newtransactionview_handlequickstart",
-      "community": 135
+      "community": 136
     },
     {
       "label": "NoResultsMessage.tsx",
@@ -7217,7 +7217,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/NoResultsMessage.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_noresultsmessage_tsx",
-      "community": 348
+      "community": 350
     },
     {
       "label": "NoResultsMessage()",
@@ -7225,7 +7225,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/NoResultsMessage.tsx",
       "source_location": "L7",
       "id": "noresultsmessage_noresultsmessage",
-      "community": 348
+      "community": 350
     },
     {
       "label": "OrderSummary.tsx",
@@ -7233,7 +7233,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
-      "community": 136
+      "community": 137
     },
     {
       "label": "handleCompleteTransaction()",
@@ -7241,7 +7241,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
       "source_location": "L128",
       "id": "ordersummary_handlecompletetransaction",
-      "community": 136
+      "community": 137
     },
     {
       "label": "handleSelectedPaymentMethod()",
@@ -7249,7 +7249,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
       "source_location": "L150",
       "id": "ordersummary_handleselectedpaymentmethod",
-      "community": 136
+      "community": 137
     },
     {
       "label": "handleNewTransaction()",
@@ -7257,7 +7257,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
       "source_location": "L162",
       "id": "ordersummary_handlenewtransaction",
-      "community": 136
+      "community": 137
     },
     {
       "label": "POSRegisterView.tsx",
@@ -7265,7 +7265,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/POSRegisterView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_posregisterview_tsx",
-      "community": 41
+      "community": 42
     },
     {
       "label": "handleSessionLoaded()",
@@ -7273,7 +7273,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/POSRegisterView.tsx",
       "source_location": "L83",
       "id": "posregisterview_handlesessionloaded",
-      "community": 41
+      "community": 42
     },
     {
       "label": "resetAutoSessionInitialized()",
@@ -7281,7 +7281,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/POSRegisterView.tsx",
       "source_location": "L87",
       "id": "posregisterview_resetautosessioninitialized",
-      "community": 41
+      "community": 42
     },
     {
       "label": "handleNewSession()",
@@ -7289,7 +7289,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/POSRegisterView.tsx",
       "source_location": "L92",
       "id": "posregisterview_handlenewsession",
-      "community": 41
+      "community": 42
     },
     {
       "label": "handleCashierAuthenticated()",
@@ -7297,7 +7297,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/POSRegisterView.tsx",
       "source_location": "L133",
       "id": "posregisterview_handlecashierauthenticated",
-      "community": 41
+      "community": 42
     },
     {
       "label": "handleBarcodeSubmit()",
@@ -7305,7 +7305,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/POSRegisterView.tsx",
       "source_location": "L606",
       "id": "posregisterview_handlebarcodesubmit",
-      "community": 41
+      "community": 42
     },
     {
       "label": "handleClearCart()",
@@ -7313,7 +7313,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/POSRegisterView.tsx",
       "source_location": "L678",
       "id": "posregisterview_handleclearcart",
-      "community": 41
+      "community": 42
     },
     {
       "label": "handleNavigateBack()",
@@ -7321,7 +7321,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/POSRegisterView.tsx",
       "source_location": "L709",
       "id": "posregisterview_handlenavigateback",
-      "community": 41
+      "community": 42
     },
     {
       "label": "PaymentView.tsx",
@@ -7329,7 +7329,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_paymentview_tsx",
-      "community": 99
+      "community": 100
     },
     {
       "label": "handleAddPayment()",
@@ -7337,7 +7337,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
       "source_location": "L178",
       "id": "paymentview_handleaddpayment",
-      "community": 99
+      "community": 100
     },
     {
       "label": "handleClearAll()",
@@ -7345,7 +7345,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
       "source_location": "L219",
       "id": "paymentview_handleclearall",
-      "community": 99
+      "community": 100
     },
     {
       "label": "handleAmountChange()",
@@ -7353,7 +7353,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
       "source_location": "L224",
       "id": "paymentview_handleamountchange",
-      "community": 99
+      "community": 100
     },
     {
       "label": "handleAmountBlur()",
@@ -7361,7 +7361,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
       "source_location": "L253",
       "id": "paymentview_handleamountblur",
-      "community": 99
+      "community": 100
     },
     {
       "label": "PaymentsAddedList.tsx",
@@ -7369,7 +7369,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_tsx",
-      "community": 65
+      "community": 66
     },
     {
       "label": "getPaymentMethodLabel()",
@@ -7377,7 +7377,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L18",
       "id": "paymentsaddedlist_getpaymentmethodlabel",
-      "community": 65
+      "community": 66
     },
     {
       "label": "handleStartEdit()",
@@ -7385,7 +7385,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L57",
       "id": "paymentsaddedlist_handlestartedit",
-      "community": 65
+      "community": 66
     },
     {
       "label": "handleSaveEdit()",
@@ -7393,7 +7393,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L62",
       "id": "paymentsaddedlist_handlesaveedit",
-      "community": 65
+      "community": 66
     },
     {
       "label": "handleCancelEdit()",
@@ -7401,7 +7401,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L93",
       "id": "paymentsaddedlist_handlecanceledit",
-      "community": 65
+      "community": 66
     },
     {
       "label": "handleRemovePayment()",
@@ -7409,7 +7409,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L98",
       "id": "paymentsaddedlist_handleremovepayment",
-      "community": 65
+      "community": 66
     },
     {
       "label": "PinInput.tsx",
@@ -7417,7 +7417,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_pininput_tsx",
-      "community": 349
+      "community": 351
     },
     {
       "label": "PinInput()",
@@ -7425,7 +7425,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
       "source_location": "L13",
       "id": "pininput_pininput",
-      "community": 349
+      "community": 351
     },
     {
       "label": "PointOfSaleView.tsx",
@@ -7433,7 +7433,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
-      "community": 350
+      "community": 352
     },
     {
       "label": "Navigation()",
@@ -7441,7 +7441,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
       "source_location": "L34",
       "id": "pointofsaleview_navigation",
-      "community": 350
+      "community": 352
     },
     {
       "label": "PrintInstructions.tsx",
@@ -7449,7 +7449,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_printinstructions_tsx",
-      "community": 351
+      "community": 353
     },
     {
       "label": "PrintInstructions()",
@@ -7457,7 +7457,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
       "source_location": "L3",
       "id": "printinstructions_printinstructions",
-      "community": 351
+      "community": 353
     },
     {
       "label": "ProductCard.tsx",
@@ -7465,7 +7465,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/ProductCard.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_productcard_tsx",
-      "community": 352
+      "community": 354
     },
     {
       "label": "ProductCard()",
@@ -7473,7 +7473,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/ProductCard.tsx",
       "source_location": "L14",
       "id": "productcard_productcard",
-      "community": 352
+      "community": 354
     },
     {
       "label": "ProductEntry.tsx",
@@ -7481,7 +7481,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_productentry_tsx",
-      "community": 353
+      "community": 355
     },
     {
       "label": "handleClearSearch()",
@@ -7489,7 +7489,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/ProductEntry.tsx",
       "source_location": "L86",
       "id": "productentry_handleclearsearch",
-      "community": 353
+      "community": 355
     },
     {
       "label": "ProductLookup.tsx",
@@ -7497,7 +7497,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/ProductLookup.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_productlookup_tsx",
-      "community": 805
+      "community": 807
     },
     {
       "label": "QuickActionsBar.tsx",
@@ -7505,7 +7505,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/QuickActionsBar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_quickactionsbar_tsx",
-      "community": 354
+      "community": 356
     },
     {
       "label": "QuickActionsBar()",
@@ -7513,7 +7513,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/QuickActionsBar.tsx",
       "source_location": "L11",
       "id": "quickactionsbar_quickactionsbar",
-      "community": 354
+      "community": 356
     },
     {
       "label": "RegisterActions.tsx",
@@ -7521,7 +7521,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/RegisterActions.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_registeractions_tsx",
-      "community": 806
+      "community": 808
     },
     {
       "label": "SearchResultsSection.tsx",
@@ -7529,7 +7529,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SearchResultsSection.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_searchresultssection_tsx",
-      "community": 807
+      "community": 809
     },
     {
       "label": "SessionDemo.tsx",
@@ -7537,7 +7537,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionDemo.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_sessiondemo_tsx",
-      "community": 355
+      "community": 357
     },
     {
       "label": "SessionDemo()",
@@ -7545,7 +7545,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionDemo.tsx",
       "source_location": "L15",
       "id": "sessiondemo_sessiondemo",
-      "community": 355
+      "community": 357
     },
     {
       "label": "SessionManager.tsx",
@@ -7553,7 +7553,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_sessionmanager_tsx",
-      "community": 100
+      "community": 101
     },
     {
       "label": "onHoldConfirm()",
@@ -7561,7 +7561,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
       "source_location": "L72",
       "id": "sessionmanager_onholdconfirm",
-      "community": 100
+      "community": 101
     },
     {
       "label": "onResumeSession()",
@@ -7569,7 +7569,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
       "source_location": "L77",
       "id": "sessionmanager_onresumesession",
-      "community": 100
+      "community": 101
     },
     {
       "label": "onVoidConfirm()",
@@ -7577,7 +7577,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
       "source_location": "L90",
       "id": "sessionmanager_onvoidconfirm",
-      "community": 100
+      "community": 101
     },
     {
       "label": "onNewSessionClick()",
@@ -7585,7 +7585,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
       "source_location": "L96",
       "id": "sessionmanager_onnewsessionclick",
-      "community": 100
+      "community": 101
     },
     {
       "label": "TotalsDisplay.tsx",
@@ -7593,7 +7593,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_tsx",
-      "community": 356
+      "community": 358
     },
     {
       "label": "TotalsDisplay()",
@@ -7601,7 +7601,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.tsx",
       "source_location": "L12",
       "id": "totalsdisplay_totalsdisplay",
-      "community": 356
+      "community": 358
     },
     {
       "label": "ExpenseReportView.tsx",
@@ -7609,7 +7609,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportview_tsx",
-      "community": 808
+      "community": 810
     },
     {
       "label": "ExpenseReportsView.tsx",
@@ -7617,7 +7617,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_tsx",
-      "community": 357
+      "community": 359
     },
     {
       "label": "isToday()",
@@ -7625,7 +7625,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
       "source_location": "L17",
       "id": "expensereportsview_istoday",
-      "community": 357
+      "community": 359
     },
     {
       "label": "expenseReportColumns.tsx",
@@ -7633,7 +7633,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/expense-reports/expenseReportColumns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportcolumns_tsx",
-      "community": 809
+      "community": 811
     },
     {
       "label": "hooks.ts",
@@ -7641,7 +7641,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/hooks.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_hooks_ts",
-      "community": 358
+      "community": 360
     },
     {
       "label": "usePOSCashier()",
@@ -7649,7 +7649,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/hooks.ts",
       "source_location": "L5",
       "id": "hooks_useposcashier",
-      "community": 358
+      "community": 360
     },
     {
       "label": "HeldSessionsList.tsx",
@@ -7657,7 +7657,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_tsx",
-      "community": 185
+      "community": 187
     },
     {
       "label": "hasExpired()",
@@ -7665,7 +7665,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx",
       "source_location": "L54",
       "id": "heldsessionslist_hasexpired",
-      "community": 185
+      "community": 187
     },
     {
       "label": "getSessionCartItemsCount()",
@@ -7673,7 +7673,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx",
       "source_location": "L58",
       "id": "heldsessionslist_getsessioncartitemscount",
-      "community": 185
+      "community": 187
     },
     {
       "label": "HoldSessionDialog.tsx",
@@ -7681,7 +7681,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/HoldSessionDialog.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_session_holdsessiondialog_tsx",
-      "community": 359
+      "community": 361
     },
     {
       "label": "HoldSessionDialog()",
@@ -7689,7 +7689,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/HoldSessionDialog.tsx",
       "source_location": "L19",
       "id": "holdsessiondialog_holdsessiondialog",
-      "community": 359
+      "community": 361
     },
     {
       "label": "VoidSessionDialog.tsx",
@@ -7697,7 +7697,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/VoidSessionDialog.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_session_voidsessiondialog_tsx",
-      "community": 360
+      "community": 362
     },
     {
       "label": "VoidSessionDialog()",
@@ -7705,7 +7705,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/VoidSessionDialog.tsx",
       "source_location": "L19",
       "id": "voidsessiondialog_voidsessiondialog",
-      "community": 360
+      "community": 362
     },
     {
       "label": "POSSettingsView.tsx",
@@ -7713,7 +7713,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_tsx",
-      "community": 137
+      "community": 138
     },
     {
       "label": "loadFingerprint()",
@@ -7721,7 +7721,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
       "source_location": "L166",
       "id": "possettingsview_loadfingerprint",
-      "community": 137
+      "community": 138
     },
     {
       "label": "handleRegisterTerminal()",
@@ -7729,7 +7729,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
       "source_location": "L247",
       "id": "possettingsview_handleregisterterminal",
-      "community": 137
+      "community": 138
     },
     {
       "label": "handleUpdateExistingTerminal()",
@@ -7737,7 +7737,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
       "source_location": "L284",
       "id": "possettingsview_handleupdateexistingterminal",
-      "community": 137
+      "community": 138
     },
     {
       "label": "TransactionView.tsx",
@@ -7745,7 +7745,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
-      "community": 810
+      "community": 812
     },
     {
       "label": "TransactionsView.tsx",
@@ -7753,7 +7753,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
-      "community": 186
+      "community": 188
     },
     {
       "label": "formatPaymentMethod()",
@@ -7761,7 +7761,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
       "source_location": "L19",
       "id": "transactionsview_formatpaymentmethod",
-      "community": 186
+      "community": 188
     },
     {
       "label": "isToday()",
@@ -7769,7 +7769,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
       "source_location": "L25",
       "id": "transactionsview_istoday",
-      "community": 186
+      "community": 188
     },
     {
       "label": "transactionColumns.tsx",
@@ -7777,7 +7777,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_tsx",
-      "community": 361
+      "community": 363
     },
     {
       "label": "getPaymentMethodIcon()",
@@ -7785,7 +7785,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
       "source_location": "L22",
       "id": "transactioncolumns_getpaymentmethodicon",
-      "community": 361
+      "community": 363
     },
     {
       "label": "types.ts",
@@ -7793,7 +7793,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/types.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_types_ts",
-      "community": 811
+      "community": 813
     },
     {
       "label": "AnalyticsInsights.tsx",
@@ -7801,7 +7801,7 @@
       "source_file": "packages/athena-webapp/src/components/product/AnalyticsInsights.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_product_analyticsinsights_tsx",
-      "community": 812
+      "community": 814
     },
     {
       "label": "AttributesView.tsx",
@@ -7809,7 +7809,7 @@
       "source_file": "packages/athena-webapp/src/components/product/AttributesView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_product_attributesview_tsx",
-      "community": 813
+      "community": 815
     },
     {
       "label": "BarcodeView.tsx",
@@ -7817,7 +7817,7 @@
       "source_file": "packages/athena-webapp/src/components/product/BarcodeView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_product_barcodeview_tsx",
-      "community": 362
+      "community": 364
     },
     {
       "label": "BarcodeView()",
@@ -7825,7 +7825,7 @@
       "source_file": "packages/athena-webapp/src/components/product/BarcodeView.tsx",
       "source_location": "L14",
       "id": "barcodeview_barcodeview",
-      "community": 362
+      "community": 364
     },
     {
       "label": "CategorizationView.tsx",
@@ -7833,7 +7833,7 @@
       "source_file": "packages/athena-webapp/src/components/product/CategorizationView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_product_categorizationview_tsx",
-      "community": 363
+      "community": 365
     },
     {
       "label": "CategorizationView()",
@@ -7841,7 +7841,7 @@
       "source_file": "packages/athena-webapp/src/components/product/CategorizationView.tsx",
       "source_location": "L6",
       "id": "categorizationview_categorizationview",
-      "community": 363
+      "community": 365
     },
     {
       "label": "DetailsView.tsx",
@@ -7849,7 +7849,7 @@
       "source_file": "packages/athena-webapp/src/components/product/DetailsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_product_detailsview_tsx",
-      "community": 814
+      "community": 816
     },
     {
       "label": "ImagesView.tsx",
@@ -7857,7 +7857,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ImagesView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_product_imagesview_tsx",
-      "community": 364
+      "community": 366
     },
     {
       "label": "handleKeyDown()",
@@ -7865,7 +7865,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ImagesView.tsx",
       "source_location": "L36",
       "id": "imagesview_handlekeydown",
-      "community": 364
+      "community": 366
     },
     {
       "label": "ProductDetailView.tsx",
@@ -7873,7 +7873,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ProductDetailView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_product_productdetailview_tsx",
-      "community": 815
+      "community": 817
     },
     {
       "label": "ProductStatus.tsx",
@@ -7881,7 +7881,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ProductStatus.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_product_productstatus_tsx",
-      "community": 816
+      "community": 818
     },
     {
       "label": "ProductStock.tsx",
@@ -7889,7 +7889,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_product_productstock_tsx",
-      "community": 138
+      "community": 139
     },
     {
       "label": "ProductStockStatus()",
@@ -7897,7 +7897,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
       "source_location": "L4",
       "id": "productstock_productstockstatus",
-      "community": 138
+      "community": 139
     },
     {
       "label": "OutOfStockStatus()",
@@ -7905,7 +7905,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
       "source_location": "L38",
       "id": "productstock_outofstockstatus",
-      "community": 138
+      "community": 139
     },
     {
       "label": "LowStockStatus()",
@@ -7913,7 +7913,7 @@
       "source_file": "packages/athena-webapp/src/components/product/ProductStock.tsx",
       "source_location": "L47",
       "id": "productstock_lowstockstatus",
-      "community": 138
+      "community": 139
     },
     {
       "label": "SKUSelector.tsx",
@@ -7921,7 +7921,7 @@
       "source_file": "packages/athena-webapp/src/components/product/SKUSelector.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_product_skuselector_tsx",
-      "community": 365
+      "community": 367
     },
     {
       "label": "SKUSelector()",
@@ -7929,7 +7929,7 @@
       "source_file": "packages/athena-webapp/src/components/product/SKUSelector.tsx",
       "source_location": "L10",
       "id": "skuselector_skuselector",
-      "community": 365
+      "community": 367
     },
     {
       "label": "product-actions.tsx",
@@ -7937,7 +7937,7 @@
       "source_file": "packages/athena-webapp/src/components/product-actions.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_product_actions_tsx",
-      "community": 366
+      "community": 368
     },
     {
       "label": "useDeleteProduct()",
@@ -7945,7 +7945,7 @@
       "source_file": "packages/athena-webapp/src/components/product-actions.tsx",
       "source_location": "L6",
       "id": "product_actions_usedeleteproduct",
-      "community": 366
+      "community": 368
     },
     {
       "label": "CategoryListView.tsx",
@@ -7953,7 +7953,7 @@
       "source_file": "packages/athena-webapp/src/components/products/CategoryListView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_categorylistview_tsx",
-      "community": 817
+      "community": 819
     },
     {
       "label": "ProductSubcategoryToggleGroup.tsx",
@@ -7961,7 +7961,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductSubcategoryToggleGroup.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_productsubcategorytogglegroup_tsx",
-      "community": 818
+      "community": 820
     },
     {
       "label": "Products.tsx",
@@ -7969,7 +7969,7 @@
       "source_file": "packages/athena-webapp/src/components/products/Products.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_products_tsx",
-      "community": 819
+      "community": 821
     },
     {
       "label": "ProductsListView.tsx",
@@ -7977,7 +7977,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsListView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_productslistview_tsx",
-      "community": 187
+      "community": 189
     },
     {
       "label": "ProductActionsToggleGroup()",
@@ -7985,7 +7985,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsListView.tsx",
       "source_location": "L20",
       "id": "productslistview_productactionstogglegroup",
-      "community": 187
+      "community": 189
     },
     {
       "label": "handleClearCache()",
@@ -7993,7 +7993,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsListView.tsx",
       "source_location": "L65",
       "id": "productslistview_handleclearcache",
-      "community": 187
+      "community": 189
     },
     {
       "label": "ProductsTableContext.tsx",
@@ -8001,7 +8001,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsTableContext.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_productstablecontext_tsx",
-      "community": 188
+      "community": 190
     },
     {
       "label": "ProductsTableProvider()",
@@ -8009,7 +8009,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsTableContext.tsx",
       "source_location": "L16",
       "id": "productstablecontext_productstableprovider",
-      "community": 188
+      "community": 190
     },
     {
       "label": "useProductsTableState()",
@@ -8017,7 +8017,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsTableContext.tsx",
       "source_location": "L60",
       "id": "productstablecontext_useproductstablestate",
-      "community": 188
+      "community": 190
     },
     {
       "label": "ProductsView.tsx",
@@ -8025,7 +8025,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_productsview_tsx",
-      "community": 367
+      "community": 369
     },
     {
       "label": "ProductsView()",
@@ -8033,7 +8033,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsView.tsx",
       "source_location": "L5",
       "id": "productsview_productsview",
-      "community": 367
+      "community": 369
     },
     {
       "label": "StoreProducts.tsx",
@@ -8041,7 +8041,7 @@
       "source_file": "packages/athena-webapp/src/components/products/StoreProducts.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_storeproducts_tsx",
-      "community": 820
+      "community": 822
     },
     {
       "label": "StoreProductsView.tsx",
@@ -8049,7 +8049,7 @@
       "source_file": "packages/athena-webapp/src/components/products/StoreProductsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_storeproductsview_tsx",
-      "community": 189
+      "community": 191
     },
     {
       "label": "ProductActionsToggleGroup()",
@@ -8057,7 +8057,7 @@
       "source_file": "packages/athena-webapp/src/components/products/StoreProductsView.tsx",
       "source_location": "L19",
       "id": "storeproductsview_productactionstogglegroup",
-      "community": 189
+      "community": 191
     },
     {
       "label": "Navigation()",
@@ -8065,7 +8065,7 @@
       "source_file": "packages/athena-webapp/src/components/products/StoreProductsView.tsx",
       "source_location": "L45",
       "id": "storeproductsview_navigation",
-      "community": 189
+      "community": 191
     },
     {
       "label": "UnresolvedProducts.tsx",
@@ -8073,7 +8073,7 @@
       "source_file": "packages/athena-webapp/src/components/products/UnresolvedProducts.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_unresolvedproducts_tsx",
-      "community": 821
+      "community": 823
     },
     {
       "label": "AddComplimentaryProduct.tsx",
@@ -8081,7 +8081,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/AddComplimentaryProduct.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_complimentary_addcomplimentaryproduct_tsx",
-      "community": 190
+      "community": 192
     },
     {
       "label": "handleAddComplimentaryProducts()",
@@ -8089,7 +8089,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/AddComplimentaryProduct.tsx",
       "source_location": "L40",
       "id": "addcomplimentaryproduct_handleaddcomplimentaryproducts",
-      "community": 190
+      "community": 192
     },
     {
       "label": "AddComplimentaryProduct()",
@@ -8097,7 +8097,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/AddComplimentaryProduct.tsx",
       "source_location": "L128",
       "id": "addcomplimentaryproduct_addcomplimentaryproduct",
-      "community": 190
+      "community": 192
     },
     {
       "label": "ComplimentaryProducts.tsx",
@@ -8105,7 +8105,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProducts.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproducts_tsx",
-      "community": 822
+      "community": 824
     },
     {
       "label": "ComplimentaryProductsView.tsx",
@@ -8113,7 +8113,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
-      "community": 139
+      "community": 140
     },
     {
       "label": "Navigation()",
@@ -8121,7 +8121,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
       "source_location": "L6",
       "id": "complimentaryproductsview_navigation",
-      "community": 139
+      "community": 140
     },
     {
       "label": "Body()",
@@ -8129,7 +8129,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
       "source_location": "L16",
       "id": "complimentaryproductsview_body",
-      "community": 139
+      "community": 140
     },
     {
       "label": "ComplimentaryProductsView()",
@@ -8137,7 +8137,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProductsView.tsx",
       "source_location": "L35",
       "id": "complimentaryproductsview_complimentaryproductsview",
-      "community": 139
+      "community": 140
     },
     {
       "label": "complimentaryProductsColumn.tsx",
@@ -8145,7 +8145,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/complimentaryProductsColumn.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductscolumn_tsx",
-      "community": 823
+      "community": 825
     },
     {
       "label": "add-product-command.tsx",
@@ -8153,7 +8153,7 @@
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/add-product-command.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_products_table_components_add_product_command_tsx",
-      "community": 368
+      "community": 370
     },
     {
       "label": "AddProductCommand()",
@@ -8161,7 +8161,7 @@
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/add-product-command.tsx",
       "source_location": "L17",
       "id": "add_product_command_addproductcommand",
-      "community": 368
+      "community": 370
     },
     {
       "label": "data-table-column-header.tsx",
@@ -8169,7 +8169,7 @@
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_column_header_tsx",
-      "community": 824
+      "community": 826
     },
     {
       "label": "data-table-faceted-filter.tsx",
@@ -8177,7 +8177,7 @@
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-faceted-filter.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_faceted_filter_tsx",
-      "community": 825
+      "community": 827
     },
     {
       "label": "data-table-pagination.tsx",
@@ -8185,7 +8185,7 @@
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_pagination_tsx",
-      "community": 826
+      "community": 828
     },
     {
       "label": "data-table-row-actions.tsx",
@@ -8193,7 +8193,7 @@
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-row-actions.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_row_actions_tsx",
-      "community": 40
+      "community": 41
     },
     {
       "label": "data-table-toolbar.tsx",
@@ -8201,7 +8201,7 @@
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-toolbar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_toolbar_tsx",
-      "community": 827
+      "community": 829
     },
     {
       "label": "data-table-view-options.tsx",
@@ -8209,7 +8209,7 @@
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-view-options.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_view_options_tsx",
-      "community": 12
+      "community": 13
     },
     {
       "label": "data-table.tsx",
@@ -8217,7 +8217,7 @@
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_tsx",
-      "community": 828
+      "community": 830
     },
     {
       "label": "data.ts",
@@ -8225,7 +8225,7 @@
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/data.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_ts",
-      "community": 829
+      "community": 831
     },
     {
       "label": "productColumns.tsx",
@@ -8233,7 +8233,7 @@
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/productColumns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_products_table_components_productcolumns_tsx",
-      "community": 830
+      "community": 832
     },
     {
       "label": "Products.tsx",
@@ -8241,7 +8241,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/Products.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_products_tsx",
-      "community": 369
+      "community": 371
     },
     {
       "label": "Products()",
@@ -8249,7 +8249,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/Products.tsx",
       "source_location": "L4",
       "id": "products_products",
-      "community": 369
+      "community": 371
     },
     {
       "label": "PromoCodeForm.tsx",
@@ -8257,7 +8257,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeForm.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeform_tsx",
-      "community": 370
+      "community": 372
     },
     {
       "label": "toggleDiscountType()",
@@ -8265,7 +8265,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeForm.tsx",
       "source_location": "L84",
       "id": "promocodeform_togglediscounttype",
-      "community": 370
+      "community": 372
     },
     {
       "label": "PromoCodeHeader.tsx",
@@ -8273,7 +8273,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_tsx",
-      "community": 371
+      "community": 373
     },
     {
       "label": "handleDeletePromoCode()",
@@ -8281,7 +8281,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
       "source_location": "L22",
       "id": "promocodeheader_handledeletepromocode",
-      "community": 371
+      "community": 373
     },
     {
       "label": "PromoCodePreview.tsx",
@@ -8289,7 +8289,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodePreview.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodepreview_tsx",
-      "community": 831
+      "community": 833
     },
     {
       "label": "PromoCodeView.tsx",
@@ -8297,7 +8297,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeview_tsx",
-      "community": 101
+      "community": 102
     },
     {
       "label": "handleAddPromoCode()",
@@ -8305,7 +8305,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
       "source_location": "L146",
       "id": "promocodeview_handleaddpromocode",
-      "community": 101
+      "community": 102
     },
     {
       "label": "handleUpdatePromoCode()",
@@ -8313,7 +8313,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
       "source_location": "L213",
       "id": "promocodeview_handleupdatepromocode",
-      "community": 101
+      "community": 102
     },
     {
       "label": "updateHomepageDiscountCode()",
@@ -8321,7 +8321,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
       "source_location": "L299",
       "id": "promocodeview_updatehomepagediscountcode",
-      "community": 101
+      "community": 102
     },
     {
       "label": "updateLeaveAReviewDiscountCode()",
@@ -8329,7 +8329,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
       "source_location": "L351",
       "id": "promocodeview_updateleaveareviewdiscountcode",
-      "community": 101
+      "community": 102
     },
     {
       "label": "PromoCodes.tsx",
@@ -8337,7 +8337,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodes.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodes_tsx",
-      "community": 832
+      "community": 834
     },
     {
       "label": "PromoCodesView.tsx",
@@ -8345,7 +8345,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodesView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodesview_tsx",
-      "community": 372
+      "community": 374
     },
     {
       "label": "PromoCodesView()",
@@ -8353,7 +8353,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodesView.tsx",
       "source_location": "L9",
       "id": "promocodesview_promocodesview",
-      "community": 372
+      "community": 374
     },
     {
       "label": "SelectableCategories.tsx",
@@ -8361,7 +8361,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/SelectableCategories.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_selectablecategories_tsx",
-      "community": 373
+      "community": 375
     },
     {
       "label": "toggle()",
@@ -8369,7 +8369,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/SelectableCategories.tsx",
       "source_location": "L23",
       "id": "selectablecategories_toggle",
-      "community": 373
+      "community": 375
     },
     {
       "label": "DiscountTypeToggleGroup.tsx",
@@ -8377,7 +8377,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/DiscountTypeToggleGroup.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_discounttypetogglegroup_tsx",
-      "community": 374
+      "community": 376
     },
     {
       "label": "DiscountTypeToggleGroup()",
@@ -8385,7 +8385,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/DiscountTypeToggleGroup.tsx",
       "source_location": "L5",
       "id": "discounttypetogglegroup_discounttypetogglegroup",
-      "community": 374
+      "community": 376
     },
     {
       "label": "PromoCodeSpanToggleGroup.tsx",
@@ -8393,7 +8393,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/PromoCodeSpanToggleGroup.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_promocodespantogglegroup_tsx",
-      "community": 375
+      "community": 377
     },
     {
       "label": "PromoCodeSpanToggleGroup()",
@@ -8401,7 +8401,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/PromoCodeSpanToggleGroup.tsx",
       "source_location": "L4",
       "id": "promocodespantogglegroup_promocodespantogglegroup",
-      "community": 375
+      "community": 377
     },
     {
       "label": "PromoCodeAnalytics.tsx",
@@ -8409,7 +8409,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/analytics/PromoCodeAnalytics.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_analytics_promocodeanalytics_tsx",
-      "community": 833
+      "community": 835
     },
     {
       "label": "CapturedEmails.tsx",
@@ -8417,7 +8417,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/captured/CapturedEmails.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_capturedemails_tsx",
-      "community": 376
+      "community": 378
     },
     {
       "label": "CapturedEmails()",
@@ -8425,7 +8425,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/captured/CapturedEmails.tsx",
       "source_location": "L13",
       "id": "capturedemails_capturedemails",
-      "community": 376
+      "community": 378
     },
     {
       "label": "captured-emails-columns.tsx",
@@ -8433,7 +8433,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/captured/captured-emails-columns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_captured_emails_columns_tsx",
-      "community": 834
+      "community": 836
     },
     {
       "label": "color-picker.tsx",
@@ -8441,7 +8441,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_color_picker_tsx",
-      "community": 191
+      "community": 193
     },
     {
       "label": "handleInputChange()",
@@ -8449,7 +8449,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
       "source_location": "L20",
       "id": "color_picker_handleinputchange",
-      "community": 191
+      "community": 193
     },
     {
       "label": "handleBlur()",
@@ -8457,7 +8457,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
       "source_location": "L24",
       "id": "color_picker_handleblur",
-      "community": 191
+      "community": 193
     },
     {
       "label": "promo-code-modal.tsx",
@@ -8465,7 +8465,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/promo-code-modal.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_promo_code_modal_tsx",
-      "community": 377
+      "community": 379
     },
     {
       "label": "PromoCodeModal()",
@@ -8473,7 +8473,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/promo-code-modal.tsx",
       "source_location": "L29",
       "id": "promo_code_modal_promocodemodal",
-      "community": 377
+      "community": 379
     },
     {
       "label": "welcome-offer-modal.tsx",
@@ -8481,7 +8481,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_welcome_offer_modal_tsx",
-      "community": 42
+      "community": 43
     },
     {
       "label": "handleChange()",
@@ -8489,7 +8489,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L76",
       "id": "welcome_offer_modal_handlechange",
-      "community": 42
+      "community": 43
     },
     {
       "label": "handleNumberChange()",
@@ -8497,7 +8497,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L83",
       "id": "welcome_offer_modal_handlenumberchange",
-      "community": 42
+      "community": 43
     },
     {
       "label": "handleSwitchChange()",
@@ -8505,7 +8505,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L88",
       "id": "welcome_offer_modal_handleswitchchange",
-      "community": 42
+      "community": 43
     },
     {
       "label": "handleColorChange()",
@@ -8513,7 +8513,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L92",
       "id": "welcome_offer_modal_handlecolorchange",
-      "community": 42
+      "community": 43
     },
     {
       "label": "handleSelectChange()",
@@ -8521,7 +8521,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L96",
       "id": "welcome_offer_modal_handleselectchange",
-      "community": 42
+      "community": 43
     },
     {
       "label": "updateImages()",
@@ -8529,7 +8529,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L100",
       "id": "welcome_offer_modal_updateimages",
-      "community": 42
+      "community": 43
     },
     {
       "label": "handleSubmit()",
@@ -8537,7 +8537,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/welcome-offer-modal.tsx",
       "source_location": "L104",
       "id": "welcome_offer_modal_handlesubmit",
-      "community": 42
+      "community": 43
     },
     {
       "label": "columns.tsx",
@@ -8545,7 +8545,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/columns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_columns_tsx",
-      "community": 835
+      "community": 837
     },
     {
       "label": "data-table-column-header.tsx",
@@ -8553,7 +8553,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_column_header_tsx",
-      "community": 836
+      "community": 838
     },
     {
       "label": "data-table-faceted-filter.tsx",
@@ -8561,7 +8561,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-faceted-filter.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_faceted_filter_tsx",
-      "community": 837
+      "community": 839
     },
     {
       "label": "data-table-pagination.tsx",
@@ -8569,7 +8569,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_pagination_tsx",
-      "community": 838
+      "community": 840
     },
     {
       "label": "data-table-row-actions.tsx",
@@ -8577,7 +8577,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-row-actions.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_row_actions_tsx",
-      "community": 40
+      "community": 41
     },
     {
       "label": "data-table-toolbar.tsx",
@@ -8585,7 +8585,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-toolbar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_toolbar_tsx",
-      "community": 839
+      "community": 841
     },
     {
       "label": "data-table-view-options.tsx",
@@ -8593,7 +8593,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-view-options.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_view_options_tsx",
-      "community": 12
+      "community": 13
     },
     {
       "label": "data-table.tsx",
@@ -8601,7 +8601,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_tsx",
-      "community": 840
+      "community": 842
     },
     {
       "label": "selectable-data-provider.tsx",
@@ -8609,7 +8609,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/selectable-data-provider.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
-      "community": 62
+      "community": 63
     },
     {
       "label": "columns.tsx",
@@ -8617,7 +8617,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/table/columns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_table_columns_tsx",
-      "community": 841
+      "community": 843
     },
     {
       "label": "constants.ts",
@@ -8625,7 +8625,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/table/constants.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_table_constants_ts",
-      "community": 842
+      "community": 844
     },
     {
       "label": "data-table-column-header.tsx",
@@ -8633,7 +8633,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_column_header_tsx",
-      "community": 15
+      "community": 16
     },
     {
       "label": "data-table-faceted-filter.tsx",
@@ -8641,7 +8641,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-faceted-filter.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_faceted_filter_tsx",
-      "community": 843
+      "community": 845
     },
     {
       "label": "data-table-pagination.tsx",
@@ -8649,7 +8649,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_pagination_tsx",
-      "community": 844
+      "community": 846
     },
     {
       "label": "data-table-toolbar-provider.tsx",
@@ -8657,7 +8657,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar-provider.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_provider_tsx",
-      "community": 22
+      "community": 23
     },
     {
       "label": "data-table-toolbar.tsx",
@@ -8665,7 +8665,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_tsx",
-      "community": 61
+      "community": 62
     },
     {
       "label": "data-table-view-options.tsx",
@@ -8673,7 +8673,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-view-options.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_view_options_tsx",
-      "community": 12
+      "community": 13
     },
     {
       "label": "data-table.tsx",
@@ -8681,7 +8681,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_tsx",
-      "community": 845
+      "community": 847
     },
     {
       "label": "data.ts",
@@ -8689,7 +8689,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/table/data.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_ts",
-      "community": 846
+      "community": 848
     },
     {
       "label": "types.ts",
@@ -8697,7 +8697,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/types.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_types_ts",
-      "community": 847
+      "community": 849
     },
     {
       "label": "welcome-offer-card.tsx",
@@ -8705,7 +8705,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/welcome-offer-card.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_welcome_offer_card_tsx",
-      "community": 848
+      "community": 850
     },
     {
       "label": "currency-provider.tsx",
@@ -8713,7 +8713,7 @@
       "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_providers_currency_provider_tsx",
-      "community": 192
+      "community": 194
     },
     {
       "label": "useStoreCurrency()",
@@ -8721,7 +8721,7 @@
       "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
       "source_location": "L17",
       "id": "currency_provider_usestorecurrency",
-      "community": 192
+      "community": 194
     },
     {
       "label": "CurrencyProvider()",
@@ -8729,7 +8729,7 @@
       "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
       "source_location": "L25",
       "id": "currency_provider_currencyprovider",
-      "community": 192
+      "community": 194
     },
     {
       "label": "RatingStars.tsx",
@@ -8737,7 +8737,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/RatingStars.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_reviews_ratingstars_tsx",
-      "community": 849
+      "community": 851
     },
     {
       "label": "ReviewActions.tsx",
@@ -8745,7 +8745,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewActions.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_reviews_reviewactions_tsx",
-      "community": 378
+      "community": 380
     },
     {
       "label": "ReviewActions()",
@@ -8753,7 +8753,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewActions.tsx",
       "source_location": "L20",
       "id": "reviewactions_reviewactions",
-      "community": 378
+      "community": 380
     },
     {
       "label": "ReviewCard.tsx",
@@ -8761,7 +8761,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewCard.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_reviews_reviewcard_tsx",
-      "community": 850
+      "community": 852
     },
     {
       "label": "ReviewMetadata.tsx",
@@ -8769,7 +8769,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewMetadata.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_reviews_reviewmetadata_tsx",
-      "community": 851
+      "community": 853
     },
     {
       "label": "ReviewsView.tsx",
@@ -8777,7 +8777,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_reviews_reviewsview_tsx",
-      "community": 66
+      "community": 67
     },
     {
       "label": "Header()",
@@ -8785,7 +8785,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L13",
       "id": "reviewsview_header",
-      "community": 66
+      "community": 67
     },
     {
       "label": "handleApprove()",
@@ -8793,7 +8793,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L42",
       "id": "reviewsview_handleapprove",
-      "community": 66
+      "community": 67
     },
     {
       "label": "handleReject()",
@@ -8801,7 +8801,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L58",
       "id": "reviewsview_handlereject",
-      "community": 66
+      "community": 67
     },
     {
       "label": "handlePublish()",
@@ -8809,7 +8809,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L74",
       "id": "reviewsview_handlepublish",
-      "community": 66
+      "community": 67
     },
     {
       "label": "handleUnpublish()",
@@ -8817,7 +8817,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L90",
       "id": "reviewsview_handleunpublish",
-      "community": 66
+      "community": 67
     },
     {
       "label": "empty-state.tsx",
@@ -8825,7 +8825,7 @@
       "source_file": "packages/athena-webapp/src/components/states/empty/empty-state.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_states_empty_empty_state_tsx",
-      "community": 379
+      "community": 381
     },
     {
       "label": "onClick()",
@@ -8833,7 +8833,7 @@
       "source_file": "packages/athena-webapp/src/components/states/empty/empty-state.tsx",
       "source_location": "L29",
       "id": "empty_state_onclick",
-      "community": 379
+      "community": 381
     },
     {
       "label": "SingleLineError.tsx",
@@ -8841,7 +8841,7 @@
       "source_file": "packages/athena-webapp/src/components/states/error/SingleLineError.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_states_error_singlelineerror_tsx",
-      "community": 193
+      "community": 195
     },
     {
       "label": "SingleLineError()",
@@ -8849,7 +8849,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/error/SingleLineError.tsx",
       "source_location": "L3",
       "id": "singlelineerror_singlelineerror",
-      "community": 193
+      "community": 195
     },
     {
       "label": "index.tsx",
@@ -8857,7 +8857,7 @@
       "source_file": "packages/athena-webapp/src/components/states/error/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_states_error_index_tsx",
-      "community": 194
+      "community": 196
     },
     {
       "label": "ErrorPage()",
@@ -8865,7 +8865,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/error/index.tsx",
       "source_location": "L9",
       "id": "index_errorpage",
-      "community": 194
+      "community": 196
     },
     {
       "label": "app-skeleton.tsx",
@@ -8873,7 +8873,7 @@
       "source_file": "packages/athena-webapp/src/components/states/loading/app-skeleton.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_states_loading_app_skeleton_tsx",
-      "community": 195
+      "community": 197
     },
     {
       "label": "AppSkeleton()",
@@ -8881,7 +8881,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/app-skeleton.tsx",
       "source_location": "L3",
       "id": "app_skeleton_appskeleton",
-      "community": 195
+      "community": 197
     },
     {
       "label": "dashboard-skeleton.tsx",
@@ -8889,7 +8889,7 @@
       "source_file": "packages/athena-webapp/src/components/states/loading/dashboard-skeleton.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_states_loading_dashboard_skeleton_tsx",
-      "community": 196
+      "community": 198
     },
     {
       "label": "DashboardSkeleton()",
@@ -8897,7 +8897,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/dashboard-skeleton.tsx",
       "source_location": "L3",
       "id": "dashboard_skeleton_dashboardskeleton",
-      "community": 196
+      "community": 198
     },
     {
       "label": "table-skeleton.tsx",
@@ -8905,7 +8905,7 @@
       "source_file": "packages/athena-webapp/src/components/states/loading/table-skeleton.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_states_loading_table_skeleton_tsx",
-      "community": 197
+      "community": 199
     },
     {
       "label": "TableSkeleton()",
@@ -8913,7 +8913,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/table-skeleton.tsx",
       "source_location": "L3",
       "id": "table_skeleton_tableskeleton",
-      "community": 197
+      "community": 199
     },
     {
       "label": "transactions-skeleton.tsx",
@@ -8921,7 +8921,7 @@
       "source_file": "packages/athena-webapp/src/components/states/loading/transactions-skeleton.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_states_loading_transactions_skeleton_tsx",
-      "community": 198
+      "community": 200
     },
     {
       "label": "TransactionsSkeleton()",
@@ -8929,7 +8929,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/transactions-skeleton.tsx",
       "source_location": "L3",
       "id": "transactions_skeleton_transactionsskeleton",
-      "community": 198
+      "community": 200
     },
     {
       "label": "NoPermission.tsx",
@@ -8937,7 +8937,7 @@
       "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermission.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermission_tsx",
-      "community": 380
+      "community": 382
     },
     {
       "label": "NoPermission()",
@@ -8945,7 +8945,7 @@
       "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermission.tsx",
       "source_location": "L3",
       "id": "nopermission_nopermission",
-      "community": 380
+      "community": 382
     },
     {
       "label": "NoPermissionView.tsx",
@@ -8953,7 +8953,7 @@
       "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermissionView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermissionview_tsx",
-      "community": 381
+      "community": 383
     },
     {
       "label": "NoPermissionView()",
@@ -8961,7 +8961,7 @@
       "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermissionView.tsx",
       "source_location": "L4",
       "id": "nopermissionview_nopermissionview",
-      "community": 381
+      "community": 383
     },
     {
       "label": "NotFound.tsx",
@@ -8969,7 +8969,7 @@
       "source_file": "packages/athena-webapp/src/components/states/not-found/NotFound.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_states_not_found_notfound_tsx",
-      "community": 199
+      "community": 201
     },
     {
       "label": "NotFound()",
@@ -8977,7 +8977,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/not-found/NotFound.tsx",
       "source_location": "L4",
       "id": "notfound_notfound",
-      "community": 199
+      "community": 201
     },
     {
       "label": "NotFoundView.tsx",
@@ -8985,7 +8985,7 @@
       "source_file": "packages/athena-webapp/src/components/states/not-found/NotFoundView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_states_not_found_notfoundview_tsx",
-      "community": 382
+      "community": 384
     },
     {
       "label": "NotFoundView()",
@@ -8993,7 +8993,7 @@
       "source_file": "packages/athena-webapp/src/components/states/not-found/NotFoundView.tsx",
       "source_location": "L4",
       "id": "notfoundview_notfoundview",
-      "community": 382
+      "community": 384
     },
     {
       "label": "ContactView.tsx",
@@ -9001,7 +9001,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/ContactView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_store_configuration_components_contactview_tsx",
-      "community": 383
+      "community": 385
     },
     {
       "label": "ContactView()",
@@ -9009,7 +9009,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/ContactView.tsx",
       "source_location": "L9",
       "id": "contactview_contactview",
-      "community": 383
+      "community": 385
     },
     {
       "label": "FeesView.tsx",
@@ -9017,7 +9017,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FeesView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_store_configuration_components_feesview_tsx",
-      "community": 200
+      "community": 202
     },
     {
       "label": "handleUpdateFees()",
@@ -9025,7 +9025,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FeesView.tsx",
       "source_location": "L36",
       "id": "feesview_handleupdatefees",
-      "community": 200
+      "community": 202
     },
     {
       "label": "handleToggleAllFees()",
@@ -9033,7 +9033,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FeesView.tsx",
       "source_location": "L104",
       "id": "feesview_handletoggleallfees",
-      "community": 200
+      "community": 202
     },
     {
       "label": "FulfillmentView.tsx",
@@ -9041,7 +9041,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_store_configuration_components_fulfillmentview_tsx",
-      "community": 36
+      "community": 37
     },
     {
       "label": "saveEnableStorePickupChanges()",
@@ -9049,7 +9049,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L43",
       "id": "fulfillmentview_saveenablestorepickupchanges",
-      "community": 36
+      "community": 37
     },
     {
       "label": "saveEnableDeliveryChanges()",
@@ -9057,7 +9057,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L75",
       "id": "fulfillmentview_saveenabledeliverychanges",
-      "community": 36
+      "community": 37
     },
     {
       "label": "savePickupRestriction()",
@@ -9065,7 +9065,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L107",
       "id": "fulfillmentview_savepickuprestriction",
-      "community": 36
+      "community": 37
     },
     {
       "label": "saveDeliveryRestriction()",
@@ -9073,7 +9073,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L132",
       "id": "fulfillmentview_savedeliveryrestriction",
-      "community": 36
+      "community": 37
     },
     {
       "label": "handlePickupRestrictionToggle()",
@@ -9081,7 +9081,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L157",
       "id": "fulfillmentview_handlepickuprestrictiontoggle",
-      "community": 36
+      "community": 37
     },
     {
       "label": "handleDeliveryRestrictionToggle()",
@@ -9089,7 +9089,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L196",
       "id": "fulfillmentview_handledeliveryrestrictiontoggle",
-      "community": 36
+      "community": 37
     },
     {
       "label": "handleSavePickupRestriction()",
@@ -9097,7 +9097,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L235",
       "id": "fulfillmentview_handlesavepickuprestriction",
-      "community": 36
+      "community": 37
     },
     {
       "label": "handleSaveDeliveryRestriction()",
@@ -9105,7 +9105,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FulfillmentView.tsx",
       "source_location": "L244",
       "id": "fulfillmentview_handlesavedeliveryrestriction",
-      "community": 36
+      "community": 37
     },
     {
       "label": "Header.tsx",
@@ -9113,7 +9113,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_store_configuration_components_header_tsx",
-      "community": 384
+      "community": 386
     },
     {
       "label": "Header()",
@@ -9121,7 +9121,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
       "source_location": "L1",
       "id": "header_header",
-      "community": 384
+      "community": 386
     },
     {
       "label": "MaintenanceView.tsx",
@@ -9129,7 +9129,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_tsx",
-      "community": 385
+      "community": 387
     },
     {
       "label": "MaintenanceView()",
@@ -9137,7 +9137,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.tsx",
       "source_location": "L13",
       "id": "maintenanceview_maintenanceview",
-      "community": 385
+      "community": 387
     },
     {
       "label": "MtnMomoView.test.tsx",
@@ -9145,7 +9145,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.test.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_test_tsx",
-      "community": 852
+      "community": 854
     },
     {
       "label": "MtnMomoView.tsx",
@@ -9153,7 +9153,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_tsx",
-      "community": 18
+      "community": 19
     },
     {
       "label": "cloneReceivingAccount()",
@@ -9161,7 +9161,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L27",
       "id": "mtnmomoview_clonereceivingaccount",
-      "community": 18
+      "community": 19
     },
     {
       "label": "createEmptyReceivingAccount()",
@@ -9169,7 +9169,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L35",
       "id": "mtnmomoview_createemptyreceivingaccount",
-      "community": 18
+      "community": 19
     },
     {
       "label": "trimToUndefined()",
@@ -9177,7 +9177,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L47",
       "id": "mtnmomoview_trimtoundefined",
-      "community": 18
+      "community": 19
     },
     {
       "label": "cleanUndefinedFields()",
@@ -9185,7 +9185,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L52",
       "id": "mtnmomoview_cleanundefinedfields",
-      "community": 18
+      "community": 19
     },
     {
       "label": "hasReceivingAccountDetails()",
@@ -9193,7 +9193,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L64",
       "id": "mtnmomoview_hasreceivingaccountdetails",
-      "community": 18
+      "community": 19
     },
     {
       "label": "normalizePrimaryAccounts()",
@@ -9201,7 +9201,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L77",
       "id": "mtnmomoview_normalizeprimaryaccounts",
-      "community": 18
+      "community": 19
     },
     {
       "label": "toPatchReceivingAccounts()",
@@ -9209,7 +9209,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L93",
       "id": "mtnmomoview_topatchreceivingaccounts",
-      "community": 18
+      "community": 19
     },
     {
       "label": "getStatusBadgeVariant()",
@@ -9217,7 +9217,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L114",
       "id": "mtnmomoview_getstatusbadgevariant",
-      "community": 18
+      "community": 19
     },
     {
       "label": "updateAccount()",
@@ -9225,7 +9225,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L141",
       "id": "mtnmomoview_updateaccount",
-      "community": 18
+      "community": 19
     },
     {
       "label": "handleAddAccount()",
@@ -9233,7 +9233,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L152",
       "id": "mtnmomoview_handleaddaccount",
-      "community": 18
+      "community": 19
     },
     {
       "label": "handleMakePrimary()",
@@ -9241,7 +9241,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L159",
       "id": "mtnmomoview_handlemakeprimary",
-      "community": 18
+      "community": 19
     },
     {
       "label": "handleRemoveAccount()",
@@ -9249,7 +9249,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L168",
       "id": "mtnmomoview_handleremoveaccount",
-      "community": 18
+      "community": 19
     },
     {
       "label": "handleSave()",
@@ -9257,7 +9257,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L188",
       "id": "mtnmomoview_handlesave",
-      "community": 18
+      "community": 19
     },
     {
       "label": "TaxView.tsx",
@@ -9265,7 +9265,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/TaxView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_store_configuration_components_taxview_tsx",
-      "community": 386
+      "community": 388
     },
     {
       "label": "handleUpdateTaxSettings()",
@@ -9273,7 +9273,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/TaxView.tsx",
       "source_location": "L25",
       "id": "taxview_handleupdatetaxsettings",
-      "community": 386
+      "community": 388
     },
     {
       "label": "useStoreConfigUpdate.ts",
@@ -9281,7 +9281,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/hooks/useStoreConfigUpdate.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_ts",
-      "community": 387
+      "community": 389
     },
     {
       "label": "useStoreConfigUpdate()",
@@ -9289,7 +9289,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/hooks/useStoreConfigUpdate.ts",
       "source_location": "L19",
       "id": "usestoreconfigupdate_usestoreconfigupdate",
-      "community": 387
+      "community": 389
     },
     {
       "label": "index.tsx",
@@ -9297,7 +9297,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_store_configuration_index_tsx",
-      "community": 853
+      "community": 855
     },
     {
       "label": "store-switcher.tsx",
@@ -9305,7 +9305,7 @@
       "source_file": "packages/athena-webapp/src/components/store-switcher.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_store_switcher_tsx",
-      "community": 388
+      "community": 390
     },
     {
       "label": "onStoreSelect()",
@@ -9313,7 +9313,7 @@
       "source_file": "packages/athena-webapp/src/components/store-switcher.tsx",
       "source_location": "L63",
       "id": "store_switcher_onstoreselect",
-      "community": 388
+      "community": 390
     },
     {
       "label": "accordion.tsx",
@@ -9321,7 +9321,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/accordion.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_accordion_tsx",
-      "community": 854
+      "community": 856
     },
     {
       "label": "app-context-menu.tsx",
@@ -9329,7 +9329,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/app-context-menu.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_app_context_menu_tsx",
-      "community": 201
+      "community": 203
     },
     {
       "label": "AppContextMenu()",
@@ -9337,7 +9337,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/app-context-menu.tsx",
       "source_location": "L20",
       "id": "app_context_menu_appcontextmenu",
-      "community": 201
+      "community": 203
     },
     {
       "label": "badge.tsx",
@@ -9345,7 +9345,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/badge.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_badge_tsx",
-      "community": 202
+      "community": 204
     },
     {
       "label": "Badge()",
@@ -9353,7 +9353,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/badge.tsx",
       "source_location": "L30",
       "id": "badge_badge",
-      "community": 202
+      "community": 204
     },
     {
       "label": "button.test.tsx",
@@ -9361,7 +9361,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/button.test.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_button_test_tsx",
-      "community": 855
+      "community": 857
     },
     {
       "label": "button.tsx",
@@ -9369,7 +9369,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/button.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_button_tsx",
-      "community": 856
+      "community": 858
     },
     {
       "label": "calendar.test.tsx",
@@ -9377,7 +9377,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/calendar.test.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_calendar_test_tsx",
-      "community": 857
+      "community": 859
     },
     {
       "label": "calendar.tsx",
@@ -9385,7 +9385,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/calendar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_calendar_tsx",
-      "community": 858
+      "community": 860
     },
     {
       "label": "card.tsx",
@@ -9393,7 +9393,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/card.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_card_tsx",
-      "community": 859
+      "community": 861
     },
     {
       "label": "chart.tsx",
@@ -9401,7 +9401,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/chart.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_chart_tsx",
-      "community": 389
+      "community": 391
     },
     {
       "label": "useChart()",
@@ -9409,7 +9409,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/chart.tsx",
       "source_location": "L25",
       "id": "chart_usechart",
-      "community": 389
+      "community": 391
     },
     {
       "label": "checkbox.tsx",
@@ -9417,7 +9417,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/checkbox.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_checkbox_tsx",
-      "community": 860
+      "community": 862
     },
     {
       "label": "collapsible.tsx",
@@ -9425,7 +9425,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/collapsible.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_collapsible_tsx",
-      "community": 861
+      "community": 863
     },
     {
       "label": "command.tsx",
@@ -9433,7 +9433,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/command.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_command_tsx",
-      "community": 862
+      "community": 864
     },
     {
       "label": "context-menu.tsx",
@@ -9441,7 +9441,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/context-menu.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_context_menu_tsx",
-      "community": 863
+      "community": 865
     },
     {
       "label": "copy-button.tsx",
@@ -9449,7 +9449,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/copy-button.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_copy_button_tsx",
-      "community": 390
+      "community": 392
     },
     {
       "label": "handleCopy()",
@@ -9457,7 +9457,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/copy-button.tsx",
       "source_location": "L15",
       "id": "copy_button_handlecopy",
-      "community": 390
+      "community": 392
     },
     {
       "label": "copy-wrapper.tsx",
@@ -9465,7 +9465,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/copy-wrapper.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_copy_wrapper_tsx",
-      "community": 391
+      "community": 393
     },
     {
       "label": "handleCopy()",
@@ -9473,7 +9473,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/copy-wrapper.tsx",
       "source_location": "L21",
       "id": "copy_wrapper_handlecopy",
-      "community": 391
+      "community": 393
     },
     {
       "label": "date-time-picker.tsx",
@@ -9481,7 +9481,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/date-time-picker.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
-      "community": 392
+      "community": 394
     },
     {
       "label": "DateTimePicker()",
@@ -9489,7 +9489,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/date-time-picker.tsx",
       "source_location": "L21",
       "id": "date_time_picker_datetimepicker",
-      "community": 392
+      "community": 394
     },
     {
       "label": "dialog.tsx",
@@ -9497,7 +9497,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/dialog.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_dialog_tsx",
-      "community": 864
+      "community": 866
     },
     {
       "label": "dropdown-menu.tsx",
@@ -9505,7 +9505,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/dropdown-menu.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_dropdown_menu_tsx",
-      "community": 865
+      "community": 867
     },
     {
       "label": "form.tsx",
@@ -9513,7 +9513,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/form.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_form_tsx",
-      "community": 866
+      "community": 868
     },
     {
       "label": "icons.tsx",
@@ -9521,7 +9521,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/icons.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_icons_tsx",
-      "community": 867
+      "community": 869
     },
     {
       "label": "image-uploader.tsx",
@@ -9529,7 +9529,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "community": 78
+      "community": 68
     },
     {
       "label": "onDrop()",
@@ -9537,7 +9537,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L20",
       "id": "image_uploader_ondrop",
-      "community": 78
+      "community": 68
     },
     {
       "label": "removeImage()",
@@ -9545,7 +9545,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L31",
       "id": "image_uploader_removeimage",
-      "community": 78
+      "community": 68
     },
     {
       "label": "unmarkForDeletion()",
@@ -9553,7 +9553,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L46",
       "id": "image_uploader_unmarkfordeletion",
-      "community": 78
+      "community": 68
     },
     {
       "label": "onDragEnd()",
@@ -9561,7 +9561,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L100",
       "id": "image_uploader_ondragend",
-      "community": 78
+      "community": 68
     },
     {
       "label": "input-otp.tsx",
@@ -9569,7 +9569,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/input-otp.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_input_otp_tsx",
-      "community": 868
+      "community": 870
     },
     {
       "label": "input.tsx",
@@ -9577,7 +9577,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/input.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_input_tsx",
-      "community": 869
+      "community": 871
     },
     {
       "label": "label.tsx",
@@ -9585,7 +9585,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/label.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_label_tsx",
-      "community": 393
+      "community": 395
     },
     {
       "label": "Label()",
@@ -9593,7 +9593,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/label.tsx",
       "source_location": "L6",
       "id": "label_label",
-      "community": 393
+      "community": 395
     },
     {
       "label": "loading-button.tsx",
@@ -9601,7 +9601,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/loading-button.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_loading_button_tsx",
-      "community": 203
+      "community": 205
     },
     {
       "label": "LoadingButton()",
@@ -9609,7 +9609,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/loading-button.tsx",
       "source_location": "L9",
       "id": "loading_button_loadingbutton",
-      "community": 203
+      "community": 205
     },
     {
       "label": "modal.tsx",
@@ -9617,7 +9617,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modal.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_modal_tsx",
-      "community": 204
+      "community": 206
     },
     {
       "label": "onChange()",
@@ -9625,7 +9625,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modal.tsx",
       "source_location": "L38",
       "id": "modal_onchange",
-      "community": 204
+      "community": 206
     },
     {
       "label": "action-modal.tsx",
@@ -9633,7 +9633,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/action-modal.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_modals_action_modal_tsx",
-      "community": 870
+      "community": 872
     },
     {
       "label": "alert-modal.tsx",
@@ -9641,7 +9641,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/alert-modal.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_modals_alert_modal_tsx",
-      "community": 205
+      "community": 207
     },
     {
       "label": "AlertModal()",
@@ -9649,7 +9649,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/alert-modal.tsx",
       "source_location": "L20",
       "id": "alert_modal_alertmodal",
-      "community": 205
+      "community": 207
     },
     {
       "label": "custom-modal-example.tsx",
@@ -9657,7 +9657,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_example_tsx",
-      "community": 102
+      "community": 103
     },
     {
       "label": "BasicModalExample()",
@@ -9665,7 +9665,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
       "source_location": "L7",
       "id": "custom_modal_example_basicmodalexample",
-      "community": 102
+      "community": 103
     },
     {
       "label": "CustomPositionModalExample()",
@@ -9673,7 +9673,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
       "source_location": "L44",
       "id": "custom_modal_example_custompositionmodalexample",
-      "community": 102
+      "community": 103
     },
     {
       "label": "CustomCloseButtonExample()",
@@ -9681,7 +9681,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
       "source_location": "L69",
       "id": "custom_modal_example_customclosebuttonexample",
-      "community": 102
+      "community": 103
     },
     {
       "label": "FullScreenModalExample()",
@@ -9689,7 +9689,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
       "source_location": "L103",
       "id": "custom_modal_example_fullscreenmodalexample",
-      "community": 102
+      "community": 103
     },
     {
       "label": "custom-modal.tsx",
@@ -9697,7 +9697,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_tsx",
-      "community": 394
+      "community": 396
     },
     {
       "label": "CustomModal()",
@@ -9705,7 +9705,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
       "source_location": "L25",
       "id": "custom_modal_custommodal",
-      "community": 394
+      "community": 396
     },
     {
       "label": "organization-modal.tsx",
@@ -9713,7 +9713,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/organization-modal.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_modals_organization_modal_tsx",
-      "community": 395
+      "community": 397
     },
     {
       "label": "onSubmit()",
@@ -9721,7 +9721,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/organization-modal.tsx",
       "source_location": "L49",
       "id": "organization_modal_onsubmit",
-      "community": 395
+      "community": 397
     },
     {
       "label": "overlay-modal.tsx",
@@ -9729,7 +9729,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/overlay-modal.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_modals_overlay_modal_tsx",
-      "community": 206
+      "community": 208
     },
     {
       "label": "OverlayModal()",
@@ -9737,7 +9737,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/overlay-modal.tsx",
       "source_location": "L12",
       "id": "overlay_modal_overlaymodal",
-      "community": 206
+      "community": 208
     },
     {
       "label": "store-modal.tsx",
@@ -9745,7 +9745,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/store-modal.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_modals_store_modal_tsx",
-      "community": 396
+      "community": 398
     },
     {
       "label": "onSubmit()",
@@ -9753,7 +9753,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/store-modal.tsx",
       "source_location": "L63",
       "id": "store_modal_onsubmit",
-      "community": 396
+      "community": 398
     },
     {
       "label": "welcome-back-modal-example.tsx",
@@ -9761,7 +9761,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal-example.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_example_tsx",
-      "community": 397
+      "community": 399
     },
     {
       "label": "WelcomeBackModalExample()",
@@ -9769,7 +9769,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal-example.tsx",
       "source_location": "L5",
       "id": "welcome_back_modal_example_welcomebackmodalexample",
-      "community": 397
+      "community": 399
     },
     {
       "label": "welcome-back-modal.tsx",
@@ -9777,7 +9777,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_tsx",
-      "community": 398
+      "community": 400
     },
     {
       "label": "WelcomeBackModal()",
@@ -9785,7 +9785,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal.tsx",
       "source_location": "L12",
       "id": "welcome_back_modal_welcomebackmodal",
-      "community": 398
+      "community": 400
     },
     {
       "label": "popover.tsx",
@@ -9793,7 +9793,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/popover.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_popover_tsx",
-      "community": 871
+      "community": 873
     },
     {
       "label": "radio-group.tsx",
@@ -9801,7 +9801,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/radio-group.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_radio_group_tsx",
-      "community": 872
+      "community": 874
     },
     {
       "label": "scroll-area.tsx",
@@ -9809,7 +9809,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/scroll-area.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
-      "community": 873
+      "community": 875
     },
     {
       "label": "select-native.tsx",
@@ -9817,7 +9817,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/select-native.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_select_native_tsx",
-      "community": 399
+      "community": 401
     },
     {
       "label": "cn()",
@@ -9825,7 +9825,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/select-native.tsx",
       "source_location": "L15",
       "id": "select_native_cn",
-      "community": 399
+      "community": 401
     },
     {
       "label": "select.tsx",
@@ -9833,7 +9833,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/select.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_select_tsx",
-      "community": 874
+      "community": 876
     },
     {
       "label": "separator.tsx",
@@ -9841,7 +9841,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/separator.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_separator_tsx",
-      "community": 875
+      "community": 877
     },
     {
       "label": "sheet.tsx",
@@ -9849,7 +9849,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sheet.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_sheet_tsx",
-      "community": 876
+      "community": 878
     },
     {
       "label": "sidebar.tsx",
@@ -9857,7 +9857,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
-      "community": 67
+      "community": 69
     },
     {
       "label": "useSidebar()",
@@ -9865,7 +9865,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L45",
       "id": "sidebar_usesidebar",
-      "community": 67
+      "community": 69
     },
     {
       "label": "handleKeyDown()",
@@ -9873,7 +9873,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L105",
       "id": "sidebar_handlekeydown",
-      "community": 67
+      "community": 69
     },
     {
       "label": "cn()",
@@ -9881,7 +9881,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L147",
       "id": "sidebar_cn",
-      "community": 67
+      "community": 69
     },
     {
       "label": "handleOnHover()",
@@ -9889,7 +9889,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L224",
       "id": "sidebar_handleonhover",
-      "community": 67
+      "community": 69
     },
     {
       "label": "handleOnMouseLeave()",
@@ -9897,7 +9897,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L228",
       "id": "sidebar_handleonmouseleave",
-      "community": 67
+      "community": 69
     },
     {
       "label": "skeleton.tsx",
@@ -9905,7 +9905,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/skeleton.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_skeleton_tsx",
-      "community": 207
+      "community": 209
     },
     {
       "label": "Skeleton()",
@@ -9913,7 +9913,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/skeleton.tsx",
       "source_location": "L3",
       "id": "skeleton_skeleton",
-      "community": 207
+      "community": 209
     },
     {
       "label": "sonner.tsx",
@@ -9921,7 +9921,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sonner.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_sonner_tsx",
-      "community": 208
+      "community": 210
     },
     {
       "label": "Toaster()",
@@ -9929,7 +9929,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/sonner.tsx",
       "source_location": "L6",
       "id": "sonner_toaster",
-      "community": 208
+      "community": 210
     },
     {
       "label": "spinner.tsx",
@@ -9937,7 +9937,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/spinner.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_spinner_tsx",
-      "community": 209
+      "community": 211
     },
     {
       "label": "Spinner()",
@@ -9945,7 +9945,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/spinner.tsx",
       "source_location": "L3",
       "id": "spinner_spinner",
-      "community": 209
+      "community": 211
     },
     {
       "label": "switch.tsx",
@@ -9953,7 +9953,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/switch.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_switch_tsx",
-      "community": 877
+      "community": 879
     },
     {
       "label": "table.tsx",
@@ -9961,7 +9961,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_table_tsx",
-      "community": 878
+      "community": 880
     },
     {
       "label": "tabs.tsx",
@@ -9969,7 +9969,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/tabs.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_tabs_tsx",
-      "community": 879
+      "community": 881
     },
     {
       "label": "textarea.tsx",
@@ -9977,7 +9977,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/textarea.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_textarea_tsx",
-      "community": 880
+      "community": 882
     },
     {
       "label": "timeline-item.tsx",
@@ -9985,7 +9985,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/timeline-item.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_timeline_item_tsx",
-      "community": 400
+      "community": 402
     },
     {
       "label": "TimelineItem()",
@@ -9993,7 +9993,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/timeline-item.tsx",
       "source_location": "L3",
       "id": "timeline_item_timelineitem",
-      "community": 400
+      "community": 402
     },
     {
       "label": "toggle-group.tsx",
@@ -10001,7 +10001,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/toggle-group.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_toggle_group_tsx",
-      "community": 881
+      "community": 883
     },
     {
       "label": "toggle.tsx",
@@ -10009,7 +10009,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/toggle.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_toggle_tsx",
-      "community": 882
+      "community": 884
     },
     {
       "label": "tooltip.tsx",
@@ -10017,7 +10017,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/tooltip.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
-      "community": 883
+      "community": 885
     },
     {
       "label": "webp-image.tsx",
@@ -10025,7 +10025,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/webp-image.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_webp_image_tsx",
-      "community": 401
+      "community": 403
     },
     {
       "label": "WebpImage()",
@@ -10033,7 +10033,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/webp-image.tsx",
       "source_location": "L1",
       "id": "webp_image_webpimage",
-      "community": 401
+      "community": 403
     },
     {
       "label": "upload-button.tsx",
@@ -10041,7 +10041,7 @@
       "source_file": "packages/athena-webapp/src/components/upload-button.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_upload_button_tsx",
-      "community": 884
+      "community": 886
     },
     {
       "label": "BagItems.tsx",
@@ -10049,7 +10049,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/BagItems.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_bagitems_tsx",
-      "community": 402
+      "community": 404
     },
     {
       "label": "BagItems()",
@@ -10057,7 +10057,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/BagItems.tsx",
       "source_location": "L5",
       "id": "bagitems_bagitems",
-      "community": 402
+      "community": 404
     },
     {
       "label": "BagItemsView.tsx",
@@ -10065,7 +10065,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/BagItemsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_bagitemsview_tsx",
-      "community": 403
+      "community": 405
     },
     {
       "label": "BagItemsView()",
@@ -10073,7 +10073,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/BagItemsView.tsx",
       "source_location": "L11",
       "id": "bagitemsview_bagitemsview",
-      "community": 403
+      "community": 405
     },
     {
       "label": "BagView.tsx",
@@ -10081,7 +10081,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/BagView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_bagview_tsx",
-      "community": 885
+      "community": 887
     },
     {
       "label": "Bags.tsx",
@@ -10089,7 +10089,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_bags_tsx",
-      "community": 404
+      "community": 406
     },
     {
       "label": "Bags()",
@@ -10097,7 +10097,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
       "source_location": "L4",
       "id": "bags_bags",
-      "community": 404
+      "community": 406
     },
     {
       "label": "columns.tsx",
@@ -10105,7 +10105,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/columns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_table_columns_tsx",
-      "community": 886
+      "community": 888
     },
     {
       "label": "constants.ts",
@@ -10113,7 +10113,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/constants.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
-      "community": 887
+      "community": 889
     },
     {
       "label": "data-table-column-header.tsx",
@@ -10121,7 +10121,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_column_header_tsx",
-      "community": 15
+      "community": 16
     },
     {
       "label": "data-table-faceted-filter.tsx",
@@ -10129,7 +10129,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-faceted-filter.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_faceted_filter_tsx",
-      "community": 888
+      "community": 890
     },
     {
       "label": "data-table-pagination.tsx",
@@ -10137,7 +10137,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_pagination_tsx",
-      "community": 889
+      "community": 891
     },
     {
       "label": "data-table-toolbar-provider.tsx",
@@ -10145,7 +10145,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_provider_tsx",
-      "community": 22
+      "community": 23
     },
     {
       "label": "data-table-toolbar.tsx",
@@ -10153,7 +10153,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_tsx",
-      "community": 61
+      "community": 62
     },
     {
       "label": "data-table-view-options.tsx",
@@ -10161,7 +10161,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-view-options.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_view_options_tsx",
-      "community": 12
+      "community": 13
     },
     {
       "label": "data-table.tsx",
@@ -10169,7 +10169,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_tsx",
-      "community": 890
+      "community": 892
     },
     {
       "label": "data.ts",
@@ -10177,7 +10177,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_ts",
-      "community": 891
+      "community": 893
     },
     {
       "label": "bag-columns.tsx",
@@ -10185,7 +10185,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bag-columns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bag_columns_tsx",
-      "community": 892
+      "community": 894
     },
     {
       "label": "bags-table.tsx",
@@ -10193,7 +10193,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/bags-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
-      "community": 893
+      "community": 895
     },
     {
       "label": "columns.tsx",
@@ -10201,7 +10201,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/columns.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_columns_tsx",
-      "community": 894
+      "community": 896
     },
     {
       "label": "data-table-column-header.tsx",
@@ -10209,7 +10209,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_column_header_tsx",
-      "community": 895
+      "community": 897
     },
     {
       "label": "data-table-faceted-filter.tsx",
@@ -10217,7 +10217,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-faceted-filter.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_faceted_filter_tsx",
-      "community": 896
+      "community": 898
     },
     {
       "label": "data-table-pagination.tsx",
@@ -10225,7 +10225,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-pagination.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_pagination_tsx",
-      "community": 897
+      "community": 899
     },
     {
       "label": "data-table-row-actions.tsx",
@@ -10233,7 +10233,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-row-actions.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_row_actions_tsx",
-      "community": 40
+      "community": 41
     },
     {
       "label": "data-table-toolbar.tsx",
@@ -10241,7 +10241,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-toolbar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
-      "community": 898
+      "community": 900
     },
     {
       "label": "data-table-view-options.tsx",
@@ -10249,7 +10249,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_view_options_tsx",
-      "community": 12
+      "community": 13
     },
     {
       "label": "data-table.tsx",
@@ -10257,7 +10257,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_tsx",
-      "community": 899
+      "community": 901
     },
     {
       "label": "selectable-data-provider.tsx",
@@ -10265,7 +10265,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
-      "community": 62
+      "community": 63
     },
     {
       "label": "ActivitySummaryCards.tsx",
@@ -10273,7 +10273,7 @@
       "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_activitysummarycards_tsx",
-      "community": 210
+      "community": 212
     },
     {
       "label": "SummaryCard()",
@@ -10281,7 +10281,7 @@
       "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
       "source_location": "L19",
       "id": "activitysummarycards_summarycard",
-      "community": 210
+      "community": 212
     },
     {
       "label": "ActivitySummaryCards()",
@@ -10289,7 +10289,7 @@
       "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
       "source_location": "L44",
       "id": "activitysummarycards_activitysummarycards",
-      "community": 210
+      "community": 212
     },
     {
       "label": "CustomerBehaviorTimeline.tsx",
@@ -10297,7 +10297,7 @@
       "source_file": "packages/athena-webapp/src/components/users/CustomerBehaviorTimeline.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_customerbehaviortimeline_tsx",
-      "community": 405
+      "community": 407
     },
     {
       "label": "String()",
@@ -10305,7 +10305,7 @@
       "source_file": "packages/athena-webapp/src/components/users/CustomerBehaviorTimeline.tsx",
       "source_location": "L110",
       "id": "customerbehaviortimeline_string",
-      "community": 405
+      "community": 407
     },
     {
       "label": "LinkedAccounts.tsx",
@@ -10313,7 +10313,7 @@
       "source_file": "packages/athena-webapp/src/components/users/LinkedAccounts.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_linkedaccounts_tsx",
-      "community": 900
+      "community": 902
     },
     {
       "label": "TimelineEventCard.test.tsx",
@@ -10321,7 +10321,7 @@
       "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.test.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_test_tsx",
-      "community": 901
+      "community": 903
     },
     {
       "label": "TimelineEventCard.tsx",
@@ -10329,7 +10329,7 @@
       "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_tsx",
-      "community": 211
+      "community": 213
     },
     {
       "label": "formatObservabilityLabel()",
@@ -10337,7 +10337,7 @@
       "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
       "source_location": "L139",
       "id": "timelineeventcard_formatobservabilitylabel",
-      "community": 211
+      "community": 213
     },
     {
       "label": "loadMore()",
@@ -10345,7 +10345,7 @@
       "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
       "source_location": "L175",
       "id": "timelineeventcard_loadmore",
-      "community": 211
+      "community": 213
     },
     {
       "label": "UserActivity.tsx",
@@ -10353,7 +10353,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_useractivity_tsx",
-      "community": 212
+      "community": 214
     },
     {
       "label": "ActivityHeader()",
@@ -10361,7 +10361,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
       "source_location": "L22",
       "id": "useractivity_activityheader",
-      "community": 212
+      "community": 214
     },
     {
       "label": "UserActivity()",
@@ -10369,7 +10369,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
       "source_location": "L45",
       "id": "useractivity_useractivity",
-      "community": 212
+      "community": 214
     },
     {
       "label": "UserAnalyticsName.tsx",
@@ -10377,7 +10377,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserAnalyticsName.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_useranalyticsname_tsx",
-      "community": 406
+      "community": 408
     },
     {
       "label": "UserAnalyticsName()",
@@ -10385,7 +10385,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserAnalyticsName.tsx",
       "source_location": "L13",
       "id": "useranalyticsname_useranalyticsname",
-      "community": 406
+      "community": 408
     },
     {
       "label": "UserBag.tsx",
@@ -10393,7 +10393,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserBag.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_userbag_tsx",
-      "community": 407
+      "community": 409
     },
     {
       "label": "UserBag()",
@@ -10401,7 +10401,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserBag.tsx",
       "source_location": "L7",
       "id": "userbag_userbag",
-      "community": 407
+      "community": 409
     },
     {
       "label": "UserCheckoutSession.tsx",
@@ -10409,7 +10409,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserCheckoutSession.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_usercheckoutsession_tsx",
-      "community": 902
+      "community": 904
     },
     {
       "label": "UserInsightsSection.tsx",
@@ -10417,7 +10417,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserInsightsSection.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_userinsightssection_tsx",
-      "community": 903
+      "community": 905
     },
     {
       "label": "UserOnlineOrders.tsx",
@@ -10425,7 +10425,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserOnlineOrders.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_useronlineorders_tsx",
-      "community": 408
+      "community": 410
     },
     {
       "label": "UserOnlineOrders()",
@@ -10433,7 +10433,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserOnlineOrders.tsx",
       "source_location": "L11",
       "id": "useronlineorders_useronlineorders",
-      "community": 408
+      "community": 410
     },
     {
       "label": "UserStatus.tsx",
@@ -10441,7 +10441,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserStatus.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_userstatus_tsx",
-      "community": 409
+      "community": 411
     },
     {
       "label": "UserStatus()",
@@ -10449,7 +10449,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserStatus.tsx",
       "source_location": "L7",
       "id": "userstatus_userstatus",
-      "community": 409
+      "community": 411
     },
     {
       "label": "UserView.tsx",
@@ -10457,7 +10457,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_userview_tsx",
-      "community": 410
+      "community": 412
     },
     {
       "label": "UserActions()",
@@ -10465,7 +10465,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserView.tsx",
       "source_location": "L45",
       "id": "userview_useractions",
-      "community": 410
+      "community": 412
     },
     {
       "label": "CustomerJourneyStage.tsx",
@@ -10473,7 +10473,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/CustomerJourneyStage.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_customerjourneystage_tsx",
-      "community": 411
+      "community": 413
     },
     {
       "label": "CustomerJourneyStageCard()",
@@ -10481,7 +10481,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/CustomerJourneyStage.tsx",
       "source_location": "L13",
       "id": "customerjourneystage_customerjourneystagecard",
-      "community": 411
+      "community": 413
     },
     {
       "label": "EngagementMetrics.tsx",
@@ -10489,7 +10489,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_engagementmetrics_tsx",
-      "community": 140
+      "community": 141
     },
     {
       "label": "formatLastActivity()",
@@ -10497,7 +10497,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
       "source_location": "L75",
       "id": "engagementmetrics_formatlastactivity",
-      "community": 140
+      "community": 141
     },
     {
       "label": "getDeviceIcon()",
@@ -10505,7 +10505,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
       "source_location": "L82",
       "id": "engagementmetrics_getdeviceicon",
-      "community": 140
+      "community": 141
     },
     {
       "label": "getDeviceLabel()",
@@ -10513,7 +10513,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/EngagementMetrics.tsx",
       "source_location": "L93",
       "id": "engagementmetrics_getdevicelabel",
-      "community": 140
+      "community": 141
     },
     {
       "label": "RiskIndicators.tsx",
@@ -10521,7 +10521,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
-      "community": 141
+      "community": 142
     },
     {
       "label": "getRiskIcon()",
@@ -10529,7 +10529,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
       "source_location": "L15",
       "id": "riskindicators_getriskicon",
-      "community": 141
+      "community": 142
     },
     {
       "label": "getRiskStyles()",
@@ -10537,7 +10537,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
       "source_location": "L28",
       "id": "riskindicators_getriskstyles",
-      "community": 141
+      "community": 142
     },
     {
       "label": "RiskIndicators()",
@@ -10545,7 +10545,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
       "source_location": "L54",
       "id": "riskindicators_riskindicators",
-      "community": 141
+      "community": 142
     },
     {
       "label": "UserBehaviorInsights.tsx",
@@ -10553,7 +10553,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/UserBehaviorInsights.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_userbehaviorinsights_tsx",
-      "community": 904
+      "community": 906
     },
     {
       "label": "index.ts",
@@ -10561,7 +10561,7 @@
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/index.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_index_ts",
-      "community": 905
+      "community": 907
     },
     {
       "label": "config.ts",
@@ -10569,7 +10569,7 @@
       "source_file": "packages/athena-webapp/src/config.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_config_ts",
-      "community": 906
+      "community": 908
     },
     {
       "label": "OnlineOrderContext.tsx",
@@ -10577,7 +10577,7 @@
       "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_contexts_onlineordercontext_tsx",
-      "community": 213
+      "community": 215
     },
     {
       "label": "OnlineOrderProvider()",
@@ -10585,7 +10585,7 @@
       "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
       "source_location": "L24",
       "id": "onlineordercontext_onlineorderprovider",
-      "community": 213
+      "community": 215
     },
     {
       "label": "useOnlineOrder()",
@@ -10593,7 +10593,7 @@
       "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
       "source_location": "L38",
       "id": "onlineordercontext_useonlineorder",
-      "community": 213
+      "community": 215
     },
     {
       "label": "PermissionsContext.tsx",
@@ -10601,7 +10601,7 @@
       "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_contexts_permissionscontext_tsx",
-      "community": 214
+      "community": 216
     },
     {
       "label": "PermissionsProvider()",
@@ -10609,7 +10609,7 @@
       "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
       "source_location": "L23",
       "id": "permissionscontext_permissionsprovider",
-      "community": 214
+      "community": 216
     },
     {
       "label": "usePermissionsContext()",
@@ -10617,7 +10617,7 @@
       "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
       "source_location": "L51",
       "id": "permissionscontext_usepermissionscontext",
-      "community": 214
+      "community": 216
     },
     {
       "label": "ProductContext.tsx",
@@ -10625,7 +10625,7 @@
       "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_contexts_productcontext_tsx",
-      "community": 215
+      "community": 217
     },
     {
       "label": "ProductProvider()",
@@ -10633,7 +10633,7 @@
       "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
       "source_location": "L54",
       "id": "productcontext_productprovider",
-      "community": 215
+      "community": 217
     },
     {
       "label": "useProduct()",
@@ -10641,7 +10641,7 @@
       "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
       "source_location": "L282",
       "id": "productcontext_useproduct",
-      "community": 215
+      "community": 217
     },
     {
       "label": "ThemeContext.tsx",
@@ -10649,7 +10649,7 @@
       "source_file": "packages/athena-webapp/src/contexts/ThemeContext.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_contexts_themecontext_tsx",
-      "community": 907
+      "community": 909
     },
     {
       "label": "UserContext.tsx",
@@ -10657,7 +10657,7 @@
       "source_file": "packages/athena-webapp/src/contexts/UserContext.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_contexts_usercontext_tsx",
-      "community": 216
+      "community": 218
     },
     {
       "label": "UserProvider()",
@@ -10665,7 +10665,7 @@
       "source_file": "packages/athena-webapp/src/contexts/UserContext.tsx",
       "source_location": "L12",
       "id": "usercontext_userprovider",
-      "community": 216
+      "community": 218
     },
     {
       "label": "useUserContext()",
@@ -10673,7 +10673,7 @@
       "source_file": "packages/athena-webapp/src/contexts/UserContext.tsx",
       "source_location": "L37",
       "id": "usercontext_useusercontext",
-      "community": 216
+      "community": 218
     },
     {
       "label": "use-image-upload.ts",
@@ -10681,7 +10681,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-image-upload.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_use_image_upload_ts",
-      "community": 412
+      "community": 414
     },
     {
       "label": "useImageUpload()",
@@ -10689,7 +10689,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-image-upload.ts",
       "source_location": "L7",
       "id": "use_image_upload_useimageupload",
-      "community": 412
+      "community": 414
     },
     {
       "label": "use-mobile.tsx",
@@ -10697,7 +10697,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_use_mobile_tsx",
-      "community": 413
+      "community": 415
     },
     {
       "label": "useIsMobile()",
@@ -10705,7 +10705,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
       "source_location": "L5",
       "id": "use_mobile_useismobile",
-      "community": 413
+      "community": 415
     },
     {
       "label": "use-navigate-back.ts",
@@ -10713,7 +10713,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_use_navigate_back_ts",
-      "community": 414
+      "community": 416
     },
     {
       "label": "useNavigateBack()",
@@ -10721,7 +10721,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
       "source_location": "L5",
       "id": "use_navigate_back_usenavigateback",
-      "community": 414
+      "community": 416
     },
     {
       "label": "use-navigation-keyboard-shortcuts.ts",
@@ -10729,7 +10729,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-navigation-keyboard-shortcuts.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_use_navigation_keyboard_shortcuts_ts",
-      "community": 415
+      "community": 417
     },
     {
       "label": "useNavigationKeyboardShortcuts()",
@@ -10737,7 +10737,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-navigation-keyboard-shortcuts.ts",
       "source_location": "L7",
       "id": "use_navigation_keyboard_shortcuts_usenavigationkeyboardshortcuts",
-      "community": 415
+      "community": 417
     },
     {
       "label": "use-pagination-persistence.ts",
@@ -10745,7 +10745,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-pagination-persistence.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_use_pagination_persistence_ts",
-      "community": 416
+      "community": 418
     },
     {
       "label": "usePaginationPersistence()",
@@ -10753,7 +10753,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-pagination-persistence.ts",
       "source_location": "L9",
       "id": "use_pagination_persistence_usepaginationpersistence",
-      "community": 416
+      "community": 418
     },
     {
       "label": "use-store-modal.tsx",
@@ -10761,7 +10761,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-store-modal.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_use_store_modal_tsx",
-      "community": 908
+      "community": 910
     },
     {
       "label": "use-table-keyboard-pagination.ts",
@@ -10769,7 +10769,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-table-keyboard-pagination.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_use_table_keyboard_pagination_ts",
-      "community": 417
+      "community": 419
     },
     {
       "label": "useTableKeyboardPagination()",
@@ -10777,7 +10777,7 @@
       "source_file": "packages/athena-webapp/src/hooks/use-table-keyboard-pagination.ts",
       "source_location": "L6",
       "id": "use_table_keyboard_pagination_usetablekeyboardpagination",
-      "community": 417
+      "community": 419
     },
     {
       "label": "useAuth.ts",
@@ -10785,7 +10785,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useAuth.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_useauth_ts",
-      "community": 217
+      "community": 219
     },
     {
       "label": "useAuth()",
@@ -10793,7 +10793,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useAuth.ts",
       "source_location": "L4",
       "id": "useauth_useauth",
-      "community": 217
+      "community": 219
     },
     {
       "label": "useBulkOperations.test.ts",
@@ -10801,7 +10801,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usebulkoperations_test_ts",
-      "community": 418
+      "community": 420
     },
     {
       "label": "makeSku()",
@@ -10809,7 +10809,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.test.ts",
       "source_location": "L168",
       "id": "usebulkoperations_test_makesku",
-      "community": 418
+      "community": 420
     },
     {
       "label": "useBulkOperations.ts",
@@ -10817,7 +10817,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
-      "community": 68
+      "community": 70
     },
     {
       "label": "applyOperation()",
@@ -10825,7 +10825,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L56",
       "id": "usebulkoperations_applyoperation",
-      "community": 68
+      "community": 70
     },
     {
       "label": "calculatePriceWithFee()",
@@ -10833,7 +10833,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L87",
       "id": "usebulkoperations_calculatepricewithfee",
-      "community": 68
+      "community": 70
     },
     {
       "label": "computePreview()",
@@ -10841,7 +10841,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L101",
       "id": "usebulkoperations_computepreview",
-      "community": 68
+      "community": 70
     },
     {
       "label": "validateOperationValue()",
@@ -10849,7 +10849,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L139",
       "id": "usebulkoperations_validateoperationvalue",
-      "community": 68
+      "community": 70
     },
     {
       "label": "useBulkOperations()",
@@ -10857,7 +10857,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L158",
       "id": "usebulkoperations_usebulkoperations",
-      "community": 68
+      "community": 70
     },
     {
       "label": "useCartOperations.ts",
@@ -10865,7 +10865,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useCartOperations.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usecartoperations_ts",
-      "community": 419
+      "community": 421
     },
     {
       "label": "useCartOperations()",
@@ -10873,7 +10873,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useCartOperations.ts",
       "source_location": "L23",
       "id": "usecartoperations_usecartoperations",
-      "community": 419
+      "community": 421
     },
     {
       "label": "useCopyText.ts",
@@ -10881,7 +10881,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useCopyText.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usecopytext_ts",
-      "community": 420
+      "community": 422
     },
     {
       "label": "useCopyText()",
@@ -10889,7 +10889,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useCopyText.ts",
       "source_location": "L1",
       "id": "usecopytext_usecopytext",
-      "community": 420
+      "community": 422
     },
     {
       "label": "useCreateComplimentaryProduct.ts",
@@ -10897,7 +10897,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useCreateComplimentaryProduct.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usecreatecomplimentaryproduct_ts",
-      "community": 421
+      "community": 423
     },
     {
       "label": "useCreateComplimentaryProduct()",
@@ -10905,7 +10905,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useCreateComplimentaryProduct.ts",
       "source_location": "L6",
       "id": "usecreatecomplimentaryproduct_usecreatecomplimentaryproduct",
-      "community": 421
+      "community": 423
     },
     {
       "label": "useCustomerOperations.ts",
@@ -10913,7 +10913,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useCustomerOperations.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usecustomeroperations_ts",
-      "community": 422
+      "community": 424
     },
     {
       "label": "useCustomerOperations()",
@@ -10921,7 +10921,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useCustomerOperations.ts",
       "source_location": "L21",
       "id": "usecustomeroperations_usecustomeroperations",
-      "community": 422
+      "community": 424
     },
     {
       "label": "useDebounce.ts",
@@ -10929,7 +10929,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useDebounce.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usedebounce_ts",
-      "community": 423
+      "community": 425
     },
     {
       "label": "useDebounce()",
@@ -10937,7 +10937,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useDebounce.ts",
       "source_location": "L12",
       "id": "usedebounce_usedebounce",
-      "community": 423
+      "community": 425
     },
     {
       "label": "useExpenseOperations.ts",
@@ -10945,7 +10945,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
-      "community": 424
+      "community": 426
     },
     {
       "label": "useExpenseOperations()",
@@ -10953,7 +10953,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
       "source_location": "L23",
       "id": "useexpenseoperations_useexpenseoperations",
-      "community": 424
+      "community": 426
     },
     {
       "label": "useExpenseSessions.ts",
@@ -10961,7 +10961,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
-      "community": 69
+      "community": 71
     },
     {
       "label": "useExpenseStoreSessions()",
@@ -10969,7 +10969,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L7",
       "id": "useexpensesessions_useexpensestoresessions",
-      "community": 69
+      "community": 71
     },
     {
       "label": "useExpenseSession()",
@@ -10977,7 +10977,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L23",
       "id": "useexpensesessions_useexpensesession",
-      "community": 69
+      "community": 71
     },
     {
       "label": "useExpenseActiveSession()",
@@ -10985,7 +10985,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L33",
       "id": "useexpensesessions_useexpenseactivesession",
-      "community": 69
+      "community": 71
     },
     {
       "label": "useExpenseSessionCreate()",
@@ -10993,7 +10993,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L48",
       "id": "useexpensesessions_useexpensesessioncreate",
-      "community": 69
+      "community": 71
     },
     {
       "label": "useExpenseSessionUpdate()",
@@ -11001,7 +11001,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L85",
       "id": "useexpensesessions_useexpensesessionupdate",
-      "community": 69
+      "community": 71
     },
     {
       "label": "useGetActiveProduct.ts",
@@ -11009,7 +11009,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usegetactiveproduct_ts",
-      "community": 425
+      "community": 427
     },
     {
       "label": "useGetActiveProduct()",
@@ -11017,7 +11017,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
       "source_location": "L6",
       "id": "usegetactiveproduct_usegetactiveproduct",
-      "community": 425
+      "community": 427
     },
     {
       "label": "useGetActiveStore.ts",
@@ -11025,7 +11025,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetActiveStore.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usegetactivestore_ts",
-      "community": 218
+      "community": 220
     },
     {
       "label": "useGetActiveStore()",
@@ -11033,7 +11033,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetActiveStore.ts",
       "source_location": "L9",
       "id": "usegetactivestore_usegetactivestore",
-      "community": 218
+      "community": 220
     },
     {
       "label": "useGetStores()",
@@ -11041,7 +11041,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetActiveStore.ts",
       "source_location": "L50",
       "id": "usegetactivestore_usegetstores",
-      "community": 218
+      "community": 220
     },
     {
       "label": "useGetAuthedUser.ts",
@@ -11049,7 +11049,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetAuthedUser.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usegetautheduser_ts",
-      "community": 426
+      "community": 428
     },
     {
       "label": "useGetAuthedUser()",
@@ -11057,7 +11057,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetAuthedUser.ts",
       "source_location": "L4",
       "id": "usegetautheduser_usegetautheduser",
-      "community": 426
+      "community": 428
     },
     {
       "label": "useGetCategories.ts",
@@ -11065,7 +11065,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetCategories.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usegetcategories_ts",
-      "community": 427
+      "community": 429
     },
     {
       "label": "useGetCategories()",
@@ -11073,7 +11073,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetCategories.ts",
       "source_location": "L5",
       "id": "usegetcategories_usegetcategories",
-      "community": 427
+      "community": 429
     },
     {
       "label": "useGetComplimentaryProducts.ts",
@@ -11081,7 +11081,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetComplimentaryProducts.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usegetcomplimentaryproducts_ts",
-      "community": 428
+      "community": 430
     },
     {
       "label": "useGetComplimentaryProducts()",
@@ -11089,7 +11089,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetComplimentaryProducts.ts",
       "source_location": "L5",
       "id": "usegetcomplimentaryproducts_usegetcomplimentaryproducts",
-      "community": 428
+      "community": 430
     },
     {
       "label": "useGetCurrencyFormatter.ts",
@@ -11097,7 +11097,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetCurrencyFormatter.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usegetcurrencyformatter_ts",
-      "community": 429
+      "community": 431
     },
     {
       "label": "useGetCurrencyFormatter()",
@@ -11105,7 +11105,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetCurrencyFormatter.ts",
       "source_location": "L4",
       "id": "usegetcurrencyformatter_usegetcurrencyformatter",
-      "community": 429
+      "community": 431
     },
     {
       "label": "useGetOrganizations.ts",
@@ -11113,7 +11113,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usegetorganizations_ts",
-      "community": 219
+      "community": 221
     },
     {
       "label": "useGetActiveOrganization()",
@@ -11121,7 +11121,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
       "source_location": "L6",
       "id": "usegetorganizations_usegetactiveorganization",
-      "community": 219
+      "community": 221
     },
     {
       "label": "useGetOrganizations()",
@@ -11129,7 +11129,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
       "source_location": "L31",
       "id": "usegetorganizations_usegetorganizations",
-      "community": 219
+      "community": 221
     },
     {
       "label": "useGetProducts.ts",
@@ -11137,7 +11137,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usegetproducts_ts",
-      "community": 220
+      "community": 222
     },
     {
       "label": "useGetProducts()",
@@ -11145,7 +11145,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
       "source_location": "L5",
       "id": "usegetproducts_usegetproducts",
-      "community": 220
+      "community": 222
     },
     {
       "label": "useGetUnresolvedProducts()",
@@ -11153,7 +11153,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
       "source_location": "L31",
       "id": "usegetproducts_usegetunresolvedproducts",
-      "community": 220
+      "community": 222
     },
     {
       "label": "useGetSubcategories.ts",
@@ -11161,7 +11161,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetSubcategories.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usegetsubcategories_ts",
-      "community": 430
+      "community": 432
     },
     {
       "label": "useGetSubcategories()",
@@ -11169,7 +11169,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetSubcategories.ts",
       "source_location": "L5",
       "id": "usegetsubcategories_usegetsubcategories",
-      "community": 430
+      "community": 432
     },
     {
       "label": "useGetTerminal.ts",
@@ -11177,7 +11177,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetTerminal.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usegetterminal_ts",
-      "community": 431
+      "community": 433
     },
     {
       "label": "useGetTerminal()",
@@ -11185,7 +11185,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetTerminal.ts",
       "source_location": "L6",
       "id": "usegetterminal_usegetterminal",
-      "community": 431
+      "community": 433
     },
     {
       "label": "useNewOrderNotification.ts",
@@ -11193,7 +11193,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useNewOrderNotification.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usenewordernotification_ts",
-      "community": 432
+      "community": 434
     },
     {
       "label": "useNewOrderNotification()",
@@ -11201,7 +11201,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useNewOrderNotification.ts",
       "source_location": "L8",
       "id": "usenewordernotification_usenewordernotification",
-      "community": 432
+      "community": 434
     },
     {
       "label": "useOrganizationModal.tsx",
@@ -11209,7 +11209,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useOrganizationModal.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
-      "community": 909
+      "community": 911
     },
     {
       "label": "usePOSCustomers.ts",
@@ -11217,7 +11217,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_useposcustomers_ts",
-      "community": 70
+      "community": 72
     },
     {
       "label": "usePOSCustomerSearch()",
@@ -11225,7 +11225,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L7",
       "id": "useposcustomers_useposcustomersearch",
-      "community": 70
+      "community": 72
     },
     {
       "label": "usePOSCustomer()",
@@ -11233,7 +11233,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L18",
       "id": "useposcustomers_useposcustomer",
-      "community": 70
+      "community": 72
     },
     {
       "label": "usePOSCustomerCreate()",
@@ -11241,7 +11241,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L26",
       "id": "useposcustomers_useposcustomercreate",
-      "community": 70
+      "community": 72
     },
     {
       "label": "usePOSCustomerUpdate()",
@@ -11249,7 +11249,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L57",
       "id": "useposcustomers_useposcustomerupdate",
-      "community": 70
+      "community": 72
     },
     {
       "label": "usePOSCustomerTransactions()",
@@ -11257,7 +11257,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L90",
       "id": "useposcustomers_useposcustomertransactions",
-      "community": 70
+      "community": 72
     },
     {
       "label": "usePOSOperations.ts",
@@ -11265,7 +11265,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSOperations.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_useposoperations_ts",
-      "community": 221
+      "community": 223
     },
     {
       "label": "usePOSOperations()",
@@ -11273,7 +11273,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSOperations.ts",
       "source_location": "L30",
       "id": "useposoperations_useposoperations",
-      "community": 221
+      "community": 223
     },
     {
       "label": "usePOSState()",
@@ -11281,7 +11281,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSOperations.ts",
       "source_location": "L580",
       "id": "useposoperations_useposstate",
-      "community": 221
+      "community": 223
     },
     {
       "label": "usePOSProducts.ts",
@@ -11289,7 +11289,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
-      "community": 103
+      "community": 104
     },
     {
       "label": "usePOSProductSearch()",
@@ -11297,7 +11297,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L10",
       "id": "useposproducts_useposproductsearch",
-      "community": 103
+      "community": 104
     },
     {
       "label": "usePOSBarcodeSearch()",
@@ -11305,7 +11305,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L30",
       "id": "useposproducts_useposbarcodesearch",
-      "community": 103
+      "community": 104
     },
     {
       "label": "usePOSProductIdSearch()",
@@ -11313,7 +11313,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L41",
       "id": "useposproducts_useposproductidsearch",
-      "community": 103
+      "community": 104
     },
     {
       "label": "usePOSTransactionComplete()",
@@ -11321,7 +11321,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L100",
       "id": "useposproducts_usepostransactioncomplete",
-      "community": 103
+      "community": 104
     },
     {
       "label": "usePOSSessions.ts",
@@ -11329,7 +11329,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usepossessions_ts",
-      "community": 23
+      "community": 24
     },
     {
       "label": "usePOSStoreSessions()",
@@ -11337,7 +11337,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L8",
       "id": "usepossessions_useposstoresessions",
-      "community": 23
+      "community": 24
     },
     {
       "label": "usePOSSession()",
@@ -11345,7 +11345,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L24",
       "id": "usepossessions_usepossession",
-      "community": 23
+      "community": 24
     },
     {
       "label": "usePOSActiveSession()",
@@ -11353,7 +11353,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L32",
       "id": "usepossessions_useposactivesession",
-      "community": 23
+      "community": 24
     },
     {
       "label": "usePOSSessionCreate()",
@@ -11361,7 +11361,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L47",
       "id": "usepossessions_usepossessioncreate",
-      "community": 23
+      "community": 24
     },
     {
       "label": "usePOSSessionUpdate()",
@@ -11369,7 +11369,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L82",
       "id": "usepossessions_usepossessionupdate",
-      "community": 23
+      "community": 24
     },
     {
       "label": "usePOSSessionHold()",
@@ -11377,7 +11377,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L117",
       "id": "usepossessions_usepossessionhold",
-      "community": 23
+      "community": 24
     },
     {
       "label": "usePOSSessionResume()",
@@ -11385,7 +11385,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L137",
       "id": "usepossessions_usepossessionresume",
-      "community": 23
+      "community": 24
     },
     {
       "label": "usePOSSessionComplete()",
@@ -11393,7 +11393,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L157",
       "id": "usepossessions_usepossessioncomplete",
-      "community": 23
+      "community": 24
     },
     {
       "label": "usePOSSessionVoid()",
@@ -11401,7 +11401,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L191",
       "id": "usepossessions_usepossessionvoid",
-      "community": 23
+      "community": 24
     },
     {
       "label": "usePOSSessionManager()",
@@ -11409,7 +11409,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSSessions.ts",
       "source_location": "L207",
       "id": "usepossessions_usepossessionmanager",
-      "community": 23
+      "community": 24
     },
     {
       "label": "usePermissions.ts",
@@ -11417,7 +11417,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePermissions.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usepermissions_ts",
-      "community": 433
+      "community": 435
     },
     {
       "label": "usePermissions()",
@@ -11425,7 +11425,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePermissions.ts",
       "source_location": "L12",
       "id": "usepermissions_usepermissions",
-      "community": 433
+      "community": 435
     },
     {
       "label": "usePrint.ts",
@@ -11433,7 +11433,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_useprint_ts",
-      "community": 434
+      "community": 436
     },
     {
       "label": "usePrint()",
@@ -11441,7 +11441,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
       "source_location": "L3",
       "id": "useprint_useprint",
-      "community": 434
+      "community": 436
     },
     {
       "label": "useProductSearchResults.ts",
@@ -11449,7 +11449,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_useproductsearchresults_ts",
-      "community": 435
+      "community": 437
     },
     {
       "label": "useProductSearchResults()",
@@ -11457,7 +11457,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
       "source_location": "L26",
       "id": "useproductsearchresults_useproductsearchresults",
-      "community": 435
+      "community": 437
     },
     {
       "label": "useProductWithNoImagesNotification.tsx",
@@ -11465,7 +11465,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useProductWithNoImagesNotification.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_useproductwithnoimagesnotification_tsx",
-      "community": 436
+      "community": 438
     },
     {
       "label": "useProductWithNoImagesNotification()",
@@ -11473,7 +11473,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useProductWithNoImagesNotification.tsx",
       "source_location": "L7",
       "id": "useproductwithnoimagesnotification_useproductwithnoimagesnotification",
-      "community": 436
+      "community": 438
     },
     {
       "label": "useSessionManagement.ts",
@@ -11481,7 +11481,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSessionManagement.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usesessionmanagement_ts",
-      "community": 437
+      "community": 439
     },
     {
       "label": "useSessionManagement()",
@@ -11489,7 +11489,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSessionManagement.ts",
       "source_location": "L17",
       "id": "usesessionmanagement_usesessionmanagement",
-      "community": 437
+      "community": 439
     },
     {
       "label": "useSessionManagementExpense.ts",
@@ -11497,7 +11497,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSessionManagementExpense.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usesessionmanagementexpense_ts",
-      "community": 438
+      "community": 440
     },
     {
       "label": "useSessionManagementExpense()",
@@ -11505,7 +11505,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSessionManagementExpense.ts",
       "source_location": "L17",
       "id": "usesessionmanagementexpense_usesessionmanagementexpense",
-      "community": 438
+      "community": 440
     },
     {
       "label": "useSessionManagerOperations.ts",
@@ -11513,7 +11513,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSessionManagerOperations.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usesessionmanageroperations_ts",
-      "community": 439
+      "community": 441
     },
     {
       "label": "useSessionManagerOperations()",
@@ -11521,7 +11521,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSessionManagerOperations.ts",
       "source_location": "L16",
       "id": "usesessionmanageroperations_usesessionmanageroperations",
-      "community": 439
+      "community": 441
     },
     {
       "label": "useSkusReservedInCheckout.ts",
@@ -11529,7 +11529,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSkusReservedInCheckout.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_useskusreservedincheckout_ts",
-      "community": 440
+      "community": 442
     },
     {
       "label": "useSkusReservedInCheckout()",
@@ -11537,7 +11537,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSkusReservedInCheckout.ts",
       "source_location": "L12",
       "id": "useskusreservedincheckout_useskusreservedincheckout",
-      "community": 440
+      "community": 442
     },
     {
       "label": "useSkusReservedInPosSession.ts",
@@ -11545,7 +11545,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSkusReservedInPosSession.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_useskusreservedinpossession_ts",
-      "community": 441
+      "community": 443
     },
     {
       "label": "useSkusReservedInPosSession()",
@@ -11553,7 +11553,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useSkusReservedInPosSession.ts",
       "source_location": "L12",
       "id": "useskusreservedinpossession_useskusreservedinpossession",
-      "community": 441
+      "community": 443
     },
     {
       "label": "useToggleComplimentaryProductActive.ts",
@@ -11561,7 +11561,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useToggleComplimentaryProductActive.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usetogglecomplimentaryproductactive_ts",
-      "community": 442
+      "community": 444
     },
     {
       "label": "useToggleComplimentaryProductActive()",
@@ -11569,7 +11569,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useToggleComplimentaryProductActive.ts",
       "source_location": "L5",
       "id": "usetogglecomplimentaryproductactive_usetogglecomplimentaryproductactive",
-      "community": 442
+      "community": 444
     },
     {
       "label": "aws.ts",
@@ -11577,7 +11577,7 @@
       "source_file": "packages/athena-webapp/src/lib/aws.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_aws_ts",
-      "community": 910
+      "community": 912
     },
     {
       "label": "behaviorUtils.ts",
@@ -11585,7 +11585,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
-      "community": 71
+      "community": 73
     },
     {
       "label": "getCustomerJourneyStage()",
@@ -11593,7 +11593,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L36",
       "id": "behaviorutils_getcustomerjourneystage",
-      "community": 71
+      "community": 73
     },
     {
       "label": "calculateRiskIndicators()",
@@ -11601,7 +11601,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L71",
       "id": "behaviorutils_calculateriskindicators",
-      "community": 71
+      "community": 73
     },
     {
       "label": "calculateEngagementMetrics()",
@@ -11609,7 +11609,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L173",
       "id": "behaviorutils_calculateengagementmetrics",
-      "community": 71
+      "community": 73
     },
     {
       "label": "getActivityPriority()",
@@ -11617,7 +11617,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L251",
       "id": "behaviorutils_getactivitypriority",
-      "community": 71
+      "community": 73
     },
     {
       "label": "getJourneyStageInfo()",
@@ -11625,7 +11625,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L277",
       "id": "behaviorutils_getjourneystageinfo",
-      "community": 71
+      "community": 73
     },
     {
       "label": "browserFingerprint.ts",
@@ -11633,7 +11633,7 @@
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_browserfingerprint_ts",
-      "community": 104
+      "community": 105
     },
     {
       "label": "bufferToHex()",
@@ -11641,7 +11641,7 @@
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
       "source_location": "L18",
       "id": "browserfingerprint_buffertohex",
-      "community": 104
+      "community": 105
     },
     {
       "label": "collectBrowserInfo()",
@@ -11649,7 +11649,7 @@
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
       "source_location": "L23",
       "id": "browserfingerprint_collectbrowserinfo",
-      "community": 104
+      "community": 105
     },
     {
       "label": "hashFingerprintSource()",
@@ -11657,7 +11657,7 @@
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
       "source_location": "L45",
       "id": "browserfingerprint_hashfingerprintsource",
-      "community": 104
+      "community": 105
     },
     {
       "label": "generateBrowserFingerprint()",
@@ -11665,7 +11665,7 @@
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
       "source_location": "L65",
       "id": "browserfingerprint_generatebrowserfingerprint",
-      "community": 104
+      "community": 105
     },
     {
       "label": "constants.ts",
@@ -11673,7 +11673,7 @@
       "source_file": "packages/athena-webapp/src/lib/constants.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_constants_ts",
-      "community": 911
+      "community": 913
     },
     {
       "label": "countries.ts",
@@ -11681,7 +11681,7 @@
       "source_file": "packages/athena-webapp/src/lib/countries.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_countries_ts",
-      "community": 912
+      "community": 914
     },
     {
       "label": "customerObservabilityTimeline.ts",
@@ -11689,7 +11689,7 @@
       "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_customerobservabilitytimeline_ts",
-      "community": 142
+      "community": 143
     },
     {
       "label": "formatObservabilityLabel()",
@@ -11697,7 +11697,7 @@
       "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
       "source_location": "L59",
       "id": "customerobservabilitytimeline_formatobservabilitylabel",
-      "community": 142
+      "community": 143
     },
     {
       "label": "getObservabilityStatusStyles()",
@@ -11705,7 +11705,7 @@
       "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
       "source_location": "L67",
       "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
-      "community": 142
+      "community": 143
     },
     {
       "label": "getDeviceIcon()",
@@ -11713,7 +11713,7 @@
       "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
       "source_location": "L114",
       "id": "customerobservabilitytimeline_getdeviceicon",
-      "community": 142
+      "community": 143
     },
     {
       "label": "ghana.ts",
@@ -11721,7 +11721,7 @@
       "source_file": "packages/athena-webapp/src/lib/ghana.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_ghana_ts",
-      "community": 913
+      "community": 915
     },
     {
       "label": "ghanaRegions.ts",
@@ -11729,7 +11729,7 @@
       "source_file": "packages/athena-webapp/src/lib/ghanaRegions.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_ghanaregions_ts",
-      "community": 914
+      "community": 916
     },
     {
       "label": "imageUtils.test.ts",
@@ -11737,7 +11737,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_imageutils_test_ts",
-      "community": 105
+      "community": 106
     },
     {
       "label": "constructor()",
@@ -11745,7 +11745,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
       "source_location": "L74",
       "id": "imageutils_test_constructor",
-      "community": 105
+      "community": 106
     },
     {
       "label": "arrayBuffer()",
@@ -11753,7 +11753,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
       "source_location": "L78",
       "id": "imageutils_test_arraybuffer",
-      "community": 105
+      "community": 106
     },
     {
       "label": "MockImage",
@@ -11761,7 +11761,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
       "source_location": "L103",
       "id": "imageutils_test_mockimage",
-      "community": 105
+      "community": 106
     },
     {
       "label": ".src()",
@@ -11769,7 +11769,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
       "source_location": "L109",
       "id": "imageutils_test_mockimage_src",
-      "community": 105
+      "community": 106
     },
     {
       "label": "imageUtils.ts",
@@ -11777,7 +11777,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_imageutils_ts",
-      "community": 106
+      "community": 107
     },
     {
       "label": "getUploadImagesData()",
@@ -11785,7 +11785,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
       "source_location": "L4",
       "id": "imageutils_getuploadimagesdata",
-      "community": 106
+      "community": 107
     },
     {
       "label": "convertImagesToWebp()",
@@ -11793,7 +11793,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
       "source_location": "L26",
       "id": "imageutils_convertimagestowebp",
-      "community": 106
+      "community": 107
     },
     {
       "label": "convertToJpg()",
@@ -11801,7 +11801,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
       "source_location": "L38",
       "id": "imageutils_converttojpg",
-      "community": 106
+      "community": 107
     },
     {
       "label": "convertImagesToJpg()",
@@ -11809,7 +11809,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
       "source_location": "L75",
       "id": "imageutils_convertimagestojpg",
-      "community": 106
+      "community": 107
     },
     {
       "label": "logger.ts",
@@ -11817,7 +11817,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_logger_ts",
-      "community": 37
+      "community": 38
     },
     {
       "label": "Logger",
@@ -11825,7 +11825,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L12",
       "id": "logger_logger",
-      "community": 37
+      "community": 38
     },
     {
       "label": ".constructor()",
@@ -11833,7 +11833,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L15",
       "id": "logger_logger_constructor",
-      "community": 37
+      "community": 38
     },
     {
       "label": ".shouldLog()",
@@ -11841,7 +11841,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L20",
       "id": "logger_logger_shouldlog",
-      "community": 37
+      "community": 38
     },
     {
       "label": ".formatMessage()",
@@ -11849,7 +11849,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L30",
       "id": "logger_logger_formatmessage",
-      "community": 37
+      "community": 38
     },
     {
       "label": ".debug()",
@@ -11857,7 +11857,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L45",
       "id": "logger_logger_debug",
-      "community": 37
+      "community": 38
     },
     {
       "label": ".info()",
@@ -11865,7 +11865,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L51",
       "id": "logger_logger_info",
-      "community": 37
+      "community": 38
     },
     {
       "label": ".warn()",
@@ -11873,7 +11873,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L57",
       "id": "logger_logger_warn",
-      "community": 37
+      "community": 38
     },
     {
       "label": ".error()",
@@ -11881,7 +11881,7 @@
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
       "source_location": "L63",
       "id": "logger_logger_error",
-      "community": 37
+      "community": 38
     },
     {
       "label": "maintenanceUtils.ts",
@@ -11889,7 +11889,7 @@
       "source_file": "packages/athena-webapp/src/lib/maintenanceUtils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_maintenanceutils_ts",
-      "community": 222
+      "community": 224
     },
     {
       "label": "isInMaintenanceMode()",
@@ -11897,7 +11897,7 @@
       "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.ts",
       "source_location": "L7",
       "id": "maintenanceutils_isinmaintenancemode",
-      "community": 222
+      "community": 224
     },
     {
       "label": "navigationUtils.ts",
@@ -11905,7 +11905,7 @@
       "source_file": "packages/athena-webapp/src/lib/navigationUtils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_navigationutils_ts",
-      "community": 443
+      "community": 445
     },
     {
       "label": "getOrigin()",
@@ -11913,7 +11913,7 @@
       "source_file": "packages/athena-webapp/src/lib/navigationUtils.ts",
       "source_location": "L1",
       "id": "navigationutils_getorigin",
-      "community": 443
+      "community": 445
     },
     {
       "label": "barcodeUtils.ts",
@@ -11921,7 +11921,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_pos_barcodeutils_ts",
-      "community": 143
+      "community": 144
     },
     {
       "label": "isValidConvexId()",
@@ -11929,7 +11929,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
       "source_location": "L16",
       "id": "barcodeutils_isvalidconvexid",
-      "community": 143
+      "community": 144
     },
     {
       "label": "extractBarcodeFromInput()",
@@ -11937,7 +11937,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
       "source_location": "L51",
       "id": "barcodeutils_extractbarcodefrominput",
-      "community": 143
+      "community": 144
     },
     {
       "label": "isUrlOrBarcode()",
@@ -11945,7 +11945,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
       "source_location": "L92",
       "id": "barcodeutils_isurlorbarcode",
-      "community": 143
+      "community": 144
     },
     {
       "label": "calculations.ts",
@@ -11953,7 +11953,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/calculations.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_pos_calculations_ts",
-      "community": 444
+      "community": 446
     },
     {
       "label": "calculateCartTotals()",
@@ -11961,7 +11961,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/calculations.ts",
       "source_location": "L10",
       "id": "calculations_calculatecarttotals",
-      "community": 444
+      "community": 446
     },
     {
       "label": "constants.ts",
@@ -11969,7 +11969,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/constants.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_pos_constants_ts",
-      "community": 915
+      "community": 917
     },
     {
       "label": "calculationService.ts",
@@ -11977,7 +11977,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_pos_services_calculationservice_ts",
-      "community": 50
+      "community": 51
     },
     {
       "label": "calculateCartTotals()",
@@ -11985,7 +11985,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
       "source_location": "L30",
       "id": "calculationservice_calculatecarttotals",
-      "community": 50
+      "community": 51
     },
     {
       "label": "calculateItemTotal()",
@@ -11993,7 +11993,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
       "source_location": "L61",
       "id": "calculationservice_calculateitemtotal",
-      "community": 50
+      "community": 51
     },
     {
       "label": "calculateChange()",
@@ -12001,7 +12001,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
       "source_location": "L68",
       "id": "calculationservice_calculatechange",
-      "community": 50
+      "community": 51
     },
     {
       "label": "formatCurrency()",
@@ -12009,7 +12009,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
       "source_location": "L75",
       "id": "calculationservice_formatcurrency",
-      "community": 50
+      "community": 51
     },
     {
       "label": "isPaymentSufficient()",
@@ -12017,7 +12017,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
       "source_location": "L85",
       "id": "calculationservice_ispaymentsufficient",
-      "community": 50
+      "community": 51
     },
     {
       "label": "getEffectivePrice()",
@@ -12025,7 +12025,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/services/calculationService.ts",
       "source_location": "L96",
       "id": "calculationservice_geteffectiveprice",
-      "community": 50
+      "community": 51
     },
     {
       "label": "toastService.ts",
@@ -12033,7 +12033,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
-      "community": 72
+      "community": 74
     },
     {
       "label": "handlePOSOperation()",
@@ -12041,7 +12041,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L171",
       "id": "toastservice_handleposoperation",
-      "community": 72
+      "community": 74
     },
     {
       "label": "showValidationError()",
@@ -12049,7 +12049,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L293",
       "id": "toastservice_showvalidationerror",
-      "community": 72
+      "community": 74
     },
     {
       "label": "showInventoryError()",
@@ -12057,7 +12057,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L302",
       "id": "toastservice_showinventoryerror",
-      "community": 72
+      "community": 74
     },
     {
       "label": "showSessionExpiredError()",
@@ -12065,7 +12065,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L312",
       "id": "toastservice_showsessionexpirederror",
-      "community": 72
+      "community": 74
     },
     {
       "label": "showNoActiveSessionError()",
@@ -12073,7 +12073,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L319",
       "id": "toastservice_shownoactivesessionerror",
-      "community": 72
+      "community": 74
     },
     {
       "label": "transactionUtils.ts",
@@ -12081,7 +12081,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_pos_transactionutils_ts",
-      "community": 107
+      "community": 108
     },
     {
       "label": "generateTransactionNumber()",
@@ -12089,7 +12089,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
       "source_location": "L14",
       "id": "transactionutils_generatetransactionnumber",
-      "community": 107
+      "community": 108
     },
     {
       "label": "formatCurrency()",
@@ -12097,7 +12097,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
       "source_location": "L29",
       "id": "transactionutils_formatcurrency",
-      "community": 107
+      "community": 108
     },
     {
       "label": "calculateChange()",
@@ -12105,7 +12105,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
       "source_location": "L42",
       "id": "transactionutils_calculatechange",
-      "community": 107
+      "community": 108
     },
     {
       "label": "formatTimestamp()",
@@ -12113,7 +12113,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
       "source_location": "L49",
       "id": "transactionutils_formattimestamp",
-      "community": 107
+      "community": 108
     },
     {
       "label": "validation.ts",
@@ -12121,7 +12121,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_pos_validation_ts",
-      "community": 20
+      "community": 21
     },
     {
       "label": "validateCart()",
@@ -12129,7 +12129,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L21",
       "id": "validation_validatecart",
-      "community": 20
+      "community": 21
     },
     {
       "label": "validateProduct()",
@@ -12137,7 +12137,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L68",
       "id": "validation_validateproduct",
-      "community": 20
+      "community": 21
     },
     {
       "label": "validateCustomer()",
@@ -12145,7 +12145,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L108",
       "id": "validation_validatecustomer",
-      "community": 20
+      "community": 21
     },
     {
       "label": "validatePayment()",
@@ -12153,7 +12153,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L146",
       "id": "validation_validatepayment",
-      "community": 20
+      "community": 21
     },
     {
       "label": "validateBarcode()",
@@ -12161,7 +12161,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L185",
       "id": "validation_validatebarcode",
-      "community": 20
+      "community": 21
     },
     {
       "label": "validateQuantity()",
@@ -12169,7 +12169,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L213",
       "id": "validation_validatequantity",
-      "community": 20
+      "community": 21
     },
     {
       "label": "isValidEmail()",
@@ -12177,7 +12177,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L244",
       "id": "validation_isvalidemail",
-      "community": 20
+      "community": 21
     },
     {
       "label": "validateSession()",
@@ -12185,7 +12185,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L252",
       "id": "validation_validatesession",
-      "community": 20
+      "community": 21
     },
     {
       "label": "isValidPhone()",
@@ -12193,7 +12193,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L304",
       "id": "validation_isvalidphone",
-      "community": 20
+      "community": 21
     },
     {
       "label": "validatePaymentAmount()",
@@ -12201,7 +12201,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L317",
       "id": "validation_validatepaymentamount",
-      "community": 20
+      "community": 21
     },
     {
       "label": "validatePayments()",
@@ -12209,7 +12209,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L359",
       "id": "validation_validatepayments",
-      "community": 20
+      "community": 21
     },
     {
       "label": "canCompleteTransaction()",
@@ -12217,7 +12217,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L404",
       "id": "validation_cancompletetransaction",
-      "community": 20
+      "community": 21
     },
     {
       "label": "productUtils.test.ts",
@@ -12225,7 +12225,7 @@
       "source_file": "packages/athena-webapp/src/lib/productUtils.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_productutils_test_ts",
-      "community": 916
+      "community": 918
     },
     {
       "label": "productUtils.ts",
@@ -12233,7 +12233,7 @@
       "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "community": 53
+      "community": 54
     },
     {
       "label": "getProductName()",
@@ -12241,7 +12241,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L18",
       "id": "productutils_getproductname",
-      "community": 53
+      "community": 54
     },
     {
       "label": "sortProduct()",
@@ -12249,7 +12249,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L66",
       "id": "productutils_sortproduct",
-      "community": 53
+      "community": 54
     },
     {
       "label": "category.ts",
@@ -12257,7 +12257,7 @@
       "source_file": "packages/athena-webapp/src/lib/schemas/category.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_schemas_category_ts",
-      "community": 917
+      "community": 919
     },
     {
       "label": "product.ts",
@@ -12265,7 +12265,7 @@
       "source_file": "packages/athena-webapp/src/lib/schemas/product.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_schemas_product_ts",
-      "community": 918
+      "community": 920
     },
     {
       "label": "store.ts",
@@ -12273,7 +12273,7 @@
       "source_file": "packages/athena-webapp/src/lib/schemas/store.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_schemas_store_ts",
-      "community": 919
+      "community": 921
     },
     {
       "label": "subcategory.ts",
@@ -12281,7 +12281,7 @@
       "source_file": "packages/athena-webapp/src/lib/schemas/subcategory.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_schemas_subcategory_ts",
-      "community": 920
+      "community": 922
     },
     {
       "label": "user.ts",
@@ -12289,7 +12289,7 @@
       "source_file": "packages/athena-webapp/src/lib/schemas/user.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_schemas_user_ts",
-      "community": 921
+      "community": 923
     },
     {
       "label": "pinHash.ts",
@@ -12297,7 +12297,7 @@
       "source_file": "packages/athena-webapp/src/lib/security/pinHash.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_security_pinhash_ts",
-      "community": 445
+      "community": 447
     },
     {
       "label": "hashPin()",
@@ -12305,7 +12305,7 @@
       "source_file": "packages/athena-webapp/src/lib/security/pinHash.ts",
       "source_location": "L12",
       "id": "pinhash_hashpin",
-      "community": 445
+      "community": 447
     },
     {
       "label": "storeConfig.test.ts",
@@ -12313,7 +12313,7 @@
       "source_file": "packages/athena-webapp/src/lib/storeConfig.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_storeconfig_test_ts",
-      "community": 922
+      "community": 924
     },
     {
       "label": "storeConfig.ts",
@@ -12457,7 +12457,7 @@
       "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_timelineutils_ts",
-      "community": 108
+      "community": 109
     },
     {
       "label": "enrichTimelineEvent()",
@@ -12465,7 +12465,7 @@
       "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
       "source_location": "L184",
       "id": "timelineutils_enrichtimelineevent",
-      "community": 108
+      "community": 109
     },
     {
       "label": "enrichTimelineEvents()",
@@ -12473,7 +12473,7 @@
       "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
       "source_location": "L200",
       "id": "timelineutils_enrichtimelineevents",
-      "community": 108
+      "community": 109
     },
     {
       "label": "groupEventsByTimeframe()",
@@ -12481,7 +12481,7 @@
       "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
       "source_location": "L206",
       "id": "timelineutils_groupeventsbytimeframe",
-      "community": 108
+      "community": 109
     },
     {
       "label": "getTimeRangeLabel()",
@@ -12489,7 +12489,7 @@
       "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
       "source_location": "L244",
       "id": "timelineutils_gettimerangelabel",
-      "community": 108
+      "community": 109
     },
     {
       "label": "utils.test.ts",
@@ -12497,7 +12497,7 @@
       "source_file": "packages/athena-webapp/src/lib/utils.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_utils_test_ts",
-      "community": 923
+      "community": 925
     },
     {
       "label": "utils.ts",
@@ -12577,7 +12577,7 @@
       "source_file": "packages/athena-webapp/src/main.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_main_tsx",
-      "community": 223
+      "community": 225
     },
     {
       "label": "App()",
@@ -12585,7 +12585,7 @@
       "source_file": "packages/storefront-webapp/src/main.tsx",
       "source_location": "L38",
       "id": "main_app",
-      "community": 223
+      "community": 225
     },
     {
       "label": "routeTree.gen.ts",
@@ -12593,7 +12593,7 @@
       "source_file": "packages/athena-webapp/src/routeTree.gen.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routetree_gen_ts",
-      "community": 924
+      "community": 926
     },
     {
       "label": "__root.tsx",
@@ -12601,7 +12601,7 @@
       "source_file": "packages/athena-webapp/src/routes/__root.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_root_tsx",
-      "community": 925
+      "community": 927
     },
     {
       "label": "index.tsx",
@@ -12609,7 +12609,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_index_tsx",
-      "community": 926
+      "community": 928
     },
     {
       "label": "index.tsx",
@@ -12617,7 +12617,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_index_tsx",
-      "community": 927
+      "community": 929
     },
     {
       "label": "index.tsx",
@@ -12625,7 +12625,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/organization/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
-      "community": 928
+      "community": 930
     },
     {
       "label": "$storeUrlSlug.tsx",
@@ -12633,7 +12633,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/stores/$storeUrlSlug.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_stores_storeurlslug_tsx",
-      "community": 929
+      "community": 931
     },
     {
       "label": "analytics.tsx",
@@ -12641,7 +12641,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/analytics.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_analytics_tsx",
-      "community": 930
+      "community": 932
     },
     {
       "label": "assets.index.tsx",
@@ -12649,7 +12649,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/assets.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_assets_index_tsx",
-      "community": 931
+      "community": 933
     },
     {
       "label": "bags.$bagId.tsx",
@@ -12657,7 +12657,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.$bagId.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_bagid_tsx",
-      "community": 932
+      "community": 934
     },
     {
       "label": "bags.index.tsx",
@@ -12665,7 +12665,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bags.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_index_tsx",
-      "community": 933
+      "community": 935
     },
     {
       "label": "index.tsx",
@@ -12673,7 +12673,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bulk-operations/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bulk_operations_index_tsx",
-      "community": 934
+      "community": 936
     },
     {
       "label": "checkout-sessions.index.tsx",
@@ -12681,7 +12681,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/checkout-sessions.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_checkout_sessions_index_tsx",
-      "community": 935
+      "community": 937
     },
     {
       "label": "configuration.index.tsx",
@@ -12689,7 +12689,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/configuration.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_configuration_index_tsx",
-      "community": 936
+      "community": 938
     },
     {
       "label": "dashboard.index.tsx",
@@ -12697,7 +12697,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/dashboard.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
-      "community": 937
+      "community": 939
     },
     {
       "label": "home.tsx",
@@ -12705,7 +12705,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/home.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
-      "community": 938
+      "community": 940
     },
     {
       "label": "index.tsx",
@@ -12713,7 +12713,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_index_tsx",
-      "community": 446
+      "community": 448
     },
     {
       "label": "StoreRootRedirect()",
@@ -12721,7 +12721,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/index.tsx",
       "source_location": "L13",
       "id": "index_storerootredirect",
-      "community": 446
+      "community": 448
     },
     {
       "label": "logs.$logId.tsx",
@@ -12729,7 +12729,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.$logId.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_logid_tsx",
-      "community": 939
+      "community": 941
     },
     {
       "label": "logs.index.tsx",
@@ -12737,7 +12737,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/logs.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_index_tsx",
-      "community": 940
+      "community": 942
     },
     {
       "label": "members.index.tsx",
@@ -12745,7 +12745,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/members.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_members_index_tsx",
-      "community": 941
+      "community": 943
     },
     {
       "label": "index.tsx",
@@ -12753,7 +12753,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/$orderSlug/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_orderslug_index_tsx",
-      "community": 942
+      "community": 944
     },
     {
       "label": "all.index.tsx",
@@ -12761,7 +12761,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/all.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_all_index_tsx",
-      "community": 943
+      "community": 945
     },
     {
       "label": "cancelled.index.tsx",
@@ -12769,7 +12769,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/cancelled.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_cancelled_index_tsx",
-      "community": 944
+      "community": 946
     },
     {
       "label": "completed.index.tsx",
@@ -12777,7 +12777,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/completed.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
-      "community": 945
+      "community": 947
     },
     {
       "label": "index.tsx",
@@ -12785,7 +12785,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_index_tsx",
-      "community": 946
+      "community": 948
     },
     {
       "label": "open.index.tsx",
@@ -12793,7 +12793,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/open.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
-      "community": 947
+      "community": 949
     },
     {
       "label": "out-for-delivery.index.tsx",
@@ -12801,7 +12801,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/out-for-delivery.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_out_for_delivery_index_tsx",
-      "community": 948
+      "community": 950
     },
     {
       "label": "ready.index.tsx",
@@ -12809,7 +12809,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/ready.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
-      "community": 949
+      "community": 951
     },
     {
       "label": "refunded.index.tsx",
@@ -12817,7 +12817,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/refunded.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
-      "community": 950
+      "community": 952
     },
     {
       "label": "$reportId.tsx",
@@ -12825,7 +12825,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports/$reportId.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
-      "community": 951
+      "community": 953
     },
     {
       "label": "expense-reports.index.tsx",
@@ -12833,7 +12833,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
-      "community": 952
+      "community": 954
     },
     {
       "label": "expense.index.tsx",
@@ -12841,7 +12841,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_index_tsx",
-      "community": 953
+      "community": 955
     },
     {
       "label": "index.tsx",
@@ -12849,7 +12849,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_index_tsx",
-      "community": 954
+      "community": 956
     },
     {
       "label": "register.index.tsx",
@@ -12857,7 +12857,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/register.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
-      "community": 955
+      "community": 957
     },
     {
       "label": "settings.index.tsx",
@@ -12865,7 +12865,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/settings.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_settings_index_tsx",
-      "community": 956
+      "community": 958
     },
     {
       "label": "$transactionId.tsx",
@@ -12873,7 +12873,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
-      "community": 957
+      "community": 959
     },
     {
       "label": "transactions.index.tsx",
@@ -12881,7 +12881,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
-      "community": 958
+      "community": 960
     },
     {
       "label": "edit.tsx",
@@ -12889,7 +12889,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/edit.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_edit_tsx",
-      "community": 959
+      "community": 961
     },
     {
       "label": "index.tsx",
@@ -12897,7 +12897,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_index_tsx",
-      "community": 960
+      "community": 962
     },
     {
       "label": "index.tsx",
@@ -12905,7 +12905,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_index_tsx",
-      "community": 961
+      "community": 963
     },
     {
       "label": "new.tsx",
@@ -12913,7 +12913,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/new.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_new_tsx",
-      "community": 962
+      "community": 964
     },
     {
       "label": "index.tsx",
@@ -12921,7 +12921,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_index_tsx",
-      "community": 963
+      "community": 965
     },
     {
       "label": "new.tsx",
@@ -12929,7 +12929,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/new.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_new_tsx",
-      "community": 964
+      "community": 966
     },
     {
       "label": "unresolved.tsx",
@@ -12937,7 +12937,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/unresolved.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_unresolved_tsx",
-      "community": 965
+      "community": 967
     },
     {
       "label": "$promoCodeSlug.tsx",
@@ -12945,7 +12945,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/$promoCodeSlug.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
-      "community": 966
+      "community": 968
     },
     {
       "label": "index.tsx",
@@ -12953,7 +12953,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
-      "community": 967
+      "community": 969
     },
     {
       "label": "new.tsx",
@@ -12961,7 +12961,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/new.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
-      "community": 968
+      "community": 970
     },
     {
       "label": "index.tsx",
@@ -12969,7 +12969,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_index_tsx",
-      "community": 969
+      "community": 971
     },
     {
       "label": "new.index.tsx",
@@ -12977,7 +12977,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/new.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_new_index_tsx",
-      "community": 970
+      "community": 972
     },
     {
       "label": "published.index.tsx",
@@ -12985,7 +12985,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/published.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_published_index_tsx",
-      "community": 447
+      "community": 449
     },
     {
       "label": "RouteComponent()",
@@ -12993,7 +12993,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/published.index.tsx",
       "source_location": "L9",
       "id": "published_index_routecomponent",
-      "community": 447
+      "community": 449
     },
     {
       "label": "users.$userId.tsx",
@@ -13001,7 +13001,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/users.$userId.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_users_userid_tsx",
-      "community": 971
+      "community": 973
     },
     {
       "label": "index.tsx",
@@ -13009,7 +13009,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_index_tsx",
-      "community": 972
+      "community": 974
     },
     {
       "label": "_authed.tsx",
@@ -13017,7 +13017,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_tsx",
-      "community": 224
+      "community": 226
     },
     {
       "label": "AuthedComponent()",
@@ -13025,7 +13025,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed.tsx",
       "source_location": "L18",
       "id": "authed_authedcomponent",
-      "community": 224
+      "community": 226
     },
     {
       "label": "Layout()",
@@ -13033,7 +13033,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed.tsx",
       "source_location": "L38",
       "id": "authed_layout",
-      "community": 224
+      "community": 226
     },
     {
       "label": "index.tsx",
@@ -13041,7 +13041,7 @@
       "source_file": "packages/athena-webapp/src/routes/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_index_tsx",
-      "community": 448
+      "community": 450
     },
     {
       "label": "Index()",
@@ -13049,7 +13049,7 @@
       "source_file": "packages/athena-webapp/src/routes/index.tsx",
       "source_location": "L13",
       "id": "index_index",
-      "community": 448
+      "community": 450
     },
     {
       "label": "join-team.index.tsx",
@@ -13057,7 +13057,7 @@
       "source_file": "packages/athena-webapp/src/routes/join-team.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_join_team_index_tsx",
-      "community": 973
+      "community": 975
     },
     {
       "label": "_layout.index.tsx",
@@ -13065,7 +13065,7 @@
       "source_file": "packages/athena-webapp/src/routes/login/_layout.index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_login_layout_index_tsx",
-      "community": 974
+      "community": 976
     },
     {
       "label": "_layout.tsx",
@@ -13073,7 +13073,7 @@
       "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_login_layout_tsx",
-      "community": 449
+      "community": 451
     },
     {
       "label": "LoginLayout()",
@@ -13081,7 +13081,7 @@
       "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
       "source_location": "L36",
       "id": "layout_loginlayout",
-      "community": 449
+      "community": 451
     },
     {
       "label": "OrganizationSettingsView.tsx",
@@ -13089,7 +13089,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
-      "community": 73
+      "community": 75
     },
     {
       "label": "OrganizationSettings()",
@@ -13097,7 +13097,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L24",
       "id": "organizationsettingsview_organizationsettings",
-      "community": 73
+      "community": 75
     },
     {
       "label": "saveStoreChanges()",
@@ -13105,7 +13105,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L71",
       "id": "organizationsettingsview_savestorechanges",
-      "community": 73
+      "community": 75
     },
     {
       "label": "onSubmit()",
@@ -13113,7 +13113,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L105",
       "id": "organizationsettingsview_onsubmit",
-      "community": 73
+      "community": 75
     },
     {
       "label": "handleDeleteStore()",
@@ -13121,7 +13121,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L156",
       "id": "organizationsettingsview_handledeletestore",
-      "community": 73
+      "community": 75
     },
     {
       "label": "Navigation()",
@@ -13129,7 +13129,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L198",
       "id": "organizationsettingsview_navigation",
-      "community": 73
+      "community": 75
     },
     {
       "label": "OrganizationsSettingsAccordion.tsx",
@@ -13137,7 +13137,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationsSettingsAccordion.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationssettingsaccordion_tsx",
-      "community": 450
+      "community": 452
     },
     {
       "label": "OrganizationSettingsAccordion()",
@@ -13145,7 +13145,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationsSettingsAccordion.tsx",
       "source_location": "L13",
       "id": "organizationssettingsaccordion_organizationsettingsaccordion",
-      "community": 450
+      "community": 452
     },
     {
       "label": "StoreSettingsView.tsx",
@@ -13153,7 +13153,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
-      "community": 74
+      "community": 76
     },
     {
       "label": "StoreSettings()",
@@ -13161,7 +13161,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L28",
       "id": "storesettingsview_storesettings",
-      "community": 74
+      "community": 76
     },
     {
       "label": "saveStoreChanges()",
@@ -13169,7 +13169,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L82",
       "id": "storesettingsview_savestorechanges",
-      "community": 74
+      "community": 76
     },
     {
       "label": "onSubmit()",
@@ -13177,7 +13177,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L116",
       "id": "storesettingsview_onsubmit",
-      "community": 74
+      "community": 76
     },
     {
       "label": "handleDeleteStore()",
@@ -13185,7 +13185,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L167",
       "id": "storesettingsview_handledeletestore",
-      "community": 74
+      "community": 76
     },
     {
       "label": "handleDeleteAllProductsInStore()",
@@ -13193,7 +13193,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L232",
       "id": "storesettingsview_handledeleteallproductsinstore",
-      "community": 74
+      "community": 76
     },
     {
       "label": "StoresSettingsAccordion.tsx",
@@ -13201,7 +13201,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoresSettingsAccordion.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_settings_store_storessettingsaccordion_tsx",
-      "community": 975
+      "community": 977
     },
     {
       "label": "expenseStore.ts",
@@ -13209,7 +13209,7 @@
       "source_file": "packages/athena-webapp/src/stores/expenseStore.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_stores_expensestore_ts",
-      "community": 976
+      "community": 978
     },
     {
       "label": "posStore.ts",
@@ -13217,7 +13217,7 @@
       "source_file": "packages/athena-webapp/src/stores/posStore.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_stores_posstore_ts",
-      "community": 977
+      "community": 979
     },
     {
       "label": "setup.ts",
@@ -13225,7 +13225,7 @@
       "source_file": "packages/athena-webapp/src/test/setup.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_test_setup_ts",
-      "community": 978
+      "community": 980
     },
     {
       "label": "backend.test.ts",
@@ -13233,7 +13233,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_tests_pos_backend_test_ts",
-      "community": 24
+      "community": 25
     },
     {
       "label": "validateInventory()",
@@ -13241,7 +13241,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L58",
       "id": "backend_test_validateinventory",
-      "community": 24
+      "community": 25
     },
     {
       "label": "generateTransactionNumber()",
@@ -13249,7 +13249,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L374",
       "id": "backend_test_generatetransactionnumber",
-      "community": 24
+      "community": 25
     },
     {
       "label": "createTransaction()",
@@ -13257,7 +13257,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L391",
       "id": "backend_test_createtransaction",
-      "community": 24
+      "community": 25
     },
     {
       "label": "updateInventory()",
@@ -13265,7 +13265,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L422",
       "id": "backend_test_updateinventory",
-      "community": 24
+      "community": 25
     },
     {
       "label": "createTransactionItems()",
@@ -13273,7 +13273,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L467",
       "id": "backend_test_createtransactionitems",
-      "community": 24
+      "community": 25
     },
     {
       "label": "validateSession()",
@@ -13281,7 +13281,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L553",
       "id": "backend_test_validatesession",
-      "community": 24
+      "community": 25
     },
     {
       "label": "validateSessionInventory()",
@@ -13289,7 +13289,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L593",
       "id": "backend_test_validatesessioninventory",
-      "community": 24
+      "community": 25
     },
     {
       "label": "completeSession()",
@@ -13297,7 +13297,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L629",
       "id": "backend_test_completesession",
-      "community": 24
+      "community": 25
     },
     {
       "label": "handleDatabaseError()",
@@ -13305,7 +13305,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L671",
       "id": "backend_test_handledatabaseerror",
-      "community": 24
+      "community": 25
     },
     {
       "label": "rollbackInventory()",
@@ -13313,7 +13313,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L692",
       "id": "backend_test_rollbackinventory",
-      "community": 24
+      "community": 25
     },
     {
       "label": "inventoryValidationLogic.test.ts",
@@ -13321,7 +13321,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/inventoryValidationLogic.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_tests_pos_inventoryvalidationlogic_test_ts",
-      "community": 225
+      "community": 227
     },
     {
       "label": "validateInventoryForTransaction()",
@@ -13329,7 +13329,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/inventoryValidationLogic.test.ts",
       "source_location": "L20",
       "id": "inventoryvalidationlogic_test_validateinventoryfortransaction",
-      "community": 225
+      "community": 227
     },
     {
       "label": "mockGetSku()",
@@ -13337,7 +13337,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/inventoryValidationLogic.test.ts",
       "source_location": "L66",
       "id": "inventoryvalidationlogic_test_mockgetsku",
-      "community": 225
+      "community": 227
     },
     {
       "label": "simple.test.ts",
@@ -13345,7 +13345,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_tests_pos_simple_test_ts",
-      "community": 31
+      "community": 32
     },
     {
       "label": "generateTransactionNumber()",
@@ -13353,7 +13353,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L38",
       "id": "simple_test_generatetransactionnumber",
-      "community": 31
+      "community": 32
     },
     {
       "label": "validateInventory()",
@@ -13361,7 +13361,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L77",
       "id": "simple_test_validateinventory",
-      "community": 31
+      "community": 32
     },
     {
       "label": "validateInventoryWithAggregation()",
@@ -13369,7 +13369,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L130",
       "id": "simple_test_validateinventorywithaggregation",
-      "community": 31
+      "community": 32
     },
     {
       "label": "formatCurrency()",
@@ -13377,7 +13377,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L173",
       "id": "simple_test_formatcurrency",
-      "community": 31
+      "community": 32
     },
     {
       "label": "formatPaymentMethod()",
@@ -13385,7 +13385,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L201",
       "id": "simple_test_formatpaymentmethod",
-      "community": 31
+      "community": 32
     },
     {
       "label": "formatReceiptDate()",
@@ -13393,7 +13393,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L225",
       "id": "simple_test_formatreceiptdate",
-      "community": 31
+      "community": 32
     },
     {
       "label": "addToCart()",
@@ -13401,7 +13401,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L249",
       "id": "simple_test_addtocart",
-      "community": 31
+      "community": 32
     },
     {
       "label": "removeFromCart()",
@@ -13409,7 +13409,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L288",
       "id": "simple_test_removefromcart",
-      "community": 31
+      "community": 32
     },
     {
       "label": "updateQuantity()",
@@ -13417,7 +13417,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L311",
       "id": "simple_test_updatequantity",
-      "community": 31
+      "community": 32
     },
     {
       "label": "usePrint.test.ts",
@@ -13425,7 +13425,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/usePrint.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_tests_pos_useprint_test_ts",
-      "community": 979
+      "community": 981
     },
     {
       "label": "formatNumber.ts",
@@ -13433,7 +13433,7 @@
       "source_file": "packages/athena-webapp/src/utils/formatNumber.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_utils_formatnumber_ts",
-      "community": 451
+      "community": 453
     },
     {
       "label": "formatNumber()",
@@ -13441,7 +13441,7 @@
       "source_file": "packages/athena-webapp/src/utils/formatNumber.ts",
       "source_location": "L1",
       "id": "formatnumber_formatnumber",
-      "community": 451
+      "community": 453
     },
     {
       "label": "index.ts",
@@ -13449,7 +13449,7 @@
       "source_file": "packages/athena-webapp/src/utils/index.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_utils_index_ts",
-      "community": 226
+      "community": 228
     },
     {
       "label": "hashPassword()",
@@ -13457,7 +13457,7 @@
       "source_file": "packages/storefront-webapp/src/utils/index.ts",
       "source_location": "L1",
       "id": "index_hashpassword",
-      "community": 226
+      "community": 228
     },
     {
       "label": "session.ts",
@@ -13465,7 +13465,7 @@
       "source_file": "packages/athena-webapp/src/utils/session.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_utils_session_ts",
-      "community": 227
+      "community": 229
     },
     {
       "label": "useAppSession()",
@@ -13473,7 +13473,7 @@
       "source_file": "packages/storefront-webapp/src/utils/session.ts",
       "source_location": "L8",
       "id": "session_useappsession",
-      "community": 227
+      "community": 229
     },
     {
       "label": "versionChecker.ts",
@@ -13481,7 +13481,7 @@
       "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_utils_versionchecker_ts",
-      "community": 228
+      "community": 230
     },
     {
       "label": "createVersionChecker()",
@@ -13489,7 +13489,7 @@
       "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
       "source_location": "L16",
       "id": "versionchecker_createversionchecker",
-      "community": 228
+      "community": 230
     },
     {
       "label": "tailwind.config.js",
@@ -13497,7 +13497,7 @@
       "source_file": "packages/athena-webapp/tailwind.config.js",
       "source_location": "L1",
       "id": "packages_athena_webapp_tailwind_config_js",
-      "community": 980
+      "community": 982
     },
     {
       "label": "types.ts",
@@ -13505,7 +13505,7 @@
       "source_file": "packages/athena-webapp/types.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_types_ts",
-      "community": 981
+      "community": 983
     },
     {
       "label": "vite.config.ts",
@@ -13513,7 +13513,7 @@
       "source_file": "packages/athena-webapp/vite.config.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_vite_config_ts",
-      "community": 229
+      "community": 231
     },
     {
       "label": "manualChunks()",
@@ -13521,7 +13521,7 @@
       "source_file": "packages/storefront-webapp/vite.config.ts",
       "source_location": "L19",
       "id": "vite_config_manualchunks",
-      "community": 229
+      "community": 231
     },
     {
       "label": "vitest.config.ts",
@@ -13529,7 +13529,7 @@
       "source_file": "packages/athena-webapp/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_vitest_config_ts",
-      "community": 982
+      "community": 984
     },
     {
       "label": "vitest.setup.ts",
@@ -13537,7 +13537,7 @@
       "source_file": "packages/athena-webapp/vitest.setup.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_vitest_setup_ts",
-      "community": 983
+      "community": 985
     },
     {
       "label": "eslint.config.js",
@@ -13545,7 +13545,7 @@
       "source_file": "packages/storefront-webapp/eslint.config.js",
       "source_location": "L1",
       "id": "packages_storefront_webapp_eslint_config_js",
-      "community": 984
+      "community": 986
     },
     {
       "label": "global.d.ts",
@@ -13553,7 +13553,7 @@
       "source_file": "packages/storefront-webapp/global.d.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_global_d_ts",
-      "community": 985
+      "community": 987
     },
     {
       "label": "playwright.config.ts",
@@ -13561,7 +13561,7 @@
       "source_file": "packages/storefront-webapp/playwright.config.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_playwright_config_ts",
-      "community": 986
+      "community": 988
     },
     {
       "label": "analytics.ts",
@@ -13569,7 +13569,7 @@
       "source_file": "packages/storefront-webapp/src/api/analytics.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_analytics_ts",
-      "community": 109
+      "community": 110
     },
     {
       "label": "postAnalytics()",
@@ -13577,7 +13577,7 @@
       "source_file": "packages/storefront-webapp/src/api/analytics.ts",
       "source_location": "L3",
       "id": "analytics_postanalytics",
-      "community": 109
+      "community": 110
     },
     {
       "label": "updateAnalyticsOwner()",
@@ -13585,7 +13585,7 @@
       "source_file": "packages/storefront-webapp/src/api/analytics.ts",
       "source_location": "L32",
       "id": "analytics_updateanalyticsowner",
-      "community": 109
+      "community": 110
     },
     {
       "label": "logout()",
@@ -13593,7 +13593,7 @@
       "source_file": "packages/storefront-webapp/src/api/analytics.ts",
       "source_location": "L60",
       "id": "analytics_logout",
-      "community": 109
+      "community": 110
     },
     {
       "label": "getProductViewCount()",
@@ -13601,7 +13601,7 @@
       "source_file": "packages/storefront-webapp/src/api/analytics.ts",
       "source_location": "L78",
       "id": "analytics_getproductviewcount",
-      "community": 109
+      "community": 110
     },
     {
       "label": "auth.ts",
@@ -13609,7 +13609,7 @@
       "source_file": "packages/storefront-webapp/src/api/auth.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_auth_ts",
-      "community": 230
+      "community": 232
     },
     {
       "label": "verifyUserAccount()",
@@ -13617,7 +13617,7 @@
       "source_file": "packages/storefront-webapp/src/api/auth.ts",
       "source_location": "L3",
       "id": "auth_verifyuseraccount",
-      "community": 230
+      "community": 232
     },
     {
       "label": "logout()",
@@ -13625,7 +13625,7 @@
       "source_file": "packages/storefront-webapp/src/api/auth.ts",
       "source_location": "L32",
       "id": "auth_logout",
-      "community": 230
+      "community": 232
     },
     {
       "label": "bag.ts",
@@ -13633,7 +13633,7 @@
       "source_file": "packages/storefront-webapp/src/api/bag.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_bag_ts",
-      "community": 43
+      "community": 44
     },
     {
       "label": "getBaseUrl()",
@@ -13641,7 +13641,7 @@
       "source_file": "packages/storefront-webapp/src/api/bag.ts",
       "source_location": "L10",
       "id": "bag_getbaseurl",
-      "community": 43
+      "community": 44
     },
     {
       "label": "getActiveBag()",
@@ -13649,7 +13649,7 @@
       "source_file": "packages/storefront-webapp/src/api/bag.ts",
       "source_location": "L12",
       "id": "bag_getactivebag",
-      "community": 43
+      "community": 44
     },
     {
       "label": "addItemToBag()",
@@ -13657,7 +13657,7 @@
       "source_file": "packages/storefront-webapp/src/api/bag.ts",
       "source_location": "L27",
       "id": "bag_additemtobag",
-      "community": 43
+      "community": 44
     },
     {
       "label": "updateBagItem()",
@@ -13665,7 +13665,7 @@
       "source_file": "packages/storefront-webapp/src/api/bag.ts",
       "source_location": "L63",
       "id": "bag_updatebagitem",
-      "community": 43
+      "community": 44
     },
     {
       "label": "removeItemFromBag()",
@@ -13673,7 +13673,7 @@
       "source_file": "packages/storefront-webapp/src/api/bag.ts",
       "source_location": "L90",
       "id": "bag_removeitemfrombag",
-      "community": 43
+      "community": 44
     },
     {
       "label": "clearBag()",
@@ -13681,7 +13681,7 @@
       "source_file": "packages/storefront-webapp/src/api/bag.ts",
       "source_location": "L106",
       "id": "bag_clearbag",
-      "community": 43
+      "community": 44
     },
     {
       "label": "updateBagOwner()",
@@ -13689,7 +13689,7 @@
       "source_file": "packages/storefront-webapp/src/api/bag.ts",
       "source_location": "L118",
       "id": "bag_updatebagowner",
-      "community": 43
+      "community": 44
     },
     {
       "label": "bannerMessage.ts",
@@ -13697,7 +13697,7 @@
       "source_file": "packages/storefront-webapp/src/api/bannerMessage.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_bannermessage_ts",
-      "community": 452
+      "community": 454
     },
     {
       "label": "getBannerMessage()",
@@ -13705,7 +13705,7 @@
       "source_file": "packages/storefront-webapp/src/api/bannerMessage.ts",
       "source_location": "L4",
       "id": "bannermessage_getbannermessage",
-      "community": 452
+      "community": 454
     },
     {
       "label": "category.ts",
@@ -13713,7 +13713,7 @@
       "source_file": "packages/storefront-webapp/src/api/category.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_category_ts",
-      "community": 110
+      "community": 111
     },
     {
       "label": "getBaseUrl()",
@@ -13721,7 +13721,7 @@
       "source_file": "packages/storefront-webapp/src/api/category.ts",
       "source_location": "L9",
       "id": "category_getbaseurl",
-      "community": 110
+      "community": 111
     },
     {
       "label": "getAllCategories()",
@@ -13729,7 +13729,7 @@
       "source_file": "packages/storefront-webapp/src/api/category.ts",
       "source_location": "L11",
       "id": "category_getallcategories",
-      "community": 110
+      "community": 111
     },
     {
       "label": "getAllCategoriesWithSubcategories()",
@@ -13737,7 +13737,7 @@
       "source_file": "packages/storefront-webapp/src/api/category.ts",
       "source_location": "L25",
       "id": "category_getallcategorieswithsubcategories",
-      "community": 110
+      "community": 111
     },
     {
       "label": "getCategory()",
@@ -13745,7 +13745,7 @@
       "source_file": "packages/storefront-webapp/src/api/category.ts",
       "source_location": "L39",
       "id": "category_getcategory",
-      "community": 110
+      "community": 111
     },
     {
       "label": "checkoutSession.test.ts",
@@ -13753,7 +13753,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.test.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_checkoutsession_test_ts",
-      "community": 453
+      "community": 455
     },
     {
       "label": "jsonResponse()",
@@ -13761,7 +13761,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.test.ts",
       "source_location": "L27",
       "id": "checkoutsession_test_jsonresponse",
-      "community": 453
+      "community": 455
     },
     {
       "label": "checkoutSession.ts",
@@ -13769,7 +13769,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_checkoutsession_ts",
-      "community": 14
+      "community": 15
     },
     {
       "label": "getBaseUrl()",
@@ -13777,7 +13777,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L5",
       "id": "checkoutsession_getbaseurl",
-      "community": 14
+      "community": 15
     },
     {
       "label": "CheckoutSessionError",
@@ -13785,7 +13785,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L64",
       "id": "checkoutsession_checkoutsessionerror",
-      "community": 14
+      "community": 15
     },
     {
       "label": ".constructor()",
@@ -13793,7 +13793,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L69",
       "id": "checkoutsession_checkoutsessionerror_constructor",
-      "community": 14
+      "community": 15
     },
     {
       "label": "isRecord()",
@@ -13801,7 +13801,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L78",
       "id": "checkoutsession_isrecord",
-      "community": 14
+      "community": 15
     },
     {
       "label": "parseJson()",
@@ -13809,7 +13809,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L81",
       "id": "checkoutsession_parsejson",
-      "community": 14
+      "community": 15
     },
     {
       "label": "getCheckoutErrorMessageFromPayload()",
@@ -13817,7 +13817,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L98",
       "id": "checkoutsession_getcheckouterrormessagefrompayload",
-      "community": 14
+      "community": 15
     },
     {
       "label": "parseCheckoutResponse()",
@@ -13825,7 +13825,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L115",
       "id": "checkoutsession_parsecheckoutresponse",
-      "community": 14
+      "community": 15
     },
     {
       "label": "defaultCheckoutActionMessage()",
@@ -13833,7 +13833,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L135",
       "id": "checkoutsession_defaultcheckoutactionmessage",
-      "community": 14
+      "community": 15
     },
     {
       "label": "getCheckoutActionErrorMessage()",
@@ -13841,7 +13841,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L147",
       "id": "checkoutsession_getcheckoutactionerrormessage",
-      "community": 14
+      "community": 15
     },
     {
       "label": "createCheckoutSession()",
@@ -13849,7 +13849,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L184",
       "id": "checkoutsession_createcheckoutsession",
-      "community": 14
+      "community": 15
     },
     {
       "label": "getActiveCheckoutSession()",
@@ -13857,7 +13857,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L204",
       "id": "checkoutsession_getactivecheckoutsession",
-      "community": 14
+      "community": 15
     },
     {
       "label": "getPendingCheckoutSessions()",
@@ -13865,7 +13865,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L215",
       "id": "checkoutsession_getpendingcheckoutsessions",
-      "community": 14
+      "community": 15
     },
     {
       "label": "getCheckoutSession()",
@@ -13873,7 +13873,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L226",
       "id": "checkoutsession_getcheckoutsession",
-      "community": 14
+      "community": 15
     },
     {
       "label": "updateCheckoutSession()",
@@ -13881,7 +13881,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L239",
       "id": "checkoutsession_updatecheckoutsession",
-      "community": 14
+      "community": 15
     },
     {
       "label": "verifyCheckoutSessionPayment()",
@@ -13889,7 +13889,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L274",
       "id": "checkoutsession_verifycheckoutsessionpayment",
-      "community": 14
+      "community": 15
     },
     {
       "label": "color.ts",
@@ -13897,7 +13897,7 @@
       "source_file": "packages/storefront-webapp/src/api/color.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_color_ts",
-      "community": 231
+      "community": 233
     },
     {
       "label": "getBaseUrl()",
@@ -13905,7 +13905,7 @@
       "source_file": "packages/storefront-webapp/src/api/color.ts",
       "source_location": "L5",
       "id": "color_getbaseurl",
-      "community": 231
+      "community": 233
     },
     {
       "label": "getAllColors()",
@@ -13913,7 +13913,7 @@
       "source_file": "packages/storefront-webapp/src/api/color.ts",
       "source_location": "L7",
       "id": "color_getallcolors",
-      "community": 231
+      "community": 233
     },
     {
       "label": "guest.ts",
@@ -13921,7 +13921,7 @@
       "source_file": "packages/storefront-webapp/src/api/guest.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_guest_ts",
-      "community": 454
+      "community": 456
     },
     {
       "label": "updateGuest()",
@@ -13929,7 +13929,7 @@
       "source_file": "packages/storefront-webapp/src/api/guest.ts",
       "source_location": "L4",
       "id": "guest_updateguest",
-      "community": 454
+      "community": 456
     },
     {
       "label": "offers.ts",
@@ -13937,7 +13937,7 @@
       "source_file": "packages/storefront-webapp/src/api/offers.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_offers_ts",
-      "community": 144
+      "community": 145
     },
     {
       "label": "getBaseUrl()",
@@ -13945,7 +13945,7 @@
       "source_file": "packages/storefront-webapp/src/api/offers.ts",
       "source_location": "L13",
       "id": "offers_getbaseurl",
-      "community": 144
+      "community": 145
     },
     {
       "label": "submitOffer()",
@@ -13953,7 +13953,7 @@
       "source_file": "packages/storefront-webapp/src/api/offers.ts",
       "source_location": "L21",
       "id": "offers_submitoffer",
-      "community": 144
+      "community": 145
     },
     {
       "label": "getUserRedeemedOffers()",
@@ -13961,7 +13961,7 @@
       "source_file": "packages/storefront-webapp/src/api/offers.ts",
       "source_location": "L46",
       "id": "offers_getuserredeemedoffers",
-      "community": 144
+      "community": 145
     },
     {
       "label": "onlineOrder.ts",
@@ -13969,7 +13969,7 @@
       "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_onlineorder_ts",
-      "community": 111
+      "community": 112
     },
     {
       "label": "getBaseUrl()",
@@ -13977,7 +13977,7 @@
       "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
       "source_location": "L4",
       "id": "onlineorder_getbaseurl",
-      "community": 111
+      "community": 112
     },
     {
       "label": "getOrders()",
@@ -13985,7 +13985,7 @@
       "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
       "source_location": "L6",
       "id": "onlineorder_getorders",
-      "community": 111
+      "community": 112
     },
     {
       "label": "getOrder()",
@@ -13993,7 +13993,7 @@
       "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
       "source_location": "L24",
       "id": "onlineorder_getorder",
-      "community": 111
+      "community": 112
     },
     {
       "label": "updateOrdersOwner()",
@@ -14001,7 +14001,7 @@
       "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
       "source_location": "L42",
       "id": "onlineorder_updateordersowner",
-      "community": 111
+      "community": 112
     },
     {
       "label": "organization.ts",
@@ -14009,7 +14009,7 @@
       "source_file": "packages/storefront-webapp/src/api/organization.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_organization_ts",
-      "community": 232
+      "community": 234
     },
     {
       "label": "getAllOrganizations()",
@@ -14017,7 +14017,7 @@
       "source_file": "packages/storefront-webapp/src/api/organization.ts",
       "source_location": "L6",
       "id": "organization_getallorganizations",
-      "community": 232
+      "community": 234
     },
     {
       "label": "getOrganization()",
@@ -14025,7 +14025,7 @@
       "source_file": "packages/storefront-webapp/src/api/organization.ts",
       "source_location": "L18",
       "id": "organization_getorganization",
-      "community": 232
+      "community": 234
     },
     {
       "label": "product.ts",
@@ -14033,7 +14033,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_product_ts",
-      "community": 44
+      "community": 45
     },
     {
       "label": "buildQueryString()",
@@ -14041,7 +14041,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L5",
       "id": "product_buildquerystring",
-      "community": 44
+      "community": 45
     },
     {
       "label": "getBaseUrl()",
@@ -14049,7 +14049,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L18",
       "id": "product_getbaseurl",
-      "community": 44
+      "community": 45
     },
     {
       "label": "getAllProducts()",
@@ -14057,7 +14057,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L20",
       "id": "product_getallproducts",
-      "community": 44
+      "community": 45
     },
     {
       "label": "getProduct()",
@@ -14065,7 +14065,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L40",
       "id": "product_getproduct",
-      "community": 44
+      "community": 45
     },
     {
       "label": "getBestSellers()",
@@ -14073,7 +14073,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L59",
       "id": "product_getbestsellers",
-      "community": 44
+      "community": 45
     },
     {
       "label": "getFeatured()",
@@ -14081,7 +14081,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L73",
       "id": "product_getfeatured",
-      "community": 44
+      "community": 45
     },
     {
       "label": "getInventoryBySkuIds()",
@@ -14089,7 +14089,7 @@
       "source_file": "packages/storefront-webapp/src/api/product.ts",
       "source_location": "L93",
       "id": "product_getinventorybyskuids",
-      "community": 44
+      "community": 45
     },
     {
       "label": "promoCodes.ts",
@@ -14097,7 +14097,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_promocodes_ts",
-      "community": 75
+      "community": 77
     },
     {
       "label": "getBaseUrl()",
@@ -14105,7 +14105,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L4",
       "id": "promocodes_getbaseurl",
-      "community": 75
+      "community": 77
     },
     {
       "label": "redeemPromoCode()",
@@ -14113,7 +14113,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L6",
       "id": "promocodes_redeempromocode",
-      "community": 75
+      "community": 77
     },
     {
       "label": "getPromoCodes()",
@@ -14121,7 +14121,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L34",
       "id": "promocodes_getpromocodes",
-      "community": 75
+      "community": 77
     },
     {
       "label": "getPromoCodeItems()",
@@ -14129,7 +14129,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L49",
       "id": "promocodes_getpromocodeitems",
-      "community": 75
+      "community": 77
     },
     {
       "label": "getRedeemedPromoCodes()",
@@ -14137,7 +14137,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L74",
       "id": "promocodes_getredeemedpromocodes",
-      "community": 75
+      "community": 77
     },
     {
       "label": "reviews.ts",
@@ -14145,7 +14145,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_reviews_ts",
-      "community": 21
+      "community": 22
     },
     {
       "label": "getBaseUrl()",
@@ -14153,7 +14153,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L4",
       "id": "reviews_getbaseurl",
-      "community": 21
+      "community": 22
     },
     {
       "label": "createReview()",
@@ -14161,7 +14161,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L13",
       "id": "reviews_createreview",
-      "community": 21
+      "community": 22
     },
     {
       "label": "getReviewByOrderItem()",
@@ -14169,7 +14169,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L32",
       "id": "reviews_getreviewbyorderitem",
-      "community": 21
+      "community": 22
     },
     {
       "label": "updateReview()",
@@ -14177,7 +14177,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L48",
       "id": "reviews_updatereview",
-      "community": 21
+      "community": 22
     },
     {
       "label": "deleteReview()",
@@ -14185,7 +14185,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L69",
       "id": "reviews_deletereview",
-      "community": 21
+      "community": 22
     },
     {
       "label": "getReviewsByProductSkuId()",
@@ -14193,7 +14193,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L83",
       "id": "reviews_getreviewsbyproductskuid",
-      "community": 21
+      "community": 22
     },
     {
       "label": "getUserReviews()",
@@ -14201,7 +14201,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L99",
       "id": "reviews_getuserreviews",
-      "community": 21
+      "community": 22
     },
     {
       "label": "getUserReviewsForProduct()",
@@ -14209,7 +14209,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L113",
       "id": "reviews_getuserreviewsforproduct",
-      "community": 21
+      "community": 22
     },
     {
       "label": "getReviewsByProductId()",
@@ -14217,7 +14217,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L132",
       "id": "reviews_getreviewsbyproductid",
-      "community": 21
+      "community": 22
     },
     {
       "label": "markReviewHelpful()",
@@ -14225,7 +14225,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L148",
       "id": "reviews_markreviewhelpful",
-      "community": 21
+      "community": 22
     },
     {
       "label": "hasReviewForOrderItem()",
@@ -14233,7 +14233,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L164",
       "id": "reviews_hasreviewfororderitem",
-      "community": 21
+      "community": 22
     },
     {
       "label": "hasUserReviewForOrderItem()",
@@ -14241,7 +14241,7 @@
       "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L183",
       "id": "reviews_hasuserreviewfororderitem",
-      "community": 21
+      "community": 22
     },
     {
       "label": "rewards.ts",
@@ -14249,7 +14249,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_rewards_ts",
-      "community": 32
+      "community": 33
     },
     {
       "label": "getBaseUrl()",
@@ -14257,7 +14257,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L3",
       "id": "rewards_getbaseurl",
-      "community": 32
+      "community": 33
     },
     {
       "label": "getUserPoints()",
@@ -14265,7 +14265,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L54",
       "id": "rewards_getuserpoints",
-      "community": 32
+      "community": 33
     },
     {
       "label": "getPointHistory()",
@@ -14273,7 +14273,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L71",
       "id": "rewards_getpointhistory",
-      "community": 32
+      "community": 33
     },
     {
       "label": "getRewardTiers()",
@@ -14281,7 +14281,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L90",
       "id": "rewards_getrewardtiers",
-      "community": 32
+      "community": 33
     },
     {
       "label": "redeemRewardPoints()",
@@ -14289,7 +14289,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L107",
       "id": "rewards_redeemrewardpoints",
-      "community": 32
+      "community": 33
     },
     {
       "label": "getEligiblePastOrders()",
@@ -14297,7 +14297,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L129",
       "id": "rewards_geteligiblepastorders",
-      "community": 32
+      "community": 33
     },
     {
       "label": "awardPointsForPastOrder()",
@@ -14305,7 +14305,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L151",
       "id": "rewards_awardpointsforpastorder",
-      "community": 32
+      "community": 33
     },
     {
       "label": "getOrderRewardPoints()",
@@ -14313,7 +14313,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L175",
       "id": "rewards_getorderrewardpoints",
-      "community": 32
+      "community": 33
     },
     {
       "label": "awardPointsForGuestOrders()",
@@ -14321,7 +14321,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L198",
       "id": "rewards_awardpointsforguestorders",
-      "community": 32
+      "community": 33
     },
     {
       "label": "savedBag.ts",
@@ -14329,7 +14329,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_savedbag_ts",
-      "community": 51
+      "community": 52
     },
     {
       "label": "getBaseUrl()",
@@ -14337,7 +14337,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L8",
       "id": "savedbag_getbaseurl",
-      "community": 51
+      "community": 52
     },
     {
       "label": "getActiveSavedBag()",
@@ -14345,7 +14345,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L10",
       "id": "savedbag_getactivesavedbag",
-      "community": 51
+      "community": 52
     },
     {
       "label": "addItemToSavedBag()",
@@ -14353,7 +14353,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L25",
       "id": "savedbag_additemtosavedbag",
-      "community": 51
+      "community": 52
     },
     {
       "label": "updateSavedBagItem()",
@@ -14361,7 +14361,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L61",
       "id": "savedbag_updatesavedbagitem",
-      "community": 51
+      "community": 52
     },
     {
       "label": "removeItemFromSavedBag()",
@@ -14369,7 +14369,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L91",
       "id": "savedbag_removeitemfromsavedbag",
-      "community": 51
+      "community": 52
     },
     {
       "label": "updateSavedBagOwner()",
@@ -14377,7 +14377,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L109",
       "id": "savedbag_updatesavedbagowner",
-      "community": 51
+      "community": 52
     },
     {
       "label": "storeFrontUser.ts",
@@ -14385,7 +14385,7 @@
       "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_storefrontuser_ts",
-      "community": 112
+      "community": 113
     },
     {
       "label": "getBaseUrl()",
@@ -14393,7 +14393,7 @@
       "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
       "source_location": "L5",
       "id": "storefrontuser_getbaseurl",
-      "community": 112
+      "community": 113
     },
     {
       "label": "getGuest()",
@@ -14401,7 +14401,7 @@
       "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
       "source_location": "L7",
       "id": "storefrontuser_getguest",
-      "community": 112
+      "community": 113
     },
     {
       "label": "getActiveUser()",
@@ -14409,7 +14409,7 @@
       "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
       "source_location": "L28",
       "id": "storefrontuser_getactiveuser",
-      "community": 112
+      "community": 113
     },
     {
       "label": "updateUser()",
@@ -14417,7 +14417,7 @@
       "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
       "source_location": "L46",
       "id": "storefrontuser_updateuser",
-      "community": 112
+      "community": 113
     },
     {
       "label": "storefront.ts",
@@ -14425,7 +14425,7 @@
       "source_file": "packages/storefront-webapp/src/api/storefront.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_storefront_ts",
-      "community": 455
+      "community": 457
     },
     {
       "label": "getStore()",
@@ -14433,7 +14433,7 @@
       "source_file": "packages/storefront-webapp/src/api/storefront.ts",
       "source_location": "L5",
       "id": "storefront_getstore",
-      "community": 455
+      "community": 457
     },
     {
       "label": "stores.ts",
@@ -14441,7 +14441,7 @@
       "source_file": "packages/storefront-webapp/src/api/stores.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_stores_ts",
-      "community": 145
+      "community": 146
     },
     {
       "label": "getBaseUrl()",
@@ -14449,7 +14449,7 @@
       "source_file": "packages/storefront-webapp/src/api/stores.ts",
       "source_location": "L5",
       "id": "stores_getbaseurl",
-      "community": 145
+      "community": 146
     },
     {
       "label": "getAllStores()",
@@ -14457,7 +14457,7 @@
       "source_file": "packages/storefront-webapp/src/api/stores.ts",
       "source_location": "L8",
       "id": "stores_getallstores",
-      "community": 145
+      "community": 146
     },
     {
       "label": "getStore()",
@@ -14465,7 +14465,7 @@
       "source_file": "packages/storefront-webapp/src/api/stores.ts",
       "source_location": "L20",
       "id": "stores_getstore",
-      "community": 145
+      "community": 146
     },
     {
       "label": "subcategory.ts",
@@ -14473,7 +14473,7 @@
       "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_subcategory_ts",
-      "community": 146
+      "community": 147
     },
     {
       "label": "getBaseUrl()",
@@ -14481,7 +14481,7 @@
       "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
       "source_location": "L9",
       "id": "subcategory_getbaseurl",
-      "community": 146
+      "community": 147
     },
     {
       "label": "getAllSubcategories()",
@@ -14489,7 +14489,7 @@
       "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
       "source_location": "L11",
       "id": "subcategory_getallsubcategories",
-      "community": 146
+      "community": 147
     },
     {
       "label": "getSubategory()",
@@ -14497,7 +14497,7 @@
       "source_file": "packages/storefront-webapp/src/api/subcategory.ts",
       "source_location": "L25",
       "id": "subcategory_getsubategory",
-      "community": 146
+      "community": 147
     },
     {
       "label": "types.ts",
@@ -14505,7 +14505,7 @@
       "source_file": "packages/storefront-webapp/src/api/types.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_types_ts",
-      "community": 987
+      "community": 989
     },
     {
       "label": "upsells.ts",
@@ -14513,7 +14513,7 @@
       "source_file": "packages/storefront-webapp/src/api/upsells.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_upsells_ts",
-      "community": 233
+      "community": 235
     },
     {
       "label": "getBaseUrl()",
@@ -14521,7 +14521,7 @@
       "source_file": "packages/storefront-webapp/src/api/upsells.ts",
       "source_location": "L3",
       "id": "upsells_getbaseurl",
-      "community": 233
+      "community": 235
     },
     {
       "label": "getLastViewedProduct()",
@@ -14529,7 +14529,7 @@
       "source_file": "packages/storefront-webapp/src/api/upsells.ts",
       "source_location": "L5",
       "id": "upsells_getlastviewedproduct",
-      "community": 233
+      "community": 235
     },
     {
       "label": "userOffers.ts",
@@ -14537,7 +14537,7 @@
       "source_file": "packages/storefront-webapp/src/api/userOffers.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_useroffers_ts",
-      "community": 234
+      "community": 236
     },
     {
       "label": "getBaseUrl()",
@@ -14545,7 +14545,7 @@
       "source_file": "packages/storefront-webapp/src/api/userOffers.ts",
       "source_location": "L18",
       "id": "useroffers_getbaseurl",
-      "community": 234
+      "community": 236
     },
     {
       "label": "getUserOffersEligibility()",
@@ -14553,7 +14553,7 @@
       "source_file": "packages/storefront-webapp/src/api/userOffers.ts",
       "source_location": "L23",
       "id": "useroffers_getuserofferseligibility",
-      "community": 234
+      "community": 236
     },
     {
       "label": "HeartIconFilled.tsx",
@@ -14561,7 +14561,7 @@
       "source_file": "packages/storefront-webapp/src/assets/icons/HeartIconFilled.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_assets_icons_hearticonfilled_tsx",
-      "community": 988
+      "community": 990
     },
     {
       "label": "client.tsx",
@@ -14569,7 +14569,7 @@
       "source_file": "packages/storefront-webapp/src/client.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_client_tsx",
-      "community": 989
+      "community": 991
     },
     {
       "label": "DefaultCatchBoundary.tsx",
@@ -14577,7 +14577,7 @@
       "source_file": "packages/storefront-webapp/src/components/DefaultCatchBoundary.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_defaultcatchboundary_tsx",
-      "community": 990
+      "community": 992
     },
     {
       "label": "EntityPage.tsx",
@@ -14585,7 +14585,7 @@
       "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_entitypage_tsx",
-      "community": 456
+      "community": 458
     },
     {
       "label": "EntityPage()",
@@ -14593,7 +14593,7 @@
       "source_file": "packages/storefront-webapp/src/components/EntityPage.tsx",
       "source_location": "L10",
       "id": "entitypage_entitypage",
-      "community": 456
+      "community": 458
     },
     {
       "label": "HomePage.tsx",
@@ -14601,7 +14601,7 @@
       "source_file": "packages/storefront-webapp/src/components/HomePage.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_homepage_tsx",
-      "community": 147
+      "community": 148
     },
     {
       "label": "handleScroll()",
@@ -14609,7 +14609,7 @@
       "source_file": "packages/storefront-webapp/src/components/HomePage.tsx",
       "source_location": "L106",
       "id": "homepage_handlescroll",
-      "community": 147
+      "community": 148
     },
     {
       "label": "handleClickOnDiscountCode()",
@@ -14617,7 +14617,7 @@
       "source_file": "packages/storefront-webapp/src/components/HomePage.tsx",
       "source_location": "L155",
       "id": "homepage_handleclickondiscountcode",
-      "community": 147
+      "community": 148
     },
     {
       "label": "handleClickOnLeaveReviewButton()",
@@ -14625,7 +14625,7 @@
       "source_file": "packages/storefront-webapp/src/components/HomePage.tsx",
       "source_location": "L167",
       "id": "homepage_handleclickonleavereviewbutton",
-      "community": 147
+      "community": 148
     },
     {
       "label": "ProductActionBar.tsx",
@@ -14633,7 +14633,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_productactionbar_tsx",
-      "community": 148
+      "community": 149
     },
     {
       "label": "checkScroll()",
@@ -14641,7 +14641,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
       "source_location": "L50",
       "id": "productactionbar_checkscroll",
-      "community": 148
+      "community": 149
     },
     {
       "label": "handleDismiss()",
@@ -14649,7 +14649,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
       "source_location": "L74",
       "id": "productactionbar_handledismiss",
-      "community": 148
+      "community": 149
     },
     {
       "label": "handleAction()",
@@ -14657,7 +14657,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductActionBar.tsx",
       "source_location": "L92",
       "id": "productactionbar_handleaction",
-      "community": 148
+      "community": 149
     },
     {
       "label": "ProductCard.tsx",
@@ -14665,7 +14665,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductCard.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_productcard_tsx",
-      "community": 991
+      "community": 993
     },
     {
       "label": "ProductReminderBar.tsx",
@@ -14673,7 +14673,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_productreminderbar_tsx",
-      "community": 149
+      "community": 150
     },
     {
       "label": "checkScroll()",
@@ -14681,7 +14681,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
       "source_location": "L62",
       "id": "productreminderbar_checkscroll",
-      "community": 149
+      "community": 150
     },
     {
       "label": "handleAddToBag()",
@@ -14689,7 +14689,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
       "source_location": "L109",
       "id": "productreminderbar_handleaddtobag",
-      "community": 149
+      "community": 150
     },
     {
       "label": "handleDismiss()",
@@ -14697,7 +14697,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductReminderBar.tsx",
       "source_location": "L177",
       "id": "productreminderbar_handledismiss",
-      "community": 149
+      "community": 150
     },
     {
       "label": "ProductsPage.tsx",
@@ -14705,7 +14705,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductsPage.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_productspage_tsx",
-      "community": 457
+      "community": 459
     },
     {
       "label": "ProductCardLoadingSkeleton()",
@@ -14713,7 +14713,7 @@
       "source_file": "packages/storefront-webapp/src/components/ProductsPage.tsx",
       "source_location": "L10",
       "id": "productspage_productcardloadingskeleton",
-      "community": 457
+      "community": 459
     },
     {
       "label": "Upsell.tsx",
@@ -14721,7 +14721,7 @@
       "source_file": "packages/storefront-webapp/src/components/Upsell.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_upsell_tsx",
-      "community": 992
+      "community": 994
     },
     {
       "label": "View.tsx",
@@ -14729,7 +14729,7 @@
       "source_file": "packages/storefront-webapp/src/components/View.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_view_tsx",
-      "community": 168
+      "community": 170
     },
     {
       "label": "Auth.tsx",
@@ -14737,7 +14737,7 @@
       "source_file": "packages/storefront-webapp/src/components/auth/Auth.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_auth_auth_tsx",
-      "community": 458
+      "community": 460
     },
     {
       "label": "AuthComponent()",
@@ -14745,7 +14745,7 @@
       "source_file": "packages/storefront-webapp/src/components/auth/Auth.tsx",
       "source_location": "L4",
       "id": "auth_authcomponent",
-      "community": 458
+      "community": 460
     },
     {
       "label": "BagSummary.tsx",
@@ -14753,7 +14753,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BagSummary.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_bagsummary_tsx",
-      "community": 459
+      "community": 461
     },
     {
       "label": "toBagSummaryItems()",
@@ -14761,7 +14761,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BagSummary.tsx",
       "source_location": "L39",
       "id": "bagsummary_tobagsummaryitems",
-      "community": 459
+      "community": 461
     },
     {
       "label": "BillingDetails.tsx",
@@ -14769,7 +14769,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
-      "community": 76
+      "community": 78
     },
     {
       "label": "EnteredBillingAddressDetails()",
@@ -14777,7 +14777,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L102",
       "id": "billingdetails_enteredbillingaddressdetails",
-      "community": 76
+      "community": 78
     },
     {
       "label": "onSubmit()",
@@ -14785,7 +14785,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L150",
       "id": "billingdetails_onsubmit",
-      "community": 76
+      "community": 78
     },
     {
       "label": "toggleSameAsDelivery()",
@@ -14793,7 +14793,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L155",
       "id": "billingdetails_togglesameasdelivery",
-      "community": 76
+      "community": 78
     },
     {
       "label": "clearForm()",
@@ -14801,7 +14801,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L173",
       "id": "billingdetails_clearform",
-      "community": 76
+      "community": 78
     },
     {
       "label": "handleUseBillingAddressOnFile()",
@@ -14809,7 +14809,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L201",
       "id": "billingdetails_handleusebillingaddressonfile",
-      "community": 76
+      "community": 78
     },
     {
       "label": "BillingDetailsSection.tsx",
@@ -14817,7 +14817,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetailssection_tsx",
-      "community": 150
+      "community": 151
     },
     {
       "label": "clearForm()",
@@ -14825,7 +14825,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
       "source_location": "L18",
       "id": "billingdetailssection_clearform",
-      "community": 150
+      "community": 151
     },
     {
       "label": "handleUseBillingAddressOnFile()",
@@ -14833,7 +14833,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
       "source_location": "L52",
       "id": "billingdetailssection_handleusebillingaddressonfile",
-      "community": 150
+      "community": 151
     },
     {
       "label": "toggleSameAsDelivery()",
@@ -14841,7 +14841,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetailsSection.tsx",
       "source_location": "L68",
       "id": "billingdetailssection_togglesameasdelivery",
-      "community": 150
+      "community": 151
     },
     {
       "label": "Checkout.tsx",
@@ -14849,7 +14849,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/Checkout.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_tsx",
-      "community": 993
+      "community": 995
     },
     {
       "label": "CheckoutForm.tsx",
@@ -14857,7 +14857,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/CheckoutForm.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutform_tsx",
-      "community": 460
+      "community": 462
     },
     {
       "label": "CheckoutForm()",
@@ -14865,7 +14865,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/CheckoutForm.tsx",
       "source_location": "L18",
       "id": "checkoutform_checkoutform",
-      "community": 460
+      "community": 462
     },
     {
       "label": "CheckoutProvider.tsx",
@@ -14873,7 +14873,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/CheckoutProvider.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutprovider_tsx",
-      "community": 461
+      "community": 463
     },
     {
       "label": "CheckoutProvider()",
@@ -14881,7 +14881,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/CheckoutProvider.tsx",
       "source_location": "L71",
       "id": "checkoutprovider_checkoutprovider",
-      "community": 461
+      "community": 463
     },
     {
       "label": "CustomerDetails.tsx",
@@ -14889,7 +14889,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/CustomerDetails.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_customerdetails_tsx",
-      "community": 235
+      "community": 237
     },
     {
       "label": "EnteredCustomerDetails()",
@@ -14897,7 +14897,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/CustomerDetails.tsx",
       "source_location": "L22",
       "id": "customerdetails_enteredcustomerdetails",
-      "community": 235
+      "community": 237
     },
     {
       "label": "onSubmit()",
@@ -14905,7 +14905,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/CustomerDetails.tsx",
       "source_location": "L55",
       "id": "customerdetails_onsubmit",
-      "community": 235
+      "community": 237
     },
     {
       "label": "CustomerInfoSection.tsx",
@@ -14913,7 +14913,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/CustomerInfoSection.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_customerinfosection_tsx",
-      "community": 994
+      "community": 996
     },
     {
       "label": "DeliveryOptionsSelector.tsx",
@@ -14921,7 +14921,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliveryoptionsselector_tsx",
-      "community": 236
+      "community": 238
     },
     {
       "label": "StoreSelector()",
@@ -14929,7 +14929,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
       "source_location": "L11",
       "id": "deliveryoptionsselector_storeselector",
-      "community": 236
+      "community": 238
     },
     {
       "label": "handleChange()",
@@ -14937,7 +14937,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
       "source_location": "L77",
       "id": "deliveryoptionsselector_handlechange",
-      "community": 236
+      "community": 238
     },
     {
       "label": "DeliverySection.tsx",
@@ -14945,7 +14945,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliverysection_tsx",
-      "community": 237
+      "community": 239
     },
     {
       "label": "DeliveryDetails()",
@@ -14953,7 +14953,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
       "source_location": "L11",
       "id": "deliverysection_deliverydetails",
-      "community": 237
+      "community": 239
     },
     {
       "label": "DeliveryOptions()",
@@ -14961,7 +14961,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
       "source_location": "L22",
       "id": "deliverysection_deliveryoptions",
-      "community": 237
+      "community": 239
     },
     {
       "label": "PickupOptions.tsx",
@@ -14969,7 +14969,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/PickupOptions.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_pickupoptions_tsx",
-      "community": 462
+      "community": 464
     },
     {
       "label": "isWithinRestrictionTime()",
@@ -14977,7 +14977,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/PickupOptions.tsx",
       "source_location": "L12",
       "id": "pickupoptions_iswithinrestrictiontime",
-      "community": 462
+      "community": 464
     },
     {
       "label": "schema.ts",
@@ -14985,7 +14985,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/schema.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_schema_ts",
-      "community": 995
+      "community": 997
     },
     {
       "label": "DeliveryDetailsSection.tsx",
@@ -14993,7 +14993,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetailsSection.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetailssection_tsx",
-      "community": 996
+      "community": 998
     },
     {
       "label": "EnteredBillingAddressDetails.tsx",
@@ -15001,7 +15001,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/EnteredBillingAddressDetails.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_enteredbillingaddressdetails_tsx",
-      "community": 463
+      "community": 465
     },
     {
       "label": "EnteredBillingAddressDetails()",
@@ -15009,7 +15009,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/EnteredBillingAddressDetails.tsx",
       "source_location": "L6",
       "id": "enteredbillingaddressdetails_enteredbillingaddressdetails",
-      "community": 463
+      "community": 465
     },
     {
       "label": "MobileBagSummary.tsx",
@@ -15017,7 +15017,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_mobilebagsummary_tsx",
-      "community": 238
+      "community": 240
     },
     {
       "label": "handleRedeemPromoCode()",
@@ -15025,7 +15025,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
       "source_location": "L89",
       "id": "mobilebagsummary_handleredeempromocode",
-      "community": 238
+      "community": 240
     },
     {
       "label": "handleKeyDown()",
@@ -15033,7 +15033,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
       "source_location": "L110",
       "id": "mobilebagsummary_handlekeydown",
-      "community": 238
+      "community": 240
     },
     {
       "label": "OrderSummary.tsx",
@@ -15041,7 +15041,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/OrderSummary.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_ordersummary_tsx",
-      "community": 464
+      "community": 466
     },
     {
       "label": "OrderSummary()",
@@ -15049,7 +15049,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/OrderSummary.tsx",
       "source_location": "L18",
       "id": "ordersummary_ordersummary",
-      "community": 464
+      "community": 466
     },
     {
       "label": "index.tsx",
@@ -15057,7 +15057,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/index.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_index_tsx",
-      "community": 465
+      "community": 467
     },
     {
       "label": "PickupDetails()",
@@ -15065,7 +15065,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/index.tsx",
       "source_location": "L10",
       "id": "index_pickupdetails",
-      "community": 465
+      "community": 467
     },
     {
       "label": "PaymentMethodSection.tsx",
@@ -15073,7 +15073,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/PaymentMethodSection.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_paymentmethodsection_tsx",
-      "community": 466
+      "community": 468
     },
     {
       "label": "PaymentMethodSection()",
@@ -15081,7 +15081,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/PaymentMethodSection.tsx",
       "source_location": "L8",
       "id": "paymentmethodsection_paymentmethodsection",
-      "community": 466
+      "community": 468
     },
     {
       "label": "PaymentSection.tsx",
@@ -15089,7 +15089,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/PaymentSection.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_paymentsection_tsx",
-      "community": 467
+      "community": 469
     },
     {
       "label": "PaymentSection()",
@@ -15097,7 +15097,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/PaymentSection.tsx",
       "source_location": "L27",
       "id": "paymentsection_paymentsection",
-      "community": 467
+      "community": 469
     },
     {
       "label": "checkoutStorage.test.ts",
@@ -15105,7 +15105,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.test.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_test_ts",
-      "community": 997
+      "community": 999
     },
     {
       "label": "checkoutStorage.ts",
@@ -15113,7 +15113,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_ts",
-      "community": 239
+      "community": 241
     },
     {
       "label": "loadCheckoutState()",
@@ -15121,7 +15121,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
       "source_location": "L4",
       "id": "checkoutstorage_loadcheckoutstate",
-      "community": 239
+      "community": 241
     },
     {
       "label": "saveCheckoutState()",
@@ -15129,7 +15129,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
       "source_location": "L24",
       "id": "checkoutstorage_savecheckoutstate",
-      "community": 239
+      "community": 241
     },
     {
       "label": "deliveryFees.test.ts",
@@ -15137,7 +15137,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.test.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_test_ts",
-      "community": 998
+      "community": 1000
     },
     {
       "label": "deliveryFees.ts",
@@ -15145,7 +15145,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_ts",
-      "community": 468
+      "community": 470
     },
     {
       "label": "calculateDeliveryFee()",
@@ -15153,7 +15153,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.ts",
       "source_location": "L40",
       "id": "deliveryfees_calculatedeliveryfee",
-      "community": 468
+      "community": 470
     },
     {
       "label": "deriveCheckoutState.test.ts",
@@ -15161,7 +15161,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.test.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_test_ts",
-      "community": 999
+      "community": 1001
     },
     {
       "label": "deriveCheckoutState.ts",
@@ -15169,7 +15169,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_ts",
-      "community": 469
+      "community": 471
     },
     {
       "label": "deriveCheckoutState()",
@@ -15177,7 +15177,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
       "source_location": "L3",
       "id": "derivecheckoutstate_derivecheckoutstate",
-      "community": 469
+      "community": 471
     },
     {
       "label": "billingDetailsSchema.ts",
@@ -15185,7 +15185,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/billingDetailsSchema.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_billingdetailsschema_ts",
-      "community": 1000
+      "community": 1002
     },
     {
       "label": "checkoutFormSchema.ts",
@@ -15193,7 +15193,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutFormSchema.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutformschema_ts",
-      "community": 1001
+      "community": 1003
     },
     {
       "label": "checkoutSchemas.test.ts",
@@ -15201,7 +15201,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutSchemas.test.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutschemas_test_ts",
-      "community": 470
+      "community": 472
     },
     {
       "label": "getIssueMap()",
@@ -15209,7 +15209,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutSchemas.test.ts",
       "source_location": "L8",
       "id": "checkoutschemas_test_getissuemap",
-      "community": 470
+      "community": 472
     },
     {
       "label": "customerDetailsSchema.ts",
@@ -15217,7 +15217,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/customerDetailsSchema.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_customerdetailsschema_ts",
-      "community": 1002
+      "community": 1004
     },
     {
       "label": "deliveryDetailsSchema.ts",
@@ -15225,7 +15225,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/deliveryDetailsSchema.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_deliverydetailsschema_ts",
-      "community": 1003
+      "community": 1005
     },
     {
       "label": "webOrderSchema.test.ts",
@@ -15233,7 +15233,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.test.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_test_ts",
-      "community": 471
+      "community": 473
     },
     {
       "label": "getIssueMap()",
@@ -15241,7 +15241,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.test.ts",
       "source_location": "L12",
       "id": "weborderschema_test_getissuemap",
-      "community": 471
+      "community": 473
     },
     {
       "label": "webOrderSchema.ts",
@@ -15249,7 +15249,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_ts",
-      "community": 1004
+      "community": 1006
     },
     {
       "label": "types.ts",
@@ -15257,7 +15257,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/types.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_types_ts",
-      "community": 1005
+      "community": 1007
     },
     {
       "label": "utils.test.ts",
@@ -15265,7 +15265,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.test.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_utils_test_ts",
-      "community": 1006
+      "community": 1008
     },
     {
       "label": "utils.ts",
@@ -15273,7 +15273,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
-      "community": 29
+      "community": 30
     },
     {
       "label": "getPotentialPoints()",
@@ -15281,7 +15281,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L107",
       "id": "utils_getpotentialpoints",
-      "community": 29
+      "community": 30
     },
     {
       "label": "FadeIn.tsx",
@@ -15289,7 +15289,7 @@
       "source_file": "packages/storefront-webapp/src/components/common/FadeIn.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_common_fadein_tsx",
-      "community": 178
+      "community": 180
     },
     {
       "label": "CustomerDetailsForm.tsx",
@@ -15297,7 +15297,7 @@
       "source_file": "packages/storefront-webapp/src/components/common/forms/CustomerDetailsForm.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_common_forms_customerdetailsform_tsx",
-      "community": 472
+      "community": 474
     },
     {
       "label": "onSubmit()",
@@ -15305,7 +15305,7 @@
       "source_file": "packages/storefront-webapp/src/components/common/forms/CustomerDetailsForm.tsx",
       "source_location": "L77",
       "id": "customerdetailsform_onsubmit",
-      "community": 472
+      "community": 474
     },
     {
       "label": "DeliveryDetailsForm.tsx",
@@ -15313,7 +15313,7 @@
       "source_file": "packages/storefront-webapp/src/components/common/forms/DeliveryDetailsForm.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_common_forms_deliverydetailsform_tsx",
-      "community": 473
+      "community": 475
     },
     {
       "label": "onSubmit()",
@@ -15321,7 +15321,7 @@
       "source_file": "packages/storefront-webapp/src/components/common/forms/DeliveryDetailsForm.tsx",
       "source_location": "L161",
       "id": "deliverydetailsform_onsubmit",
-      "community": 473
+      "community": 475
     },
     {
       "label": "hooks.ts",
@@ -15329,7 +15329,7 @@
       "source_file": "packages/storefront-webapp/src/components/common/hooks.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_common_hooks_ts",
-      "community": 474
+      "community": 476
     },
     {
       "label": "useCountdown()",
@@ -15337,7 +15337,7 @@
       "source_file": "packages/storefront-webapp/src/components/common/hooks.ts",
       "source_location": "L3",
       "id": "hooks_usecountdown",
-      "community": 474
+      "community": 476
     },
     {
       "label": "TrustSignals.tsx",
@@ -15345,7 +15345,7 @@
       "source_file": "packages/storefront-webapp/src/components/communication/TrustSignals.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_communication_trustsignals_tsx",
-      "community": 475
+      "community": 477
     },
     {
       "label": "TrustSignals()",
@@ -15353,7 +15353,7 @@
       "source_file": "packages/storefront-webapp/src/components/communication/TrustSignals.tsx",
       "source_location": "L4",
       "id": "trustsignals_trustsignals",
-      "community": 475
+      "community": 477
     },
     {
       "label": "ProductFilter.tsx",
@@ -15361,7 +15361,7 @@
       "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_filter_productfilter_tsx",
-      "community": 476
+      "community": 478
     },
     {
       "label": "ProductFilter()",
@@ -15369,7 +15369,7 @@
       "source_file": "packages/storefront-webapp/src/components/filter/ProductFilter.tsx",
       "source_location": "L14",
       "id": "productfilter_productfilter",
-      "community": 476
+      "community": 478
     },
     {
       "label": "ProductFilterBar.tsx",
@@ -15377,7 +15377,7 @@
       "source_file": "packages/storefront-webapp/src/components/filter/ProductFilterBar.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_filter_productfilterbar_tsx",
-      "community": 1007
+      "community": 1009
     },
     {
       "label": "Filter.tsx",
@@ -15385,7 +15385,7 @@
       "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_footer_filter_tsx",
-      "community": 477
+      "community": 479
     },
     {
       "label": "handleCheckboxChange()",
@@ -15393,7 +15393,7 @@
       "source_file": "packages/storefront-webapp/src/components/footer/Filter.tsx",
       "source_location": "L27",
       "id": "filter_handlecheckboxchange",
-      "community": 477
+      "community": 479
     },
     {
       "label": "Footer.tsx",
@@ -15401,7 +15401,7 @@
       "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_footer_footer_tsx",
-      "community": 478
+      "community": 480
     },
     {
       "label": "LinkGroup()",
@@ -15409,7 +15409,7 @@
       "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
       "source_location": "L13",
       "id": "footer_linkgroup",
-      "community": 478
+      "community": 480
     },
     {
       "label": "BestSellersSection.tsx",
@@ -15417,7 +15417,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_tsx",
-      "community": 479
+      "community": 481
     },
     {
       "label": "BestSellersSection()",
@@ -15425,7 +15425,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.tsx",
       "source_location": "L17",
       "id": "bestsellerssection_bestsellerssection",
-      "community": 479
+      "community": 481
     },
     {
       "label": "FeaturedProductsSection.tsx",
@@ -15433,7 +15433,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_home_featuredproductssection_tsx",
-      "community": 240
+      "community": 242
     },
     {
       "label": "FeaturedProductsSection()",
@@ -15441,7 +15441,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
       "source_location": "L20",
       "id": "featuredproductssection_featuredproductssection",
-      "community": 240
+      "community": 242
     },
     {
       "label": "FeaturedSection()",
@@ -15449,7 +15449,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
       "source_location": "L46",
       "id": "featuredproductssection_featuredsection",
-      "community": 240
+      "community": 242
     },
     {
       "label": "HomeHero.tsx",
@@ -15457,7 +15457,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/HomeHero.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_home_homehero_tsx",
-      "community": 1008
+      "community": 1010
     },
     {
       "label": "HomeHeroSection.tsx",
@@ -15465,7 +15465,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/HomeHeroSection.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_home_homeherosection_tsx",
-      "community": 1009
+      "community": 1011
     },
     {
       "label": "PromoAlert.tsx",
@@ -15473,7 +15473,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_home_promoalert_tsx",
-      "community": 241
+      "community": 243
     },
     {
       "label": "getPromoAlertCopy()",
@@ -15481,7 +15481,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
       "source_location": "L20",
       "id": "promoalert_getpromoalertcopy",
-      "community": 241
+      "community": 243
     },
     {
       "label": "PromoAlert()",
@@ -15489,7 +15489,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
       "source_location": "L59",
       "id": "promoalert_promoalert",
-      "community": 241
+      "community": 243
     },
     {
       "label": "RewardsAlert.tsx",
@@ -15497,7 +15497,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_home_rewardsalert_tsx",
-      "community": 242
+      "community": 244
     },
     {
       "label": "onRewardsAlertClose()",
@@ -15505,7 +15505,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
       "source_location": "L20",
       "id": "rewardsalert_onrewardsalertclose",
-      "community": 242
+      "community": 244
     },
     {
       "label": "handleShopNow()",
@@ -15513,7 +15513,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
       "source_location": "L25",
       "id": "rewardsalert_handleshopnow",
-      "community": 242
+      "community": 244
     },
     {
       "label": "VideoPlayer.tsx",
@@ -15521,7 +15521,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_home_videoplayer_tsx",
-      "community": 181
+      "community": 183
     },
     {
       "label": "hooks.ts",
@@ -15529,7 +15529,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
-      "community": 151
+      "community": 152
     },
     {
       "label": "useGetStoreSubcategories()",
@@ -15537,7 +15537,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
       "source_location": "L10",
       "id": "hooks_usegetstoresubcategories",
-      "community": 151
+      "community": 152
     },
     {
       "label": "useGetStoreCategories()",
@@ -15545,7 +15545,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
       "source_location": "L21",
       "id": "hooks_usegetstorecategories",
-      "community": 151
+      "community": 152
     },
     {
       "label": "useGetShopSearchParams()",
@@ -15553,7 +15553,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation/hooks.ts",
       "source_location": "L55",
       "id": "hooks_usegetshopsearchparams",
-      "community": 151
+      "community": 152
     },
     {
       "label": "BagMenu.tsx",
@@ -15561,7 +15561,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/BagMenu.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_navigation_bar_bagmenu_tsx",
-      "community": 480
+      "community": 482
     },
     {
       "label": "handleOnLinkClick()",
@@ -15569,7 +15569,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/BagMenu.tsx",
       "source_location": "L47",
       "id": "bagmenu_handleonlinkclick",
-      "community": 480
+      "community": 482
     },
     {
       "label": "MobileBagMenu.tsx",
@@ -15577,7 +15577,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileBagMenu.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilebagmenu_tsx",
-      "community": 481
+      "community": 483
     },
     {
       "label": "MobileBagMenu()",
@@ -15585,7 +15585,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileBagMenu.tsx",
       "source_location": "L7",
       "id": "mobilebagmenu_mobilebagmenu",
-      "community": 481
+      "community": 483
     },
     {
       "label": "MobileMenu.tsx",
@@ -15593,7 +15593,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileMenu.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilemenu_tsx",
-      "community": 1010
+      "community": 1012
     },
     {
       "label": "NavigationBar.tsx",
@@ -15601,7 +15601,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/NavigationBar.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navigationbar_tsx",
-      "community": 482
+      "community": 484
     },
     {
       "label": "StoreCategoriesSubmenu()",
@@ -15609,7 +15609,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/NavigationBar.tsx",
       "source_location": "L62",
       "id": "navigationbar_storecategoriessubmenu",
-      "community": 482
+      "community": 484
     },
     {
       "label": "SiteBanner.tsx",
@@ -15617,7 +15617,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/SiteBanner.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_navigation_bar_sitebanner_tsx",
-      "community": 483
+      "community": 485
     },
     {
       "label": "SiteBanner()",
@@ -15625,7 +15625,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/SiteBanner.tsx",
       "source_location": "L17",
       "id": "sitebanner_sitebanner",
-      "community": 483
+      "community": 485
     },
     {
       "label": "constants.ts",
@@ -15633,7 +15633,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/constants.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_navigation_bar_constants_ts",
-      "community": 1011
+      "community": 1013
     },
     {
       "label": "navBarConstants.ts",
@@ -15641,7 +15641,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarConstants.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navbarconstants_ts",
-      "community": 1012
+      "community": 1014
     },
     {
       "label": "navBarStyles.ts",
@@ -15649,7 +15649,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navbarstyles_ts",
-      "community": 25
+      "community": 26
     },
     {
       "label": "getMainWrapperClass()",
@@ -15657,7 +15657,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L28",
       "id": "navbarstyles_getmainwrapperclass",
-      "community": 25
+      "community": 26
     },
     {
       "label": "getNavBGClass()",
@@ -15665,7 +15665,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L43",
       "id": "navbarstyles_getnavbgclass",
-      "community": 25
+      "community": 26
     },
     {
       "label": "getHoverClass()",
@@ -15673,7 +15673,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L76",
       "id": "navbarstyles_gethoverclass",
-      "community": 25
+      "community": 26
     },
     {
       "label": "getSubmenuBGClass()",
@@ -15681,7 +15681,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L93",
       "id": "navbarstyles_getsubmenubgclass",
-      "community": 25
+      "community": 26
     },
     {
       "label": "getBannerTextClass()",
@@ -15689,7 +15689,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L119",
       "id": "navbarstyles_getbannertextclass",
-      "community": 25
+      "community": 26
     },
     {
       "label": "getBannerBGClass()",
@@ -15697,7 +15697,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L136",
       "id": "navbarstyles_getbannerbgclass",
-      "community": 25
+      "community": 26
     },
     {
       "label": "getBannerAnimationDelay()",
@@ -15705,7 +15705,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L152",
       "id": "navbarstyles_getbanneranimationdelay",
-      "community": 25
+      "community": 26
     },
     {
       "label": "getNavBarWrapperClass()",
@@ -15713,7 +15713,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L163",
       "id": "navbarstyles_getnavbarwrapperclass",
-      "community": 25
+      "community": 26
     },
     {
       "label": "getNavBarAnimationDelay()",
@@ -15721,7 +15721,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L174",
       "id": "navbarstyles_getnavbaranimationdelay",
-      "community": 25
+      "community": 26
     },
     {
       "label": "getOverlayClass()",
@@ -15729,7 +15729,7 @@
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L184",
       "id": "navbarstyles_getoverlayclass",
-      "community": 25
+      "community": 26
     },
     {
       "label": "NotificationPill.tsx",
@@ -15737,7 +15737,7 @@
       "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_notification_notificationpill_tsx",
-      "community": 484
+      "community": 486
     },
     {
       "label": "NotificationPill()",
@@ -15745,7 +15745,7 @@
       "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
       "source_location": "L1",
       "id": "notificationpill_notificationpill",
-      "community": 484
+      "community": 486
     },
     {
       "label": "About.tsx",
@@ -15753,7 +15753,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/About.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_page_about_tsx",
-      "community": 1013
+      "community": 1015
     },
     {
       "label": "AboutProduct.tsx",
@@ -15761,7 +15761,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/AboutProduct.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_page_aboutproduct_tsx",
-      "community": 1014
+      "community": 1016
     },
     {
       "label": "DimensionBar.tsx",
@@ -15769,7 +15769,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_page_dimensionbar_tsx",
-      "community": 485
+      "community": 487
     },
     {
       "label": "mapValueToLabelIndex()",
@@ -15777,7 +15777,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
       "source_location": "L12",
       "id": "dimensionbar_mapvaluetolabelindex",
-      "community": 485
+      "community": 487
     },
     {
       "label": "DiscountBadge.tsx",
@@ -15785,7 +15785,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/DiscountBadge.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_page_discountbadge_tsx",
-      "community": 486
+      "community": 488
     },
     {
       "label": "DiscountBadge()",
@@ -15793,7 +15793,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/DiscountBadge.tsx",
       "source_location": "L7",
       "id": "discountbadge_discountbadge",
-      "community": 486
+      "community": 488
     },
     {
       "label": "GalleryViewer.tsx",
@@ -15801,7 +15801,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/GalleryViewer.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_page_galleryviewer_tsx",
-      "community": 487
+      "community": 489
     },
     {
       "label": "handleClickOnPreview()",
@@ -15809,7 +15809,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/GalleryViewer.tsx",
       "source_location": "L45",
       "id": "galleryviewer_handleclickonpreview",
-      "community": 487
+      "community": 489
     },
     {
       "label": "InventoryLevelBadge.tsx",
@@ -15817,7 +15817,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_page_inventorylevelbadge_tsx",
-      "community": 113
+      "community": 114
     },
     {
       "label": "SoldOutBadge()",
@@ -15825,7 +15825,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
       "source_location": "L3",
       "id": "inventorylevelbadge_soldoutbadge",
-      "community": 113
+      "community": 114
     },
     {
       "label": "LowStockBadge()",
@@ -15833,7 +15833,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
       "source_location": "L14",
       "id": "inventorylevelbadge_lowstockbadge",
-      "community": 113
+      "community": 114
     },
     {
       "label": "SellingFastBadge()",
@@ -15841,7 +15841,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
       "source_location": "L22",
       "id": "inventorylevelbadge_sellingfastbadge",
-      "community": 113
+      "community": 114
     },
     {
       "label": "SellingFastSignal()",
@@ -15849,7 +15849,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
       "source_location": "L30",
       "id": "inventorylevelbadge_sellingfastsignal",
-      "community": 113
+      "community": 114
     },
     {
       "label": "OnSaleProduct.tsx",
@@ -15857,7 +15857,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/OnSaleProduct.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_page_onsaleproduct_tsx",
-      "community": 488
+      "community": 490
     },
     {
       "label": "OnsaleProduct()",
@@ -15865,7 +15865,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/OnSaleProduct.tsx",
       "source_location": "L5",
       "id": "onsaleproduct_onsaleproduct",
-      "community": 488
+      "community": 490
     },
     {
       "label": "ProductActions.tsx",
@@ -15873,7 +15873,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_tsx",
-      "community": 489
+      "community": 491
     },
     {
       "label": "ProductActions()",
@@ -15881,7 +15881,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.tsx",
       "source_location": "L17",
       "id": "productactions_productactions",
-      "community": 489
+      "community": 491
     },
     {
       "label": "ProductAttribute.tsx",
@@ -15889,7 +15889,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
-      "community": 243
+      "community": 245
     },
     {
       "label": "findSize()",
@@ -15897,7 +15897,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
       "source_location": "L61",
       "id": "productattribute_findsize",
-      "community": 243
+      "community": 245
     },
     {
       "label": "handleClick()",
@@ -15905,7 +15905,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
       "source_location": "L65",
       "id": "productattribute_handleclick",
-      "community": 243
+      "community": 245
     },
     {
       "label": "ProductAttributes.tsx",
@@ -15913,7 +15913,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttributes.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_page_productattributes_tsx",
-      "community": 490
+      "community": 492
     },
     {
       "label": "ProductAttributes()",
@@ -15921,7 +15921,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttributes.tsx",
       "source_location": "L3",
       "id": "productattributes_productattributes",
-      "community": 490
+      "community": 492
     },
     {
       "label": "ProductDetails.tsx",
@@ -15929,7 +15929,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_page_productdetails_tsx",
-      "community": 152
+      "community": 153
     },
     {
       "label": "PickupDetails()",
@@ -15937,7 +15937,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
       "source_location": "L13",
       "id": "productdetails_pickupdetails",
-      "community": 152
+      "community": 153
     },
     {
       "label": "BagProduct()",
@@ -15945,7 +15945,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
       "source_location": "L43",
       "id": "productdetails_bagproduct",
-      "community": 152
+      "community": 153
     },
     {
       "label": "ShippingPolicy()",
@@ -15953,7 +15953,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
       "source_location": "L88",
       "id": "productdetails_shippingpolicy",
-      "community": 152
+      "community": 153
     },
     {
       "label": "ProductInfo.tsx",
@@ -15961,7 +15961,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductInfo.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_page_productinfo_tsx",
-      "community": 1015
+      "community": 1017
     },
     {
       "label": "ProductPage.tsx",
@@ -15969,7 +15969,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductPage.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_page_productpage_tsx",
-      "community": 491
+      "community": 493
     },
     {
       "label": "showShippingPolicy()",
@@ -15977,7 +15977,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductPage.tsx",
       "source_location": "L78",
       "id": "productpage_showshippingpolicy",
-      "community": 491
+      "community": 493
     },
     {
       "label": "ProductReview.tsx",
@@ -15985,7 +15985,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductReview.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_page_productreview_tsx",
-      "community": 492
+      "community": 494
     },
     {
       "label": "handleHelpful()",
@@ -15993,7 +15993,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductReview.tsx",
       "source_location": "L87",
       "id": "productreview_handlehelpful",
-      "community": 492
+      "community": 494
     },
     {
       "label": "ProductReviews.tsx",
@@ -16001,7 +16001,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductReviews.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_page_productreviews_tsx",
-      "community": 1016
+      "community": 1018
     },
     {
       "label": "ProductsNavigationBar.tsx",
@@ -16009,7 +16009,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductsNavigationBar.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_page_productsnavigationbar_tsx",
-      "community": 1017
+      "community": 1019
     },
     {
       "label": "ReviewSummary.tsx",
@@ -16017,7 +16017,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_page_reviewsummary_tsx",
-      "community": 493
+      "community": 495
     },
     {
       "label": "ReviewSummary()",
@@ -16025,7 +16025,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
       "source_location": "L8",
       "id": "reviewsummary_reviewsummary",
-      "community": 493
+      "community": 495
     },
     {
       "label": "ErrorMessage.tsx",
@@ -16033,7 +16033,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ErrorMessage.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_reviews_errormessage_tsx",
-      "community": 1018
+      "community": 1020
     },
     {
       "label": "ExistingReviewMessage.tsx",
@@ -16041,7 +16041,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ExistingReviewMessage.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_reviews_existingreviewmessage_tsx",
-      "community": 1019
+      "community": 1021
     },
     {
       "label": "OrderItem.tsx",
@@ -16049,7 +16049,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_tsx",
-      "community": 494
+      "community": 496
     },
     {
       "label": "OrderItem()",
@@ -16057,7 +16057,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
       "source_location": "L12",
       "id": "orderitem_orderitem",
-      "community": 494
+      "community": 496
     },
     {
       "label": "RatingSelector.tsx",
@@ -16065,7 +16065,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/RatingSelector.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_reviews_ratingselector_tsx",
-      "community": 495
+      "community": 497
     },
     {
       "label": "RatingSelector()",
@@ -16073,7 +16073,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/RatingSelector.tsx",
       "source_location": "L18",
       "id": "ratingselector_ratingselector",
-      "community": 495
+      "community": 497
     },
     {
       "label": "ReviewEditor.tsx",
@@ -16081,7 +16081,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_reviews_revieweditor_tsx",
-      "community": 244
+      "community": 246
     },
     {
       "label": "handleFormDataChange()",
@@ -16089,7 +16089,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
       "source_location": "L150",
       "id": "revieweditor_handleformdatachange",
-      "community": 244
+      "community": 246
     },
     {
       "label": "handleSubmit()",
@@ -16097,7 +16097,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
       "source_location": "L157",
       "id": "revieweditor_handlesubmit",
-      "community": 244
+      "community": 246
     },
     {
       "label": "ReviewForm.tsx",
@@ -16105,7 +16105,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewForm.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_reviews_reviewform_tsx",
-      "community": 1020
+      "community": 1022
     },
     {
       "label": "SuccessMessage.tsx",
@@ -16113,7 +16113,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/SuccessMessage.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_reviews_successmessage_tsx",
-      "community": 1021
+      "community": 1023
     },
     {
       "label": "types.ts",
@@ -16121,7 +16121,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/types.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_reviews_types_ts",
-      "community": 1022
+      "community": 1024
     },
     {
       "label": "GuestRewardsPrompt.tsx",
@@ -16129,7 +16129,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/GuestRewardsPrompt.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_rewards_guestrewardsprompt_tsx",
-      "community": 496
+      "community": 498
     },
     {
       "label": "GuestRewardsPrompt()",
@@ -16137,7 +16137,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/GuestRewardsPrompt.tsx",
       "source_location": "L10",
       "id": "guestrewardsprompt_guestrewardsprompt",
-      "community": 496
+      "community": 498
     },
     {
       "label": "OrderPointsDisplay.tsx",
@@ -16145,7 +16145,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_rewards_orderpointsdisplay_tsx",
-      "community": 497
+      "community": 499
     },
     {
       "label": "OrderPointsDisplay()",
@@ -16153,7 +16153,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/OrderPointsDisplay.tsx",
       "source_location": "L11",
       "id": "orderpointsdisplay_orderpointsdisplay",
-      "community": 497
+      "community": 499
     },
     {
       "label": "PastOrdersRewards.tsx",
@@ -16161,7 +16161,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/PastOrdersRewards.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_rewards_pastordersrewards_tsx",
-      "community": 498
+      "community": 500
     },
     {
       "label": "handleClaimPoints()",
@@ -16169,7 +16169,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/PastOrdersRewards.tsx",
       "source_location": "L59",
       "id": "pastordersrewards_handleclaimpoints",
-      "community": 498
+      "community": 500
     },
     {
       "label": "RewardsPanel.tsx",
@@ -16177,7 +16177,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/RewardsPanel.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_rewards_rewardspanel_tsx",
-      "community": 499
+      "community": 501
     },
     {
       "label": "handleRedeemReward()",
@@ -16185,7 +16185,7 @@
       "source_file": "packages/storefront-webapp/src/components/rewards/RewardsPanel.tsx",
       "source_location": "L33",
       "id": "rewardspanel_handleredeemreward",
-      "community": 499
+      "community": 501
     },
     {
       "label": "SavedBag.tsx",
@@ -16193,7 +16193,7 @@
       "source_file": "packages/storefront-webapp/src/components/saved-items/SavedBag.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_saved_items_savedbag_tsx",
-      "community": 1023
+      "community": 1025
     },
     {
       "label": "SavedIcon.tsx",
@@ -16201,7 +16201,7 @@
       "source_file": "packages/storefront-webapp/src/components/saved-items/SavedIcon.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_saved_items_savedicon_tsx",
-      "community": 1024
+      "community": 1026
     },
     {
       "label": "BagItem.tsx",
@@ -16209,7 +16209,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/BagItem.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_shopping_bag_bagitem_tsx",
-      "community": 500
+      "community": 502
     },
     {
       "label": "BagItem()",
@@ -16217,7 +16217,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/BagItem.tsx",
       "source_location": "L19",
       "id": "bagitem_bagitem",
-      "community": 500
+      "community": 502
     },
     {
       "label": "CartIcon.tsx",
@@ -16225,7 +16225,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/CartIcon.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_shopping_bag_carticon_tsx",
-      "community": 1025
+      "community": 1027
     },
     {
       "label": "ShoppingBag.tsx",
@@ -16233,7 +16233,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_tsx",
-      "community": 52
+      "community": 53
     },
     {
       "label": "PendingItem()",
@@ -16241,7 +16241,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L62",
       "id": "shoppingbag_pendingitem",
-      "community": 52
+      "community": 53
     },
     {
       "label": "handleOnCheckoutClick()",
@@ -16249,7 +16249,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L476",
       "id": "shoppingbag_handleoncheckoutclick",
-      "community": 52
+      "community": 53
     },
     {
       "label": "handleClickOnDiscountCode()",
@@ -16257,7 +16257,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L525",
       "id": "shoppingbag_handleclickondiscountcode",
-      "community": 52
+      "community": 53
     },
     {
       "label": "isSkuUnavailable()",
@@ -16265,7 +16265,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L537",
       "id": "shoppingbag_isskuunavailable",
-      "community": 52
+      "community": 53
     },
     {
       "label": "handleMoveToSaved()",
@@ -16273,7 +16273,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L552",
       "id": "shoppingbag_handlemovetosaved",
-      "community": 52
+      "community": 53
     },
     {
       "label": "handleDeleteItem()",
@@ -16281,7 +16281,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L566",
       "id": "shoppingbag_handledeleteitem",
-      "community": 52
+      "community": 53
     },
     {
       "label": "CheckoutUnavailable.tsx",
@@ -16289,7 +16289,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout unavailable/CheckoutUnavailable.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_states_checkout_unavailable_checkoutunavailable_tsx",
-      "community": 501
+      "community": 503
     },
     {
       "label": "CheckoutUnavailable()",
@@ -16297,7 +16297,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout unavailable/CheckoutUnavailable.tsx",
       "source_location": "L4",
       "id": "checkoutunavailable_checkoutunavailable",
-      "community": 501
+      "community": 503
     },
     {
       "label": "CheckoutExpired.tsx",
@@ -16305,7 +16305,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
-      "community": 77
+      "community": 79
     },
     {
       "label": "CheckoutExpired()",
@@ -16313,7 +16313,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L9",
       "id": "checkoutexpired_checkoutexpired",
-      "community": 77
+      "community": 79
     },
     {
       "label": "NoCheckoutSession()",
@@ -16321,7 +16321,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L33",
       "id": "checkoutexpired_nocheckoutsession",
-      "community": 77
+      "community": 79
     },
     {
       "label": "CheckoutSessionNotFound()",
@@ -16329,7 +16329,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L54",
       "id": "checkoutexpired_checkoutsessionnotfound",
-      "community": 77
+      "community": 79
     },
     {
       "label": "CheckoutSessionGeneric()",
@@ -16337,7 +16337,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L73",
       "id": "checkoutexpired_checkoutsessiongeneric",
-      "community": 77
+      "community": 79
     },
     {
       "label": "handleSendEmail()",
@@ -16345,7 +16345,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L98",
       "id": "checkoutexpired_handlesendemail",
-      "community": 77
+      "community": 79
     },
     {
       "label": "empty-state.tsx",
@@ -16353,7 +16353,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/empty/empty-state.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_states_empty_empty_state_tsx",
-      "community": 1026
+      "community": 1028
     },
     {
       "label": "ErrorBoundary.tsx",
@@ -16361,7 +16361,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/error/ErrorBoundary.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_states_error_errorboundary_tsx",
-      "community": 502
+      "community": 504
     },
     {
       "label": "ErrorBoundary()",
@@ -16369,7 +16369,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/error/ErrorBoundary.tsx",
       "source_location": "L22",
       "id": "errorboundary_errorboundary",
-      "community": 502
+      "community": 504
     },
     {
       "label": "SingleLineError.tsx",
@@ -16377,7 +16377,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/error/SingleLineError.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_states_error_singlelineerror_tsx",
-      "community": 193
+      "community": 195
     },
     {
       "label": "index.tsx",
@@ -16385,7 +16385,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/error/index.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_states_error_index_tsx",
-      "community": 194
+      "community": 196
     },
     {
       "label": "app-skeleton.tsx",
@@ -16393,7 +16393,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/app-skeleton.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_states_loading_app_skeleton_tsx",
-      "community": 195
+      "community": 197
     },
     {
       "label": "dashboard-skeleton.tsx",
@@ -16401,7 +16401,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/dashboard-skeleton.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_states_loading_dashboard_skeleton_tsx",
-      "community": 196
+      "community": 198
     },
     {
       "label": "table-skeleton.tsx",
@@ -16409,7 +16409,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/table-skeleton.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_states_loading_table_skeleton_tsx",
-      "community": 197
+      "community": 199
     },
     {
       "label": "transactions-skeleton.tsx",
@@ -16417,7 +16417,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/transactions-skeleton.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_states_loading_transactions_skeleton_tsx",
-      "community": 198
+      "community": 200
     },
     {
       "label": "Maintenance.tsx",
@@ -16425,7 +16425,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/maintenance/Maintenance.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_tsx",
-      "community": 1027
+      "community": 1029
     },
     {
       "label": "NotFound.tsx",
@@ -16433,7 +16433,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/not-found/NotFound.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_states_not_found_notfound_tsx",
-      "community": 199
+      "community": 201
     },
     {
       "label": "AnimatedCard.tsx",
@@ -16441,7 +16441,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/AnimatedCard.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_animatedcard_tsx",
-      "community": 1028
+      "community": 1030
     },
     {
       "label": "ScrollDownButton.tsx",
@@ -16449,7 +16449,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/ScrollDownButton.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_scrolldownbutton_tsx",
-      "community": 503
+      "community": 505
     },
     {
       "label": "ScrollDownButton()",
@@ -16457,7 +16457,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/ScrollDownButton.tsx",
       "source_location": "L11",
       "id": "scrolldownbutton_scrolldownbutton",
-      "community": 503
+      "community": 505
     },
     {
       "label": "accordion.tsx",
@@ -16465,7 +16465,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/accordion.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_accordion_tsx",
-      "community": 1029
+      "community": 1031
     },
     {
       "label": "alert.tsx",
@@ -16473,7 +16473,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/alert.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_alert_tsx",
-      "community": 1030
+      "community": 1032
     },
     {
       "label": "app-context-menu.tsx",
@@ -16481,7 +16481,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/app-context-menu.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_app_context_menu_tsx",
-      "community": 201
+      "community": 203
     },
     {
       "label": "badge.tsx",
@@ -16489,7 +16489,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/badge.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_badge_tsx",
-      "community": 202
+      "community": 204
     },
     {
       "label": "breadcrumb.tsx",
@@ -16497,7 +16497,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/breadcrumb.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_breadcrumb_tsx",
-      "community": 1031
+      "community": 1033
     },
     {
       "label": "button.tsx",
@@ -16505,7 +16505,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/button.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_button_tsx",
-      "community": 1032
+      "community": 1034
     },
     {
       "label": "card.tsx",
@@ -16513,7 +16513,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/card.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_card_tsx",
-      "community": 1033
+      "community": 1035
     },
     {
       "label": "checkbox.tsx",
@@ -16521,7 +16521,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/checkbox.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_checkbox_tsx",
-      "community": 1034
+      "community": 1036
     },
     {
       "label": "command.tsx",
@@ -16529,7 +16529,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/command.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_command_tsx",
-      "community": 1035
+      "community": 1037
     },
     {
       "label": "context-menu.tsx",
@@ -16537,7 +16537,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/context-menu.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_context_menu_tsx",
-      "community": 1036
+      "community": 1038
     },
     {
       "label": "country-select.tsx",
@@ -16545,7 +16545,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/country-select.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_country_select_tsx",
-      "community": 504
+      "community": 506
     },
     {
       "label": "CountrySelect()",
@@ -16553,7 +16553,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/country-select.tsx",
       "source_location": "L3",
       "id": "country_select_countryselect",
-      "community": 504
+      "community": 506
     },
     {
       "label": "dialog.tsx",
@@ -16561,7 +16561,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/dialog.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_dialog_tsx",
-      "community": 1037
+      "community": 1039
     },
     {
       "label": "dropdown-menu.tsx",
@@ -16569,7 +16569,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/dropdown-menu.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_dropdown_menu_tsx",
-      "community": 1038
+      "community": 1040
     },
     {
       "label": "form.tsx",
@@ -16577,7 +16577,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/form.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_form_tsx",
-      "community": 1039
+      "community": 1041
     },
     {
       "label": "ghana-region-select.tsx",
@@ -16585,7 +16585,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/ghana-region-select.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_ghana_region_select_tsx",
-      "community": 505
+      "community": 507
     },
     {
       "label": "GhanaRegionSelect()",
@@ -16593,7 +16593,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/ghana-region-select.tsx",
       "source_location": "L3",
       "id": "ghana_region_select_ghanaregionselect",
-      "community": 505
+      "community": 507
     },
     {
       "label": "ghost-button.tsx",
@@ -16601,7 +16601,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/ghost-button.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_ghost_button_tsx",
-      "community": 506
+      "community": 508
     },
     {
       "label": "GhostButton()",
@@ -16609,7 +16609,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/ghost-button.tsx",
       "source_location": "L9",
       "id": "ghost_button_ghostbutton",
-      "community": 506
+      "community": 508
     },
     {
       "label": "icons.tsx",
@@ -16617,7 +16617,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/icons.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_icons_tsx",
-      "community": 1040
+      "community": 1042
     },
     {
       "label": "image-uploader.tsx",
@@ -16625,7 +16625,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "community": 78
+      "community": 68
     },
     {
       "label": "image-with-fallback.tsx",
@@ -16633,7 +16633,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/image-with-fallback.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_image_with_fallback_tsx",
-      "community": 1041
+      "community": 1043
     },
     {
       "label": "input-otp.tsx",
@@ -16641,7 +16641,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/input-otp.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_input_otp_tsx",
-      "community": 1042
+      "community": 1044
     },
     {
       "label": "input-with-end-button.tsx",
@@ -16649,7 +16649,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/input-with-end-button.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_input_with_end_button_tsx",
-      "community": 1043
+      "community": 1045
     },
     {
       "label": "input.tsx",
@@ -16657,7 +16657,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/input.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_input_tsx",
-      "community": 1044
+      "community": 1046
     },
     {
       "label": "label.tsx",
@@ -16665,7 +16665,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/label.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_label_tsx",
-      "community": 1045
+      "community": 1047
     },
     {
       "label": "loading-button.tsx",
@@ -16673,7 +16673,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/loading-button.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_loading_button_tsx",
-      "community": 203
+      "community": 205
     },
     {
       "label": "modal.tsx",
@@ -16681,7 +16681,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modal.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modal_tsx",
-      "community": 204
+      "community": 206
     },
     {
       "label": "LeaveAReviewModal.tsx",
@@ -16689,7 +16689,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodal_tsx",
-      "community": 507
+      "community": 509
     },
     {
       "label": "handleClose()",
@@ -16697,7 +16697,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModal.tsx",
       "source_location": "L66",
       "id": "leaveareviewmodal_handleclose",
-      "community": 507
+      "community": 509
     },
     {
       "label": "LeaveAReviewModalForm.tsx",
@@ -16705,7 +16705,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModalForm.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodalform_tsx",
-      "community": 1046
+      "community": 1048
     },
     {
       "label": "UpsellModal.tsx",
@@ -16713,7 +16713,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
-      "community": 153
+      "community": 154
     },
     {
       "label": "handleScroll()",
@@ -16721,7 +16721,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
       "source_location": "L66",
       "id": "upsellmodal_handlescroll",
-      "community": 153
+      "community": 154
     },
     {
       "label": "handleClose()",
@@ -16729,7 +16729,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
       "source_location": "L111",
       "id": "upsellmodal_handleclose",
-      "community": 153
+      "community": 154
     },
     {
       "label": "handleSuccess()",
@@ -16737,7 +16737,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
       "source_location": "L127",
       "id": "upsellmodal_handlesuccess",
-      "community": 153
+      "community": 154
     },
     {
       "label": "UpsellModalForm.tsx",
@@ -16745,7 +16745,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalform_tsx",
-      "community": 245
+      "community": 247
     },
     {
       "label": "handleSubmit()",
@@ -16753,7 +16753,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
       "source_location": "L48",
       "id": "upsellmodalform_handlesubmit",
-      "community": 245
+      "community": 247
     },
     {
       "label": "handleInputChange()",
@@ -16761,7 +16761,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
       "source_location": "L63",
       "id": "upsellmodalform_handleinputchange",
-      "community": 245
+      "community": 247
     },
     {
       "label": "UpsellModalSuccess.tsx",
@@ -16769,7 +16769,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalSuccess.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalsuccess_tsx",
-      "community": 508
+      "community": 510
     },
     {
       "label": "UpsellModalSuccess()",
@@ -16777,7 +16777,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalSuccess.tsx",
       "source_location": "L19",
       "id": "upsellmodalsuccess_upsellmodalsuccess",
-      "community": 508
+      "community": 510
     },
     {
       "label": "WelcomeBackModal.tsx",
@@ -16785,7 +16785,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodal_tsx",
-      "community": 246
+      "community": 248
     },
     {
       "label": "handleClose()",
@@ -16793,7 +16793,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
       "source_location": "L63",
       "id": "welcomebackmodal_handleclose",
-      "community": 246
+      "community": 248
     },
     {
       "label": "handleSuccess()",
@@ -16801,7 +16801,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
       "source_location": "L76",
       "id": "welcomebackmodal_handlesuccess",
-      "community": 246
+      "community": 248
     },
     {
       "label": "WelcomeBackModalForm.tsx",
@@ -16809,7 +16809,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalform_tsx",
-      "community": 247
+      "community": 249
     },
     {
       "label": "handleSubmit()",
@@ -16817,7 +16817,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
       "source_location": "L36",
       "id": "welcomebackmodalform_handlesubmit",
-      "community": 247
+      "community": 249
     },
     {
       "label": "handleInputChange()",
@@ -16825,7 +16825,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
       "source_location": "L51",
       "id": "welcomebackmodalform_handleinputchange",
-      "community": 247
+      "community": 249
     },
     {
       "label": "WelcomeBackModalSuccess.tsx",
@@ -16833,7 +16833,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalSuccess.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalsuccess_tsx",
-      "community": 509
+      "community": 511
     },
     {
       "label": "WelcomeBackModalSuccess()",
@@ -16841,7 +16841,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalSuccess.tsx",
       "source_location": "L13",
       "id": "welcomebackmodalsuccess_welcomebackmodalsuccess",
-      "community": 509
+      "community": 511
     },
     {
       "label": "action-modal.tsx",
@@ -16849,7 +16849,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/action-modal.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_action_modal_tsx",
-      "community": 1047
+      "community": 1049
     },
     {
       "label": "alert-modal.tsx",
@@ -16857,7 +16857,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/alert-modal.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_alert_modal_tsx",
-      "community": 205
+      "community": 207
     },
     {
       "label": "welcomeBackModalAnimations.ts",
@@ -16865,7 +16865,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/animations/welcomeBackModalAnimations.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_animations_welcomebackmodalanimations_ts",
-      "community": 1048
+      "community": 1050
     },
     {
       "label": "leaveReviewModalConfig.tsx",
@@ -16873,7 +16873,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/config/leaveReviewModalConfig.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_leavereviewmodalconfig_tsx",
-      "community": 510
+      "community": 512
     },
     {
       "label": "getModalConfig()",
@@ -16881,7 +16881,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/config/leaveReviewModalConfig.tsx",
       "source_location": "L46",
       "id": "leavereviewmodalconfig_getmodalconfig",
-      "community": 510
+      "community": 512
     },
     {
       "label": "welcomeBackModalConfig.tsx",
@@ -16889,7 +16889,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/config/welcomeBackModalConfig.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_welcomebackmodalconfig_tsx",
-      "community": 511
+      "community": 513
     },
     {
       "label": "getModalConfig()",
@@ -16897,7 +16897,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/config/welcomeBackModalConfig.tsx",
       "source_location": "L46",
       "id": "welcomebackmodalconfig_getmodalconfig",
-      "community": 511
+      "community": 513
     },
     {
       "label": "index.ts",
@@ -16905,7 +16905,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/index.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_index_ts",
-      "community": 1049
+      "community": 1051
     },
     {
       "label": "overlay-modal.tsx",
@@ -16913,7 +16913,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/overlay-modal.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_overlay_modal_tsx",
-      "community": 206
+      "community": 208
     },
     {
       "label": "types.ts",
@@ -16921,7 +16921,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/types.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_types_ts",
-      "community": 1050
+      "community": 1052
     },
     {
       "label": "navigation-menu.tsx",
@@ -16929,7 +16929,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/navigation-menu.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_navigation_menu_tsx",
-      "community": 1051
+      "community": 1053
     },
     {
       "label": "popover.tsx",
@@ -16937,7 +16937,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/popover.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_popover_tsx",
-      "community": 1052
+      "community": 1054
     },
     {
       "label": "radio-group.tsx",
@@ -16945,7 +16945,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/radio-group.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_radio_group_tsx",
-      "community": 1053
+      "community": 1055
     },
     {
       "label": "scroll-area.tsx",
@@ -16953,7 +16953,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/scroll-area.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_scroll_area_tsx",
-      "community": 1054
+      "community": 1056
     },
     {
       "label": "select.tsx",
@@ -16961,7 +16961,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/select.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_select_tsx",
-      "community": 1055
+      "community": 1057
     },
     {
       "label": "separator.tsx",
@@ -16969,7 +16969,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/separator.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_separator_tsx",
-      "community": 1056
+      "community": 1058
     },
     {
       "label": "sheet.tsx",
@@ -16977,7 +16977,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/sheet.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_sheet_tsx",
-      "community": 1057
+      "community": 1059
     },
     {
       "label": "skeleton.tsx",
@@ -16985,7 +16985,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/skeleton.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_skeleton_tsx",
-      "community": 207
+      "community": 209
     },
     {
       "label": "sonner.tsx",
@@ -16993,7 +16993,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/sonner.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_sonner_tsx",
-      "community": 208
+      "community": 210
     },
     {
       "label": "spinner.tsx",
@@ -17001,7 +17001,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/spinner.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_spinner_tsx",
-      "community": 209
+      "community": 211
     },
     {
       "label": "table.tsx",
@@ -17009,7 +17009,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/table.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_table_tsx",
-      "community": 1058
+      "community": 1060
     },
     {
       "label": "tabs.tsx",
@@ -17017,7 +17017,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/tabs.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_tabs_tsx",
-      "community": 1059
+      "community": 1061
     },
     {
       "label": "textarea.tsx",
@@ -17025,7 +17025,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/textarea.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_textarea_tsx",
-      "community": 1060
+      "community": 1062
     },
     {
       "label": "toggle-group.tsx",
@@ -17033,7 +17033,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/toggle-group.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_toggle_group_tsx",
-      "community": 1061
+      "community": 1063
     },
     {
       "label": "toggle.tsx",
@@ -17041,7 +17041,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/toggle.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_toggle_tsx",
-      "community": 1062
+      "community": 1064
     },
     {
       "label": "tooltip.tsx",
@@ -17049,7 +17049,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/tooltip.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_tooltip_tsx",
-      "community": 1063
+      "community": 1065
     },
     {
       "label": "webp-jpg.tsx",
@@ -17057,7 +17057,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/webp-jpg.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_webp_jpg_tsx",
-      "community": 512
+      "community": 514
     },
     {
       "label": "WebpImage()",
@@ -17065,7 +17065,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/webp-jpg.tsx",
       "source_location": "L1",
       "id": "webp_jpg_webpimage",
-      "community": 512
+      "community": 514
     },
     {
       "label": "config.ts",
@@ -17073,7 +17073,7 @@
       "source_file": "packages/storefront-webapp/src/config.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_config_ts",
-      "community": 1064
+      "community": 1066
     },
     {
       "label": "FormSubmissionProvider.tsx",
@@ -17081,7 +17081,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/FormSubmissionProvider.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_contexts_formsubmissionprovider_tsx",
-      "community": 513
+      "community": 515
     },
     {
       "label": "useFormSubmission()",
@@ -17089,7 +17089,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/FormSubmissionProvider.tsx",
       "source_location": "L15",
       "id": "formsubmissionprovider_useformsubmission",
-      "community": 513
+      "community": 515
     },
     {
       "label": "NavigationBarProvider.tsx",
@@ -17097,7 +17097,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_contexts_navigationbarprovider_tsx",
-      "community": 248
+      "community": 250
     },
     {
       "label": "NavigationBarProvider()",
@@ -17105,7 +17105,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
       "source_location": "L16",
       "id": "navigationbarprovider_navigationbarprovider",
-      "community": 248
+      "community": 250
     },
     {
       "label": "useNavigationBarContext()",
@@ -17113,7 +17113,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
       "source_location": "L39",
       "id": "navigationbarprovider_usenavigationbarcontext",
-      "community": 248
+      "community": 250
     },
     {
       "label": "StoreContext.tsx",
@@ -17121,7 +17121,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
-      "community": 249
+      "community": 251
     },
     {
       "label": "StoreProvider()",
@@ -17129,7 +17129,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
       "source_location": "L25",
       "id": "storecontext_storeprovider",
-      "community": 249
+      "community": 251
     },
     {
       "label": "useStoreContext()",
@@ -17137,7 +17137,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
       "source_location": "L82",
       "id": "storecontext_usestorecontext",
-      "community": 249
+      "community": 251
     },
     {
       "label": "StorefrontObservabilityProvider.tsx",
@@ -17145,7 +17145,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_tsx",
-      "community": 250
+      "community": 252
     },
     {
       "label": "StorefrontObservabilityProvider()",
@@ -17153,7 +17153,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
       "source_location": "L20",
       "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
-      "community": 250
+      "community": 252
     },
     {
       "label": "useStorefrontObservability()",
@@ -17161,7 +17161,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
       "source_location": "L55",
       "id": "storefrontobservabilityprovider_usestorefrontobservability",
-      "community": 250
+      "community": 252
     },
     {
       "label": "use-store-modal.tsx",
@@ -17169,7 +17169,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/use-store-modal.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_use_store_modal_tsx",
-      "community": 1065
+      "community": 1067
     },
     {
       "label": "useAuth.ts",
@@ -17177,7 +17177,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useAuth.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_useauth_ts",
-      "community": 217
+      "community": 219
     },
     {
       "label": "useCheckout.ts",
@@ -17185,7 +17185,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useCheckout.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_usecheckout_ts",
-      "community": 514
+      "community": 516
     },
     {
       "label": "useCheckout()",
@@ -17193,7 +17193,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useCheckout.ts",
       "source_location": "L5",
       "id": "usecheckout_usecheckout",
-      "community": 514
+      "community": 516
     },
     {
       "label": "useDiscountCodeAlert.tsx",
@@ -17201,7 +17201,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useDiscountCodeAlert.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_usediscountcodealert_tsx",
-      "community": 515
+      "community": 517
     },
     {
       "label": "useDiscountCodeAlert()",
@@ -17209,7 +17209,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useDiscountCodeAlert.tsx",
       "source_location": "L14",
       "id": "usediscountcodealert_usediscountcodealert",
-      "community": 515
+      "community": 517
     },
     {
       "label": "useEnhancedTracking.ts",
@@ -17217,7 +17217,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useEnhancedTracking.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_useenhancedtracking_ts",
-      "community": 516
+      "community": 518
     },
     {
       "label": "useEnhancedTracking()",
@@ -17225,7 +17225,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useEnhancedTracking.ts",
       "source_location": "L29",
       "id": "useenhancedtracking_useenhancedtracking",
-      "community": 516
+      "community": 518
     },
     {
       "label": "useGetActiveCheckoutSession.tsx",
@@ -17233,7 +17233,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetActiveCheckoutSession.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_usegetactivecheckoutsession_tsx",
-      "community": 517
+      "community": 519
     },
     {
       "label": "useGetActiveCheckoutSession()",
@@ -17241,7 +17241,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetActiveCheckoutSession.tsx",
       "source_location": "L5",
       "id": "usegetactivecheckoutsession_usegetactivecheckoutsession",
-      "community": 517
+      "community": 519
     },
     {
       "label": "useGetProduct.tsx",
@@ -17249,7 +17249,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetProduct.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_usegetproduct_tsx",
-      "community": 518
+      "community": 520
     },
     {
       "label": "useGetProductQuery()",
@@ -17257,7 +17257,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetProduct.tsx",
       "source_location": "L5",
       "id": "usegetproduct_usegetproductquery",
-      "community": 518
+      "community": 520
     },
     {
       "label": "useGetProductFilters.ts",
@@ -17265,7 +17265,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetProductFilters.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_usegetproductfilters_ts",
-      "community": 519
+      "community": 521
     },
     {
       "label": "useGetProductFilters()",
@@ -17273,7 +17273,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetProductFilters.ts",
       "source_location": "L3",
       "id": "usegetproductfilters_usegetproductfilters",
-      "community": 519
+      "community": 521
     },
     {
       "label": "useGetProductReviews.ts",
@@ -17281,7 +17281,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetProductReviews.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_usegetproductreviews_ts",
-      "community": 520
+      "community": 522
     },
     {
       "label": "useGetProductReviewsQuery()",
@@ -17289,7 +17289,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetProductReviews.ts",
       "source_location": "L4",
       "id": "usegetproductreviews_usegetproductreviewsquery",
-      "community": 520
+      "community": 522
     },
     {
       "label": "useGetStore.ts",
@@ -17297,7 +17297,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetStore.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_usegetstore_ts",
-      "community": 521
+      "community": 523
     },
     {
       "label": "useGetStore()",
@@ -17305,7 +17305,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useGetStore.ts",
       "source_location": "L4",
       "id": "usegetstore_usegetstore",
-      "community": 521
+      "community": 523
     },
     {
       "label": "useInventoryStatus.ts",
@@ -17313,7 +17313,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useInventoryStatus.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_useinventorystatus_ts",
-      "community": 522
+      "community": 524
     },
     {
       "label": "useInventoryStatus()",
@@ -17321,7 +17321,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useInventoryStatus.ts",
       "source_location": "L9",
       "id": "useinventorystatus_useinventorystatus",
-      "community": 522
+      "community": 524
     },
     {
       "label": "useLeaveAReviewModal.tsx",
@@ -17329,7 +17329,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useLeaveAReviewModal.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_useleaveareviewmodal_tsx",
-      "community": 523
+      "community": 525
     },
     {
       "label": "useLeaveAReviewModal()",
@@ -17337,7 +17337,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useLeaveAReviewModal.tsx",
       "source_location": "L17",
       "id": "useleaveareviewmodal_useleaveareviewmodal",
-      "community": 523
+      "community": 525
     },
     {
       "label": "useLogout.ts",
@@ -17345,7 +17345,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useLogout.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_uselogout_ts",
-      "community": 524
+      "community": 526
     },
     {
       "label": "useLogout()",
@@ -17353,7 +17353,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useLogout.ts",
       "source_location": "L5",
       "id": "uselogout_uselogout",
-      "community": 524
+      "community": 526
     },
     {
       "label": "useModalState.tsx",
@@ -17361,7 +17361,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useModalState.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_usemodalstate_tsx",
-      "community": 525
+      "community": 527
     },
     {
       "label": "useModalState()",
@@ -17369,7 +17369,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useModalState.tsx",
       "source_location": "L15",
       "id": "usemodalstate_usemodalstate",
-      "community": 525
+      "community": 527
     },
     {
       "label": "useOrganizationModal.tsx",
@@ -17377,7 +17377,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useOrganizationModal.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_useorganizationmodal_tsx",
-      "community": 1066
+      "community": 1068
     },
     {
       "label": "useProductDiscount.ts",
@@ -17385,7 +17385,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_useproductdiscount_ts",
-      "community": 251
+      "community": 253
     },
     {
       "label": "useProductDiscounts()",
@@ -17393,7 +17393,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
       "source_location": "L25",
       "id": "useproductdiscount_useproductdiscounts",
-      "community": 251
+      "community": 253
     },
     {
       "label": "useProductDiscount()",
@@ -17401,7 +17401,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
       "source_location": "L107",
       "id": "useproductdiscount_useproductdiscount",
-      "community": 251
+      "community": 253
     },
     {
       "label": "useProductPageLogic.ts",
@@ -17409,7 +17409,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useProductPageLogic.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_useproductpagelogic_ts",
-      "community": 526
+      "community": 528
     },
     {
       "label": "useProductPageLogic()",
@@ -17417,7 +17417,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useProductPageLogic.ts",
       "source_location": "L18",
       "id": "useproductpagelogic_useproductpagelogic",
-      "community": 526
+      "community": 528
     },
     {
       "label": "useProductReminder.tsx",
@@ -17425,7 +17425,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useProductReminder.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_useproductreminder_tsx",
-      "community": 527
+      "community": 529
     },
     {
       "label": "useProductReminder()",
@@ -17433,7 +17433,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useProductReminder.tsx",
       "source_location": "L9",
       "id": "useproductreminder_useproductreminder",
-      "community": 527
+      "community": 529
     },
     {
       "label": "usePromoAlert.tsx",
@@ -17441,7 +17441,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/usePromoAlert.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_usepromoalert_tsx",
-      "community": 528
+      "community": 530
     },
     {
       "label": "usePromoAlert()",
@@ -17449,7 +17449,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/usePromoAlert.tsx",
       "source_location": "L16",
       "id": "usepromoalert_usepromoalert",
-      "community": 528
+      "community": 530
     },
     {
       "label": "useQueryEnabled.ts",
@@ -17457,7 +17457,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useQueryEnabled.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_usequeryenabled_ts",
-      "community": 529
+      "community": 531
     },
     {
       "label": "useQueryEnabled()",
@@ -17465,7 +17465,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useQueryEnabled.ts",
       "source_location": "L4",
       "id": "usequeryenabled_usequeryenabled",
-      "community": 529
+      "community": 531
     },
     {
       "label": "useRewardsAlert.tsx",
@@ -17473,7 +17473,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useRewardsAlert.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_userewardsalert_tsx",
-      "community": 530
+      "community": 532
     },
     {
       "label": "useRewardsAlert()",
@@ -17481,7 +17481,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useRewardsAlert.tsx",
       "source_location": "L11",
       "id": "userewardsalert_userewardsalert",
-      "community": 530
+      "community": 532
     },
     {
       "label": "useScrollToTop.ts",
@@ -17489,7 +17489,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useScrollToTop.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_usescrolltotop_ts",
-      "community": 531
+      "community": 533
     },
     {
       "label": "useScrollToTop()",
@@ -17497,7 +17497,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useScrollToTop.ts",
       "source_location": "L3",
       "id": "usescrolltotop_usescrolltotop",
-      "community": 531
+      "community": 533
     },
     {
       "label": "useShoppingBag.ts",
@@ -17505,7 +17505,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_useshoppingbag_ts",
-      "community": 252
+      "community": 254
     },
     {
       "label": "useShoppingBag()",
@@ -17513,7 +17513,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
       "source_location": "L52",
       "id": "useshoppingbag_useshoppingbag",
-      "community": 252
+      "community": 254
     },
     {
       "label": "isUnavailableProductList()",
@@ -17521,7 +17521,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
       "source_location": "L540",
       "id": "useshoppingbag_isunavailableproductlist",
-      "community": 252
+      "community": 254
     },
     {
       "label": "useStorefrontObservability.ts",
@@ -17529,7 +17529,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useStorefrontObservability.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_usestorefrontobservability_ts",
-      "community": 1067
+      "community": 1069
     },
     {
       "label": "useTrackAction.ts",
@@ -17537,7 +17537,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useTrackAction.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_usetrackaction_ts",
-      "community": 532
+      "community": 534
     },
     {
       "label": "useTrackAction()",
@@ -17545,7 +17545,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useTrackAction.ts",
       "source_location": "L5",
       "id": "usetrackaction_usetrackaction",
-      "community": 532
+      "community": 534
     },
     {
       "label": "useTrackEvent.ts",
@@ -17553,7 +17553,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useTrackEvent.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_usetrackevent_ts",
-      "community": 533
+      "community": 535
     },
     {
       "label": "useTrackEvent()",
@@ -17561,7 +17561,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useTrackEvent.ts",
       "source_location": "L5",
       "id": "usetrackevent_usetrackevent",
-      "community": 533
+      "community": 535
     },
     {
       "label": "useUpsellModal.tsx",
@@ -17569,7 +17569,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useUpsellModal.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_useupsellmodal_tsx",
-      "community": 534
+      "community": 536
     },
     {
       "label": "useUpsellModal()",
@@ -17577,7 +17577,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useUpsellModal.tsx",
       "source_location": "L14",
       "id": "useupsellmodal_useupsellmodal",
-      "community": 534
+      "community": 536
     },
     {
       "label": "constants.ts",
@@ -17585,7 +17585,7 @@
       "source_file": "packages/storefront-webapp/src/lib/constants.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_constants_ts",
-      "community": 1068
+      "community": 1070
     },
     {
       "label": "countries.ts",
@@ -17593,7 +17593,7 @@
       "source_file": "packages/storefront-webapp/src/lib/countries.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_countries_ts",
-      "community": 1069
+      "community": 1071
     },
     {
       "label": "currency.ts",
@@ -17601,7 +17601,7 @@
       "source_file": "packages/storefront-webapp/src/lib/currency.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_currency_ts",
-      "community": 123
+      "community": 124
     },
     {
       "label": "feeUtils.test.ts",
@@ -17609,7 +17609,7 @@
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.test.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_feeutils_test_ts",
-      "community": 1070
+      "community": 1072
     },
     {
       "label": "feeUtils.ts",
@@ -17617,7 +17617,7 @@
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_feeutils_ts",
-      "community": 79
+      "community": 80
     },
     {
       "label": "meetsThreshold()",
@@ -17625,7 +17625,7 @@
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L17",
       "id": "feeutils_meetsthreshold",
-      "community": 79
+      "community": 80
     },
     {
       "label": "isFeeWaived()",
@@ -17633,7 +17633,7 @@
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L34",
       "id": "feeutils_isfeewaived",
-      "community": 79
+      "community": 80
     },
     {
       "label": "isAnyFeeWaived()",
@@ -17641,7 +17641,7 @@
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L74",
       "id": "feeutils_isanyfeewaived",
-      "community": 79
+      "community": 80
     },
     {
       "label": "hasWaiverConfigured()",
@@ -17649,7 +17649,7 @@
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L100",
       "id": "feeutils_haswaiverconfigured",
-      "community": 79
+      "community": 80
     },
     {
       "label": "getRemainingForFreeDelivery()",
@@ -17657,7 +17657,7 @@
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L138",
       "id": "feeutils_getremainingforfreedelivery",
-      "community": 79
+      "community": 80
     },
     {
       "label": "ghana.ts",
@@ -17665,7 +17665,7 @@
       "source_file": "packages/storefront-webapp/src/lib/ghana.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_ghana_ts",
-      "community": 1071
+      "community": 1073
     },
     {
       "label": "ghanaRegions.ts",
@@ -17673,7 +17673,7 @@
       "source_file": "packages/storefront-webapp/src/lib/ghanaRegions.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_ghanaregions_ts",
-      "community": 1072
+      "community": 1074
     },
     {
       "label": "maintenanceUtils.test.ts",
@@ -17681,7 +17681,7 @@
       "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.test.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_test_ts",
-      "community": 1073
+      "community": 1075
     },
     {
       "label": "maintenanceUtils.ts",
@@ -17689,7 +17689,7 @@
       "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_ts",
-      "community": 222
+      "community": 224
     },
     {
       "label": "analytics.ts",
@@ -17697,7 +17697,7 @@
       "source_file": "packages/storefront-webapp/src/lib/mutations.ts/analytics.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_analytics_ts",
-      "community": 535
+      "community": 537
     },
     {
       "label": "usePostAnalytics()",
@@ -17705,7 +17705,7 @@
       "source_file": "packages/storefront-webapp/src/lib/mutations.ts/analytics.ts",
       "source_location": "L4",
       "id": "analytics_usepostanalytics",
-      "community": 535
+      "community": 537
     },
     {
       "label": "index.ts",
@@ -17713,7 +17713,7 @@
       "source_file": "packages/storefront-webapp/src/lib/mutations.ts/index.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_index_ts",
-      "community": 1074
+      "community": 1076
     },
     {
       "label": "productUtils.ts",
@@ -17721,7 +17721,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "community": 53
+      "community": 54
     },
     {
       "label": "isSoldOut()",
@@ -17729,7 +17729,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L45",
       "id": "productutils_issoldout",
-      "community": 53
+      "community": 54
     },
     {
       "label": "hasLowStock()",
@@ -17737,7 +17737,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L52",
       "id": "productutils_haslowstock",
-      "community": 53
+      "community": 54
     },
     {
       "label": "sortSkusByLength()",
@@ -17745,7 +17745,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L62",
       "id": "productutils_sortskusbylength",
-      "community": 53
+      "community": 54
     },
     {
       "label": "bag.ts",
@@ -17753,7 +17753,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/bag.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_queries_bag_ts",
-      "community": 536
+      "community": 538
     },
     {
       "label": "useBagQueries()",
@@ -17761,7 +17761,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/bag.ts",
       "source_location": "L7",
       "id": "bag_usebagqueries",
-      "community": 536
+      "community": 538
     },
     {
       "label": "bannerMessage.ts",
@@ -17769,7 +17769,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/bannerMessage.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_queries_bannermessage_ts",
-      "community": 537
+      "community": 539
     },
     {
       "label": "useBannerMessageQueries()",
@@ -17777,7 +17777,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/bannerMessage.ts",
       "source_location": "L6",
       "id": "bannermessage_usebannermessagequeries",
-      "community": 537
+      "community": 539
     },
     {
       "label": "checkout.ts",
@@ -17785,7 +17785,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/checkout.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_queries_checkout_ts",
-      "community": 538
+      "community": 540
     },
     {
       "label": "useCheckoutSessionQueries()",
@@ -17793,7 +17793,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/checkout.ts",
       "source_location": "L10",
       "id": "checkout_usecheckoutsessionqueries",
-      "community": 538
+      "community": 540
     },
     {
       "label": "inventory.ts",
@@ -17801,7 +17801,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/inventory.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_queries_inventory_ts",
-      "community": 539
+      "community": 541
     },
     {
       "label": "useInventoryQueries()",
@@ -17809,7 +17809,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/inventory.ts",
       "source_location": "L6",
       "id": "inventory_useinventoryqueries",
-      "community": 539
+      "community": 541
     },
     {
       "label": "onlineOrder.ts",
@@ -17817,7 +17817,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/onlineOrder.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_queries_onlineorder_ts",
-      "community": 540
+      "community": 542
     },
     {
       "label": "useOnlineOrderQueries()",
@@ -17825,7 +17825,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/onlineOrder.ts",
       "source_location": "L5",
       "id": "onlineorder_useonlineorderqueries",
-      "community": 540
+      "community": 542
     },
     {
       "label": "product.ts",
@@ -17833,7 +17833,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/product.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_queries_product_ts",
-      "community": 541
+      "community": 543
     },
     {
       "label": "useProductQueries()",
@@ -17841,7 +17841,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/product.ts",
       "source_location": "L14",
       "id": "product_useproductqueries",
-      "community": 541
+      "community": 543
     },
     {
       "label": "promoCode.ts",
@@ -17849,7 +17849,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/promoCode.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_queries_promocode_ts",
-      "community": 542
+      "community": 544
     },
     {
       "label": "usePromoCodesQueries()",
@@ -17857,7 +17857,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/promoCode.ts",
       "source_location": "L9",
       "id": "promocode_usepromocodesqueries",
-      "community": 542
+      "community": 544
     },
     {
       "label": "reviews.ts",
@@ -17865,7 +17865,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/reviews.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_queries_reviews_ts",
-      "community": 543
+      "community": 545
     },
     {
       "label": "useReviewQueries()",
@@ -17873,7 +17873,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/reviews.ts",
       "source_location": "L10",
       "id": "reviews_usereviewqueries",
-      "community": 543
+      "community": 545
     },
     {
       "label": "rewards.ts",
@@ -17881,7 +17881,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/rewards.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_queries_rewards_ts",
-      "community": 544
+      "community": 546
     },
     {
       "label": "useRewardsQueries()",
@@ -17889,7 +17889,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/rewards.ts",
       "source_location": "L11",
       "id": "rewards_userewardsqueries",
-      "community": 544
+      "community": 546
     },
     {
       "label": "store.ts",
@@ -17897,7 +17897,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/store.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_queries_store_ts",
-      "community": 1075
+      "community": 1077
     },
     {
       "label": "upsells.ts",
@@ -17905,7 +17905,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/upsells.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_queries_upsells_ts",
-      "community": 545
+      "community": 547
     },
     {
       "label": "useUpsellsQueries()",
@@ -17913,7 +17913,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/upsells.ts",
       "source_location": "L6",
       "id": "upsells_useupsellsqueries",
-      "community": 545
+      "community": 547
     },
     {
       "label": "user.ts",
@@ -17921,7 +17921,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/user.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_queries_user_ts",
-      "community": 546
+      "community": 548
     },
     {
       "label": "useUserQueries()",
@@ -17929,7 +17929,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/user.ts",
       "source_location": "L5",
       "id": "user_useuserqueries",
-      "community": 546
+      "community": 548
     },
     {
       "label": "userOffers.ts",
@@ -17937,7 +17937,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/userOffers.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_queries_useroffers_ts",
-      "community": 547
+      "community": 549
     },
     {
       "label": "useUserOffersQueries()",
@@ -17945,7 +17945,7 @@
       "source_file": "packages/storefront-webapp/src/lib/queries/userOffers.ts",
       "source_location": "L6",
       "id": "useroffers_useuseroffersqueries",
-      "community": 547
+      "community": 549
     },
     {
       "label": "bag.ts",
@@ -17953,7 +17953,7 @@
       "source_file": "packages/storefront-webapp/src/lib/schemas/bag.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_schemas_bag_ts",
-      "community": 1076
+      "community": 1078
     },
     {
       "label": "bagItem.ts",
@@ -17961,7 +17961,7 @@
       "source_file": "packages/storefront-webapp/src/lib/schemas/bagItem.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_schemas_bagitem_ts",
-      "community": 1077
+      "community": 1079
     },
     {
       "label": "category.ts",
@@ -17969,7 +17969,7 @@
       "source_file": "packages/storefront-webapp/src/lib/schemas/category.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_schemas_category_ts",
-      "community": 1078
+      "community": 1080
     },
     {
       "label": "organization.ts",
@@ -17977,7 +17977,7 @@
       "source_file": "packages/storefront-webapp/src/lib/schemas/organization.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_schemas_organization_ts",
-      "community": 1079
+      "community": 1081
     },
     {
       "label": "product.ts",
@@ -17985,7 +17985,7 @@
       "source_file": "packages/storefront-webapp/src/lib/schemas/product.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_schemas_product_ts",
-      "community": 1080
+      "community": 1082
     },
     {
       "label": "store.ts",
@@ -17993,7 +17993,7 @@
       "source_file": "packages/storefront-webapp/src/lib/schemas/store.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_schemas_store_ts",
-      "community": 1081
+      "community": 1083
     },
     {
       "label": "subcategory.ts",
@@ -18001,7 +18001,7 @@
       "source_file": "packages/storefront-webapp/src/lib/schemas/subcategory.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_schemas_subcategory_ts",
-      "community": 1082
+      "community": 1084
     },
     {
       "label": "user.ts",
@@ -18009,7 +18009,7 @@
       "source_file": "packages/storefront-webapp/src/lib/schemas/user.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_schemas_user_ts",
-      "community": 1083
+      "community": 1085
     },
     {
       "label": "states.ts",
@@ -18017,7 +18017,7 @@
       "source_file": "packages/storefront-webapp/src/lib/states.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_states_ts",
-      "community": 1084
+      "community": 1086
     },
     {
       "label": "storeConfig.test.ts",
@@ -18025,7 +18025,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.test.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_storeconfig_test_ts",
-      "community": 548
+      "community": 550
     },
     {
       "label": "buildV2Config()",
@@ -18033,7 +18033,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.test.ts",
       "source_location": "L10",
       "id": "storeconfig_test_buildv2config",
-      "community": 548
+      "community": 550
     },
     {
       "label": "storeConfig.ts",
@@ -18081,7 +18081,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.test.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_test_ts",
-      "community": 1085
+      "community": 1087
     },
     {
       "label": "storefrontFailureObservability.ts",
@@ -18089,7 +18089,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_ts",
-      "community": 114
+      "community": 115
     },
     {
       "label": "inferStorefrontJourneyFromRoute()",
@@ -18097,7 +18097,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
       "source_location": "L25",
       "id": "storefrontfailureobservability_inferstorefrontjourneyfromroute",
-      "community": 114
+      "community": 115
     },
     {
       "label": "normalizeStorefrontError()",
@@ -18105,7 +18105,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
       "source_location": "L47",
       "id": "storefrontfailureobservability_normalizestorefronterror",
-      "community": 114
+      "community": 115
     },
     {
       "label": "createStorefrontFailureEvent()",
@@ -18113,7 +18113,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
       "source_location": "L136",
       "id": "storefrontfailureobservability_createstorefrontfailureevent",
-      "community": 114
+      "community": 115
     },
     {
       "label": "emitStorefrontFailure()",
@@ -18121,7 +18121,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
       "source_location": "L154",
       "id": "storefrontfailureobservability_emitstorefrontfailure",
-      "community": 114
+      "community": 115
     },
     {
       "label": "storefrontJourneyEvents.test.ts",
@@ -18129,7 +18129,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.test.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_storefrontjourneyevents_test_ts",
-      "community": 1086
+      "community": 1088
     },
     {
       "label": "storefrontJourneyEvents.ts",
@@ -18505,7 +18505,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.test.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_storefrontobservability_test_ts",
-      "community": 549
+      "community": 551
     },
     {
       "label": "createMemoryStorage()",
@@ -18513,7 +18513,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.test.ts",
       "source_location": "L12",
       "id": "storefrontobservability_test_creatememorystorage",
-      "community": 549
+      "community": 551
     },
     {
       "label": "storefrontObservability.ts",
@@ -18521,7 +18521,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_storefrontobservability_ts",
-      "community": 115
+      "community": 116
     },
     {
       "label": "getOrCreateStorefrontObservabilitySessionId()",
@@ -18529,7 +18529,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L109",
       "id": "storefrontobservability_getorcreatestorefrontobservabilitysessionid",
-      "community": 115
+      "community": 116
     },
     {
       "label": "createStorefrontObservabilityContext()",
@@ -18537,7 +18537,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L134",
       "id": "storefrontobservability_createstorefrontobservabilitycontext",
-      "community": 115
+      "community": 116
     },
     {
       "label": "createStorefrontObservabilityPayload()",
@@ -18545,7 +18545,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L157",
       "id": "storefrontobservability_createstorefrontobservabilitypayload",
-      "community": 115
+      "community": 116
     },
     {
       "label": "trackStorefrontEvent()",
@@ -18553,7 +18553,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L193",
       "id": "storefrontobservability_trackstorefrontevent",
-      "community": 115
+      "community": 116
     },
     {
       "label": "utils.test.ts",
@@ -18561,7 +18561,7 @@
       "source_file": "packages/storefront-webapp/src/lib/utils.test.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_utils_test_ts",
-      "community": 1087
+      "community": 1089
     },
     {
       "label": "utils.ts",
@@ -18593,7 +18593,7 @@
       "source_file": "packages/storefront-webapp/src/lib/validations/email.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_validations_email_ts",
-      "community": 550
+      "community": 552
     },
     {
       "label": "validateEmail()",
@@ -18601,7 +18601,7 @@
       "source_file": "packages/storefront-webapp/src/lib/validations/email.ts",
       "source_location": "L14",
       "id": "email_validateemail",
-      "community": 550
+      "community": 552
     },
     {
       "label": "main.tsx",
@@ -18609,7 +18609,7 @@
       "source_file": "packages/storefront-webapp/src/main.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_main_tsx",
-      "community": 223
+      "community": 225
     },
     {
       "label": "routeTree.gen.ts",
@@ -18617,7 +18617,7 @@
       "source_file": "packages/storefront-webapp/src/routeTree.gen.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routetree_gen_ts",
-      "community": 1088
+      "community": 1090
     },
     {
       "label": "router.tsx",
@@ -18625,7 +18625,7 @@
       "source_file": "packages/storefront-webapp/src/router.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_router_tsx",
-      "community": 551
+      "community": 553
     },
     {
       "label": "createRouter()",
@@ -18633,7 +18633,7 @@
       "source_file": "packages/storefront-webapp/src/router.tsx",
       "source_location": "L5",
       "id": "router_createrouter",
-      "community": 551
+      "community": 553
     },
     {
       "label": "__root.tsx",
@@ -18641,7 +18641,7 @@
       "source_file": "packages/storefront-webapp/src/routes/__root.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_root_tsx",
-      "community": 1089
+      "community": 1091
     },
     {
       "label": "$orderItemId.review.tsx",
@@ -18649,7 +18649,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/$orderItemId.review.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_orderitemid_review_tsx",
-      "community": 1090
+      "community": 1092
     },
     {
       "label": "index.tsx",
@@ -18657,7 +18657,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_index_tsx",
-      "community": 253
+      "community": 255
     },
     {
       "label": "getPaymentText()",
@@ -18665,7 +18665,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
       "source_location": "L102",
       "id": "index_getpaymenttext",
-      "community": 253
+      "community": 255
     },
     {
       "label": "getOrderMessage()",
@@ -18673,7 +18673,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
       "source_location": "L429",
       "id": "index_getordermessage",
-      "community": 253
+      "community": 255
     },
     {
       "label": "review.tsx",
@@ -18681,7 +18681,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_review_tsx",
-      "community": 254
+      "community": 256
     },
     {
       "label": "OrderNavigation()",
@@ -18689,7 +18689,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
       "source_location": "L46",
       "id": "review_ordernavigation",
-      "community": 254
+      "community": 256
     },
     {
       "label": "getOrderMessage()",
@@ -18697,7 +18697,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
       "source_location": "L250",
       "id": "review_getordermessage",
-      "community": 254
+      "community": 256
     },
     {
       "label": "index.tsx",
@@ -18705,7 +18705,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/index.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_index_tsx",
-      "community": 1091
+      "community": 1093
     },
     {
       "label": "_ordersLayout.tsx",
@@ -18713,7 +18713,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_tsx",
-      "community": 552
+      "community": 554
     },
     {
       "label": "LayoutComponent()",
@@ -18721,7 +18721,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout.tsx",
       "source_location": "L8",
       "id": "orderslayout_layoutcomponent",
-      "community": 552
+      "community": 554
     },
     {
       "label": "$subcategorySlug.tsx",
@@ -18729,7 +18729,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout/shop/$categorySlug/$subcategorySlug.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_subcategoryslug_tsx",
-      "community": 1092
+      "community": 1094
     },
     {
       "label": "index.tsx",
@@ -18737,7 +18737,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout/shop/$categorySlug/index.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_index_tsx",
-      "community": 1093
+      "community": 1095
     },
     {
       "label": "_shopLayout.tsx",
@@ -18745,7 +18745,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_tsx",
-      "community": 154
+      "community": 155
     },
     {
       "label": "onClickOnMobileFilters()",
@@ -18753,7 +18753,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
       "source_location": "L105",
       "id": "shoplayout_onclickonmobilefilters",
-      "community": 154
+      "community": 155
     },
     {
       "label": "onMobileFiltersCloseClick()",
@@ -18761,7 +18761,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
       "source_location": "L110",
       "id": "shoplayout_onmobilefilterscloseclick",
-      "community": 154
+      "community": 155
     },
     {
       "label": "clearFilters()",
@@ -18769,7 +18769,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout.tsx",
       "source_location": "L115",
       "id": "shoplayout_clearfilters",
-      "community": 154
+      "community": 155
     },
     {
       "label": "account.tsx",
@@ -18777,7 +18777,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_layout_account_tsx",
-      "community": 255
+      "community": 257
     },
     {
       "label": "accountBeforeLoad()",
@@ -18785,7 +18785,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
       "source_location": "L17",
       "id": "account_accountbeforeload",
-      "community": 255
+      "community": 257
     },
     {
       "label": "handleOnSubmitForm()",
@@ -18793,7 +18793,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
       "source_location": "L63",
       "id": "account_handleonsubmitform",
-      "community": 255
+      "community": 257
     },
     {
       "label": "contact-us.tsx",
@@ -18801,7 +18801,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/contact-us.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_layout_contact_us_tsx",
-      "community": 553
+      "community": 555
     },
     {
       "label": "ContactUs()",
@@ -18809,7 +18809,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/contact-us.tsx",
       "source_location": "L14",
       "id": "contact_us_contactus",
-      "community": 553
+      "community": 555
     },
     {
       "label": "delivery-returns-exchanges.index.tsx",
@@ -18817,7 +18817,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/delivery-returns-exchanges.index.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_layout_policies_delivery_returns_exchanges_index_tsx",
-      "community": 554
+      "community": 556
     },
     {
       "label": "OnlineOrderPolicy()",
@@ -18825,7 +18825,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/delivery-returns-exchanges.index.tsx",
       "source_location": "L13",
       "id": "delivery_returns_exchanges_index_onlineorderpolicy",
-      "community": 554
+      "community": 556
     },
     {
       "label": "privacy.index.tsx",
@@ -18833,7 +18833,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/privacy.index.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_layout_policies_privacy_index_tsx",
-      "community": 555
+      "community": 557
     },
     {
       "label": "PrivacyPolicy()",
@@ -18841,7 +18841,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/privacy.index.tsx",
       "source_location": "L9",
       "id": "privacy_index_privacypolicy",
-      "community": 555
+      "community": 557
     },
     {
       "label": "tos.index.tsx",
@@ -18849,7 +18849,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_layout_policies_tos_index_tsx",
-      "community": 556
+      "community": 558
     },
     {
       "label": "TosSection()",
@@ -18857,7 +18857,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
       "source_location": "L15",
       "id": "tos_index_tossection",
-      "community": 556
+      "community": 558
     },
     {
       "label": "rewards.index.tsx",
@@ -18865,7 +18865,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/rewards.index.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_layout_rewards_index_tsx",
-      "community": 1094
+      "community": 1096
     },
     {
       "label": "shop.product.$productSlug.tsx",
@@ -18873,7 +18873,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/shop.product.$productSlug.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_layout_shop_product_productslug_tsx",
-      "community": 557
+      "community": 559
     },
     {
       "label": "Component()",
@@ -18881,7 +18881,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/shop.product.$productSlug.tsx",
       "source_location": "L16",
       "id": "shop_product_productslug_component",
-      "community": 557
+      "community": 559
     },
     {
       "label": "shop.saved.index.tsx",
@@ -18889,7 +18889,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/shop.saved.index.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_layout_shop_saved_index_tsx",
-      "community": 1095
+      "community": 1097
     },
     {
       "label": "_layout.tsx",
@@ -18897,7 +18897,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_layout_tsx",
-      "community": 558
+      "community": 560
     },
     {
       "label": "LayoutComponent()",
@@ -18905,7 +18905,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout.tsx",
       "source_location": "L6",
       "id": "layout_layoutcomponent",
-      "community": 558
+      "community": 560
     },
     {
       "label": "auth.verify.tsx",
@@ -18913,7 +18913,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_auth_verify_tsx",
-      "community": 80
+      "community": 81
     },
     {
       "label": "reportAuthFailure()",
@@ -18921,7 +18921,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L93",
       "id": "auth_verify_reportauthfailure",
-      "community": 80
+      "community": 81
     },
     {
       "label": "formatTime()",
@@ -18929,7 +18929,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L149",
       "id": "auth_verify_formattime",
-      "community": 80
+      "community": 81
     },
     {
       "label": "handleCodeChange()",
@@ -18937,7 +18937,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L156",
       "id": "auth_verify_handlecodechange",
-      "community": 80
+      "community": 81
     },
     {
       "label": "onSubmit()",
@@ -18945,7 +18945,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L201",
       "id": "auth_verify_onsubmit",
-      "community": 80
+      "community": 81
     },
     {
       "label": "resendVerificationCode()",
@@ -18953,7 +18953,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L282",
       "id": "auth_verify_resendverificationcode",
-      "community": 80
+      "community": 81
     },
     {
       "label": "index.tsx",
@@ -18961,7 +18961,7 @@
       "source_file": "packages/storefront-webapp/src/routes/index.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_index_tsx",
-      "community": 1096
+      "community": 1098
     },
     {
       "label": "login.tsx",
@@ -18969,7 +18969,7 @@
       "source_file": "packages/storefront-webapp/src/routes/login.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_login_tsx",
-      "community": 256
+      "community": 258
     },
     {
       "label": "loginBeforeLoad()",
@@ -18977,7 +18977,7 @@
       "source_file": "packages/storefront-webapp/src/routes/login.tsx",
       "source_location": "L47",
       "id": "login_loginbeforeload",
-      "community": 256
+      "community": 258
     },
     {
       "label": "onSubmit()",
@@ -18985,7 +18985,7 @@
       "source_file": "packages/storefront-webapp/src/routes/login.tsx",
       "source_location": "L141",
       "id": "login_onsubmit",
-      "community": 256
+      "community": 258
     },
     {
       "label": "bag.index.tsx",
@@ -18993,7 +18993,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/bag.index.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_shop_bag_index_tsx",
-      "community": 1097
+      "community": 1099
     },
     {
       "label": "canceled.tsx",
@@ -19001,7 +19001,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/canceled.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_canceled_tsx",
-      "community": 559
+      "community": 561
     },
     {
       "label": "CheckoutCanceledView()",
@@ -19009,7 +19009,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/canceled.tsx",
       "source_location": "L21",
       "id": "canceled_checkoutcanceledview",
-      "community": 559
+      "community": 561
     },
     {
       "label": "complete.tsx",
@@ -19017,7 +19017,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/complete.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_complete_tsx",
-      "community": 1098
+      "community": 1100
     },
     {
       "label": "incomplete.tsx",
@@ -19025,7 +19025,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/incomplete.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_incomplete_tsx",
-      "community": 1099
+      "community": 1101
     },
     {
       "label": "index.tsx",
@@ -19033,7 +19033,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_index_tsx",
-      "community": 155
+      "community": 156
     },
     {
       "label": "getErrorMessage()",
@@ -19041,7 +19041,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
       "source_location": "L26",
       "id": "index_geterrormessage",
-      "community": 155
+      "community": 156
     },
     {
       "label": "placeOrder()",
@@ -19049,7 +19049,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
       "source_location": "L71",
       "id": "index_placeorder",
-      "community": 155
+      "community": 156
     },
     {
       "label": "cancelOrder()",
@@ -19057,7 +19057,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/index.tsx",
       "source_location": "L121",
       "id": "index_cancelorder",
-      "community": 155
+      "community": 156
     },
     {
       "label": "complete.index.tsx",
@@ -19065,7 +19065,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/complete.index.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_complete_index_tsx",
-      "community": 560
+      "community": 562
     },
     {
       "label": "CheckoutComplete()",
@@ -19073,7 +19073,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/complete.index.tsx",
       "source_location": "L33",
       "id": "complete_index_checkoutcomplete",
-      "community": 560
+      "community": 562
     },
     {
       "label": "index.tsx",
@@ -19081,7 +19081,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/index.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_index_tsx",
-      "community": 1100
+      "community": 1102
     },
     {
       "label": "pending.tsx",
@@ -19089,7 +19089,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/pending.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pending_tsx",
-      "community": 1101
+      "community": 1103
     },
     {
       "label": "pod-confirmation.tsx",
@@ -19097,7 +19097,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/pod-confirmation.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pod_confirmation_tsx",
-      "community": 561
+      "community": 563
     },
     {
       "label": "completePODCheckoutSession()",
@@ -19105,7 +19105,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/pod-confirmation.tsx",
       "source_location": "L193",
       "id": "pod_confirmation_completepodcheckoutsession",
-      "community": 561
+      "community": 563
     },
     {
       "label": "verify.index.tsx",
@@ -19113,7 +19113,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_verify_index_tsx",
-      "community": 257
+      "community": 259
     },
     {
       "label": "Verify()",
@@ -19121,7 +19121,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
       "source_location": "L21",
       "id": "verify_index_verify",
-      "community": 257
+      "community": 259
     },
     {
       "label": "VerifyCheckoutSessionPayment()",
@@ -19129,7 +19129,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
       "source_location": "L107",
       "id": "verify_index_verifycheckoutsessionpayment",
-      "community": 257
+      "community": 259
     },
     {
       "label": "signup.tsx",
@@ -19137,7 +19137,7 @@
       "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_signup_tsx",
-      "community": 258
+      "community": 260
     },
     {
       "label": "signupBeforeLoad()",
@@ -19145,7 +19145,7 @@
       "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
       "source_location": "L66",
       "id": "signup_signupbeforeload",
-      "community": 258
+      "community": 260
     },
     {
       "label": "onSubmit()",
@@ -19153,7 +19153,7 @@
       "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
       "source_location": "L161",
       "id": "signup_onsubmit",
-      "community": 258
+      "community": 260
     },
     {
       "label": "ssr.tsx",
@@ -19161,7 +19161,7 @@
       "source_file": "packages/storefront-webapp/src/ssr.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_ssr_tsx",
-      "community": 1102
+      "community": 1104
     },
     {
       "label": "index.ts",
@@ -19169,7 +19169,7 @@
       "source_file": "packages/storefront-webapp/src/utils/index.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_utils_index_ts",
-      "community": 226
+      "community": 228
     },
     {
       "label": "session.ts",
@@ -19177,7 +19177,7 @@
       "source_file": "packages/storefront-webapp/src/utils/session.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_utils_session_ts",
-      "community": 227
+      "community": 229
     },
     {
       "label": "versionChecker.ts",
@@ -19185,7 +19185,7 @@
       "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
-      "community": 228
+      "community": 230
     },
     {
       "label": "tailwind.config.js",
@@ -19193,7 +19193,7 @@
       "source_file": "packages/storefront-webapp/tailwind.config.js",
       "source_location": "L1",
       "id": "packages_storefront_webapp_tailwind_config_js",
-      "community": 1103
+      "community": 1105
     },
     {
       "label": "bootstrap.ts",
@@ -19201,7 +19201,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_tests_e2e_helpers_bootstrap_ts",
-      "community": 156
+      "community": 157
     },
     {
       "label": "createMarker()",
@@ -19209,7 +19209,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
       "source_location": "L20",
       "id": "bootstrap_createmarker",
-      "community": 156
+      "community": 157
     },
     {
       "label": "createBootstrapToken()",
@@ -19217,7 +19217,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
       "source_location": "L24",
       "id": "bootstrap_createbootstraptoken",
-      "community": 156
+      "community": 157
     },
     {
       "label": "bootstrapCheckout()",
@@ -19225,7 +19225,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/bootstrap.ts",
       "source_location": "L46",
       "id": "bootstrap_bootstrapcheckout",
-      "community": 156
+      "community": 157
     },
     {
       "label": "env.ts",
@@ -19233,7 +19233,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_tests_e2e_helpers_env_ts",
-      "community": 259
+      "community": 261
     },
     {
       "label": "requireEnv()",
@@ -19241,7 +19241,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
       "source_location": "L1",
       "id": "env_requireenv",
-      "community": 259
+      "community": 261
     },
     {
       "label": "optionalNumberEnv()",
@@ -19249,7 +19249,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
       "source_location": "L11",
       "id": "env_optionalnumberenv",
-      "community": 259
+      "community": 261
     },
     {
       "label": "vite.config.ts",
@@ -19257,7 +19257,7 @@
       "source_file": "packages/storefront-webapp/vite.config.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_vite_config_ts",
-      "community": 229
+      "community": 231
     },
     {
       "label": "vitest.config.ts",
@@ -19265,7 +19265,7 @@
       "source_file": "packages/storefront-webapp/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_vitest_config_ts",
-      "community": 1104
+      "community": 1106
     },
     {
       "label": "vitest.setup.ts",
@@ -19273,7 +19273,7 @@
       "source_file": "packages/storefront-webapp/vitest.setup.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_vitest_setup_ts",
-      "community": 1105
+      "community": 1107
     },
     {
       "label": "index.js",
@@ -19281,7 +19281,7 @@
       "source_file": "packages/valkey-proxy-server/index.js",
       "source_location": "L1",
       "id": "packages_valkey_proxy_server_index_js",
-      "community": 1106
+      "community": 1108
     },
     {
       "label": "test-connection.js",
@@ -19289,7 +19289,7 @@
       "source_file": "packages/valkey-proxy-server/test-connection.js",
       "source_location": "L1",
       "id": "packages_valkey_proxy_server_test_connection_js",
-      "community": 116
+      "community": 117
     },
     {
       "label": "testConnection()",
@@ -19297,7 +19297,7 @@
       "source_file": "packages/valkey-proxy-server/test-connection.js",
       "source_location": "L40",
       "id": "test_connection_testconnection",
-      "community": 116
+      "community": 117
     },
     {
       "label": "testClusterInfo()",
@@ -19305,7 +19305,7 @@
       "source_file": "packages/valkey-proxy-server/test-connection.js",
       "source_location": "L52",
       "id": "test_connection_testclusterinfo",
-      "community": 116
+      "community": 117
     },
     {
       "label": "testBasicOperations()",
@@ -19313,7 +19313,7 @@
       "source_file": "packages/valkey-proxy-server/test-connection.js",
       "source_location": "L64",
       "id": "test_connection_testbasicoperations",
-      "community": 116
+      "community": 117
     },
     {
       "label": "runTests()",
@@ -19321,7 +19321,7 @@
       "source_file": "packages/valkey-proxy-server/test-connection.js",
       "source_location": "L89",
       "id": "test_connection_runtests",
-      "community": 116
+      "community": 117
     },
     {
       "label": "architecture-boundaries.test.ts",
@@ -19329,7 +19329,7 @@
       "source_file": "scripts/architecture-boundaries.test.ts",
       "source_location": "L1",
       "id": "scripts_architecture_boundaries_test_ts",
-      "community": 562
+      "community": 564
     },
     {
       "label": "createSnippetLinter()",
@@ -19337,7 +19337,7 @@
       "source_file": "scripts/architecture-boundaries.test.ts",
       "source_location": "L10",
       "id": "architecture_boundaries_test_createsnippetlinter",
-      "community": 562
+      "community": 564
     },
     {
       "label": "architecture-boundary-check.ts",
@@ -19345,7 +19345,7 @@
       "source_file": "scripts/architecture-boundary-check.ts",
       "source_location": "L1",
       "id": "scripts_architecture_boundary_check_ts",
-      "community": 563
+      "community": 565
     },
     {
       "label": "run()",
@@ -19353,7 +19353,7 @@
       "source_file": "scripts/architecture-boundary-check.ts",
       "source_location": "L29",
       "id": "architecture_boundary_check_run",
-      "community": 563
+      "community": 565
     },
     {
       "label": "graphify-check.test.ts",
@@ -19361,23 +19361,31 @@
       "source_file": "scripts/graphify-check.test.ts",
       "source_location": "L1",
       "id": "scripts_graphify_check_test_ts",
-      "community": 260
+      "community": 158
     },
     {
       "label": "write()",
       "file_type": "code",
       "source_file": "scripts/graphify-check.test.ts",
-      "source_location": "L10",
+      "source_location": "L11",
       "id": "graphify_check_test_write",
-      "community": 260
+      "community": 158
     },
     {
       "label": "createFixtureRoot()",
       "file_type": "code",
       "source_file": "scripts/graphify-check.test.ts",
-      "source_location": "L16",
+      "source_location": "L17",
       "id": "graphify_check_test_createfixtureroot",
-      "community": 260
+      "community": 158
+    },
+    {
+      "label": "writeGraphifyWikiArtifacts()",
+      "file_type": "code",
+      "source_file": "scripts/graphify-check.test.ts",
+      "source_location": "L24",
+      "id": "graphify_check_test_writegraphifywikiartifacts",
+      "community": 158
     },
     {
       "label": "graphify-check.ts",
@@ -19385,47 +19393,47 @@
       "source_file": "scripts/graphify-check.ts",
       "source_location": "L1",
       "id": "scripts_graphify_check_ts",
-      "community": 81
+      "community": 82
     },
     {
       "label": "fileExists()",
       "file_type": "code",
       "source_file": "scripts/graphify-check.ts",
-      "source_location": "L58",
+      "source_location": "L62",
       "id": "graphify_check_fileexists",
-      "community": 81
+      "community": 82
     },
     {
       "label": "collectRepoCodeFiles()",
       "file_type": "code",
       "source_file": "scripts/graphify-check.ts",
-      "source_location": "L67",
+      "source_location": "L71",
       "id": "graphify_check_collectrepocodefiles",
-      "community": 81
+      "community": 82
     },
     {
       "label": "copyGraphifyCheckInputs()",
       "file_type": "code",
       "source_file": "scripts/graphify-check.ts",
-      "source_location": "L101",
+      "source_location": "L105",
       "id": "graphify_check_copygraphifycheckinputs",
-      "community": 81
+      "community": 82
     },
     {
       "label": "collectStaleGraphifyArtifacts()",
       "file_type": "code",
       "source_file": "scripts/graphify-check.ts",
-      "source_location": "L119",
+      "source_location": "L123",
       "id": "graphify_check_collectstalegraphifyartifacts",
-      "community": 81
+      "community": 82
     },
     {
       "label": "runGraphifyCheck()",
       "file_type": "code",
       "source_file": "scripts/graphify-check.ts",
-      "source_location": "L146",
+      "source_location": "L150",
       "id": "graphify_check_rungraphifycheck",
-      "community": 81
+      "community": 82
     },
     {
       "label": "graphify-rebuild.test.ts",
@@ -19433,7 +19441,7 @@
       "source_file": "scripts/graphify-rebuild.test.ts",
       "source_location": "L1",
       "id": "scripts_graphify_rebuild_test_ts",
-      "community": 157
+      "community": 159
     },
     {
       "label": "write()",
@@ -19441,7 +19449,7 @@
       "source_file": "scripts/graphify-rebuild.test.ts",
       "source_location": "L10",
       "id": "graphify_rebuild_test_write",
-      "community": 157
+      "community": 159
     },
     {
       "label": "createFixtureRoot()",
@@ -19449,7 +19457,7 @@
       "source_file": "scripts/graphify-rebuild.test.ts",
       "source_location": "L16",
       "id": "graphify_rebuild_test_createfixtureroot",
-      "community": 157
+      "community": 159
     },
     {
       "label": "spawn()",
@@ -19457,7 +19465,7 @@
       "source_file": "scripts/graphify-rebuild.test.ts",
       "source_location": "L57",
       "id": "graphify_rebuild_test_spawn",
-      "community": 157
+      "community": 159
     },
     {
       "label": "graphify-rebuild.ts",
@@ -19465,31 +19473,199 @@
       "source_file": "scripts/graphify-rebuild.ts",
       "source_location": "L1",
       "id": "scripts_graphify_rebuild_ts",
-      "community": 158
+      "community": 160
     },
     {
       "label": "fileExists()",
       "file_type": "code",
       "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L78",
+      "source_location": "L81",
       "id": "graphify_rebuild_fileexists",
-      "community": 158
+      "community": 160
     },
     {
       "label": "resolveGraphifyPython()",
       "file_type": "code",
       "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L87",
+      "source_location": "L90",
       "id": "graphify_rebuild_resolvegraphifypython",
-      "community": 158
+      "community": 160
     },
     {
       "label": "runGraphifyRebuild()",
       "file_type": "code",
       "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L114",
+      "source_location": "L117",
       "id": "graphify_rebuild_rungraphifyrebuild",
-      "community": 158
+      "community": 160
+    },
+    {
+      "label": "graphify-wiki.test.ts",
+      "file_type": "code",
+      "source_file": "scripts/graphify-wiki.test.ts",
+      "source_location": "L1",
+      "id": "scripts_graphify_wiki_test_ts",
+      "community": 262
+    },
+    {
+      "label": "write()",
+      "file_type": "code",
+      "source_file": "scripts/graphify-wiki.test.ts",
+      "source_location": "L10",
+      "id": "graphify_wiki_test_write",
+      "community": 262
+    },
+    {
+      "label": "createFixtureRoot()",
+      "file_type": "code",
+      "source_file": "scripts/graphify-wiki.test.ts",
+      "source_location": "L16",
+      "id": "graphify_wiki_test_createfixtureroot",
+      "community": 262
+    },
+    {
+      "label": "graphify-wiki.ts",
+      "file_type": "code",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L1",
+      "id": "scripts_graphify_wiki_ts",
+      "community": 12
+    },
+    {
+      "label": "fileExists()",
+      "file_type": "code",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L78",
+      "id": "graphify_wiki_fileexists",
+      "community": 12
+    },
+    {
+      "label": "collectRepoCodeFiles()",
+      "file_type": "code",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L87",
+      "id": "graphify_wiki_collectrepocodefiles",
+      "community": 12
+    },
+    {
+      "label": "readDir()",
+      "file_type": "code",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L121",
+      "id": "graphify_wiki_readdir",
+      "community": 12
+    },
+    {
+      "label": "normalizeRepoPath()",
+      "file_type": "code",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L126",
+      "id": "graphify_wiki_normalizerepopath",
+      "community": 12
+    },
+    {
+      "label": "toMarkdownLink()",
+      "file_type": "code",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L130",
+      "id": "graphify_wiki_tomarkdownlink",
+      "community": 12
+    },
+    {
+      "label": "toSourceLink()",
+      "file_type": "code",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L138",
+      "id": "graphify_wiki_tosourcelink",
+      "community": 12
+    },
+    {
+      "label": "formatList()",
+      "file_type": "code",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L143",
+      "id": "graphify_wiki_formatlist",
+      "community": 12
+    },
+    {
+      "label": "countCommunities()",
+      "file_type": "code",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L147",
+      "id": "graphify_wiki_countcommunities",
+      "community": 12
+    },
+    {
+      "label": "buildDegreeIndex()",
+      "file_type": "code",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L151",
+      "id": "graphify_wiki_builddegreeindex",
+      "community": 12
+    },
+    {
+      "label": "scoreNode()",
+      "file_type": "code",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L162",
+      "id": "graphify_wiki_scorenode",
+      "community": 12
+    },
+    {
+      "label": "compareHotspots()",
+      "file_type": "code",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L169",
+      "id": "graphify_wiki_comparehotspots",
+      "community": 12
+    },
+    {
+      "label": "buildHotspotLines()",
+      "file_type": "code",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L189",
+      "id": "graphify_wiki_buildhotspotlines",
+      "community": 12
+    },
+    {
+      "label": "loadGraphifyGraph()",
+      "file_type": "code",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L212",
+      "id": "graphify_wiki_loadgraphifygraph",
+      "community": 12
+    },
+    {
+      "label": "buildRootIndexPage()",
+      "file_type": "code",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L226",
+      "id": "graphify_wiki_buildrootindexpage",
+      "community": 12
+    },
+    {
+      "label": "buildPackagePage()",
+      "file_type": "code",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L267",
+      "id": "graphify_wiki_buildpackagepage",
+      "community": 12
+    },
+    {
+      "label": "generateGraphifyWikiPages()",
+      "file_type": "code",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L333",
+      "id": "graphify_wiki_generategraphifywikipages",
+      "community": 12
+    },
+    {
+      "label": "writeGraphifyWikiPages()",
+      "file_type": "code",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L365",
+      "id": "graphify_wiki_writegraphifywikipages",
+      "community": 12
     },
     {
       "label": "harness-app-registry.ts",
@@ -19497,7 +19673,7 @@
       "source_file": "scripts/harness-app-registry.ts",
       "source_location": "L1",
       "id": "scripts_harness_app_registry_ts",
-      "community": 261
+      "community": 263
     },
     {
       "label": "buildHarnessDocPaths()",
@@ -19505,7 +19681,7 @@
       "source_file": "scripts/harness-app-registry.ts",
       "source_location": "L104",
       "id": "harness_app_registry_buildharnessdocpaths",
-      "community": 261
+      "community": 263
     },
     {
       "label": "getHarnessPackageRegistration()",
@@ -19513,7 +19689,7 @@
       "source_file": "scripts/harness-app-registry.ts",
       "source_location": "L387",
       "id": "harness_app_registry_getharnesspackageregistration",
-      "community": 261
+      "community": 263
     },
     {
       "label": "harness-audit.test.ts",
@@ -19521,7 +19697,7 @@
       "source_file": "scripts/harness-audit.test.ts",
       "source_location": "L1",
       "id": "scripts_harness_audit_test_ts",
-      "community": 262
+      "community": 264
     },
     {
       "label": "write()",
@@ -19529,7 +19705,7 @@
       "source_file": "scripts/harness-audit.test.ts",
       "source_location": "L11",
       "id": "harness_audit_test_write",
-      "community": 262
+      "community": 264
     },
     {
       "label": "createFixtureRepo()",
@@ -19537,7 +19713,7 @@
       "source_file": "scripts/harness-audit.test.ts",
       "source_location": "L17",
       "id": "harness_audit_test_createfixturerepo",
-      "community": 262
+      "community": 264
     },
     {
       "label": "harness-audit.ts",
@@ -19545,7 +19721,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L1",
       "id": "scripts_harness_audit_ts",
-      "community": 19
+      "community": 20
     },
     {
       "label": "normalizeRepoPath()",
@@ -19553,7 +19729,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L39",
       "id": "harness_audit_normalizerepopath",
-      "community": 19
+      "community": 20
     },
     {
       "label": "matchesPathPrefix()",
@@ -19561,7 +19737,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L43",
       "id": "harness_audit_matchespathprefix",
-      "community": 19
+      "community": 20
     },
     {
       "label": "fileExists()",
@@ -19569,7 +19745,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L57",
       "id": "harness_audit_fileexists",
-      "community": 19
+      "community": 20
     },
     {
       "label": "readJsonFile()",
@@ -19577,7 +19753,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L66",
       "id": "harness_audit_readjsonfile",
-      "community": 19
+      "community": 20
     },
     {
       "label": "normalizeValidationCommand()",
@@ -19585,7 +19761,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L70",
       "id": "harness_audit_normalizevalidationcommand",
-      "community": 19
+      "community": 20
     },
     {
       "label": "normalizeBehaviorScenarioName()",
@@ -19593,7 +19769,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L78",
       "id": "harness_audit_normalizebehaviorscenarioname",
-      "community": 19
+      "community": 20
     },
     {
       "label": "addGroupedError()",
@@ -19601,7 +19777,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L82",
       "id": "harness_audit_addgroupederror",
-      "community": 19
+      "community": 20
     },
     {
       "label": "inferGroupFromError()",
@@ -19609,7 +19785,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L96",
       "id": "harness_audit_infergroupfromerror",
-      "community": 19
+      "community": 20
     },
     {
       "label": "shouldSkipSurfaceEntry()",
@@ -19617,7 +19793,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L101",
       "id": "harness_audit_shouldskipsurfaceentry",
-      "community": 19
+      "community": 20
     },
     {
       "label": "collectLiveSurfaceEntries()",
@@ -19625,7 +19801,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L112",
       "id": "harness_audit_collectlivesurfaceentries",
-      "community": 19
+      "community": 20
     },
     {
       "label": "loadAuditTarget()",
@@ -19633,7 +19809,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L141",
       "id": "harness_audit_loadaudittarget",
-      "community": 19
+      "community": 20
     },
     {
       "label": "formatGroupedErrors()",
@@ -19641,7 +19817,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L319",
       "id": "harness_audit_formatgroupederrors",
-      "community": 19
+      "community": 20
     },
     {
       "label": "runHarnessAudit()",
@@ -19649,7 +19825,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L334",
       "id": "harness_audit_runharnessaudit",
-      "community": 19
+      "community": 20
     },
     {
       "label": "athena-runtime-app.ts",
@@ -19657,7 +19833,7 @@
       "source_file": "scripts/harness-behavior-fixtures/athena-runtime-app.ts",
       "source_location": "L1",
       "id": "scripts_harness_behavior_fixtures_athena_runtime_app_ts",
-      "community": 564
+      "community": 566
     },
     {
       "label": "shutdown()",
@@ -19665,7 +19841,7 @@
       "source_file": "scripts/harness-behavior-fixtures/athena-runtime-app.ts",
       "source_location": "L211",
       "id": "athena_runtime_app_shutdown",
-      "community": 564
+      "community": 566
     },
     {
       "label": "sample-app.ts",
@@ -19673,7 +19849,7 @@
       "source_file": "scripts/harness-behavior-fixtures/sample-app.ts",
       "source_location": "L1",
       "id": "scripts_harness_behavior_fixtures_sample_app_ts",
-      "community": 565
+      "community": 567
     },
     {
       "label": "shutdown()",
@@ -19681,7 +19857,7 @@
       "source_file": "scripts/harness-behavior-fixtures/sample-app.ts",
       "source_location": "L85",
       "id": "sample_app_shutdown",
-      "community": 565
+      "community": 567
     },
     {
       "label": "storefront-runtime-api.ts",
@@ -19689,7 +19865,7 @@
       "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
       "source_location": "L1",
       "id": "scripts_harness_behavior_fixtures_storefront_runtime_api_ts",
-      "community": 54
+      "community": 55
     },
     {
       "label": "withCorsHeaders()",
@@ -19697,7 +19873,7 @@
       "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
       "source_location": "L171",
       "id": "storefront_runtime_api_withcorsheaders",
-      "community": 54
+      "community": 55
     },
     {
       "label": "jsonResponse()",
@@ -19705,7 +19881,7 @@
       "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
       "source_location": "L186",
       "id": "storefront_runtime_api_jsonresponse",
-      "community": 54
+      "community": 55
     },
     {
       "label": "emitSignal()",
@@ -19713,7 +19889,7 @@
       "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
       "source_location": "L195",
       "id": "storefront_runtime_api_emitsignal",
-      "community": 54
+      "community": 55
     },
     {
       "label": "handleCheckoutSessionFetch()",
@@ -19721,7 +19897,7 @@
       "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
       "source_location": "L199",
       "id": "storefront_runtime_api_handlecheckoutsessionfetch",
-      "community": 54
+      "community": 55
     },
     {
       "label": "handleCheckoutSessionUpdate()",
@@ -19729,7 +19905,7 @@
       "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
       "source_location": "L221",
       "id": "storefront_runtime_api_handlecheckoutsessionupdate",
-      "community": 54
+      "community": 55
     },
     {
       "label": "shutdown()",
@@ -19737,7 +19913,7 @@
       "source_file": "scripts/harness-behavior-fixtures/storefront-runtime-api.ts",
       "source_location": "L394",
       "id": "storefront_runtime_api_shutdown",
-      "community": 54
+      "community": 55
     },
     {
       "label": "harness-behavior-scenarios.test.ts",
@@ -19745,7 +19921,7 @@
       "source_file": "scripts/harness-behavior-scenarios.test.ts",
       "source_location": "L1",
       "id": "scripts_harness_behavior_scenarios_test_ts",
-      "community": 1107
+      "community": 1109
     },
     {
       "label": "harness-behavior-scenarios.ts",
@@ -19753,7 +19929,7 @@
       "source_file": "scripts/harness-behavior-scenarios.ts",
       "source_location": "L1",
       "id": "scripts_harness_behavior_scenarios_ts",
-      "community": 159
+      "community": 161
     },
     {
       "label": "createAthenaRuntimeProcess()",
@@ -19761,7 +19937,7 @@
       "source_file": "scripts/harness-behavior-scenarios.ts",
       "source_location": "L105",
       "id": "harness_behavior_scenarios_createathenaruntimeprocess",
-      "community": 159
+      "community": 161
     },
     {
       "label": "buildAthenaRuntimeUrl()",
@@ -19769,7 +19945,7 @@
       "source_file": "scripts/harness-behavior-scenarios.ts",
       "source_location": "L117",
       "id": "harness_behavior_scenarios_buildathenaruntimeurl",
-      "community": 159
+      "community": 161
     },
     {
       "label": "createStorefrontRuntimeProcesses()",
@@ -19777,7 +19953,7 @@
       "source_file": "scripts/harness-behavior-scenarios.ts",
       "source_location": "L121",
       "id": "harness_behavior_scenarios_createstorefrontruntimeprocesses",
-      "community": 159
+      "community": 161
     },
     {
       "label": "harness-behavior.test.ts",
@@ -19785,7 +19961,7 @@
       "source_file": "scripts/harness-behavior.test.ts",
       "source_location": "L1",
       "id": "scripts_harness_behavior_test_ts",
-      "community": 263
+      "community": 265
     },
     {
       "label": "write()",
@@ -19793,7 +19969,7 @@
       "source_file": "scripts/harness-behavior.test.ts",
       "source_location": "L15",
       "id": "harness_behavior_test_write",
-      "community": 263
+      "community": 265
     },
     {
       "label": "createFixtureRoot()",
@@ -19801,7 +19977,7 @@
       "source_file": "scripts/harness-behavior.test.ts",
       "source_location": "L21",
       "id": "harness_behavior_test_createfixtureroot",
-      "community": 263
+      "community": 265
     },
     {
       "label": "harness-behavior.ts",
@@ -20017,7 +20193,7 @@
       "source_file": "scripts/harness-check.test.ts",
       "source_location": "L1",
       "id": "scripts_harness_check_test_ts",
-      "community": 264
+      "community": 266
     },
     {
       "label": "write()",
@@ -20025,7 +20201,7 @@
       "source_file": "scripts/harness-check.test.ts",
       "source_location": "L29",
       "id": "harness_check_test_write",
-      "community": 264
+      "community": 266
     },
     {
       "label": "createFixtureRepo()",
@@ -20033,7 +20209,7 @@
       "source_file": "scripts/harness-check.test.ts",
       "source_location": "L35",
       "id": "harness_check_test_createfixturerepo",
-      "community": 264
+      "community": 266
     },
     {
       "label": "harness-check.ts",
@@ -20233,7 +20409,7 @@
       "source_file": "scripts/harness-generate.test.ts",
       "source_location": "L1",
       "id": "scripts_harness_generate_test_ts",
-      "community": 265
+      "community": 267
     },
     {
       "label": "write()",
@@ -20241,7 +20417,7 @@
       "source_file": "scripts/harness-generate.test.ts",
       "source_location": "L10",
       "id": "harness_generate_test_write",
-      "community": 265
+      "community": 267
     },
     {
       "label": "createFixtureRepo()",
@@ -20249,7 +20425,7 @@
       "source_file": "scripts/harness-generate.test.ts",
       "source_location": "L16",
       "id": "harness_generate_test_createfixturerepo",
-      "community": 265
+      "community": 267
     },
     {
       "label": "harness-generate.ts",
@@ -20473,7 +20649,7 @@
       "source_file": "scripts/harness-inferential-review.test.ts",
       "source_location": "L1",
       "id": "scripts_harness_inferential_review_test_ts",
-      "community": 266
+      "community": 268
     },
     {
       "label": "write()",
@@ -20481,7 +20657,7 @@
       "source_file": "scripts/harness-inferential-review.test.ts",
       "source_location": "L10",
       "id": "harness_inferential_review_test_write",
-      "community": 266
+      "community": 268
     },
     {
       "label": "createFixtureRepo()",
@@ -20489,7 +20665,7 @@
       "source_file": "scripts/harness-inferential-review.test.ts",
       "source_location": "L16",
       "id": "harness_inferential_review_test_createfixturerepo",
-      "community": 266
+      "community": 268
     },
     {
       "label": "harness-inferential-review.ts",
@@ -20721,7 +20897,7 @@
       "source_file": "scripts/harness-janitor.test.ts",
       "source_location": "L1",
       "id": "scripts_harness_janitor_test_ts",
-      "community": 55
+      "community": 56
     },
     {
       "label": "write()",
@@ -20729,7 +20905,7 @@
       "source_file": "scripts/harness-janitor.test.ts",
       "source_location": "L23",
       "id": "harness_janitor_test_write",
-      "community": 55
+      "community": 56
     },
     {
       "label": "createFixtureRoot()",
@@ -20737,7 +20913,7 @@
       "source_file": "scripts/harness-janitor.test.ts",
       "source_location": "L29",
       "id": "harness_janitor_test_createfixtureroot",
-      "community": 55
+      "community": 56
     },
     {
       "label": "seedArtifacts()",
@@ -20745,7 +20921,7 @@
       "source_file": "scripts/harness-janitor.test.ts",
       "source_location": "L35",
       "id": "harness_janitor_test_seedartifacts",
-      "community": 55
+      "community": 56
     },
     {
       "label": "overwriteFreshGeneratedDocs()",
@@ -20753,7 +20929,7 @@
       "source_file": "scripts/harness-janitor.test.ts",
       "source_location": "L46",
       "id": "harness_janitor_test_overwritefreshgenerateddocs",
-      "community": 55
+      "community": 56
     },
     {
       "label": "overwriteFreshGraphifyArtifacts()",
@@ -20761,7 +20937,7 @@
       "source_file": "scripts/harness-janitor.test.ts",
       "source_location": "L54",
       "id": "harness_janitor_test_overwritefreshgraphifyartifacts",
-      "community": 55
+      "community": 56
     },
     {
       "label": "sortPaths()",
@@ -20769,7 +20945,7 @@
       "source_file": "scripts/harness-janitor.test.ts",
       "source_location": "L61",
       "id": "harness_janitor_test_sortpaths",
-      "community": 55
+      "community": 56
     },
     {
       "label": "harness-janitor.ts",
@@ -20777,7 +20953,7 @@
       "source_file": "scripts/harness-janitor.ts",
       "source_location": "L1",
       "id": "scripts_harness_janitor_ts",
-      "community": 13
+      "community": 14
     },
     {
       "label": "formatError()",
@@ -20785,7 +20961,7 @@
       "source_file": "scripts/harness-janitor.ts",
       "source_location": "L69",
       "id": "harness_janitor_formaterror",
-      "community": 13
+      "community": 14
     },
     {
       "label": "sortUniquePaths()",
@@ -20793,7 +20969,7 @@
       "source_file": "scripts/harness-janitor.ts",
       "source_location": "L73",
       "id": "harness_janitor_sortuniquepaths",
-      "community": 13
+      "community": 14
     },
     {
       "label": "fileExists()",
@@ -20801,7 +20977,7 @@
       "source_file": "scripts/harness-janitor.ts",
       "source_location": "L79",
       "id": "harness_janitor_fileexists",
-      "community": 13
+      "community": 14
     },
     {
       "label": "readUtf8OrNull()",
@@ -20809,7 +20985,7 @@
       "source_file": "scripts/harness-janitor.ts",
       "source_location": "L88",
       "id": "harness_janitor_readutf8ornull",
-      "community": 13
+      "community": 14
     },
     {
       "label": "snapshotFiles()",
@@ -20817,7 +20993,7 @@
       "source_file": "scripts/harness-janitor.ts",
       "source_location": "L96",
       "id": "harness_janitor_snapshotfiles",
-      "community": 13
+      "community": 14
     },
     {
       "label": "compareSnapshots()",
@@ -20825,7 +21001,7 @@
       "source_file": "scripts/harness-janitor.ts",
       "source_location": "L107",
       "id": "harness_janitor_comparesnapshots",
-      "community": 13
+      "community": 14
     },
     {
       "label": "formatDetailLines()",
@@ -20833,7 +21009,7 @@
       "source_file": "scripts/harness-janitor.ts",
       "source_location": "L124",
       "id": "harness_janitor_formatdetaillines",
-      "community": 13
+      "community": 14
     },
     {
       "label": "formatArtifactList()",
@@ -20841,7 +21017,7 @@
       "source_file": "scripts/harness-janitor.ts",
       "source_location": "L131",
       "id": "harness_janitor_formatartifactlist",
-      "community": 13
+      "community": 14
     },
     {
       "label": "withCapturedConsole()",
@@ -20849,7 +21025,7 @@
       "source_file": "scripts/harness-janitor.ts",
       "source_location": "L139",
       "id": "harness_janitor_withcapturedconsole",
-      "community": 13
+      "community": 14
     },
     {
       "label": "runCheckStep()",
@@ -20857,7 +21033,7 @@
       "source_file": "scripts/harness-janitor.ts",
       "source_location": "L163",
       "id": "harness_janitor_runcheckstep",
-      "community": 13
+      "community": 14
     },
     {
       "label": "runRepairStep()",
@@ -20865,7 +21041,7 @@
       "source_file": "scripts/harness-janitor.ts",
       "source_location": "L175",
       "id": "harness_janitor_runrepairstep",
-      "community": 13
+      "community": 14
     },
     {
       "label": "buildSummary()",
@@ -20873,7 +21049,7 @@
       "source_file": "scripts/harness-janitor.ts",
       "source_location": "L215",
       "id": "harness_janitor_buildsummary",
-      "community": 13
+      "community": 14
     },
     {
       "label": "hasFailures()",
@@ -20881,7 +21057,7 @@
       "source_file": "scripts/harness-janitor.ts",
       "source_location": "L242",
       "id": "harness_janitor_hasfailures",
-      "community": 13
+      "community": 14
     },
     {
       "label": "runHarnessJanitor()",
@@ -20889,7 +21065,7 @@
       "source_file": "scripts/harness-janitor.ts",
       "source_location": "L252",
       "id": "harness_janitor_runharnessjanitor",
-      "community": 13
+      "community": 14
     },
     {
       "label": "parseHarnessJanitorCliArgs()",
@@ -20897,7 +21073,7 @@
       "source_file": "scripts/harness-janitor.ts",
       "source_location": "L342",
       "id": "harness_janitor_parseharnessjanitorcliargs",
-      "community": 13
+      "community": 14
     },
     {
       "label": "formatHarnessJanitorReport()",
@@ -20905,7 +21081,7 @@
       "source_file": "scripts/harness-janitor.ts",
       "source_location": "L372",
       "id": "harness_janitor_formatharnessjanitorreport",
-      "community": 13
+      "community": 14
     },
     {
       "label": "harness-review.test.ts",
@@ -20913,7 +21089,7 @@
       "source_file": "scripts/harness-review.test.ts",
       "source_location": "L1",
       "id": "scripts_harness_review_test_ts",
-      "community": 117
+      "community": 118
     },
     {
       "label": "write()",
@@ -20921,7 +21097,7 @@
       "source_file": "scripts/harness-review.test.ts",
       "source_location": "L10",
       "id": "harness_review_test_write",
-      "community": 117
+      "community": 118
     },
     {
       "label": "createFixtureRepo()",
@@ -20929,7 +21105,7 @@
       "source_file": "scripts/harness-review.test.ts",
       "source_location": "L16",
       "id": "harness_review_test_createfixturerepo",
-      "community": 117
+      "community": 118
     },
     {
       "label": "log()",
@@ -20937,7 +21113,7 @@
       "source_file": "scripts/harness-review.test.ts",
       "source_location": "L167",
       "id": "harness_review_test_log",
-      "community": 117
+      "community": 118
     },
     {
       "label": "error()",
@@ -20945,7 +21121,7 @@
       "source_file": "scripts/harness-review.test.ts",
       "source_location": "L168",
       "id": "harness_review_test_error",
-      "community": 117
+      "community": 118
     },
     {
       "label": "harness-review.ts",
@@ -20953,7 +21129,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L1",
       "id": "scripts_harness_review_ts",
-      "community": 16
+      "community": 17
     },
     {
       "label": "normalizeRepoPath()",
@@ -20961,7 +21137,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L44",
       "id": "harness_review_normalizerepopath",
-      "community": 16
+      "community": 17
     },
     {
       "label": "matchesPathPrefix()",
@@ -20969,7 +21145,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L48",
       "id": "harness_review_matchespathprefix",
-      "community": 16
+      "community": 17
     },
     {
       "label": "normalizeValidationCommand()",
@@ -20977,7 +21153,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L62",
       "id": "harness_review_normalizevalidationcommand",
-      "community": 16
+      "community": 17
     },
     {
       "label": "normalizeBehaviorScenarioName()",
@@ -20985,7 +21161,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L70",
       "id": "harness_review_normalizebehaviorscenarioname",
-      "community": 16
+      "community": 17
     },
     {
       "label": "fileExists()",
@@ -20993,7 +21169,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L74",
       "id": "harness_review_fileexists",
-      "community": 16
+      "community": 17
     },
     {
       "label": "readJsonFile()",
@@ -21001,7 +21177,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L83",
       "id": "harness_review_readjsonfile",
-      "community": 16
+      "community": 17
     },
     {
       "label": "loadReviewTarget()",
@@ -21009,7 +21185,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L87",
       "id": "harness_review_loadreviewtarget",
-      "community": 16
+      "community": 17
     },
     {
       "label": "loadReviewTargets()",
@@ -21017,7 +21193,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L211",
       "id": "harness_review_loadreviewtargets",
-      "community": 16
+      "community": 17
     },
     {
       "label": "collectCommandsForChangedFiles()",
@@ -21025,7 +21201,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L227",
       "id": "harness_review_collectcommandsforchangedfiles",
-      "community": 16
+      "community": 17
     },
     {
       "label": "getChangedFilesFromGit()",
@@ -21033,7 +21209,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L312",
       "id": "harness_review_getchangedfilesfromgit",
-      "community": 16
+      "community": 17
     },
     {
       "label": "runPackageScript()",
@@ -21041,7 +21217,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L350",
       "id": "harness_review_runpackagescript",
-      "community": 16
+      "community": 17
     },
     {
       "label": "runRawCommand()",
@@ -21049,7 +21225,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L364",
       "id": "harness_review_runrawcommand",
-      "community": 16
+      "community": 17
     },
     {
       "label": "runHarnessBehaviorScenario()",
@@ -21057,7 +21233,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L377",
       "id": "harness_review_runharnessbehaviorscenario",
-      "community": 16
+      "community": 17
     },
     {
       "label": "runHarnessReview()",
@@ -21065,7 +21241,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L391",
       "id": "harness_review_runharnessreview",
-      "community": 16
+      "community": 17
     },
     {
       "label": "harness-runtime-trends.test.ts",
@@ -21073,7 +21249,7 @@
       "source_file": "scripts/harness-runtime-trends.test.ts",
       "source_location": "L1",
       "id": "scripts_harness_runtime_trends_test_ts",
-      "community": 566
+      "community": 568
     },
     {
       "label": "buildReportLine()",
@@ -21081,7 +21257,7 @@
       "source_file": "scripts/harness-runtime-trends.test.ts",
       "source_location": "L5",
       "id": "harness_runtime_trends_test_buildreportline",
-      "community": 566
+      "community": 568
     },
     {
       "label": "harness-runtime-trends.ts",
@@ -21089,7 +21265,7 @@
       "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L1",
       "id": "scripts_harness_runtime_trends_ts",
-      "community": 17
+      "community": 18
     },
     {
       "label": "splitInputLines()",
@@ -21097,7 +21273,7 @@
       "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L109",
       "id": "harness_runtime_trends_splitinputlines",
-      "community": 17
+      "community": 18
     },
     {
       "label": "sortUnique()",
@@ -21105,7 +21281,7 @@
       "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L115",
       "id": "harness_runtime_trends_sortunique",
-      "community": 17
+      "community": 18
     },
     {
       "label": "isHarnessBehaviorScenarioReport()",
@@ -21113,7 +21289,7 @@
       "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L121",
       "id": "harness_runtime_trends_isharnessbehaviorscenarioreport",
-      "community": 17
+      "community": 18
     },
     {
       "label": "parseHarnessBehaviorReportLines()",
@@ -21121,7 +21297,7 @@
       "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L139",
       "id": "harness_runtime_trends_parseharnessbehaviorreportlines",
-      "community": 17
+      "community": 18
     },
     {
       "label": "percentile()",
@@ -21129,7 +21305,7 @@
       "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L181",
       "id": "harness_runtime_trends_percentile",
-      "community": 17
+      "community": 18
     },
     {
       "label": "buildNumericTrendStats()",
@@ -21137,7 +21313,7 @@
       "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L192",
       "id": "harness_runtime_trends_buildnumerictrendstats",
-      "community": 17
+      "community": 18
     },
     {
       "label": "sortCountEntries()",
@@ -21145,7 +21321,7 @@
       "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L217",
       "id": "harness_runtime_trends_sortcountentries",
-      "community": 17
+      "community": 18
     },
     {
       "label": "formatPercent()",
@@ -21153,7 +21329,7 @@
       "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L223",
       "id": "harness_runtime_trends_formatpercent",
-      "community": 17
+      "community": 18
     },
     {
       "label": "formatMs()",
@@ -21161,7 +21337,7 @@
       "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L227",
       "id": "harness_runtime_trends_formatms",
-      "community": 17
+      "community": 18
     },
     {
       "label": "buildScenarioTrend()",
@@ -21169,7 +21345,7 @@
       "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L231",
       "id": "harness_runtime_trends_buildscenariotrend",
-      "community": 17
+      "community": 18
     },
     {
       "label": "buildRegressionWarnings()",
@@ -21177,7 +21353,7 @@
       "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L327",
       "id": "harness_runtime_trends_buildregressionwarnings",
-      "community": 17
+      "community": 18
     },
     {
       "label": "buildRuntimeTrendOutput()",
@@ -21185,7 +21361,7 @@
       "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L399",
       "id": "harness_runtime_trends_buildruntimetrendoutput",
-      "community": 17
+      "community": 18
     },
     {
       "label": "collectHarnessRuntimeTrends()",
@@ -21193,7 +21369,7 @@
       "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L463",
       "id": "harness_runtime_trends_collectharnessruntimetrends",
-      "community": 17
+      "community": 18
     },
     {
       "label": "runHarnessRuntimeTrends()",
@@ -21201,7 +21377,7 @@
       "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L471",
       "id": "harness_runtime_trends_runharnessruntimetrends",
-      "community": 17
+      "community": 18
     },
     {
       "label": "harness-scorecard.test.ts",
@@ -21209,7 +21385,7 @@
       "source_file": "scripts/harness-scorecard.test.ts",
       "source_location": "L1",
       "id": "scripts_harness_scorecard_test_ts",
-      "community": 267
+      "community": 269
     },
     {
       "label": "write()",
@@ -21217,7 +21393,7 @@
       "source_file": "scripts/harness-scorecard.test.ts",
       "source_location": "L11",
       "id": "harness_scorecard_test_write",
-      "community": 267
+      "community": 269
     },
     {
       "label": "createFixtureRepo()",
@@ -21225,7 +21401,7 @@
       "source_file": "scripts/harness-scorecard.test.ts",
       "source_location": "L17",
       "id": "harness_scorecard_test_createfixturerepo",
-      "community": 267
+      "community": 269
     },
     {
       "label": "harness-scorecard.ts",
@@ -21385,7 +21561,7 @@
       "source_file": "scripts/harness-self-review.test.ts",
       "source_location": "L1",
       "id": "scripts_harness_self_review_test_ts",
-      "community": 268
+      "community": 270
     },
     {
       "label": "write()",
@@ -21393,7 +21569,7 @@
       "source_file": "scripts/harness-self-review.test.ts",
       "source_location": "L10",
       "id": "harness_self_review_test_write",
-      "community": 268
+      "community": 270
     },
     {
       "label": "createFixtureRepo()",
@@ -21401,7 +21577,7 @@
       "source_file": "scripts/harness-self-review.test.ts",
       "source_location": "L16",
       "id": "harness_self_review_test_createfixturerepo",
-      "community": 268
+      "community": 270
     },
     {
       "label": "harness-self-review.ts",
@@ -21609,7 +21785,7 @@
       "source_file": "scripts/harness-test.test.ts",
       "source_location": "L1",
       "id": "scripts_harness_test_test_ts",
-      "community": 269
+      "community": 271
     },
     {
       "label": "write()",
@@ -21617,7 +21793,7 @@
       "source_file": "scripts/harness-test.test.ts",
       "source_location": "L14",
       "id": "harness_test_test_write",
-      "community": 269
+      "community": 271
     },
     {
       "label": "createFixtureRoot()",
@@ -21625,7 +21801,7 @@
       "source_file": "scripts/harness-test.test.ts",
       "source_location": "L20",
       "id": "harness_test_test_createfixtureroot",
-      "community": 269
+      "community": 271
     },
     {
       "label": "harness-test.ts",
@@ -21633,7 +21809,7 @@
       "source_file": "scripts/harness-test.ts",
       "source_location": "L1",
       "id": "scripts_harness_test_ts",
-      "community": 160
+      "community": 162
     },
     {
       "label": "collectHarnessTestTargets()",
@@ -21641,7 +21817,7 @@
       "source_file": "scripts/harness-test.ts",
       "source_location": "L26",
       "id": "harness_test_collectharnesstesttargets",
-      "community": 160
+      "community": 162
     },
     {
       "label": "runHarnessTest()",
@@ -21649,7 +21825,7 @@
       "source_file": "scripts/harness-test.ts",
       "source_location": "L36",
       "id": "harness_test_runharnesstest",
-      "community": 160
+      "community": 162
     },
     {
       "label": "parseHarnessTestCliArgs()",
@@ -21657,7 +21833,7 @@
       "source_file": "scripts/harness-test.ts",
       "source_location": "L72",
       "id": "harness_test_parseharnesstestcliargs",
-      "community": 160
+      "community": 162
     },
     {
       "label": "pre-push-review.test.ts",
@@ -21665,7 +21841,7 @@
       "source_file": "scripts/pre-push-review.test.ts",
       "source_location": "L1",
       "id": "scripts_pre_push_review_test_ts",
-      "community": 161
+      "community": 163
     },
     {
       "label": "log()",
@@ -21673,7 +21849,7 @@
       "source_file": "scripts/pre-push-review.test.ts",
       "source_location": "L84",
       "id": "pre_push_review_test_log",
-      "community": 161
+      "community": 163
     },
     {
       "label": "warn()",
@@ -21681,7 +21857,7 @@
       "source_file": "scripts/pre-push-review.test.ts",
       "source_location": "L85",
       "id": "pre_push_review_test_warn",
-      "community": 161
+      "community": 163
     },
     {
       "label": "error()",
@@ -21689,7 +21865,7 @@
       "source_file": "scripts/pre-push-review.test.ts",
       "source_location": "L86",
       "id": "pre_push_review_test_error",
-      "community": 161
+      "community": 163
     },
     {
       "label": "pre-push-review.ts",
@@ -21697,7 +21873,7 @@
       "source_file": "scripts/pre-push-review.ts",
       "source_location": "L1",
       "id": "scripts_pre_push_review_ts",
-      "community": 118
+      "community": 119
     },
     {
       "label": "getChangedFilesVsOriginMain()",
@@ -21705,7 +21881,7 @@
       "source_file": "scripts/pre-push-review.ts",
       "source_location": "L25",
       "id": "pre_push_review_getchangedfilesvsoriginmain",
-      "community": 118
+      "community": 119
     },
     {
       "label": "runArchitectureCheck()",
@@ -21713,7 +21889,7 @@
       "source_file": "scripts/pre-push-review.ts",
       "source_location": "L66",
       "id": "pre_push_review_runarchitecturecheck",
-      "community": 118
+      "community": 119
     },
     {
       "label": "runHarnessSelfReview()",
@@ -21721,7 +21897,7 @@
       "source_file": "scripts/pre-push-review.ts",
       "source_location": "L78",
       "id": "pre_push_review_runharnessselfreview",
-      "community": 118
+      "community": 119
     },
     {
       "label": "runPrePushReview()",
@@ -21729,7 +21905,7 @@
       "source_file": "scripts/pre-push-review.ts",
       "source_location": "L93",
       "id": "pre_push_review_runprepushreview",
-      "community": 118
+      "community": 119
     }
   ],
   "links": [
@@ -42185,7 +42361,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/graphify-check.test.ts",
-      "source_location": "L10",
+      "source_location": "L11",
       "weight": 1.0,
       "_src": "scripts_graphify_check_test_ts",
       "_tgt": "graphify_check_test_write",
@@ -42197,7 +42373,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/graphify-check.test.ts",
-      "source_location": "L16",
+      "source_location": "L17",
       "weight": 1.0,
       "_src": "scripts_graphify_check_test_ts",
       "_tgt": "graphify_check_test_createfixtureroot",
@@ -42206,10 +42382,22 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-check.test.ts",
+      "source_location": "L24",
+      "weight": 1.0,
+      "_src": "scripts_graphify_check_test_ts",
+      "_tgt": "graphify_check_test_writegraphifywikiartifacts",
+      "source": "scripts_graphify_check_test_ts",
+      "target": "graphify_check_test_writegraphifywikiartifacts",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/graphify-check.test.ts",
-      "source_location": "L19",
+      "source_location": "L20",
       "weight": 1.0,
       "_src": "graphify_check_test_createfixtureroot",
       "_tgt": "graphify_check_test_write",
@@ -42218,10 +42406,22 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-check.test.ts",
+      "source_location": "L26",
+      "weight": 1.0,
+      "_src": "graphify_check_test_writegraphifywikiartifacts",
+      "_tgt": "graphify_check_test_write",
+      "source": "graphify_check_test_write",
+      "target": "graphify_check_test_writegraphifywikiartifacts",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/graphify-check.ts",
-      "source_location": "L58",
+      "source_location": "L62",
       "weight": 1.0,
       "_src": "scripts_graphify_check_ts",
       "_tgt": "graphify_check_fileexists",
@@ -42233,7 +42433,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/graphify-check.ts",
-      "source_location": "L67",
+      "source_location": "L71",
       "weight": 1.0,
       "_src": "scripts_graphify_check_ts",
       "_tgt": "graphify_check_collectrepocodefiles",
@@ -42245,7 +42445,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/graphify-check.ts",
-      "source_location": "L101",
+      "source_location": "L105",
       "weight": 1.0,
       "_src": "scripts_graphify_check_ts",
       "_tgt": "graphify_check_copygraphifycheckinputs",
@@ -42257,7 +42457,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/graphify-check.ts",
-      "source_location": "L119",
+      "source_location": "L123",
       "weight": 1.0,
       "_src": "scripts_graphify_check_ts",
       "_tgt": "graphify_check_collectstalegraphifyartifacts",
@@ -42269,7 +42469,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/graphify-check.ts",
-      "source_location": "L146",
+      "source_location": "L150",
       "weight": 1.0,
       "_src": "scripts_graphify_check_ts",
       "_tgt": "graphify_check_rungraphifycheck",
@@ -42281,7 +42481,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/graphify-check.ts",
-      "source_location": "L114",
+      "source_location": "L118",
       "weight": 1.0,
       "_src": "graphify_check_copygraphifycheckinputs",
       "_tgt": "graphify_check_fileexists",
@@ -42293,7 +42493,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/graphify-check.ts",
-      "source_location": "L125",
+      "source_location": "L129",
       "weight": 1.0,
       "_src": "graphify_check_collectstalegraphifyartifacts",
       "_tgt": "graphify_check_fileexists",
@@ -42305,7 +42505,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/graphify-check.ts",
-      "source_location": "L102",
+      "source_location": "L106",
       "weight": 1.0,
       "_src": "graphify_check_copygraphifycheckinputs",
       "_tgt": "graphify_check_collectrepocodefiles",
@@ -42317,7 +42517,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/graphify-check.ts",
-      "source_location": "L154",
+      "source_location": "L158",
       "weight": 1.0,
       "_src": "graphify_check_rungraphifycheck",
       "_tgt": "graphify_check_copygraphifycheckinputs",
@@ -42329,7 +42529,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/graphify-check.ts",
-      "source_location": "L156",
+      "source_location": "L160",
       "weight": 1.0,
       "_src": "graphify_check_rungraphifycheck",
       "_tgt": "graphify_check_collectstalegraphifyartifacts",
@@ -42365,7 +42565,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/graphify-rebuild.test.ts",
-      "source_location": "L113",
+      "source_location": "L135",
       "weight": 1.0,
       "_src": "scripts_graphify_rebuild_test_ts",
       "_tgt": "graphify_rebuild_test_spawn",
@@ -42377,7 +42577,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L78",
+      "source_location": "L81",
       "weight": 1.0,
       "_src": "scripts_graphify_rebuild_ts",
       "_tgt": "graphify_rebuild_fileexists",
@@ -42389,7 +42589,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L87",
+      "source_location": "L90",
       "weight": 1.0,
       "_src": "scripts_graphify_rebuild_ts",
       "_tgt": "graphify_rebuild_resolvegraphifypython",
@@ -42401,7 +42601,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L114",
+      "source_location": "L117",
       "weight": 1.0,
       "_src": "scripts_graphify_rebuild_ts",
       "_tgt": "graphify_rebuild_rungraphifyrebuild",
@@ -42413,7 +42613,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L89",
+      "source_location": "L92",
       "weight": 1.0,
       "_src": "graphify_rebuild_resolvegraphifypython",
       "_tgt": "graphify_rebuild_fileexists",
@@ -42425,12 +42625,444 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L118",
+      "source_location": "L121",
       "weight": 1.0,
       "_src": "graphify_rebuild_rungraphifyrebuild",
       "_tgt": "graphify_rebuild_resolvegraphifypython",
       "source": "graphify_rebuild_resolvegraphifypython",
       "target": "graphify_rebuild_rungraphifyrebuild",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-wiki.test.ts",
+      "source_location": "L10",
+      "weight": 1.0,
+      "_src": "scripts_graphify_wiki_test_ts",
+      "_tgt": "graphify_wiki_test_write",
+      "source": "scripts_graphify_wiki_test_ts",
+      "target": "graphify_wiki_test_write",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-wiki.test.ts",
+      "source_location": "L16",
+      "weight": 1.0,
+      "_src": "scripts_graphify_wiki_test_ts",
+      "_tgt": "graphify_wiki_test_createfixtureroot",
+      "source": "scripts_graphify_wiki_test_ts",
+      "target": "graphify_wiki_test_createfixtureroot",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L78",
+      "weight": 1.0,
+      "_src": "scripts_graphify_wiki_ts",
+      "_tgt": "graphify_wiki_fileexists",
+      "source": "scripts_graphify_wiki_ts",
+      "target": "graphify_wiki_fileexists",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L87",
+      "weight": 1.0,
+      "_src": "scripts_graphify_wiki_ts",
+      "_tgt": "graphify_wiki_collectrepocodefiles",
+      "source": "scripts_graphify_wiki_ts",
+      "target": "graphify_wiki_collectrepocodefiles",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L121",
+      "weight": 1.0,
+      "_src": "scripts_graphify_wiki_ts",
+      "_tgt": "graphify_wiki_readdir",
+      "source": "scripts_graphify_wiki_ts",
+      "target": "graphify_wiki_readdir",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L126",
+      "weight": 1.0,
+      "_src": "scripts_graphify_wiki_ts",
+      "_tgt": "graphify_wiki_normalizerepopath",
+      "source": "scripts_graphify_wiki_ts",
+      "target": "graphify_wiki_normalizerepopath",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L130",
+      "weight": 1.0,
+      "_src": "scripts_graphify_wiki_ts",
+      "_tgt": "graphify_wiki_tomarkdownlink",
+      "source": "scripts_graphify_wiki_ts",
+      "target": "graphify_wiki_tomarkdownlink",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L138",
+      "weight": 1.0,
+      "_src": "scripts_graphify_wiki_ts",
+      "_tgt": "graphify_wiki_tosourcelink",
+      "source": "scripts_graphify_wiki_ts",
+      "target": "graphify_wiki_tosourcelink",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L143",
+      "weight": 1.0,
+      "_src": "scripts_graphify_wiki_ts",
+      "_tgt": "graphify_wiki_formatlist",
+      "source": "scripts_graphify_wiki_ts",
+      "target": "graphify_wiki_formatlist",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L147",
+      "weight": 1.0,
+      "_src": "scripts_graphify_wiki_ts",
+      "_tgt": "graphify_wiki_countcommunities",
+      "source": "scripts_graphify_wiki_ts",
+      "target": "graphify_wiki_countcommunities",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L151",
+      "weight": 1.0,
+      "_src": "scripts_graphify_wiki_ts",
+      "_tgt": "graphify_wiki_builddegreeindex",
+      "source": "scripts_graphify_wiki_ts",
+      "target": "graphify_wiki_builddegreeindex",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L162",
+      "weight": 1.0,
+      "_src": "scripts_graphify_wiki_ts",
+      "_tgt": "graphify_wiki_scorenode",
+      "source": "scripts_graphify_wiki_ts",
+      "target": "graphify_wiki_scorenode",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L169",
+      "weight": 1.0,
+      "_src": "scripts_graphify_wiki_ts",
+      "_tgt": "graphify_wiki_comparehotspots",
+      "source": "scripts_graphify_wiki_ts",
+      "target": "graphify_wiki_comparehotspots",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L189",
+      "weight": 1.0,
+      "_src": "scripts_graphify_wiki_ts",
+      "_tgt": "graphify_wiki_buildhotspotlines",
+      "source": "scripts_graphify_wiki_ts",
+      "target": "graphify_wiki_buildhotspotlines",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L212",
+      "weight": 1.0,
+      "_src": "scripts_graphify_wiki_ts",
+      "_tgt": "graphify_wiki_loadgraphifygraph",
+      "source": "scripts_graphify_wiki_ts",
+      "target": "graphify_wiki_loadgraphifygraph",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L226",
+      "weight": 1.0,
+      "_src": "scripts_graphify_wiki_ts",
+      "_tgt": "graphify_wiki_buildrootindexpage",
+      "source": "scripts_graphify_wiki_ts",
+      "target": "graphify_wiki_buildrootindexpage",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L267",
+      "weight": 1.0,
+      "_src": "scripts_graphify_wiki_ts",
+      "_tgt": "graphify_wiki_buildpackagepage",
+      "source": "scripts_graphify_wiki_ts",
+      "target": "graphify_wiki_buildpackagepage",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L333",
+      "weight": 1.0,
+      "_src": "scripts_graphify_wiki_ts",
+      "_tgt": "graphify_wiki_generategraphifywikipages",
+      "source": "scripts_graphify_wiki_ts",
+      "target": "graphify_wiki_generategraphifywikipages",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L365",
+      "weight": 1.0,
+      "_src": "scripts_graphify_wiki_ts",
+      "_tgt": "graphify_wiki_writegraphifywikipages",
+      "source": "scripts_graphify_wiki_ts",
+      "target": "graphify_wiki_writegraphifywikipages",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L214",
+      "weight": 1.0,
+      "_src": "graphify_wiki_loadgraphifygraph",
+      "_tgt": "graphify_wiki_fileexists",
+      "source": "graphify_wiki_fileexists",
+      "target": "graphify_wiki_loadgraphifygraph",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L94",
+      "weight": 1.0,
+      "_src": "graphify_wiki_collectrepocodefiles",
+      "_tgt": "graphify_wiki_readdir",
+      "source": "graphify_wiki_collectrepocodefiles",
+      "target": "graphify_wiki_readdir",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L336",
+      "weight": 1.0,
+      "_src": "graphify_wiki_generategraphifywikipages",
+      "_tgt": "graphify_wiki_collectrepocodefiles",
+      "source": "graphify_wiki_collectrepocodefiles",
+      "target": "graphify_wiki_generategraphifywikipages",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L289",
+      "weight": 1.0,
+      "_src": "graphify_wiki_buildpackagepage",
+      "_tgt": "graphify_wiki_normalizerepopath",
+      "source": "graphify_wiki_normalizerepopath",
+      "target": "graphify_wiki_buildpackagepage",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L260",
+      "weight": 1.0,
+      "_src": "graphify_wiki_buildrootindexpage",
+      "_tgt": "graphify_wiki_tomarkdownlink",
+      "source": "graphify_wiki_tomarkdownlink",
+      "target": "graphify_wiki_buildrootindexpage",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L287",
+      "weight": 1.0,
+      "_src": "graphify_wiki_buildpackagepage",
+      "_tgt": "graphify_wiki_tomarkdownlink",
+      "source": "graphify_wiki_tomarkdownlink",
+      "target": "graphify_wiki_buildpackagepage",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L264",
+      "weight": 1.0,
+      "_src": "graphify_wiki_buildrootindexpage",
+      "_tgt": "graphify_wiki_formatlist",
+      "source": "graphify_wiki_formatlist",
+      "target": "graphify_wiki_buildrootindexpage",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L330",
+      "weight": 1.0,
+      "_src": "graphify_wiki_buildpackagepage",
+      "_tgt": "graphify_wiki_formatlist",
+      "source": "graphify_wiki_formatlist",
+      "target": "graphify_wiki_buildpackagepage",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L242",
+      "weight": 1.0,
+      "_src": "graphify_wiki_buildrootindexpage",
+      "_tgt": "graphify_wiki_countcommunities",
+      "source": "graphify_wiki_countcommunities",
+      "target": "graphify_wiki_buildrootindexpage",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L338",
+      "weight": 1.0,
+      "_src": "graphify_wiki_generategraphifywikipages",
+      "_tgt": "graphify_wiki_builddegreeindex",
+      "source": "graphify_wiki_builddegreeindex",
+      "target": "graphify_wiki_generategraphifywikipages",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L174",
+      "weight": 1.0,
+      "_src": "graphify_wiki_comparehotspots",
+      "_tgt": "graphify_wiki_scorenode",
+      "source": "graphify_wiki_scorenode",
+      "target": "graphify_wiki_comparehotspots",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L245",
+      "weight": 1.0,
+      "_src": "graphify_wiki_buildrootindexpage",
+      "_tgt": "graphify_wiki_buildhotspotlines",
+      "source": "graphify_wiki_buildhotspotlines",
+      "target": "graphify_wiki_buildrootindexpage",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L319",
+      "weight": 1.0,
+      "_src": "graphify_wiki_buildpackagepage",
+      "_tgt": "graphify_wiki_buildhotspotlines",
+      "source": "graphify_wiki_buildhotspotlines",
+      "target": "graphify_wiki_buildpackagepage",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L335",
+      "weight": 1.0,
+      "_src": "graphify_wiki_generategraphifywikipages",
+      "_tgt": "graphify_wiki_loadgraphifygraph",
+      "source": "graphify_wiki_loadgraphifygraph",
+      "target": "graphify_wiki_generategraphifywikipages",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L343",
+      "weight": 1.0,
+      "_src": "graphify_wiki_generategraphifywikipages",
+      "_tgt": "graphify_wiki_buildrootindexpage",
+      "source": "graphify_wiki_buildrootindexpage",
+      "target": "graphify_wiki_generategraphifywikipages",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L354",
+      "weight": 1.0,
+      "_src": "graphify_wiki_generategraphifywikipages",
+      "_tgt": "graphify_wiki_buildpackagepage",
+      "source": "graphify_wiki_buildpackagepage",
+      "target": "graphify_wiki_generategraphifywikipages",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/graphify-wiki.ts",
+      "source_location": "L368",
+      "weight": 1.0,
+      "_src": "graphify_wiki_writegraphifywikipages",
+      "_tgt": "graphify_wiki_generategraphifywikipages",
+      "source": "graphify_wiki_generategraphifywikipages",
+      "target": "graphify_wiki_writegraphifywikipages",
       "confidence_score": 1.0
     },
     {

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -1,0 +1,27 @@
+# Graphify Wiki
+
+Graphify is the navigation layer for the repo graph. For deeper analysis, open `graphify-out/GRAPH_REPORT.md`.
+
+## Repo Summary
+- Code files discovered: 1195
+- Graph nodes: 2738
+- Graph edges: 2229
+- Communities: 1110
+
+## Graph Hotspots
+- `storefrontJourneyEvents.ts` (45 edges, Community 0) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
+- `createJourneyEvent()` (40 edges, Community 0) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
+- `harness-inferential-review.ts` (27 edges, Community 2) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
+- `storeConfigV2.ts` (27 edges, Community 1) - [`packages/athena-webapp/convex/inventory/storeConfigV2.ts`](../../packages/athena-webapp/convex/inventory/storeConfigV2.ts)
+- `harness-generate.ts` (26 edges, Community 3) - [`scripts/harness-generate.ts`](../../scripts/harness-generate.ts)
+- `harness-behavior.ts` (24 edges, Community 4) - [`scripts/harness-behavior.ts`](../../scripts/harness-behavior.ts)
+- `harness-self-review.ts` (24 edges, Community 5) - [`scripts/harness-self-review.ts`](../../scripts/harness-self-review.ts)
+- `harness-check.ts` (23 edges, Community 6) - [`scripts/harness-check.ts`](../../scripts/harness-check.ts)
+
+## Registered Packages
+- [Athena Webapp](packages/athena-webapp.md)
+- [Storefront Webapp](packages/storefront-webapp.md)
+
+## Deep Dives
+- [GRAPH_REPORT.md](../GRAPH_REPORT.md) - canonical graph report
+- [graph.html](../graph.html) - interactive graph view

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -1,0 +1,28 @@
+# Athena Webapp
+
+Landing page for packages/athena-webapp. Start with the package entry docs, then jump into the graph hotspots below.
+
+## Package Docs
+- [AGENTS.md](../../../packages/athena-webapp/AGENTS.md)
+- [index.md](../../../packages/athena-webapp/docs/agent/index.md)
+- [architecture.md](../../../packages/athena-webapp/docs/agent/architecture.md)
+- [testing.md](../../../packages/athena-webapp/docs/agent/testing.md)
+- [code-map.md](../../../packages/athena-webapp/docs/agent/code-map.md)
+
+## Generated Harness Docs
+- [route-index.md](../../../packages/athena-webapp/docs/agent/route-index.md)
+- [test-index.md](../../../packages/athena-webapp/docs/agent/test-index.md)
+- [key-folder-index.md](../../../packages/athena-webapp/docs/agent/key-folder-index.md)
+- [validation-guide.md](../../../packages/athena-webapp/docs/agent/validation-guide.md)
+- [validation-map.json](../../../packages/athena-webapp/docs/agent/validation-map.json)
+
+## Graph Hotspots
+- `storeConfigV2.ts` (27 edges, Community 1) - [`packages/athena-webapp/convex/inventory/storeConfigV2.ts`](../../../packages/athena-webapp/convex/inventory/storeConfigV2.ts)
+- `ProductStock.tsx` (19 edges, Community 8) - [`packages/athena-webapp/src/components/add-product/ProductStock.tsx`](../../../packages/athena-webapp/src/components/add-product/ProductStock.tsx)
+- `checkoutSession.ts` (17 edges, Community 11) - [`packages/athena-webapp/convex/storeFront/checkoutSession.ts`](../../../packages/athena-webapp/convex/storeFront/checkoutSession.ts)
+- `DataTableViewOptions()` (16 edges, Community 13) - [`packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx`](../../../packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx)
+- `storeConfig.ts` (16 edges, Community 7) - [`packages/athena-webapp/src/lib/storeConfig.ts`](../../../packages/athena-webapp/src/lib/storeConfig.ts)
+
+## Navigation
+- [wiki index](../index.md) - back to the wiki index
+- [GRAPH_REPORT.md](../../GRAPH_REPORT.md) - full graph report

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -1,0 +1,28 @@
+# Storefront Webapp
+
+Landing page for packages/storefront-webapp. Start with the package entry docs, then jump into the graph hotspots below.
+
+## Package Docs
+- [AGENTS.md](../../../packages/storefront-webapp/AGENTS.md)
+- [index.md](../../../packages/storefront-webapp/docs/agent/index.md)
+- [architecture.md](../../../packages/storefront-webapp/docs/agent/architecture.md)
+- [testing.md](../../../packages/storefront-webapp/docs/agent/testing.md)
+- [code-map.md](../../../packages/storefront-webapp/docs/agent/code-map.md)
+
+## Generated Harness Docs
+- [route-index.md](../../../packages/storefront-webapp/docs/agent/route-index.md)
+- [test-index.md](../../../packages/storefront-webapp/docs/agent/test-index.md)
+- [key-folder-index.md](../../../packages/storefront-webapp/docs/agent/key-folder-index.md)
+- [validation-guide.md](../../../packages/storefront-webapp/docs/agent/validation-guide.md)
+- [validation-map.json](../../../packages/storefront-webapp/docs/agent/validation-map.json)
+
+## Graph Hotspots
+- `storefrontJourneyEvents.ts` (45 edges, Community 0) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
+- `createJourneyEvent()` (40 edges, Community 0) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
+- `getStoreConfigV2()` (17 edges, Community 7) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+- `checkoutSession.ts` (14 edges, Community 15) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
+- `storeConfig.ts` (14 edges, Community 7) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+
+## Navigation
+- [wiki index](../index.md) - back to the wiki index
+- [GRAPH_REPORT.md](../../GRAPH_REPORT.md) - full graph report

--- a/scripts/graphify-check.test.ts
+++ b/scripts/graphify-check.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { runGraphifyCheck } from "./graphify-check";
+import { GRAPHIFY_WIKI_ARTIFACTS } from "./graphify-wiki";
 
 const tempRoots: string[] = [];
 
@@ -20,6 +21,16 @@ async function createFixtureRoot() {
   return rootDir;
 }
 
+async function writeGraphifyWikiArtifacts(rootDir: string, variant: "fresh" | "stale") {
+  for (const artifactPath of GRAPHIFY_WIKI_ARTIFACTS) {
+    await write(
+      artifactPath,
+      `${variant === "fresh" ? "fresh" : "stale"} ${path.basename(artifactPath)}\n`,
+      rootDir
+    );
+  }
+}
+
 afterEach(async () => {
   await Promise.all(
     tempRoots.splice(0).map((rootDir) =>
@@ -33,12 +44,14 @@ describe("runGraphifyCheck", () => {
     const rootDir = await createFixtureRoot();
     await write("graphify-out/GRAPH_REPORT.md", "fresh report\n", rootDir);
     await write("graphify-out/graph.json", '{"fresh":true}\n', rootDir);
+    await writeGraphifyWikiArtifacts(rootDir, "fresh");
 
     await expect(
       runGraphifyCheck(rootDir, {
         runGraphifyRebuild: async (workspaceRoot) => {
           await write("graphify-out/GRAPH_REPORT.md", "fresh report\n", workspaceRoot);
           await write("graphify-out/graph.json", '{"fresh":true}\n', workspaceRoot);
+          await writeGraphifyWikiArtifacts(workspaceRoot, "fresh");
         },
       })
     ).resolves.toBeUndefined();
@@ -48,15 +61,34 @@ describe("runGraphifyCheck", () => {
     const rootDir = await createFixtureRoot();
     await write("graphify-out/GRAPH_REPORT.md", "stale report\n", rootDir);
     await write("graphify-out/graph.json", '{"stale":true}\n', rootDir);
+    await writeGraphifyWikiArtifacts(rootDir, "stale");
 
     await expect(
       runGraphifyCheck(rootDir, {
         runGraphifyRebuild: async (workspaceRoot) => {
           await write("graphify-out/GRAPH_REPORT.md", "fresh report\n", workspaceRoot);
           await write("graphify-out/graph.json", '{"fresh":true}\n', workspaceRoot);
+          await writeGraphifyWikiArtifacts(workspaceRoot, "fresh");
         },
       })
     ).rejects.toThrow("bun run graphify:rebuild");
+  });
+
+  it("fails when wiki artifacts drift even if the graph report stays fresh", async () => {
+    const rootDir = await createFixtureRoot();
+    await write("graphify-out/GRAPH_REPORT.md", "fresh report\n", rootDir);
+    await write("graphify-out/graph.json", '{"fresh":true}\n', rootDir);
+    await writeGraphifyWikiArtifacts(rootDir, "stale");
+
+    await expect(
+      runGraphifyCheck(rootDir, {
+        runGraphifyRebuild: async (workspaceRoot) => {
+          await write("graphify-out/GRAPH_REPORT.md", "fresh report\n", workspaceRoot);
+          await write("graphify-out/graph.json", '{"fresh":true}\n', workspaceRoot);
+          await writeGraphifyWikiArtifacts(workspaceRoot, "fresh");
+        },
+      })
+    ).rejects.toThrow("graphify-out/wiki/index.md");
   });
 
   it("does not rewrite tracked artifacts while performing the check", async () => {

--- a/scripts/graphify-check.ts
+++ b/scripts/graphify-check.ts
@@ -11,9 +11,13 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { runGraphifyRebuild } from "./graphify-rebuild";
+import { GRAPHIFY_WIKI_ARTIFACTS } from "./graphify-wiki";
 
-const TRACKED_GRAPHIFY_ARTIFACTS = ["GRAPH_REPORT.md", "graph.json"] as const;
-const GRAPHIFY_OUTPUT_DIR = "graphify-out";
+const TRACKED_GRAPHIFY_ARTIFACTS = [
+  ...GRAPHIFY_WIKI_ARTIFACTS,
+  "graphify-out/GRAPH_REPORT.md",
+  "graphify-out/graph.json",
+] as const;
 const SKIP_DIRS = new Set([
   "node_modules",
   "worktrees",
@@ -120,13 +124,13 @@ async function collectStaleGraphifyArtifacts(rootDir: string, workspaceRoot: str
   const staleArtifacts: string[] = [];
 
   for (const artifactName of TRACKED_GRAPHIFY_ARTIFACTS) {
-    const trackedArtifactPath = path.join(rootDir, GRAPHIFY_OUTPUT_DIR, artifactName);
-    const freshArtifactPath = path.join(workspaceRoot, GRAPHIFY_OUTPUT_DIR, artifactName);
+    const trackedArtifactPath = path.join(rootDir, artifactName);
+    const freshArtifactPath = path.join(workspaceRoot, artifactName);
     const trackedExists = await fileExists(trackedArtifactPath);
     const freshExists = await fileExists(freshArtifactPath);
 
     if (!trackedExists || !freshExists) {
-      staleArtifacts.push(`- ${GRAPHIFY_OUTPUT_DIR}/${artifactName} (missing artifact)`);
+      staleArtifacts.push(`- ${artifactName} (missing artifact)`);
       continue;
     }
 
@@ -136,7 +140,7 @@ async function collectStaleGraphifyArtifacts(rootDir: string, workspaceRoot: str
     ]);
 
     if (!trackedContents.equals(freshContents)) {
-      staleArtifacts.push(`- ${GRAPHIFY_OUTPUT_DIR}/${artifactName}`);
+      staleArtifacts.push(`- ${artifactName}`);
     }
   }
 

--- a/scripts/graphify-rebuild.test.ts
+++ b/scripts/graphify-rebuild.test.ts
@@ -61,6 +61,7 @@ describe("runGraphifyRebuild", () => {
           stderr: new ReadableStream(),
         };
       },
+      writeGraphifyWikiPages: async () => {},
     });
 
     expect(commands).toEqual([
@@ -80,6 +81,7 @@ describe("runGraphifyRebuild", () => {
           stderr: new ReadableStream(),
         };
       },
+      writeGraphifyWikiPages: async () => {},
     });
 
     expect(commands).toEqual([["python3", "-c", GRAPHIFY_REBUILD_SNIPPET]]);
@@ -99,9 +101,29 @@ describe("runGraphifyRebuild", () => {
           stderr: new ReadableStream(),
         };
       },
+      writeGraphifyWikiPages: async () => {},
     });
 
     expect(commands).toEqual([["python3", "-c", GRAPHIFY_REBUILD_SNIPPET]]);
+  });
+
+  it("writes graphify wiki pages after a successful rebuild", async () => {
+    const rootDir = await createFixtureRoot();
+    const writes: string[] = [];
+
+    await runGraphifyRebuild(rootDir, {
+      spawn() {
+        return {
+          exited: Promise.resolve(0),
+          stderr: new ReadableStream(),
+        };
+      },
+      writeGraphifyWikiPages: async (receivedRootDir) => {
+        writes.push(receivedRootDir);
+      },
+    });
+
+    expect(writes).toEqual([rootDir]);
   });
 
   it("surfaces stderr when the graphify rebuild command fails", async () => {

--- a/scripts/graphify-rebuild.ts
+++ b/scripts/graphify-rebuild.ts
@@ -1,6 +1,8 @@
 import { access, readFile } from "node:fs/promises";
 import path from "node:path";
 
+import { writeGraphifyWikiPages } from "./graphify-wiki";
+
 export const GRAPHIFY_REBUILD_SNIPPET =
   [
     "import os",
@@ -73,6 +75,7 @@ type SpawnedProcess = {
 
 type GraphifyRebuildOptions = {
   spawn?: (command: string[], options: { cwd: string }) => SpawnedProcess;
+  writeGraphifyWikiPages?: (rootDir: string) => Promise<void>;
 };
 
 async function fileExists(filePath: string) {
@@ -127,6 +130,7 @@ export async function runGraphifyRebuild(
   const exitCode = await subprocess.exited;
 
   if (exitCode === 0) {
+    await (options.writeGraphifyWikiPages ?? writeGraphifyWikiPages)(rootDir);
     return;
   }
 

--- a/scripts/graphify-wiki.test.ts
+++ b/scripts/graphify-wiki.test.ts
@@ -1,0 +1,110 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { generateGraphifyWikiPages, GRAPHIFY_WIKI_ARTIFACTS } from "./graphify-wiki";
+
+const tempRoots: string[] = [];
+
+async function write(relativePath: string, contents: string, rootDir: string) {
+  const filePath = path.join(rootDir, relativePath);
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, contents);
+}
+
+async function createFixtureRoot() {
+  const rootDir = await mkdtemp(path.join(tmpdir(), "athena-graphify-wiki-"));
+  tempRoots.push(rootDir);
+  return rootDir;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((rootDir) =>
+      rm(rootDir, { recursive: true, force: true })
+    )
+  );
+});
+
+describe("generateGraphifyWikiPages", () => {
+  it("builds a root index and package landing pages from graph and harness metadata", async () => {
+    const rootDir = await createFixtureRoot();
+    await write(
+      "graphify-out/graph.json",
+      JSON.stringify(
+        {
+          directed: false,
+          multigraph: false,
+          graph: {},
+          nodes: [
+            {
+              label: "sharedHotspot()",
+              file_type: "code",
+              source_file: "packages/athena-webapp/src/lib/shared.ts",
+              source_location: "L1",
+              id: "shared_hotspot",
+              community: 11,
+            },
+            {
+              label: "storeHotspot()",
+              file_type: "code",
+              source_file: "packages/storefront-webapp/src/lib/store.ts",
+              source_location: "L1",
+              id: "store_hotspot",
+              community: 22,
+            },
+            {
+              label: "supportingFile.ts",
+              file_type: "code",
+              source_file: "scripts/supporting-file.ts",
+              source_location: "L1",
+              id: "supporting_file",
+              community: 33,
+            },
+          ],
+          links: [
+            {
+              relation: "calls",
+              confidence: "EXTRACTED",
+              source_file: "packages/athena-webapp/src/lib/shared.ts",
+              source_location: "L1",
+              weight: 1,
+              _src: "shared_hotspot",
+              _tgt: "store_hotspot",
+              source: "shared_hotspot",
+              target: "store_hotspot",
+              confidence_score: 1,
+            },
+          ],
+          hyperedges: [],
+        },
+        null,
+        2
+      ),
+      rootDir
+    );
+
+    const pages = await generateGraphifyWikiPages(rootDir);
+
+    expect(Array.from(pages.keys())).toEqual(GRAPHIFY_WIKI_ARTIFACTS);
+    expect(pages.get("graphify-out/wiki/index.md")).toContain("# Graphify Wiki");
+    expect(pages.get("graphify-out/wiki/index.md")).toContain("Repo Summary");
+    expect(pages.get("graphify-out/wiki/index.md")).toContain("sharedHotspot()");
+    expect(pages.get("graphify-out/wiki/index.md")).toContain(
+      "packages/athena-webapp"
+    );
+    expect(
+      pages.get("graphify-out/wiki/packages/athena-webapp.md")
+    ).toContain("AGENTS.md");
+    expect(
+      pages.get("graphify-out/wiki/packages/athena-webapp.md")
+    ).toContain("docs/agent/testing.md");
+    expect(
+      pages.get("graphify-out/wiki/packages/storefront-webapp.md")
+    ).toContain("storeHotspot()");
+    expect(
+      pages.get("graphify-out/wiki/packages/storefront-webapp.md")
+    ).toContain("docs/agent/code-map.md");
+  });
+});

--- a/scripts/graphify-wiki.ts
+++ b/scripts/graphify-wiki.ts
@@ -1,0 +1,375 @@
+import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { HARNESS_APP_REGISTRY } from "./harness-app-registry";
+
+const GRAPHIFY_OUTPUT_DIR = "graphify-out";
+const GRAPHIFY_WIKI_DIR = path.posix.join(GRAPHIFY_OUTPUT_DIR, "wiki");
+const GRAPHIFY_REPORT_PATH = path.posix.join(GRAPHIFY_OUTPUT_DIR, "GRAPH_REPORT.md");
+const GRAPHIFY_HTML_PATH = path.posix.join(GRAPHIFY_OUTPUT_DIR, "graph.html");
+const CODE_EXTENSIONS = new Set([
+  ".py",
+  ".js",
+  ".ts",
+  ".tsx",
+  ".go",
+  ".rs",
+  ".java",
+  ".c",
+  ".h",
+  ".cpp",
+  ".cc",
+  ".cxx",
+  ".hpp",
+  ".rb",
+  ".cs",
+  ".kt",
+  ".kts",
+  ".scala",
+  ".php",
+  ".swift",
+  ".lua",
+  ".toc",
+  ".zig",
+  ".ps1",
+  ".m",
+  ".mm",
+]);
+const SKIP_DIRS = new Set([
+  "node_modules",
+  "worktrees",
+  "graphify-out",
+  "__pycache__",
+  "coverage",
+  "dist",
+]);
+
+type GraphifyNode = {
+  label: string;
+  file_type?: string;
+  source_file: string;
+  source_location?: string;
+  id: string;
+  community?: number;
+};
+
+type GraphifyLink = {
+  source: string;
+  target: string;
+};
+
+type GraphifyGraph = {
+  nodes: GraphifyNode[];
+  links: GraphifyLink[];
+};
+
+type GraphifyWikiPage = {
+  path: string;
+  contents: string;
+};
+
+export const GRAPHIFY_WIKI_ARTIFACTS = [
+  path.posix.join(GRAPHIFY_WIKI_DIR, "index.md"),
+  ...HARNESS_APP_REGISTRY.map((entry) =>
+    path.posix.join(GRAPHIFY_WIKI_DIR, "packages", `${entry.appName}.md`)
+  ),
+] as const;
+
+async function fileExists(filePath: string) {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function collectRepoCodeFiles(rootDir: string) {
+  const files: string[] = [];
+  const queue = [""];
+
+  while (queue.length > 0) {
+    const currentRelativeDir = queue.pop()!;
+    const currentAbsoluteDir = path.join(rootDir, currentRelativeDir);
+    const entries = await readDir(currentAbsoluteDir);
+
+    for (const entry of entries) {
+      if (entry.name.startsWith(".")) {
+        continue;
+      }
+
+      const relativePath = currentRelativeDir
+        ? path.join(currentRelativeDir, entry.name)
+        : entry.name;
+
+      if (entry.isDirectory()) {
+        if (!SKIP_DIRS.has(entry.name)) {
+          queue.push(relativePath);
+        }
+        continue;
+      }
+
+      if (entry.isFile() && CODE_EXTENSIONS.has(path.extname(entry.name))) {
+        files.push(relativePath);
+      }
+    }
+  }
+
+  return files.sort((left, right) => left.localeCompare(right));
+}
+
+async function readDir(dirPath: string) {
+  const { readdir } = await import("node:fs/promises");
+  return readdir(dirPath, { withFileTypes: true });
+}
+
+function normalizeRepoPath(filePath: string) {
+  return filePath.split(path.sep).join("/");
+}
+
+function toMarkdownLink(pagePath: string, targetPath: string, label?: string) {
+  const relativePath = path.posix.relative(
+    path.posix.dirname(pagePath),
+    targetPath
+  );
+  return `[${label ?? targetPath}](${relativePath})`;
+}
+
+function toSourceLink(pagePath: string, sourceFile: string) {
+  const relativePath = path.posix.relative(path.posix.dirname(pagePath), sourceFile);
+  return `[\`${sourceFile}\`](${relativePath})`;
+}
+
+function formatList(lines: string[]) {
+  return lines.join("\n");
+}
+
+function countCommunities(nodes: GraphifyNode[]) {
+  return new Set(nodes.map((node) => node.community)).size;
+}
+
+function buildDegreeIndex(links: GraphifyLink[]) {
+  const degreeByNodeId = new Map<string, number>();
+
+  for (const link of links) {
+    degreeByNodeId.set(link.source, (degreeByNodeId.get(link.source) ?? 0) + 1);
+    degreeByNodeId.set(link.target, (degreeByNodeId.get(link.target) ?? 0) + 1);
+  }
+
+  return degreeByNodeId;
+}
+
+function scoreNode(
+  node: GraphifyNode,
+  degreeByNodeId: Map<string, number>
+): number {
+  return degreeByNodeId.get(node.id) ?? 0;
+}
+
+function compareHotspots(
+  left: GraphifyNode,
+  right: GraphifyNode,
+  degreeByNodeId: Map<string, number>
+) {
+  const leftDegree = scoreNode(left, degreeByNodeId);
+  const rightDegree = scoreNode(right, degreeByNodeId);
+
+  if (leftDegree !== rightDegree) {
+    return rightDegree - leftDegree;
+  }
+
+  const labelComparison = left.label.localeCompare(right.label);
+  if (labelComparison !== 0) {
+    return labelComparison;
+  }
+
+  return left.source_file.localeCompare(right.source_file);
+}
+
+function buildHotspotLines(
+  pagePath: string,
+  nodes: GraphifyNode[],
+  degreeByNodeId: Map<string, number>,
+  limit: number
+) {
+  const hotspots = [...nodes]
+    .sort((left, right) => compareHotspots(left, right, degreeByNodeId))
+    .slice(0, limit);
+
+  if (hotspots.length === 0) {
+    return ["- No graph hotspots were found for this scope."];
+  }
+
+  return hotspots.map((node) => {
+    const degree = scoreNode(node, degreeByNodeId);
+    const sourceLink = toSourceLink(pagePath, normalizeRepoPath(node.source_file));
+    const community = node.community === undefined ? "unknown" : `Community ${node.community}`;
+
+    return `- \`${node.label}\` (${degree} edge${degree === 1 ? "" : "s"}, ${community}) - ${sourceLink}`;
+  });
+}
+
+async function loadGraphifyGraph(rootDir: string) {
+  const graphPath = path.join(rootDir, GRAPHIFY_OUTPUT_DIR, "graph.json");
+  if (!(await fileExists(graphPath))) {
+    throw new Error(
+      `Missing graphify graph output: ${path.posix.join(
+        GRAPHIFY_OUTPUT_DIR,
+        "graph.json"
+      )}`
+    );
+  }
+
+  return JSON.parse(await readFile(graphPath, "utf8")) as GraphifyGraph;
+}
+
+function buildRootIndexPage(params: {
+  rootDir: string;
+  graph: GraphifyGraph;
+  codeFileCount: number;
+  degreeByNodeId: Map<string, number>;
+}) {
+  const pagePath = path.posix.join(GRAPHIFY_WIKI_DIR, "index.md");
+  const lines = [
+    "# Graphify Wiki",
+    "",
+    "Graphify is the navigation layer for the repo graph. For deeper analysis, open `graphify-out/GRAPH_REPORT.md`.",
+    "",
+    "## Repo Summary",
+    `- Code files discovered: ${params.codeFileCount}`,
+    `- Graph nodes: ${params.graph.nodes.length}`,
+    `- Graph edges: ${params.graph.links.length}`,
+    `- Communities: ${countCommunities(params.graph.nodes)}`,
+    "",
+    "## Graph Hotspots",
+    ...buildHotspotLines(pagePath, params.graph.nodes, params.degreeByNodeId, 8),
+    "",
+    "## Registered Packages",
+    ...HARNESS_APP_REGISTRY.map((entry) => {
+      const packagePagePath = path.posix.join(
+        GRAPHIFY_WIKI_DIR,
+        "packages",
+        `${entry.appName}.md`
+      );
+      const link = toMarkdownLink(pagePath, packagePagePath, entry.label);
+
+      return `- ${link}`;
+    }),
+    "",
+    "## Deep Dives",
+    `- ${toMarkdownLink(pagePath, GRAPHIFY_REPORT_PATH, "GRAPH_REPORT.md")} - canonical graph report`,
+    `- ${toMarkdownLink(pagePath, GRAPHIFY_HTML_PATH, "graph.html")} - interactive graph view`,
+  ];
+
+  return formatList(lines);
+}
+
+function buildPackagePage(params: {
+  packageEntry: (typeof HARNESS_APP_REGISTRY)[number];
+  graph: GraphifyGraph;
+  degreeByNodeId: Map<string, number>;
+}) {
+  const pagePath = path.posix.join(
+    GRAPHIFY_WIKI_DIR,
+    "packages",
+    `${params.packageEntry.appName}.md`
+  );
+  const packageNodes = params.graph.nodes.filter((node) =>
+    normalizeRepoPath(node.source_file).startsWith(`${params.packageEntry.packageDir}/`)
+  );
+
+  const lines = [
+    `# ${params.packageEntry.label}`,
+    "",
+    `Landing page for ${params.packageEntry.packageDir}. Start with the package entry docs, then jump into the graph hotspots below.`,
+    "",
+    "## Package Docs",
+    `- ${toMarkdownLink(
+      pagePath,
+      normalizeRepoPath(params.packageEntry.harnessDocs.agentsPath),
+      "AGENTS.md"
+    )}`,
+    `- ${toMarkdownLink(
+      pagePath,
+      normalizeRepoPath(params.packageEntry.harnessDocs.indexPath),
+      "index.md"
+    )}`,
+    `- ${toMarkdownLink(
+      pagePath,
+      normalizeRepoPath(params.packageEntry.harnessDocs.architecturePath),
+      "architecture.md"
+    )}`,
+    `- ${toMarkdownLink(
+      pagePath,
+      normalizeRepoPath(params.packageEntry.harnessDocs.testingPath),
+      "testing.md"
+    )}`,
+    `- ${toMarkdownLink(
+      pagePath,
+      normalizeRepoPath(params.packageEntry.harnessDocs.codeMapPath),
+      "code-map.md"
+    )}`,
+    "",
+    "## Generated Harness Docs",
+    ...params.packageEntry.harnessDocs.generatedDocs.map((docPath) =>
+      `- ${toMarkdownLink(pagePath, normalizeRepoPath(docPath), path.posix.basename(docPath))}`
+    ),
+    "",
+    "## Graph Hotspots",
+    ...buildHotspotLines(pagePath, packageNodes, params.degreeByNodeId, 5),
+    "",
+    "## Navigation",
+    `- ${toMarkdownLink(
+      pagePath,
+      path.posix.join(GRAPHIFY_WIKI_DIR, "index.md"),
+      "wiki index"
+    )} - back to the wiki index`,
+    `- ${toMarkdownLink(pagePath, GRAPHIFY_REPORT_PATH, "GRAPH_REPORT.md")} - full graph report`,
+  ];
+
+  return formatList(lines);
+}
+
+export async function generateGraphifyWikiPages(rootDir: string) {
+  const [graph, codeFiles] = await Promise.all([
+    loadGraphifyGraph(rootDir),
+    collectRepoCodeFiles(rootDir),
+  ]);
+  const degreeByNodeId = buildDegreeIndex(graph.links);
+  const pages = new Map<string, string>();
+
+  pages.set(
+    path.posix.join(GRAPHIFY_WIKI_DIR, "index.md"),
+    buildRootIndexPage({
+      rootDir,
+      graph,
+      codeFileCount: codeFiles.length,
+      degreeByNodeId,
+    })
+  );
+
+  for (const packageEntry of HARNESS_APP_REGISTRY) {
+    pages.set(
+      path.posix.join(GRAPHIFY_WIKI_DIR, "packages", `${packageEntry.appName}.md`),
+      buildPackagePage({
+        packageEntry,
+        graph,
+        degreeByNodeId,
+      })
+    );
+  }
+
+  return pages;
+}
+
+export async function writeGraphifyWikiPages(rootDir: string) {
+  const wikiDir = path.join(rootDir, GRAPHIFY_WIKI_DIR);
+  await rm(wikiDir, { recursive: true, force: true });
+  const pages = await generateGraphifyWikiPages(rootDir);
+
+  for (const [relativePath, contents] of pages) {
+    const filePath = path.join(rootDir, relativePath);
+    await mkdir(path.dirname(filePath), { recursive: true });
+    await writeFile(filePath, contents.endsWith("\n") ? contents : `${contents}\n`);
+  }
+}


### PR DESCRIPTION
## Summary
- add a deterministic Graphify wiki generator and wire it into `graphify:rebuild`
- extend `graphify:check` and focused tests so wiki artifacts participate in freshness validation
- generate wiki navigation pages under `graphify-out/wiki/` alongside refreshed graph artifacts

## Why
- agents are instructed to prefer `graphify-out/wiki/index.md` when present, but the repo did not generate that surface yet
- this change turns Graphify into a practical navigation layer instead of a report-only artifact
- keeping wiki generation inside rebuild/check preserves determinism and reduces navigation drift

## Validation
- `bun test scripts/graphify-wiki.test.ts scripts/graphify-rebuild.test.ts scripts/graphify-check.test.ts`
- `bun run graphify:rebuild`
- `bun run graphify:check`
- `bun run pr:athena`
- `bun run harness:behavior --scenario sample-runtime-smoke --record-video`

https://linear.app/v26-labs/issue/V26-221/generate-graphify-wiki-navigation-pages-from-graph-and-harness
