### PR TITLE
[V26-223]: stabilize runtime signal threshold test

### DIFF
--- a/scripts/harness-behavior.test.ts
+++ b/scripts/harness-behavior.test.ts
@@ -298,7 +298,16 @@ describe("runHarnessBehaviorScenario", () => {
             readyTimeoutMs: 2_000,
           },
         ],
-        readiness: [],
+        readiness: [
+          {
+            name: "runtime-error-observed",
+            kind: "log",
+            processId: "runtime-app",
+            source: "combined",
+            pattern: "RUNTIME_ERROR:",
+            timeoutMs: 2_000,
+          },
+        ],
         browser: async () => ({ ok: true }),
         runtimeSignals: [
           {


### PR DESCRIPTION
## Summary
- make the runtime-signal max-threshold harness test wait until `RUNTIME_ERROR:` is actually observed
- keep the fix scoped to `scripts/harness-behavior.test.ts`
- preserve existing harness runtime semantics while removing the Linux CI race

## Why
- `V26-222` merged before the CI stabilization commit landed
- GitHub Actions on Ubuntu occasionally missed the early one-shot stderr line before runtime signal collection
- the harness test should prove the signal path before asserting the threshold failure

## Validation
- `bun test scripts/harness-behavior.test.ts`
- `bun run graphify:rebuild`
- `bun run harness:test`
- `bun run pr:athena`
- `bun run harness:behavior --scenario sample-runtime-smoke --record-video`
- `git diff --check`

https://linear.app/v26-labs/issue/V26-223/stabilize-harness-runtime-signal-threshold-test-on-linux-ci
