### PR TITLE
[V26-222]: wire graphify navigation entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ re-running checks.
 
 The repo keeps a graphify knowledge graph at `graphify-out/`.
 
+Start with [the Graphify wiki index](./graphify-out/wiki/index.md) for repo-wide navigation, package landing pages, and graph hotspots.
+
+Use [the packages agent router](./packages/AGENTS.md) plus each package's `AGENTS.md` and `docs/agent/*` docs as the operational source of truth for edits and validation.
+
 Use `bun run graphify:check` as the non-mutating freshness gate for tracked graphify artifacts.
 
 Use `bun run graphify:rebuild` as the repair path when the check reports stale artifacts. The rebuild command uses the interpreter recorded in `.graphify_python` (default `python3` in this repo).
@@ -77,6 +81,8 @@ Tracked graphify artifacts:
 
 - `graphify-out/GRAPH_REPORT.md`
 - `graphify-out/graph.json`
+- `graphify-out/wiki/index.md`
+- `graphify-out/wiki/packages/*.md`
 
 Local-only graphify artifacts:
 

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 2764 nodes · 2274 edges · 1113 communities detected
+- 2769 nodes · 2289 edges · 1113 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1130,9 +1130,9 @@
 3. `DataTableViewOptions()` - 16 edges
 4. `DataTableColumnHeader()` - 14 edges
 5. `toV2Config()` - 13 edges
-6. `getBaseUrl()` - 12 edges
-7. `fileExists()` - 12 edges
-8. `validateHarnessDocs()` - 10 edges
+6. `validateHarnessDocs()` - 13 edges
+7. `getBaseUrl()` - 12 edges
+8. `fileExists()` - 12 edges
 9. `OrdersTableToolbarProvider()` - 9 edges
 10. `useOrdersTableToolbar()` - 9 edges
 
@@ -1156,15 +1156,15 @@ Nodes (45): compactContext(), createAuthEntryViewedEvent(), createAuthRequestSta
 
 ### Community 1 - "Community 1"
 Cohesion: 0.15
-Nodes (27): buildDiscoveryIndex(), buildGeneratedDoc(), buildKeyFolderIndex(), buildTestIndex(), buildValidationGuide(), buildValidationMap(), collectFolderFacts(), collectRouteGroups() (+19 more)
+Nodes (31): collectHarnessOnboardingErrors(), collectMarkdownLinkErrors(), collectMissingRequiredLinkErrors(), collectPackageGuideLinkErrors(), collectPackagesRouterLinkErrors(), collectReadmeLinkErrors(), collectReferencedPathErrors(), collectRuntimeScenarioDocSyncErrors() (+23 more)
 
 ### Community 2 - "Community 2"
-Cohesion: 0.16
-Nodes (25): asArray(), asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), assignOrDelete(), asString() (+17 more)
+Cohesion: 0.15
+Nodes (27): buildDiscoveryIndex(), buildGeneratedDoc(), buildKeyFolderIndex(), buildTestIndex(), buildValidationGuide(), buildValidationMap(), collectFolderFacts(), collectRouteGroups() (+19 more)
 
 ### Community 3 - "Community 3"
-Cohesion: 0.17
-Nodes (25): collectHarnessOnboardingErrors(), collectMarkdownLinkErrors(), collectReferencedPathErrors(), collectRuntimeScenarioDocSyncErrors(), collectServiceDocumentedSurfaces(), collectTestingDocErrors(), collectTestSurfaceRoots(), extractInlineCode() (+17 more)
+Cohesion: 0.16
+Nodes (25): asArray(), asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), assignOrDelete(), asString() (+17 more)
 
 ### Community 4 - "Community 4"
 Cohesion: 0.17
@@ -1363,16 +1363,16 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 53 - "Community 53"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
+
+### Community 54 - "Community 54"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
-### Community 54 - "Community 54"
+### Community 55 - "Community 55"
 Cohesion: 0.29
 Nodes (0):
-
-### Community 55 - "Community 55"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
 
 ### Community 56 - "Community 56"
 Cohesion: 0.52

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -1401,7 +1401,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_storeconfigv2_ts",
-      "community": 2
+      "community": 3
     },
     {
       "label": "isPlainObject()",
@@ -1409,7 +1409,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L53",
       "id": "storeconfigv2_isplainobject",
-      "community": 2
+      "community": 3
     },
     {
       "label": "asRecord()",
@@ -1417,7 +1417,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L57",
       "id": "storeconfigv2_asrecord",
-      "community": 2
+      "community": 3
     },
     {
       "label": "asNumber()",
@@ -1425,7 +1425,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L61",
       "id": "storeconfigv2_asnumber",
-      "community": 2
+      "community": 3
     },
     {
       "label": "asString()",
@@ -1433,7 +1433,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L65",
       "id": "storeconfigv2_asstring",
-      "community": 2
+      "community": 3
     },
     {
       "label": "asBoolean()",
@@ -1441,7 +1441,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L69",
       "id": "storeconfigv2_asboolean",
-      "community": 2
+      "community": 3
     },
     {
       "label": "asArray()",
@@ -1449,7 +1449,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L77",
       "id": "storeconfigv2_asarray",
-      "community": 2
+      "community": 3
     },
     {
       "label": "asOptionalArray()",
@@ -1457,7 +1457,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L90",
       "id": "storeconfigv2_asoptionalarray",
-      "community": 2
+      "community": 3
     },
     {
       "label": "firstDefined()",
@@ -1465,7 +1465,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L101",
       "id": "storeconfigv2_firstdefined",
-      "community": 2
+      "community": 3
     },
     {
       "label": "mapPromotion()",
@@ -1473,7 +1473,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L111",
       "id": "storeconfigv2_mappromotion",
-      "community": 2
+      "community": 3
     },
     {
       "label": "mapStreamReel()",
@@ -1481,7 +1481,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L115",
       "id": "storeconfigv2_mapstreamreel",
-      "community": 2
+      "community": 3
     },
     {
       "label": "normalizeWaiveDeliveryFees()",
@@ -1489,7 +1489,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L135",
       "id": "storeconfigv2_normalizewaivedeliveryfees",
-      "community": 2
+      "community": 3
     },
     {
       "label": "cleanUndefined()",
@@ -1497,7 +1497,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L153",
       "id": "storeconfigv2_cleanundefined",
-      "community": 2
+      "community": 3
     },
     {
       "label": "asMtnMomoSetupStatus()",
@@ -1505,7 +1505,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L165",
       "id": "storeconfigv2_asmtnmomosetupstatus",
-      "community": 2
+      "community": 3
     },
     {
       "label": "hasMtnMomoReceivingAccountDetails()",
@@ -1513,7 +1513,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L178",
       "id": "storeconfigv2_hasmtnmomoreceivingaccountdetails",
-      "community": 2
+      "community": 3
     },
     {
       "label": "mapMtnMomoReceivingAccount()",
@@ -1521,7 +1521,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L191",
       "id": "storeconfigv2_mapmtnmomoreceivingaccount",
-      "community": 2
+      "community": 3
     },
     {
       "label": "normalizeMtnMomoReceivingAccounts()",
@@ -1529,7 +1529,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L214",
       "id": "storeconfigv2_normalizemtnmomoreceivingaccounts",
-      "community": 2
+      "community": 3
     },
     {
       "label": "toV2Config()",
@@ -1537,7 +1537,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L231",
       "id": "storeconfigv2_tov2config",
-      "community": 2
+      "community": 3
     },
     {
       "label": "normalizeStoreConfig()",
@@ -1545,7 +1545,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L474",
       "id": "storeconfigv2_normalizestoreconfig",
-      "community": 2
+      "community": 3
     },
     {
       "label": "deepMerge()",
@@ -1553,7 +1553,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L478",
       "id": "storeconfigv2_deepmerge",
-      "community": 2
+      "community": 3
     },
     {
       "label": "patchV2Config()",
@@ -1561,7 +1561,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L498",
       "id": "storeconfigv2_patchv2config",
-      "community": 2
+      "community": 3
     },
     {
       "label": "assignOrDelete()",
@@ -1569,7 +1569,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L507",
       "id": "storeconfigv2_assignordelete",
-      "community": 2
+      "community": 3
     },
     {
       "label": "mirrorLegacyKeys()",
@@ -1577,7 +1577,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L520",
       "id": "storeconfigv2_mirrorlegacykeys",
-      "community": 2
+      "community": 3
     },
     {
       "label": "getUnknownStoreConfigRootKeys()",
@@ -1585,7 +1585,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L591",
       "id": "storeconfigv2_getunknownstoreconfigrootkeys",
-      "community": 2
+      "community": 3
     },
     {
       "label": "isStoreCheckoutDisabled()",
@@ -1593,7 +1593,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L597",
       "id": "storeconfigv2_isstorecheckoutdisabled",
-      "community": 2
+      "community": 3
     },
     {
       "label": "removeLegacyRootKeysFromConfig()",
@@ -1601,7 +1601,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L606",
       "id": "storeconfigv2_removelegacyrootkeysfromconfig",
-      "community": 2
+      "community": 3
     },
     {
       "label": "isLegacyRootKey()",
@@ -1609,7 +1609,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L623",
       "id": "storeconfigv2_islegacyrootkey",
-      "community": 2
+      "community": 3
     },
     {
       "label": "isV2RootKey()",
@@ -1617,7 +1617,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L627",
       "id": "storeconfigv2_isv2rootkey",
-      "community": 2
+      "community": 3
     },
     {
       "label": "stores.ts",
@@ -12233,7 +12233,7 @@
       "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "community": 55
+      "community": 53
     },
     {
       "label": "getProductName()",
@@ -12241,7 +12241,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L18",
       "id": "productutils_getproductname",
-      "community": 55
+      "community": 53
     },
     {
       "label": "sortProduct()",
@@ -12249,7 +12249,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L66",
       "id": "productutils_sortproduct",
-      "community": 55
+      "community": 53
     },
     {
       "label": "category.ts",
@@ -14329,7 +14329,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_savedbag_ts",
-      "community": 53
+      "community": 54
     },
     {
       "label": "getBaseUrl()",
@@ -14337,7 +14337,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L8",
       "id": "savedbag_getbaseurl",
-      "community": 53
+      "community": 54
     },
     {
       "label": "getActiveSavedBag()",
@@ -14345,7 +14345,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L10",
       "id": "savedbag_getactivesavedbag",
-      "community": 53
+      "community": 54
     },
     {
       "label": "addItemToSavedBag()",
@@ -14353,7 +14353,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L25",
       "id": "savedbag_additemtosavedbag",
-      "community": 53
+      "community": 54
     },
     {
       "label": "updateSavedBagItem()",
@@ -14361,7 +14361,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L61",
       "id": "savedbag_updatesavedbagitem",
-      "community": 53
+      "community": 54
     },
     {
       "label": "removeItemFromSavedBag()",
@@ -14369,7 +14369,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L91",
       "id": "savedbag_removeitemfromsavedbag",
-      "community": 53
+      "community": 54
     },
     {
       "label": "updateSavedBagOwner()",
@@ -14377,7 +14377,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L109",
       "id": "savedbag_updatesavedbagowner",
-      "community": 53
+      "community": 54
     },
     {
       "label": "storeFrontUser.ts",
@@ -16233,7 +16233,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_tsx",
-      "community": 54
+      "community": 55
     },
     {
       "label": "PendingItem()",
@@ -16241,7 +16241,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L62",
       "id": "shoppingbag_pendingitem",
-      "community": 54
+      "community": 55
     },
     {
       "label": "handleOnCheckoutClick()",
@@ -16249,7 +16249,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L476",
       "id": "shoppingbag_handleoncheckoutclick",
-      "community": 54
+      "community": 55
     },
     {
       "label": "handleClickOnDiscountCode()",
@@ -16257,7 +16257,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L525",
       "id": "shoppingbag_handleclickondiscountcode",
-      "community": 54
+      "community": 55
     },
     {
       "label": "isSkuUnavailable()",
@@ -16265,7 +16265,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L537",
       "id": "shoppingbag_isskuunavailable",
-      "community": 54
+      "community": 55
     },
     {
       "label": "handleMoveToSaved()",
@@ -16273,7 +16273,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L552",
       "id": "shoppingbag_handlemovetosaved",
-      "community": 54
+      "community": 55
     },
     {
       "label": "handleDeleteItem()",
@@ -16281,7 +16281,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L566",
       "id": "shoppingbag_handledeleteitem",
-      "community": 54
+      "community": 55
     },
     {
       "label": "CheckoutUnavailable.tsx",
@@ -17721,7 +17721,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "community": 55
+      "community": 53
     },
     {
       "label": "isSoldOut()",
@@ -17729,7 +17729,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L45",
       "id": "productutils_issoldout",
-      "community": 55
+      "community": 53
     },
     {
       "label": "hasLowStock()",
@@ -17737,7 +17737,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L52",
       "id": "productutils_haslowstock",
-      "community": 55
+      "community": 53
     },
     {
       "label": "sortSkusByLength()",
@@ -17745,7 +17745,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L62",
       "id": "productutils_sortskusbylength",
-      "community": 55
+      "community": 53
     },
     {
       "label": "bag.ts",
@@ -19743,7 +19743,7 @@
       "label": "buildPackagePage()",
       "file_type": "code",
       "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L267",
+      "source_location": "L271",
       "id": "graphify_wiki_buildpackagepage",
       "community": 12
     },
@@ -19751,7 +19751,7 @@
       "label": "generateGraphifyWikiPages()",
       "file_type": "code",
       "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L333",
+      "source_location": "L338",
       "id": "graphify_wiki_generategraphifywikipages",
       "community": 12
     },
@@ -19759,7 +19759,7 @@
       "label": "writeGraphifyWikiPages()",
       "file_type": "code",
       "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L365",
+      "source_location": "L370",
       "id": "graphify_wiki_writegraphifywikipages",
       "community": 12
     },
@@ -20337,223 +20337,263 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L1",
       "id": "scripts_harness_check_ts",
-      "community": 3
+      "community": 1
     },
     {
       "label": "normalizeRepoPath()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L37",
+      "source_location": "L39",
       "id": "harness_check_normalizerepopath",
-      "community": 3
+      "community": 1
     },
     {
       "label": "stripLinkDecorations()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L41",
+      "source_location": "L43",
       "id": "harness_check_striplinkdecorations",
-      "community": 3
+      "community": 1
+    },
+    {
+      "label": "toRelativeLinkTarget()",
+      "file_type": "code",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L47",
+      "id": "harness_check_torelativelinktarget",
+      "community": 1
+    },
+    {
+      "label": "collectMissingRequiredLinkErrors()",
+      "file_type": "code",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L55",
+      "id": "harness_check_collectmissingrequiredlinkerrors",
+      "community": 1
     },
     {
       "label": "isRelativeLink()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L45",
+      "source_location": "L72",
       "id": "harness_check_isrelativelink",
-      "community": 3
+      "community": 1
     },
     {
       "label": "fileExists()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L53",
+      "source_location": "L80",
       "id": "harness_check_fileexists",
-      "community": 3
+      "community": 1
     },
     {
       "label": "hasAnyHarnessDocs()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L62",
+      "source_location": "L89",
       "id": "harness_check_hasanyharnessdocs",
-      "community": 3
+      "community": 1
     },
     {
       "label": "isEnforcedHarnessApp()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L78",
+      "source_location": "L105",
       "id": "harness_check_isenforcedharnessapp",
-      "community": 3
+      "community": 1
     },
     {
       "label": "sortUniqueEntries()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L89",
+      "source_location": "L116",
       "id": "harness_check_sortuniqueentries",
-      "community": 3
+      "community": 1
     },
     {
       "label": "formatScenarioList()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L95",
+      "source_location": "L122",
       "id": "harness_check_formatscenariolist",
-      "community": 3
+      "community": 1
     },
     {
       "label": "isRuntimeScenarioName()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L99",
+      "source_location": "L126",
       "id": "harness_check_isruntimescenarioname",
-      "community": 3
+      "community": 1
     },
     {
       "label": "extractRuntimeScenarioSection()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L107",
+      "source_location": "L134",
       "id": "harness_check_extractruntimescenariosection",
-      "community": 3
+      "community": 1
     },
     {
       "label": "collectRuntimeScenarioDocSyncErrors()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L129",
+      "source_location": "L156",
       "id": "harness_check_collectruntimescenariodocsyncerrors",
-      "community": 3
+      "community": 1
     },
     {
       "label": "collectMarkdownLinkErrors()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L188",
+      "source_location": "L215",
       "id": "harness_check_collectmarkdownlinkerrors",
-      "community": 3
+      "community": 1
     },
     {
       "label": "extractInlineCode()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L217",
+      "source_location": "L244",
       "id": "harness_check_extractinlinecode",
-      "community": 3
+      "community": 1
     },
     {
       "label": "normalizePathReference()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L223",
+      "source_location": "L250",
       "id": "harness_check_normalizepathreference",
-      "community": 3
+      "community": 1
     },
     {
       "label": "isLikelyPathReference()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L236",
+      "source_location": "L263",
       "id": "harness_check_islikelypathreference",
-      "community": 3
+      "community": 1
     },
     {
       "label": "resolvePathReference()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L261",
+      "source_location": "L288",
       "id": "harness_check_resolvepathreference",
-      "community": 3
+      "community": 1
     },
     {
       "label": "collectReferencedPathErrors()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L287",
+      "source_location": "L314",
       "id": "harness_check_collectreferencedpatherrors",
-      "community": 3
+      "community": 1
     },
     {
       "label": "readPackageConfig()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L322",
+      "source_location": "L349",
       "id": "harness_check_readpackageconfig",
-      "community": 3
+      "community": 1
     },
     {
       "label": "listWorkspacePackageDirs()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L350",
+      "source_location": "L377",
       "id": "harness_check_listworkspacepackagedirs",
-      "community": 3
+      "community": 1
     },
     {
       "label": "collectHarnessOnboardingErrors()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L373",
+      "source_location": "L400",
       "id": "harness_check_collectharnessonboardingerrors",
-      "community": 3
+      "community": 1
     },
     {
       "label": "extractTestScriptFromCommand()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L404",
+      "source_location": "L431",
       "id": "harness_check_extracttestscriptfromcommand",
-      "community": 3
+      "community": 1
     },
     {
       "label": "walkFiles()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L436",
+      "source_location": "L463",
       "id": "harness_check_walkfiles",
-      "community": 3
+      "community": 1
     },
     {
       "label": "collectServiceDocumentedSurfaces()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L456",
+      "source_location": "L483",
       "id": "harness_check_collectservicedocumentedsurfaces",
-      "community": 3
+      "community": 1
     },
     {
       "label": "collectTestSurfaceRoots()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L481",
+      "source_location": "L508",
       "id": "harness_check_collecttestsurfaceroots",
-      "community": 3
+      "community": 1
     },
     {
       "label": "collectTestingDocErrors()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L528",
+      "source_location": "L555",
       "id": "harness_check_collecttestingdocerrors",
-      "community": 3
+      "community": 1
+    },
+    {
+      "label": "collectReadmeLinkErrors()",
+      "file_type": "code",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L608",
+      "id": "harness_check_collectreadmelinkerrors",
+      "community": 1
+    },
+    {
+      "label": "collectPackagesRouterLinkErrors()",
+      "file_type": "code",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L620",
+      "id": "harness_check_collectpackagesrouterlinkerrors",
+      "community": 1
+    },
+    {
+      "label": "collectPackageGuideLinkErrors()",
+      "file_type": "code",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L644",
+      "id": "harness_check_collectpackageguidelinkerrors",
+      "community": 1
     },
     {
       "label": "validateHarnessDocs()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L581",
+      "source_location": "L666",
       "id": "harness_check_validateharnessdocs",
-      "community": 3
+      "community": 1
     },
     {
       "label": "runHarnessCheck()",
       "file_type": "code",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L723",
+      "source_location": "L825",
       "id": "harness_check_runharnesscheck",
-      "community": 3
+      "community": 1
     },
     {
       "label": "harness-generate.test.ts",
@@ -20585,7 +20625,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L1",
       "id": "scripts_harness_generate_ts",
-      "community": 1
+      "community": 2
     },
     {
       "label": "normalizeRepoPath()",
@@ -20593,7 +20633,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L24",
       "id": "harness_generate_normalizerepopath",
-      "community": 1
+      "community": 2
     },
     {
       "label": "shouldSkipGeneratedEntry()",
@@ -20601,7 +20641,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L28",
       "id": "harness_generate_shouldskipgeneratedentry",
-      "community": 1
+      "community": 2
     },
     {
       "label": "fileExists()",
@@ -20609,7 +20649,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L32",
       "id": "harness_generate_fileexists",
-      "community": 1
+      "community": 2
     },
     {
       "label": "walkFiles()",
@@ -20617,7 +20657,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L41",
       "id": "harness_generate_walkfiles",
-      "community": 1
+      "community": 2
     },
     {
       "label": "readPackageConfig()",
@@ -20625,7 +20665,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L63",
       "id": "harness_generate_readpackageconfig",
-      "community": 1
+      "community": 2
     },
     {
       "label": "toDocPath()",
@@ -20633,7 +20673,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L81",
       "id": "harness_generate_todocpath",
-      "community": 1
+      "community": 2
     },
     {
       "label": "formatMarkdownLink()",
@@ -20641,7 +20681,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L85",
       "id": "harness_generate_formatmarkdownlink",
-      "community": 1
+      "community": 2
     },
     {
       "label": "headingFromSegment()",
@@ -20649,7 +20689,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L89",
       "id": "harness_generate_headingfromsegment",
-      "community": 1
+      "community": 2
     },
     {
       "label": "summarizeChildren()",
@@ -20657,7 +20697,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L97",
       "id": "harness_generate_summarizechildren",
-      "community": 1
+      "community": 2
     },
     {
       "label": "isWithinFolder()",
@@ -20665,7 +20705,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L105",
       "id": "harness_generate_iswithinfolder",
-      "community": 1
+      "community": 2
     },
     {
       "label": "toPackageRelativeGeneratedDocPaths()",
@@ -20673,7 +20713,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L116",
       "id": "harness_generate_topackagerelativegenerateddocpaths",
-      "community": 1
+      "community": 2
     },
     {
       "label": "collectRouteGroups()",
@@ -20681,7 +20721,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L126",
       "id": "harness_generate_collectroutegroups",
-      "community": 1
+      "community": 2
     },
     {
       "label": "collectServiceDocumentedEntries()",
@@ -20689,7 +20729,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L152",
       "id": "harness_generate_collectservicedocumentedentries",
-      "community": 1
+      "community": 2
     },
     {
       "label": "collectServiceEntryGroups()",
@@ -20697,7 +20737,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L177",
       "id": "harness_generate_collectserviceentrygroups",
-      "community": 1
+      "community": 2
     },
     {
       "label": "collectTestFiles()",
@@ -20705,7 +20745,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L196",
       "id": "harness_generate_collecttestfiles",
-      "community": 1
+      "community": 2
     },
     {
       "label": "collectTestSurfaceRoots()",
@@ -20713,7 +20753,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L226",
       "id": "harness_generate_collecttestsurfaceroots",
-      "community": 1
+      "community": 2
     },
     {
       "label": "collectFolderFacts()",
@@ -20721,7 +20761,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L272",
       "id": "harness_generate_collectfolderfacts",
-      "community": 1
+      "community": 2
     },
     {
       "label": "formatScriptCommand()",
@@ -20729,7 +20769,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L316",
       "id": "harness_generate_formatscriptcommand",
-      "community": 1
+      "community": 2
     },
     {
       "label": "toRepoValidationPath()",
@@ -20737,7 +20777,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L326",
       "id": "harness_generate_torepovalidationpath",
-      "community": 1
+      "community": 2
     },
     {
       "label": "slugifyTitle()",
@@ -20745,7 +20785,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L331",
       "id": "harness_generate_slugifytitle",
-      "community": 1
+      "community": 2
     },
     {
       "label": "formatValidationCommandForDoc()",
@@ -20753,7 +20793,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L338",
       "id": "harness_generate_formatvalidationcommandfordoc",
-      "community": 1
+      "community": 2
     },
     {
       "label": "toGeneratedValidationMap()",
@@ -20761,7 +20801,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L347",
       "id": "harness_generate_togeneratedvalidationmap",
-      "community": 1
+      "community": 2
     },
     {
       "label": "buildGeneratedDoc()",
@@ -20769,7 +20809,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L376",
       "id": "harness_generate_buildgenerateddoc",
-      "community": 1
+      "community": 2
     },
     {
       "label": "buildDiscoveryIndex()",
@@ -20777,7 +20817,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L386",
       "id": "harness_generate_builddiscoveryindex",
-      "community": 1
+      "community": 2
     },
     {
       "label": "buildTestIndex()",
@@ -20785,7 +20825,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L421",
       "id": "harness_generate_buildtestindex",
-      "community": 1
+      "community": 2
     },
     {
       "label": "buildKeyFolderIndex()",
@@ -20793,7 +20833,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L478",
       "id": "harness_generate_buildkeyfolderindex",
-      "community": 1
+      "community": 2
     },
     {
       "label": "buildValidationGuide()",
@@ -20801,7 +20841,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L511",
       "id": "harness_generate_buildvalidationguide",
-      "community": 1
+      "community": 2
     },
     {
       "label": "buildValidationMap()",
@@ -20809,7 +20849,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L553",
       "id": "harness_generate_buildvalidationmap",
-      "community": 1
+      "community": 2
     },
     {
       "label": "generateHarnessDocs()",
@@ -20817,7 +20857,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L560",
       "id": "harness_generate_generateharnessdocs",
-      "community": 1
+      "community": 2
     },
     {
       "label": "writeGeneratedHarnessDocs()",
@@ -20825,7 +20865,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L590",
       "id": "harness_generate_writegeneratedharnessdocs",
-      "community": 1
+      "community": 2
     },
     {
       "label": "harness-inferential-review.test.ts",
@@ -43181,7 +43221,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L267",
+      "source_location": "L271",
       "weight": 1.0,
       "_src": "scripts_graphify_wiki_ts",
       "_tgt": "graphify_wiki_buildpackagepage",
@@ -43193,7 +43233,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L333",
+      "source_location": "L338",
       "weight": 1.0,
       "_src": "scripts_graphify_wiki_ts",
       "_tgt": "graphify_wiki_generategraphifywikipages",
@@ -43205,7 +43245,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L365",
+      "source_location": "L370",
       "weight": 1.0,
       "_src": "scripts_graphify_wiki_ts",
       "_tgt": "graphify_wiki_writegraphifywikipages",
@@ -43241,7 +43281,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L336",
+      "source_location": "L341",
       "weight": 1.0,
       "_src": "graphify_wiki_generategraphifywikipages",
       "_tgt": "graphify_wiki_collectrepocodefiles",
@@ -43253,7 +43293,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L289",
+      "source_location": "L293",
       "weight": 1.0,
       "_src": "graphify_wiki_buildpackagepage",
       "_tgt": "graphify_wiki_normalizerepopath",
@@ -43265,7 +43305,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L260",
+      "source_location": "L239",
       "weight": 1.0,
       "_src": "graphify_wiki_buildrootindexpage",
       "_tgt": "graphify_wiki_tomarkdownlink",
@@ -43277,7 +43317,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L287",
+      "source_location": "L291",
       "weight": 1.0,
       "_src": "graphify_wiki_buildpackagepage",
       "_tgt": "graphify_wiki_tomarkdownlink",
@@ -43289,7 +43329,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L264",
+      "source_location": "L268",
       "weight": 1.0,
       "_src": "graphify_wiki_buildrootindexpage",
       "_tgt": "graphify_wiki_formatlist",
@@ -43301,7 +43341,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L330",
+      "source_location": "L335",
       "weight": 1.0,
       "_src": "graphify_wiki_buildpackagepage",
       "_tgt": "graphify_wiki_formatlist",
@@ -43313,7 +43353,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L242",
+      "source_location": "L246",
       "weight": 1.0,
       "_src": "graphify_wiki_buildrootindexpage",
       "_tgt": "graphify_wiki_countcommunities",
@@ -43325,7 +43365,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L338",
+      "source_location": "L343",
       "weight": 1.0,
       "_src": "graphify_wiki_generategraphifywikipages",
       "_tgt": "graphify_wiki_builddegreeindex",
@@ -43349,7 +43389,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L245",
+      "source_location": "L249",
       "weight": 1.0,
       "_src": "graphify_wiki_buildrootindexpage",
       "_tgt": "graphify_wiki_buildhotspotlines",
@@ -43361,7 +43401,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L319",
+      "source_location": "L323",
       "weight": 1.0,
       "_src": "graphify_wiki_buildpackagepage",
       "_tgt": "graphify_wiki_buildhotspotlines",
@@ -43373,7 +43413,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L335",
+      "source_location": "L340",
       "weight": 1.0,
       "_src": "graphify_wiki_generategraphifywikipages",
       "_tgt": "graphify_wiki_loadgraphifygraph",
@@ -43385,7 +43425,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L343",
+      "source_location": "L348",
       "weight": 1.0,
       "_src": "graphify_wiki_generategraphifywikipages",
       "_tgt": "graphify_wiki_buildrootindexpage",
@@ -43397,7 +43437,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L354",
+      "source_location": "L359",
       "weight": 1.0,
       "_src": "graphify_wiki_generategraphifywikipages",
       "_tgt": "graphify_wiki_buildpackagepage",
@@ -43409,7 +43449,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/graphify-wiki.ts",
-      "source_location": "L368",
+      "source_location": "L373",
       "weight": 1.0,
       "_src": "graphify_wiki_writegraphifywikipages",
       "_tgt": "graphify_wiki_generategraphifywikipages",
@@ -44621,7 +44661,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L37",
+      "source_location": "L39",
       "weight": 1.0,
       "_src": "scripts_harness_check_ts",
       "_tgt": "harness_check_normalizerepopath",
@@ -44633,7 +44673,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L41",
+      "source_location": "L43",
       "weight": 1.0,
       "_src": "scripts_harness_check_ts",
       "_tgt": "harness_check_striplinkdecorations",
@@ -44645,7 +44685,31 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L45",
+      "source_location": "L47",
+      "weight": 1.0,
+      "_src": "scripts_harness_check_ts",
+      "_tgt": "harness_check_torelativelinktarget",
+      "source": "scripts_harness_check_ts",
+      "target": "harness_check_torelativelinktarget",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L55",
+      "weight": 1.0,
+      "_src": "scripts_harness_check_ts",
+      "_tgt": "harness_check_collectmissingrequiredlinkerrors",
+      "source": "scripts_harness_check_ts",
+      "target": "harness_check_collectmissingrequiredlinkerrors",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L72",
       "weight": 1.0,
       "_src": "scripts_harness_check_ts",
       "_tgt": "harness_check_isrelativelink",
@@ -44657,7 +44721,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L53",
+      "source_location": "L80",
       "weight": 1.0,
       "_src": "scripts_harness_check_ts",
       "_tgt": "harness_check_fileexists",
@@ -44669,7 +44733,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L62",
+      "source_location": "L89",
       "weight": 1.0,
       "_src": "scripts_harness_check_ts",
       "_tgt": "harness_check_hasanyharnessdocs",
@@ -44681,7 +44745,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L78",
+      "source_location": "L105",
       "weight": 1.0,
       "_src": "scripts_harness_check_ts",
       "_tgt": "harness_check_isenforcedharnessapp",
@@ -44693,7 +44757,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L89",
+      "source_location": "L116",
       "weight": 1.0,
       "_src": "scripts_harness_check_ts",
       "_tgt": "harness_check_sortuniqueentries",
@@ -44705,7 +44769,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L95",
+      "source_location": "L122",
       "weight": 1.0,
       "_src": "scripts_harness_check_ts",
       "_tgt": "harness_check_formatscenariolist",
@@ -44717,7 +44781,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L99",
+      "source_location": "L126",
       "weight": 1.0,
       "_src": "scripts_harness_check_ts",
       "_tgt": "harness_check_isruntimescenarioname",
@@ -44729,7 +44793,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L107",
+      "source_location": "L134",
       "weight": 1.0,
       "_src": "scripts_harness_check_ts",
       "_tgt": "harness_check_extractruntimescenariosection",
@@ -44741,7 +44805,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L129",
+      "source_location": "L156",
       "weight": 1.0,
       "_src": "scripts_harness_check_ts",
       "_tgt": "harness_check_collectruntimescenariodocsyncerrors",
@@ -44753,7 +44817,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L188",
+      "source_location": "L215",
       "weight": 1.0,
       "_src": "scripts_harness_check_ts",
       "_tgt": "harness_check_collectmarkdownlinkerrors",
@@ -44765,7 +44829,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L217",
+      "source_location": "L244",
       "weight": 1.0,
       "_src": "scripts_harness_check_ts",
       "_tgt": "harness_check_extractinlinecode",
@@ -44777,7 +44841,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L223",
+      "source_location": "L250",
       "weight": 1.0,
       "_src": "scripts_harness_check_ts",
       "_tgt": "harness_check_normalizepathreference",
@@ -44789,7 +44853,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L236",
+      "source_location": "L263",
       "weight": 1.0,
       "_src": "scripts_harness_check_ts",
       "_tgt": "harness_check_islikelypathreference",
@@ -44801,7 +44865,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L261",
+      "source_location": "L288",
       "weight": 1.0,
       "_src": "scripts_harness_check_ts",
       "_tgt": "harness_check_resolvepathreference",
@@ -44813,7 +44877,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L287",
+      "source_location": "L314",
       "weight": 1.0,
       "_src": "scripts_harness_check_ts",
       "_tgt": "harness_check_collectreferencedpatherrors",
@@ -44825,7 +44889,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L322",
+      "source_location": "L349",
       "weight": 1.0,
       "_src": "scripts_harness_check_ts",
       "_tgt": "harness_check_readpackageconfig",
@@ -44837,7 +44901,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L350",
+      "source_location": "L377",
       "weight": 1.0,
       "_src": "scripts_harness_check_ts",
       "_tgt": "harness_check_listworkspacepackagedirs",
@@ -44849,7 +44913,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L373",
+      "source_location": "L400",
       "weight": 1.0,
       "_src": "scripts_harness_check_ts",
       "_tgt": "harness_check_collectharnessonboardingerrors",
@@ -44861,7 +44925,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L404",
+      "source_location": "L431",
       "weight": 1.0,
       "_src": "scripts_harness_check_ts",
       "_tgt": "harness_check_extracttestscriptfromcommand",
@@ -44873,7 +44937,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L436",
+      "source_location": "L463",
       "weight": 1.0,
       "_src": "scripts_harness_check_ts",
       "_tgt": "harness_check_walkfiles",
@@ -44885,7 +44949,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L456",
+      "source_location": "L483",
       "weight": 1.0,
       "_src": "scripts_harness_check_ts",
       "_tgt": "harness_check_collectservicedocumentedsurfaces",
@@ -44897,7 +44961,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L481",
+      "source_location": "L508",
       "weight": 1.0,
       "_src": "scripts_harness_check_ts",
       "_tgt": "harness_check_collecttestsurfaceroots",
@@ -44909,7 +44973,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L528",
+      "source_location": "L555",
       "weight": 1.0,
       "_src": "scripts_harness_check_ts",
       "_tgt": "harness_check_collecttestingdocerrors",
@@ -44921,7 +44985,43 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L581",
+      "source_location": "L608",
+      "weight": 1.0,
+      "_src": "scripts_harness_check_ts",
+      "_tgt": "harness_check_collectreadmelinkerrors",
+      "source": "scripts_harness_check_ts",
+      "target": "harness_check_collectreadmelinkerrors",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L620",
+      "weight": 1.0,
+      "_src": "scripts_harness_check_ts",
+      "_tgt": "harness_check_collectpackagesrouterlinkerrors",
+      "source": "scripts_harness_check_ts",
+      "target": "harness_check_collectpackagesrouterlinkerrors",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L644",
+      "weight": 1.0,
+      "_src": "scripts_harness_check_ts",
+      "_tgt": "harness_check_collectpackageguidelinkerrors",
+      "source": "scripts_harness_check_ts",
+      "target": "harness_check_collectpackageguidelinkerrors",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L666",
       "weight": 1.0,
       "_src": "scripts_harness_check_ts",
       "_tgt": "harness_check_validateharnessdocs",
@@ -44933,7 +45033,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L723",
+      "source_location": "L825",
       "weight": 1.0,
       "_src": "scripts_harness_check_ts",
       "_tgt": "harness_check_runharnesscheck",
@@ -44945,7 +45045,19 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L194",
+      "source_location": "L48",
+      "weight": 1.0,
+      "_src": "harness_check_torelativelinktarget",
+      "_tgt": "harness_check_normalizerepopath",
+      "source": "harness_check_normalizerepopath",
+      "target": "harness_check_torelativelinktarget",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L221",
       "weight": 1.0,
       "_src": "harness_check_collectmarkdownlinkerrors",
       "_tgt": "harness_check_striplinkdecorations",
@@ -44957,7 +45069,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L224",
+      "source_location": "L251",
       "weight": 1.0,
       "_src": "harness_check_normalizepathreference",
       "_tgt": "harness_check_striplinkdecorations",
@@ -44969,7 +45081,79 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L196",
+      "source_location": "L613",
+      "weight": 1.0,
+      "_src": "harness_check_collectreadmelinkerrors",
+      "_tgt": "harness_check_torelativelinktarget",
+      "source": "harness_check_torelativelinktarget",
+      "target": "harness_check_collectreadmelinkerrors",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L626",
+      "weight": 1.0,
+      "_src": "harness_check_collectpackagesrouterlinkerrors",
+      "_tgt": "harness_check_torelativelinktarget",
+      "source": "harness_check_torelativelinktarget",
+      "target": "harness_check_collectpackagesrouterlinkerrors",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L653",
+      "weight": 1.0,
+      "_src": "harness_check_collectpackageguidelinkerrors",
+      "_tgt": "harness_check_torelativelinktarget",
+      "source": "harness_check_torelativelinktarget",
+      "target": "harness_check_collectpackageguidelinkerrors",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L609",
+      "weight": 1.0,
+      "_src": "harness_check_collectreadmelinkerrors",
+      "_tgt": "harness_check_collectmissingrequiredlinkerrors",
+      "source": "harness_check_collectmissingrequiredlinkerrors",
+      "target": "harness_check_collectreadmelinkerrors",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L636",
+      "weight": 1.0,
+      "_src": "harness_check_collectpackagesrouterlinkerrors",
+      "_tgt": "harness_check_collectmissingrequiredlinkerrors",
+      "source": "harness_check_collectmissingrequiredlinkerrors",
+      "target": "harness_check_collectpackagesrouterlinkerrors",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L649",
+      "weight": 1.0,
+      "_src": "harness_check_collectpackageguidelinkerrors",
+      "_tgt": "harness_check_collectmissingrequiredlinkerrors",
+      "source": "harness_check_collectmissingrequiredlinkerrors",
+      "target": "harness_check_collectpackageguidelinkerrors",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L223",
       "weight": 1.0,
       "_src": "harness_check_collectmarkdownlinkerrors",
       "_tgt": "harness_check_isrelativelink",
@@ -44981,7 +45165,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L70",
+      "source_location": "L97",
       "weight": 1.0,
       "_src": "harness_check_hasanyharnessdocs",
       "_tgt": "harness_check_fileexists",
@@ -44993,7 +45177,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L137",
+      "source_location": "L164",
       "weight": 1.0,
       "_src": "harness_check_collectruntimescenariodocsyncerrors",
       "_tgt": "harness_check_fileexists",
@@ -45005,7 +45189,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L206",
+      "source_location": "L233",
       "weight": 1.0,
       "_src": "harness_check_collectmarkdownlinkerrors",
       "_tgt": "harness_check_fileexists",
@@ -45017,7 +45201,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L314",
+      "source_location": "L341",
       "weight": 1.0,
       "_src": "harness_check_collectreferencedpatherrors",
       "_tgt": "harness_check_fileexists",
@@ -45029,7 +45213,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L329",
+      "source_location": "L356",
       "weight": 1.0,
       "_src": "harness_check_readpackageconfig",
       "_tgt": "harness_check_fileexists",
@@ -45041,7 +45225,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L352",
+      "source_location": "L379",
       "weight": 1.0,
       "_src": "harness_check_listworkspacepackagedirs",
       "_tgt": "harness_check_fileexists",
@@ -45053,7 +45237,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L393",
+      "source_location": "L420",
       "weight": 1.0,
       "_src": "harness_check_collectharnessonboardingerrors",
       "_tgt": "harness_check_fileexists",
@@ -45065,7 +45249,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L437",
+      "source_location": "L464",
       "weight": 1.0,
       "_src": "harness_check_walkfiles",
       "_tgt": "harness_check_fileexists",
@@ -45077,7 +45261,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L473",
+      "source_location": "L500",
       "weight": 1.0,
       "_src": "harness_check_collectservicedocumentedsurfaces",
       "_tgt": "harness_check_fileexists",
@@ -45089,7 +45273,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L515",
+      "source_location": "L542",
       "weight": 1.0,
       "_src": "harness_check_collecttestsurfaceroots",
       "_tgt": "harness_check_fileexists",
@@ -45101,7 +45285,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L588",
+      "source_location": "L673",
       "weight": 1.0,
       "_src": "harness_check_validateharnessdocs",
       "_tgt": "harness_check_fileexists",
@@ -45113,7 +45297,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L86",
+      "source_location": "L113",
       "weight": 1.0,
       "_src": "harness_check_isenforcedharnessapp",
       "_tgt": "harness_check_hasanyharnessdocs",
@@ -45125,7 +45309,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L388",
+      "source_location": "L415",
       "weight": 1.0,
       "_src": "harness_check_collectharnessonboardingerrors",
       "_tgt": "harness_check_isenforcedharnessapp",
@@ -45137,7 +45321,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L599",
+      "source_location": "L684",
       "weight": 1.0,
       "_src": "harness_check_validateharnessdocs",
       "_tgt": "harness_check_isenforcedharnessapp",
@@ -45149,7 +45333,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L131",
+      "source_location": "L158",
       "weight": 1.0,
       "_src": "harness_check_collectruntimescenariodocsyncerrors",
       "_tgt": "harness_check_sortuniqueentries",
@@ -45161,7 +45345,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L170",
+      "source_location": "L197",
       "weight": 1.0,
       "_src": "harness_check_collectruntimescenariodocsyncerrors",
       "_tgt": "harness_check_formatscenariolist",
@@ -45173,7 +45357,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L143",
+      "source_location": "L170",
       "weight": 1.0,
       "_src": "harness_check_collectruntimescenariodocsyncerrors",
       "_tgt": "harness_check_extractruntimescenariosection",
@@ -45185,7 +45369,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L718",
+      "source_location": "L820",
       "weight": 1.0,
       "_src": "harness_check_validateharnessdocs",
       "_tgt": "harness_check_collectruntimescenariodocsyncerrors",
@@ -45197,7 +45381,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L627",
+      "source_location": "L712",
       "weight": 1.0,
       "_src": "harness_check_validateharnessdocs",
       "_tgt": "harness_check_collectmarkdownlinkerrors",
@@ -45209,7 +45393,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L296",
+      "source_location": "L323",
       "weight": 1.0,
       "_src": "harness_check_collectreferencedpatherrors",
       "_tgt": "harness_check_extractinlinecode",
@@ -45221,7 +45405,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L538",
+      "source_location": "L565",
       "weight": 1.0,
       "_src": "harness_check_collecttestingdocerrors",
       "_tgt": "harness_check_extractinlinecode",
@@ -45233,7 +45417,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L241",
+      "source_location": "L268",
       "weight": 1.0,
       "_src": "harness_check_islikelypathreference",
       "_tgt": "harness_check_normalizepathreference",
@@ -45245,7 +45429,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L267",
+      "source_location": "L294",
       "weight": 1.0,
       "_src": "harness_check_resolvepathreference",
       "_tgt": "harness_check_normalizepathreference",
@@ -45257,7 +45441,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L301",
+      "source_location": "L328",
       "weight": 1.0,
       "_src": "harness_check_collectreferencedpatherrors",
       "_tgt": "harness_check_normalizepathreference",
@@ -45269,7 +45453,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L297",
+      "source_location": "L324",
       "weight": 1.0,
       "_src": "harness_check_collectreferencedpatherrors",
       "_tgt": "harness_check_islikelypathreference",
@@ -45281,7 +45465,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L307",
+      "source_location": "L334",
       "weight": 1.0,
       "_src": "harness_check_collectreferencedpatherrors",
       "_tgt": "harness_check_resolvepathreference",
@@ -45293,7 +45477,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L651",
+      "source_location": "L753",
       "weight": 1.0,
       "_src": "harness_check_validateharnessdocs",
       "_tgt": "harness_check_collectreferencedpatherrors",
@@ -45305,7 +45489,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L594",
+      "source_location": "L679",
       "weight": 1.0,
       "_src": "harness_check_validateharnessdocs",
       "_tgt": "harness_check_readpackageconfig",
@@ -45317,7 +45501,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L379",
+      "source_location": "L406",
       "weight": 1.0,
       "_src": "harness_check_collectharnessonboardingerrors",
       "_tgt": "harness_check_listworkspacepackagedirs",
@@ -45329,7 +45513,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L582",
+      "source_location": "L667",
       "weight": 1.0,
       "_src": "harness_check_validateharnessdocs",
       "_tgt": "harness_check_collectharnessonboardingerrors",
@@ -45341,7 +45525,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L539",
+      "source_location": "L566",
       "weight": 1.0,
       "_src": "harness_check_collecttestingdocerrors",
       "_tgt": "harness_check_extracttestscriptfromcommand",
@@ -45353,7 +45537,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L491",
+      "source_location": "L518",
       "weight": 1.0,
       "_src": "harness_check_collecttestsurfaceroots",
       "_tgt": "harness_check_walkfiles",
@@ -45365,7 +45549,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L487",
+      "source_location": "L514",
       "weight": 1.0,
       "_src": "harness_check_collecttestsurfaceroots",
       "_tgt": "harness_check_collectservicedocumentedsurfaces",
@@ -45377,7 +45561,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L571",
+      "source_location": "L598",
       "weight": 1.0,
       "_src": "harness_check_collecttestingdocerrors",
       "_tgt": "harness_check_collecttestsurfaceroots",
@@ -45389,7 +45573,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L670",
+      "source_location": "L772",
       "weight": 1.0,
       "_src": "harness_check_validateharnessdocs",
       "_tgt": "harness_check_collecttestingdocerrors",
@@ -45401,7 +45585,43 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-check.ts",
-      "source_location": "L724",
+      "source_location": "L729",
+      "weight": 1.0,
+      "_src": "harness_check_validateharnessdocs",
+      "_tgt": "harness_check_collectreadmelinkerrors",
+      "source": "harness_check_collectreadmelinkerrors",
+      "target": "harness_check_validateharnessdocs",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L735",
+      "weight": 1.0,
+      "_src": "harness_check_validateharnessdocs",
+      "_tgt": "harness_check_collectpackagesrouterlinkerrors",
+      "source": "harness_check_collectpackagesrouterlinkerrors",
+      "target": "harness_check_validateharnessdocs",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L741",
+      "weight": 1.0,
+      "_src": "harness_check_validateharnessdocs",
+      "_tgt": "harness_check_collectpackageguidelinkerrors",
+      "source": "harness_check_collectpackageguidelinkerrors",
+      "target": "harness_check_validateharnessdocs",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-check.ts",
+      "source_location": "L826",
       "weight": 1.0,
       "_src": "harness_check_runharnesscheck",
       "_tgt": "harness_check_validateharnessdocs",

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -1,20 +1,24 @@
 # Graphify Wiki
 
-Graphify is the navigation layer for the repo graph. For deeper analysis, open `graphify-out/GRAPH_REPORT.md`.
+Graphify is the navigation layer for the repo graph. Use the entry docs below for operational rules and validation, and open `graphify-out/GRAPH_REPORT.md` for deeper analysis.
+
+## Entry Docs
+- [AGENTS.md](../../AGENTS.md) - repo-wide workflow, guardrails, and graphify usage rules
+- [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
 - Code files discovered: 1198
-- Graph nodes: 2764
-- Graph edges: 2274
+- Graph nodes: 2769
+- Graph edges: 2289
 - Communities: 1113
 
 ## Graph Hotspots
 - `storefrontJourneyEvents.ts` (45 edges, Community 0) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 0) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `harness-generate.ts` (30 edges, Community 1) - [`scripts/harness-generate.ts`](../../scripts/harness-generate.ts)
-- `harness-check.ts` (27 edges, Community 3) - [`scripts/harness-check.ts`](../../scripts/harness-check.ts)
+- `harness-check.ts` (32 edges, Community 1) - [`scripts/harness-check.ts`](../../scripts/harness-check.ts)
+- `harness-generate.ts` (30 edges, Community 2) - [`scripts/harness-generate.ts`](../../scripts/harness-generate.ts)
 - `harness-inferential-review.ts` (27 edges, Community 4) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
-- `storeConfigV2.ts` (27 edges, Community 2) - [`packages/athena-webapp/convex/inventory/storeConfigV2.ts`](../../packages/athena-webapp/convex/inventory/storeConfigV2.ts)
+- `storeConfigV2.ts` (27 edges, Community 3) - [`packages/athena-webapp/convex/inventory/storeConfigV2.ts`](../../packages/athena-webapp/convex/inventory/storeConfigV2.ts)
 - `harness-behavior.ts` (24 edges, Community 5) - [`scripts/harness-behavior.ts`](../../scripts/harness-behavior.ts)
 - `harness-self-review.ts` (24 edges, Community 6) - [`scripts/harness-self-review.ts`](../../scripts/harness-self-review.ts)
 

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -1,6 +1,6 @@
 # Athena Webapp
 
-Landing page for packages/athena-webapp. Start with the package entry docs, then jump into the graph hotspots below.
+Landing page for packages/athena-webapp. Use this page to orient around graph hotspots, then switch to the package entry docs for operational rules and validation.
 
 ## Package Docs
 - [AGENTS.md](../../../packages/athena-webapp/AGENTS.md)
@@ -17,7 +17,7 @@ Landing page for packages/athena-webapp. Start with the package entry docs, then
 - [validation-map.json](../../../packages/athena-webapp/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `storeConfigV2.ts` (27 edges, Community 2) - [`packages/athena-webapp/convex/inventory/storeConfigV2.ts`](../../../packages/athena-webapp/convex/inventory/storeConfigV2.ts)
+- `storeConfigV2.ts` (27 edges, Community 3) - [`packages/athena-webapp/convex/inventory/storeConfigV2.ts`](../../../packages/athena-webapp/convex/inventory/storeConfigV2.ts)
 - `ProductStock.tsx` (19 edges, Community 9) - [`packages/athena-webapp/src/components/add-product/ProductStock.tsx`](../../../packages/athena-webapp/src/components/add-product/ProductStock.tsx)
 - `checkoutSession.ts` (17 edges, Community 11) - [`packages/athena-webapp/convex/storeFront/checkoutSession.ts`](../../../packages/athena-webapp/convex/storeFront/checkoutSession.ts)
 - `DataTableViewOptions()` (16 edges, Community 13) - [`packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx`](../../../packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx)
@@ -25,4 +25,5 @@ Landing page for packages/athena-webapp. Start with the package entry docs, then
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index
+- [packages/AGENTS.md](../../../packages/AGENTS.md) - package router and operational guide entrypoint
 - [GRAPH_REPORT.md](../../GRAPH_REPORT.md) - full graph report

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -1,6 +1,6 @@
 # Storefront Webapp
 
-Landing page for packages/storefront-webapp. Start with the package entry docs, then jump into the graph hotspots below.
+Landing page for packages/storefront-webapp. Use this page to orient around graph hotspots, then switch to the package entry docs for operational rules and validation.
 
 ## Package Docs
 - [AGENTS.md](../../../packages/storefront-webapp/AGENTS.md)
@@ -25,4 +25,5 @@ Landing page for packages/storefront-webapp. Start with the package entry docs, 
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index
+- [packages/AGENTS.md](../../../packages/AGENTS.md) - package router and operational guide entrypoint
 - [GRAPH_REPORT.md](../../GRAPH_REPORT.md) - full graph report

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -1,6 +1,6 @@
 # Valkey Proxy Server
 
-Landing page for packages/valkey-proxy-server. Start with the package entry docs, then jump into the graph hotspots below.
+Landing page for packages/valkey-proxy-server. Use this page to orient around graph hotspots, then switch to the package entry docs for operational rules and validation.
 
 ## Package Docs
 - [AGENTS.md](../../../packages/valkey-proxy-server/AGENTS.md)
@@ -25,4 +25,5 @@ Landing page for packages/valkey-proxy-server. Start with the package entry docs
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index
+- [packages/AGENTS.md](../../../packages/AGENTS.md) - package router and operational guide entrypoint
 - [GRAPH_REPORT.md](../../GRAPH_REPORT.md) - full graph report

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -1,5 +1,11 @@
 # Athena Packages Agent Router
 
+- Start with [the Graphify wiki index](../graphify-out/wiki/index.md) for repo-wide navigation, package landing pages, and graph hotspots.
+- Use the package-specific wiki landing pages for graph-guided orientation:
+  - [Athena Webapp graph page](../graphify-out/wiki/packages/athena-webapp.md)
+  - [Storefront Webapp graph page](../graphify-out/wiki/packages/storefront-webapp.md)
+  - [Valkey Proxy Server graph page](../graphify-out/wiki/packages/valkey-proxy-server.md)
+- After you orient in graphify, switch to the package `AGENTS.md` files below for operational rules and validation.
 - For `packages/athena-webapp`, start with [athena-webapp/AGENTS.md](./athena-webapp/AGENTS.md).
 - For `packages/storefront-webapp`, start with [storefront-webapp/AGENTS.md](./storefront-webapp/AGENTS.md).
 - For `packages/valkey-proxy-server`, start with [valkey-proxy-server/AGENTS.md](./valkey-proxy-server/AGENTS.md).

--- a/packages/athena-webapp/AGENTS.md
+++ b/packages/athena-webapp/AGENTS.md
@@ -1,6 +1,7 @@
 # Athena Webapp Agent Guide
 
-- Start with [docs/agent/index.md](./docs/agent/index.md).
+- Use [the Athena Webapp graph page](../../graphify-out/wiki/packages/athena-webapp.md) for graph-guided orientation and hotspot discovery.
+- Start implementation and validation from [docs/agent/index.md](./docs/agent/index.md); the local package docs are the operational source of truth.
 - Read [docs/agent/architecture.md](./docs/agent/architecture.md) before changing router, auth-shell, or Convex boundaries.
 - Use [docs/agent/testing.md](./docs/agent/testing.md) to choose the smallest honest validation set.
 - Use [docs/agent/code-map.md](./docs/agent/code-map.md) when tracing ownership across `src/` and `convex/`.

--- a/packages/storefront-webapp/AGENTS.md
+++ b/packages/storefront-webapp/AGENTS.md
@@ -1,6 +1,7 @@
 # Storefront Webapp Agent Guide
 
-- Start with [docs/agent/index.md](./docs/agent/index.md).
+- Use [the Storefront Webapp graph page](../../graphify-out/wiki/packages/storefront-webapp.md) for graph-guided orientation and hotspot discovery.
+- Start implementation and validation from [docs/agent/index.md](./docs/agent/index.md); the local package docs are the operational source of truth.
 - Read [docs/agent/architecture.md](./docs/agent/architecture.md) before changing TanStack Start runtime, route layout, or API boundaries.
 - Use [docs/agent/testing.md](./docs/agent/testing.md) to choose the smallest honest validation set.
 - Use [docs/agent/code-map.md](./docs/agent/code-map.md) when tracing checkout, catalog, or observability code paths.

--- a/packages/valkey-proxy-server/AGENTS.md
+++ b/packages/valkey-proxy-server/AGENTS.md
@@ -1,6 +1,7 @@
 # Valkey Proxy Server Agent Guide
 
-- Start with [docs/agent/index.md](./docs/agent/index.md).
+- Use [the Valkey Proxy Server graph page](../../graphify-out/wiki/packages/valkey-proxy-server.md) for graph-guided orientation and hotspot discovery.
+- Start implementation and validation from [docs/agent/index.md](./docs/agent/index.md); the local package docs are the operational source of truth.
 - Read [docs/agent/architecture.md](./docs/agent/architecture.md) before changing Redis client setup, HTTP handlers, or invalidation behavior.
 - Use [docs/agent/testing.md](./docs/agent/testing.md) to pick the smallest honest validation set.
 - Use [docs/agent/code-map.md](./docs/agent/code-map.md) when tracing request handlers, connection probes, or package boundaries.

--- a/scripts/graphify-wiki.test.ts
+++ b/scripts/graphify-wiki.test.ts
@@ -89,6 +89,8 @@ describe("generateGraphifyWikiPages", () => {
 
     expect(Array.from(pages.keys())).toEqual(GRAPHIFY_WIKI_ARTIFACTS);
     expect(pages.get("graphify-out/wiki/index.md")).toContain("# Graphify Wiki");
+    expect(pages.get("graphify-out/wiki/index.md")).toContain("## Entry Docs");
+    expect(pages.get("graphify-out/wiki/index.md")).toContain("packages/AGENTS.md");
     expect(pages.get("graphify-out/wiki/index.md")).toContain("Repo Summary");
     expect(pages.get("graphify-out/wiki/index.md")).toContain("sharedHotspot()");
     expect(pages.get("graphify-out/wiki/index.md")).toContain(
@@ -101,10 +103,19 @@ describe("generateGraphifyWikiPages", () => {
       pages.get("graphify-out/wiki/packages/athena-webapp.md")
     ).toContain("docs/agent/testing.md");
     expect(
+      pages.get("graphify-out/wiki/packages/athena-webapp.md")
+    ).toContain("packages/AGENTS.md");
+    expect(
       pages.get("graphify-out/wiki/packages/storefront-webapp.md")
     ).toContain("storeHotspot()");
     expect(
       pages.get("graphify-out/wiki/packages/storefront-webapp.md")
     ).toContain("docs/agent/code-map.md");
+    expect(
+      pages.get("graphify-out/wiki/packages/valkey-proxy-server.md")
+    ).toContain("# Valkey Proxy Server");
+    expect(
+      pages.get("graphify-out/wiki/packages/valkey-proxy-server.md")
+    ).toContain("No graph hotspots were found");
   });
 });

--- a/scripts/graphify-wiki.ts
+++ b/scripts/graphify-wiki.ts
@@ -1,7 +1,7 @@
 import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 
-import { HARNESS_APP_REGISTRY } from "./harness-app-registry";
+import { HARNESS_APP_REGISTRY, PACKAGES_AGENTS_PATH } from "./harness-app-registry";
 
 const GRAPHIFY_OUTPUT_DIR = "graphify-out";
 const GRAPHIFY_WIKI_DIR = path.posix.join(GRAPHIFY_OUTPUT_DIR, "wiki");
@@ -233,7 +233,11 @@ function buildRootIndexPage(params: {
   const lines = [
     "# Graphify Wiki",
     "",
-    "Graphify is the navigation layer for the repo graph. For deeper analysis, open `graphify-out/GRAPH_REPORT.md`.",
+    "Graphify is the navigation layer for the repo graph. Use the entry docs below for operational rules and validation, and open `graphify-out/GRAPH_REPORT.md` for deeper analysis.",
+    "",
+    "## Entry Docs",
+    `- ${toMarkdownLink(pagePath, "AGENTS.md", "AGENTS.md")} - repo-wide workflow, guardrails, and graphify usage rules`,
+    `- ${toMarkdownLink(pagePath, "packages/AGENTS.md", "packages/AGENTS.md")} - package router plus the operational guides for each harnessed package`,
     "",
     "## Repo Summary",
     `- Code files discovered: ${params.codeFileCount}`,
@@ -281,7 +285,7 @@ function buildPackagePage(params: {
   const lines = [
     `# ${params.packageEntry.label}`,
     "",
-    `Landing page for ${params.packageEntry.packageDir}. Start with the package entry docs, then jump into the graph hotspots below.`,
+    `Landing page for ${params.packageEntry.packageDir}. Use this page to orient around graph hotspots, then switch to the package entry docs for operational rules and validation.`,
     "",
     "## Package Docs",
     `- ${toMarkdownLink(
@@ -324,6 +328,7 @@ function buildPackagePage(params: {
       path.posix.join(GRAPHIFY_WIKI_DIR, "index.md"),
       "wiki index"
     )} - back to the wiki index`,
+    `- ${toMarkdownLink(pagePath, PACKAGES_AGENTS_PATH, "packages/AGENTS.md")} - package router and operational guide entrypoint`,
     `- ${toMarkdownLink(pagePath, GRAPHIFY_REPORT_PATH, "GRAPH_REPORT.md")} - full graph report`,
   ];
 

--- a/scripts/harness-audit.test.ts
+++ b/scripts/harness-audit.test.ts
@@ -23,6 +23,9 @@ async function createFixtureRepo() {
     [
       "# athena",
       "",
+      "Start with [the Graphify wiki index](./graphify-out/wiki/index.md) for repo and package navigation.",
+      "Use [the packages router](./packages/AGENTS.md) for operational package entry docs.",
+      "",
       "List runtime behavior scenarios with `bun run harness:behavior --list`.",
       "Bundled scenarios include:",
       "",
@@ -43,10 +46,31 @@ async function createFixtureRepo() {
     [
       "# Packages Agent Router",
       "",
+      "- [Graphify wiki index](../graphify-out/wiki/index.md)",
+      "- [Athena webapp graph page](../graphify-out/wiki/packages/athena-webapp.md)",
+      "- [Storefront webapp graph page](../graphify-out/wiki/packages/storefront-webapp.md)",
+      "- [Valkey proxy server graph page](../graphify-out/wiki/packages/valkey-proxy-server.md)",
       "- [Athena webapp](./athena-webapp/AGENTS.md)",
       "- [Storefront webapp](./storefront-webapp/AGENTS.md)",
       "- [Valkey proxy server](./valkey-proxy-server/AGENTS.md)",
     ].join("\n"),
+    rootDir
+  );
+
+  await write("graphify-out/wiki/index.md", "# Graphify Wiki\n", rootDir);
+  await write(
+    "graphify-out/wiki/packages/athena-webapp.md",
+    "# Athena Webapp\n",
+    rootDir
+  );
+  await write(
+    "graphify-out/wiki/packages/storefront-webapp.md",
+    "# Storefront Webapp\n",
+    rootDir
+  );
+  await write(
+    "graphify-out/wiki/packages/valkey-proxy-server.md",
+    "# Valkey Proxy Server\n",
     rootDir
   );
 
@@ -113,6 +137,7 @@ async function createFixtureRepo() {
     [
       "# Athena Webapp Agent Guide",
       "",
+      "- [Graph page](../../graphify-out/wiki/packages/athena-webapp.md)",
       "- [Harness index](./docs/agent/index.md)",
       "- [Architecture](./docs/agent/architecture.md)",
       "- [Testing](./docs/agent/testing.md)",
@@ -125,6 +150,7 @@ async function createFixtureRepo() {
     [
       "# Storefront Webapp Agent Guide",
       "",
+      "- [Graph page](../../graphify-out/wiki/packages/storefront-webapp.md)",
       "- [Harness index](./docs/agent/index.md)",
       "- [Architecture](./docs/agent/architecture.md)",
       "- [Testing](./docs/agent/testing.md)",
@@ -137,6 +163,7 @@ async function createFixtureRepo() {
     [
       "# Valkey Proxy Server Agent Guide",
       "",
+      "- [Graph page](../../graphify-out/wiki/packages/valkey-proxy-server.md)",
       "- [Harness index](./docs/agent/index.md)",
       "- [Architecture](./docs/agent/architecture.md)",
       "- [Testing](./docs/agent/testing.md)",

--- a/scripts/harness-check.test.ts
+++ b/scripts/harness-check.test.ts
@@ -54,6 +54,9 @@ async function createFixtureRepo() {
     [
       "# athena",
       "",
+      "Start with [the Graphify wiki index](./graphify-out/wiki/index.md) for repo and package navigation.",
+      "Use [the packages router](./packages/AGENTS.md) for operational package entry docs.",
+      "",
       "List runtime behavior scenarios with `bun run harness:behavior --list`.",
       "Bundled scenarios include:",
       "",
@@ -74,10 +77,31 @@ async function createFixtureRepo() {
     [
       "# Packages Agent Router",
       "",
+      "- [Graphify wiki index](../graphify-out/wiki/index.md)",
+      "- [Athena webapp graph page](../graphify-out/wiki/packages/athena-webapp.md)",
+      "- [Storefront webapp graph page](../graphify-out/wiki/packages/storefront-webapp.md)",
+      "- [Valkey proxy server graph page](../graphify-out/wiki/packages/valkey-proxy-server.md)",
       "- [Athena webapp](./athena-webapp/AGENTS.md)",
       "- [Storefront webapp](./storefront-webapp/AGENTS.md)",
       "- [Valkey proxy server](./valkey-proxy-server/AGENTS.md)",
     ].join("\n"),
+    rootDir
+  );
+
+  await write("graphify-out/wiki/index.md", "# Graphify Wiki\n", rootDir);
+  await write(
+    "graphify-out/wiki/packages/athena-webapp.md",
+    "# Athena Webapp\n",
+    rootDir
+  );
+  await write(
+    "graphify-out/wiki/packages/storefront-webapp.md",
+    "# Storefront Webapp\n",
+    rootDir
+  );
+  await write(
+    "graphify-out/wiki/packages/valkey-proxy-server.md",
+    "# Valkey Proxy Server\n",
     rootDir
   );
 
@@ -112,6 +136,7 @@ async function createFixtureRepo() {
       [
         `# ${appName}`,
         "",
+        `- [Graph page](../../graphify-out/wiki/packages/${appName}.md)`,
         "- [Harness index](./docs/agent/index.md)",
         "- [Architecture](./docs/agent/architecture.md)",
         "- [Testing](./docs/agent/testing.md)",
@@ -262,6 +287,7 @@ async function createFixtureRepo() {
     [
       "# valkey-proxy-server",
       "",
+      "- [Graph page](../../graphify-out/wiki/packages/valkey-proxy-server.md)",
       "- [Harness index](./docs/agent/index.md)",
       "- [Architecture](./docs/agent/architecture.md)",
       "- [Testing](./docs/agent/testing.md)",
@@ -508,6 +534,72 @@ describe("validateHarnessDocs", () => {
 
     await expect(validateHarnessDocs(rootDir)).resolves.toContain(
       "Broken markdown link in packages/athena-webapp/AGENTS.md: ./docs/agent/missing.md"
+    );
+  });
+
+  it("reports missing graphify links from the README", async () => {
+    const rootDir = await createFixtureRepo();
+    await write(
+      "README.md",
+      [
+        "# athena",
+        "",
+        "List runtime behavior scenarios with `bun run harness:behavior --list`.",
+        "Bundled scenarios include:",
+        "",
+        "- `sample-runtime-smoke`",
+        "- `athena-admin-shell-boot`",
+        "- `athena-convex-storefront-composition`",
+        "- `athena-convex-storefront-failure-visibility`",
+        "- `storefront-checkout-bootstrap`",
+        "- `storefront-checkout-validation-blocker`",
+        "- `storefront-checkout-verification-recovery`",
+        "",
+      ].join("\n"),
+      rootDir
+    );
+
+    await expect(validateHarnessDocs(rootDir)).resolves.toContain(
+      "Missing required README graphify link in README.md: ./graphify-out/wiki/index.md"
+    );
+  });
+
+  it("reports missing graphify links from the packages router", async () => {
+    const rootDir = await createFixtureRepo();
+    await write(
+      "packages/AGENTS.md",
+      [
+        "# Packages Agent Router",
+        "",
+        "- [Athena webapp](./athena-webapp/AGENTS.md)",
+        "- [Storefront webapp](./storefront-webapp/AGENTS.md)",
+        "- [Valkey proxy server](./valkey-proxy-server/AGENTS.md)",
+      ].join("\n"),
+      rootDir
+    );
+
+    await expect(validateHarnessDocs(rootDir)).resolves.toContain(
+      "Missing required packages router link in packages/AGENTS.md: ../graphify-out/wiki/index.md"
+    );
+  });
+
+  it("reports missing graphify links from package AGENTS guides", async () => {
+    const rootDir = await createFixtureRepo();
+    await write(
+      "packages/athena-webapp/AGENTS.md",
+      [
+        "# athena-webapp",
+        "",
+        "- [Harness index](./docs/agent/index.md)",
+        "- [Architecture](./docs/agent/architecture.md)",
+        "- [Testing](./docs/agent/testing.md)",
+        "- [Code map](./docs/agent/code-map.md)",
+      ].join("\n"),
+      rootDir
+    );
+
+    await expect(validateHarnessDocs(rootDir)).resolves.toContain(
+      "Missing required package guide link in packages/athena-webapp/AGENTS.md: ../../graphify-out/wiki/packages/athena-webapp.md"
     );
   });
 

--- a/scripts/harness-check.ts
+++ b/scripts/harness-check.ts
@@ -26,6 +26,8 @@ const RUNTIME_SCENARIO_DOCS = [
   "packages/athena-webapp/docs/agent/testing.md",
   "packages/storefront-webapp/docs/agent/testing.md",
 ] as const;
+const README_PATH = "README.md" as const;
+const GRAPHIFY_WIKI_INDEX_PATH = "graphify-out/wiki/index.md" as const;
 
 type HarnessAppConfig = {
   appName: HarnessAppName;
@@ -40,6 +42,31 @@ function normalizeRepoPath(repoPath: string) {
 
 function stripLinkDecorations(linkTarget: string) {
   return linkTarget.split("#", 1)[0]?.split("?", 1)[0] ?? "";
+}
+
+function toRelativeLinkTarget(filePath: string, targetPath: string) {
+  const relativePath = normalizeRepoPath(
+    path.posix.relative(path.posix.dirname(filePath), normalizeRepoPath(targetPath))
+  );
+
+  return relativePath.startsWith(".") ? relativePath : `./${relativePath}`;
+}
+
+function collectMissingRequiredLinkErrors(
+  filePath: string,
+  linkTargets: Set<string>,
+  requiredLinks: string[],
+  label: string
+) {
+  const errors: string[] = [];
+
+  for (const requiredLink of requiredLinks) {
+    if (!linkTargets.has(requiredLink)) {
+      errors.push(`Missing required ${label} link in ${filePath}: ${requiredLink}`);
+    }
+  }
+
+  return errors;
 }
 
 function isRelativeLink(linkTarget: string) {
@@ -578,9 +605,67 @@ async function collectTestingDocErrors(
   return errors;
 }
 
+function collectReadmeLinkErrors(filePath: string, linkTargets: Set<string>) {
+  return collectMissingRequiredLinkErrors(
+    filePath,
+    linkTargets,
+    [
+      toRelativeLinkTarget(filePath, GRAPHIFY_WIKI_INDEX_PATH),
+      toRelativeLinkTarget(filePath, PACKAGES_AGENTS_PATH),
+    ],
+    "README graphify"
+  );
+}
+
+function collectPackagesRouterLinkErrors(
+  filePath: string,
+  linkTargets: Set<string>,
+  apps: HarnessAppRegistryEntry[]
+) {
+  const requiredLinks = [
+    toRelativeLinkTarget(filePath, GRAPHIFY_WIKI_INDEX_PATH),
+    ...apps.flatMap((app) => [
+      toRelativeLinkTarget(filePath, app.harnessDocs.agentsPath),
+      toRelativeLinkTarget(
+        filePath,
+        path.posix.join("graphify-out/wiki/packages", `${app.appName}.md`)
+      ),
+    ]),
+  ];
+
+  return collectMissingRequiredLinkErrors(
+    filePath,
+    linkTargets,
+    requiredLinks,
+    "packages router"
+  );
+}
+
+function collectPackageGuideLinkErrors(
+  filePath: string,
+  linkTargets: Set<string>,
+  app: HarnessAppRegistryEntry
+) {
+  return collectMissingRequiredLinkErrors(
+    filePath,
+    linkTargets,
+    [
+      toRelativeLinkTarget(
+        filePath,
+        path.posix.join("graphify-out/wiki/packages", `${app.appName}.md`)
+      ),
+      toRelativeLinkTarget(filePath, app.harnessDocs.indexPath),
+      toRelativeLinkTarget(filePath, app.harnessDocs.architecturePath),
+      toRelativeLinkTarget(filePath, app.harnessDocs.testingPath),
+      toRelativeLinkTarget(filePath, app.harnessDocs.codeMapPath),
+    ],
+    "package guide"
+  );
+}
+
 export async function validateHarnessDocs(rootDir: string) {
   const errors = await collectHarnessOnboardingErrors(rootDir);
-  const markdownFiles = [PACKAGES_AGENTS_PATH];
+  const markdownFiles = [README_PATH, PACKAGES_AGENTS_PATH];
   const packageConfigs = new Map<HarnessAppName, HarnessAppConfig>();
   const generatedDocs = await generateHarnessDocs(rootDir);
   const enforcedApps: HarnessAppRegistryEntry[] = [];
@@ -639,6 +724,23 @@ export async function validateHarnessDocs(rootDir: string) {
         .map((match) => stripLinkDecorations(match[1]?.trim() ?? ""))
         .filter(Boolean)
     );
+
+    if (markdownFile === README_PATH) {
+      errors.push(...collectReadmeLinkErrors(markdownFile, linkTargets));
+      continue;
+    }
+
+    if (markdownFile === PACKAGES_AGENTS_PATH) {
+      errors.push(
+        ...collectPackagesRouterLinkErrors(markdownFile, linkTargets, enforcedApps)
+      );
+      continue;
+    }
+
+    if (app && markdownFile === app.harnessDocs.agentsPath) {
+      errors.push(...collectPackageGuideLinkErrors(markdownFile, linkTargets, app));
+      continue;
+    }
 
     if (!markdownFile.endsWith("/docs/agent/index.md")) {
       if (


### PR DESCRIPTION
## Summary
- route repo and package entrypoints through the Graphify wiki for graph-first navigation
- keep package-local `AGENTS.md` and `docs/agent/*` as the operational source of truth
- enforce the navigation contract in `harness:check` and extend fixture coverage for wiki drift

## Why
- make Graphify a practical repo navigation layer instead of a passive artifact set
- keep generated wiki pages and human-maintained harness docs aligned as valkey and future packages onboard
- catch router/wiki drift mechanically before it reaches PR review

## Validation
- `bun test scripts/graphify-wiki.test.ts scripts/harness-check.test.ts scripts/harness-test.test.ts`
- `bun test scripts/harness-audit.test.ts scripts/architecture-boundaries.test.ts`
- `bun run graphify:rebuild`
- `bun run harness:test`
- `bun run graphify:check`
- `bun run harness:check`
- `bun run harness:audit`
- `bun run harness:review`
- `bun run harness:inferential-review`
- `bun run pr:athena`
- `bun run harness:behavior --scenario sample-runtime-smoke --record-video`
- `git diff --check`

https://linear.app/v26-labs/issue/V26-222/wire-graphify-wiki-navigation-into-repo-agent-entrypoints-and-checks
