### PR TITLE
[V26-225]: add semantic shadow mode to inferential review

### DIFF
--- a/docs/superpowers/plans/2026-04-12-inferential-shadow-mode.md
+++ b/docs/superpowers/plans/2026-04-12-inferential-shadow-mode.md
@@ -1,0 +1,61 @@
+# Inferential Shadow-Mode Semantic Review Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a semantic shadow-mode lane to inferential review, persist inferential and runtime trend history, and surface the new telemetry in scorecards and CI without changing current merge semantics.
+
+**Architecture:** Keep `scripts/harness-inferential-review.ts` as the single entrypoint, but split it into deterministic and semantic lanes with a combined artifact model. Extend the artifact consumers in `scripts/harness-scorecard.ts` and `scripts/harness-runtime-trends.ts` to understand history snapshots, then wire the new mode into GitHub Actions and docs.
+
+**Tech Stack:** Bun, TypeScript, Vitest, GitHub Actions YAML, repo-local JSON artifacts
+
+---
+
+## File Structure
+
+- Modify: `scripts/harness-inferential-review.ts` - add lane coordination, semantic shadow mode, history persistence, and CLI config parsing.
+- Modify: `scripts/harness-inferential-review.test.ts` - cover dual-lane artifacts, shadow-mode failure handling, and history writes.
+- Modify: `scripts/harness-runtime-trends.ts` - add latest-plus-history persistence helpers and CI metadata support.
+- Modify: `scripts/harness-runtime-trends.test.ts` - cover history snapshot writing and malformed-input handling.
+- Modify: `scripts/harness-scorecard.ts` - surface semantic lane status, inferential/trend history presence, and provider error rollups.
+- Modify: `.github/workflows/athena-pr-tests.yml` - wire semantic shadow mode for PRs and persistence for scheduled/manual runs.
+- Modify: `README.md` - document semantic shadow mode and history locations.
+
+### Task 1: Inferential coordinator and semantic shadow mode
+
+**Files:**
+- Modify: `scripts/harness-inferential-review.ts`
+- Test: `scripts/harness-inferential-review.test.ts`
+
+- [ ] Write failing tests for dual-lane artifacts and shadow-mode provider failures.
+- [ ] Run `bun test scripts/harness-inferential-review.test.ts` and confirm the new assertions fail first.
+- [ ] Implement deterministic and semantic lanes with one combined inferential artifact.
+- [ ] Preserve deterministic blocking semantics while recording semantic-lane findings and errors in shadow mode.
+- [ ] Re-run the inferential-review test file and commit the passing change.
+
+### Task 2: History persistence and scorecard surfacing
+
+**Files:**
+- Modify: `scripts/harness-inferential-review.ts`
+- Modify: `scripts/harness-runtime-trends.ts`
+- Modify: `scripts/harness-scorecard.ts`
+- Test: `scripts/harness-inferential-review.test.ts`
+- Test: `scripts/harness-runtime-trends.test.ts`
+- Test: `scripts/harness-scorecard.test.ts`
+
+- [ ] Add failing tests for inferential history snapshots, runtime trend history snapshots, and scorecard history rollups.
+- [ ] Implement latest-plus-history persistence helpers with deterministic timestamped filenames.
+- [ ] Extend scorecard metrics to summarize inferential history presence, runtime trend history presence, and semantic-lane provider health.
+- [ ] Re-run the focused test files and commit the passing change.
+
+### Task 3: CI wiring and documentation
+
+**Files:**
+- Modify: `.github/workflows/athena-pr-tests.yml`
+- Modify: `README.md`
+- Modify: `scripts/harness-scorecard.test.ts` or other affected fixtures if expectations change.
+
+- [ ] Add or update tests/fixtures that assert shadow-mode env wiring and persisted history paths.
+- [ ] Update CI to run inferential review in semantic shadow mode and persist history on scheduled/manual runs.
+- [ ] Update repo docs to explain semantic shadow mode, persistence controls, and artifact locations.
+- [ ] Run repo validation: `bun run harness:test`, `bun run harness:check`, `bun run harness:audit`, `bun run harness:inferential-review`, `bun run harness:scorecard`, `bun run graphify:rebuild`, `bun run graphify:check`, and `bun run pr:athena`.
+- [ ] Commit the validated CI/docs changes.

--- a/docs/superpowers/specs/2026-04-12-inferential-shadow-mode-design.md
+++ b/docs/superpowers/specs/2026-04-12-inferential-shadow-mode-design.md
@@ -1,0 +1,268 @@
+# Inferential Shadow-Mode Semantic Review Design
+
+## Goal
+
+Upgrade Athena's inferential harness from a deterministic-only policy gate to a dual-sensor review flow that adds a true semantic reviewer in shadow mode, persists run history for both inferential and runtime trend signals, and surfaces the new telemetry in scorecards without making merges depend on the new semantic path yet.
+
+## Why
+
+The current `harness:inferential-review` command is useful, but its "inferential" layer is still deterministic policy. That means it is good at catching known wiring regressions, but weak at judging semantic drift, incomplete docs, or inconsistent harness changes. At the same time, `harness:runtime-trends` and `harness:scorecard` only reflect the latest artifact, so we cannot measure whether new signals are stable enough to trust. Shadow mode closes both gaps safely: it adds semantic signal collection now and gives us history to evaluate precision before we ever let it block.
+
+## Non-Goals
+
+- Do not make semantic findings block PRs in this phase.
+- Do not introduce a network-required merge gate for local development.
+- Do not replace the current deterministic checks or relax any existing blocking safety policy.
+- Do not build an external telemetry service; persistence should use repo-local artifacts and CI-managed history first.
+
+## Architecture
+
+### 1. Inferential coordinator
+
+`harness:inferential-review` remains the single command entrypoint and becomes a coordinator with two review lanes:
+
+- `deterministic`: the current merge-gating review lane
+- `semantic`: a richer review lane that emits structured findings in shadow mode
+
+The coordinator will:
+
+- discover changed files and target harness-critical files
+- run deterministic review exactly as today
+- attempt semantic review when configuration enables it
+- downgrade semantic provider/runtime failures into shadow-mode artifact errors instead of process failure
+- write one combined machine artifact with lane-specific results and an overall summary
+- exit non-zero only for deterministic failures or fatal command-integrity failures
+
+### 2. Semantic provider contract
+
+Introduce a provider abstraction for semantic review so the harness can support multiple implementations without changing the command contract.
+
+Provider contract requirements:
+
+- input: repo root, base ref, changed files, target files, and selected file contents
+- output: provider name, review mode, structured findings, optional observations, and provider/runtime errors
+- deterministic JSON shape suitable for tests and scorecards
+
+The first semantic implementation should be a real semantic reviewer, but it must be gated by explicit configuration. The harness should support these modes:
+
+- `off`: skip semantic review entirely
+- `shadow`: run semantic review and record findings, but never fail the command from semantic findings
+
+For this phase, `shadow` is the only CI mode we enable.
+
+### 3. Machine artifact model
+
+Replace the current single-lane inferential artifact with a combined artifact that preserves backward-compatible high-level fields while adding lane detail.
+
+Artifact additions:
+
+- `reviewMode`: `deterministic-only` or `semantic-shadow`
+- `lanes.deterministic`: status, findings, errors, provider name, summary
+- `lanes.semantic`: status, findings, errors, provider name, summary, execution mode
+- `summaryCounts`: finding/error counts per lane and total
+- `historyKey`: stable key used by history persistence
+
+Backward-compatible top-level fields such as `status`, `summary`, `changedFiles`, and `targetFiles` remain so existing tools do not break.
+
+### 4. History persistence
+
+Persist append-only history snapshots for:
+
+- inferential review runs
+- runtime trend aggregations
+
+History locations:
+
+- `artifacts/harness-inferential-review/history/*.json`
+- `artifacts/harness-behavior/trends/history/*.json`
+- stable latest pointers remain at:
+  - `artifacts/harness-inferential-review/latest.json`
+  - `artifacts/harness-behavior/trends/latest.json`
+
+Each history snapshot should include:
+
+- `generatedAt`
+- source command/version
+- CI context when available (`event_name`, branch/ref, PR number if known)
+- lane statuses
+- compact summary counts
+
+History writing rules:
+
+- local runs can write `latest.json` only by default
+- explicit persistence mode writes both `latest.json` and a timestamped history snapshot
+- CI scheduled and manual harness runs should use persistence mode
+- PR runs can stay latest-only unless we intentionally opt into denser history later
+
+### 5. Scorecard and trend surfacing
+
+`harness:scorecard` should evolve from "latest artifact present" into "latest artifact plus recent trend quality".
+
+Add scorecard metrics for:
+
+- semantic lane presence/status/provider
+- shadow-mode finding counts vs deterministic counts
+- whether inferential history exists and how many recent samples are available
+- whether runtime trend history exists and how many recent samples are available
+- recent semantic provider error rate over the retained history window
+
+The scorecard summary should remain deterministic and easy to gate on. In this phase it should never degrade the repo solely because the semantic lane found issues; it should degrade only on missing artifacts, repeated provider/runtime errors, or obviously broken persistence.
+
+### 6. CI integration
+
+Keep the PR workflow safe and incremental:
+
+- PR validation: run inferential review in semantic shadow mode, write latest artifact, generate scorecard
+- scheduled and manual harness jobs: run inferential review in semantic shadow mode and persist history snapshots
+- runtime trend history: add a scheduled/manual path that consumes harness behavior report logs when available and persists latest plus history snapshot
+
+This phase does not require uploading artifacts to an external system. GitHub Actions artifacts are optional for debugging, not required for the design to work.
+
+## Components
+
+### `scripts/harness-inferential-review.ts`
+
+Refactor into clear units:
+
+- changed-file discovery
+- target-file selection
+- deterministic lane
+- semantic lane
+- combined artifact builder
+- history persistence helpers
+- CLI environment/config parsing
+
+### `scripts/harness-runtime-trends.ts`
+
+Add a persistence helper that can write latest and optional history snapshots with metadata, without changing the existing stdin-driven aggregation contract.
+
+### `scripts/harness-scorecard.ts`
+
+Extend inferential and trend inspection to read:
+
+- latest inferential artifact
+- optional inferential history directory
+- optional runtime trend latest/history artifacts
+
+Surface recent-history rollups without requiring any network call.
+
+### `.github/workflows/athena-pr-tests.yml`
+
+Add explicit environment wiring for semantic shadow mode and history-persisting scheduled/manual runs.
+
+### `README.md`
+
+Document:
+
+- semantic shadow mode behavior
+- any required env vars for enabling the provider
+- how history persistence works locally vs CI
+- where to inspect scorecard/history outputs
+
+## Data Flow
+
+### PR flow
+
+1. `harness:inferential-review` discovers harness-critical files.
+2. Deterministic lane evaluates the diff and remains blocking.
+3. Semantic lane runs in shadow mode when configured.
+4. Combined artifact is written to `artifacts/harness-inferential-review/latest.json`.
+5. `harness:scorecard` reads the latest inferential artifact plus any existing history and emits repo health.
+6. PR succeeds or fails based on existing blocking rules, not semantic findings.
+
+### Scheduled/manual flow
+
+1. CI runs inferential review in semantic shadow mode with persistence enabled.
+2. Combined inferential artifact is written to `latest.json` and a timestamped history snapshot.
+3. Runtime trend aggregation, when available, writes `latest.json` and a timestamped history snapshot.
+4. Scorecard summarizes the latest state and recent-history stability.
+5. Humans review history to decide when semantic review is reliable enough for future tightening.
+
+## Error Handling
+
+- Deterministic lane failures remain blocking and exit non-zero.
+- Semantic provider failures in shadow mode are captured as semantic-lane errors and reflected in the scorecard/history, but they do not fail the command.
+- Invalid persisted history files should be ignored with explicit parse-error accounting rather than crashing the scorecard.
+- If the coordinator cannot write the latest artifact at all, the command should fail because the harness contract is broken.
+- If history persistence is requested and the history snapshot write fails, the command should fail in CI-oriented persistence mode because the requested telemetry was not produced.
+
+## Testing Strategy
+
+### Unit and implementation tests
+
+Add or update deterministic tests for:
+
+- semantic shadow-mode artifacts when both lanes run
+- semantic provider failure in shadow mode staying non-blocking while being recorded
+- deterministic findings remaining blocking even when semantic lane passes
+- history snapshot writing for inferential artifacts
+- history snapshot writing for runtime trend artifacts
+- scorecard behavior with no history, healthy history, malformed history, and repeated semantic provider errors
+
+### Integration validation
+
+Run at least:
+
+- `bun run harness:test`
+- `bun run harness:check`
+- `bun run harness:audit`
+- `bun run harness:inferential-review`
+- `bun run harness:scorecard`
+- `bun run graphify:rebuild`
+- `bun run graphify:check`
+- `bun run pr:athena`
+
+## Ticket Split
+
+### Ticket A: inferential semantic shadow-mode coordinator
+
+Scope:
+
+- add lane abstraction and semantic shadow-mode execution
+- evolve inferential artifact schema while preserving top-level compatibility
+- add inferential tests for lane behavior and shadow-mode failures
+
+Acceptance signal:
+
+- `harness:inferential-review` can run deterministic-only or semantic shadow mode and emits a combined artifact
+
+### Ticket B: history persistence and scorecard trend surfacing
+
+Scope:
+
+- add inferential history persistence helpers
+- add runtime trend history persistence helpers
+- extend scorecard to summarize recent inferential/trend history and semantic-lane health
+- document the new telemetry model
+
+Acceptance signal:
+
+- scheduled/manual harness runs can persist history snapshots and the scorecard reports recent history presence and semantic health
+
+### Ticket C: CI wiring and validation hardening
+
+Scope:
+
+- wire semantic shadow-mode env/config into GitHub Actions
+- persist history on scheduled/manual jobs
+- update tests or fixtures affected by workflow and documentation changes
+
+Acceptance signal:
+
+- CI runs the semantic lane in shadow mode without changing PR merge semantics, and scheduled/manual runs persist telemetry history
+
+Dependencies:
+
+- Ticket B depends on Ticket A's artifact schema
+- Ticket C depends on Ticket A and Ticket B for stable command/paths
+
+## Rollout
+
+Phase 1 in this design is complete when:
+
+- semantic review runs in shadow mode in CI
+- deterministic review remains the only blocking inferential lane
+- inferential and runtime trend history can be persisted on schedule/manual runs
+- scorecard shows whether the semantic lane is healthy enough to trust
+
+A later phase can decide whether to tighten the semantic lane into a blocking signal once the retained history shows acceptable stability and usefulness.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 2769 nodes · 2289 edges · 1113 communities detected
+- 2779 nodes · 2313 edges · 1113 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1133,8 +1133,8 @@
 6. `validateHarnessDocs()` - 13 edges
 7. `getBaseUrl()` - 12 edges
 8. `fileExists()` - 12 edges
-9. `OrdersTableToolbarProvider()` - 9 edges
-10. `useOrdersTableToolbar()` - 9 edges
+9. `runHarnessInferentialReview()` - 12 edges
+10. `OrdersTableToolbarProvider()` - 9 edges
 
 ## Surprising Connections (you probably didn't know these)
 - `getAmountPaidForOrder()` --calls--> `getDiscountValue()`  [EXTRACTED]
@@ -1155,20 +1155,20 @@ Cohesion: 0.09
 Nodes (45): compactContext(), createAuthEntryViewedEvent(), createAuthRequestStartedEvent(), createAuthVerificationSucceededEvent(), createAuthVerificationViewedEvent(), createBagAddSucceededEvent(), createBagMoveToSavedEvent(), createBagRemoveSucceededEvent() (+37 more)
 
 ### Community 1 - "Community 1"
-Cohesion: 0.15
-Nodes (31): collectHarnessOnboardingErrors(), collectMarkdownLinkErrors(), collectMissingRequiredLinkErrors(), collectPackageGuideLinkErrors(), collectPackagesRouterLinkErrors(), collectReadmeLinkErrors(), collectReferencedPathErrors(), collectRuntimeScenarioDocSyncErrors() (+23 more)
+Cohesion: 0.13
+Nodes (36): buildFinding(), buildHumanReport(), buildSemanticPrompt(), buildShadowSummary(), collectHarnessSafetySignalFindings(), collectHarnessScriptTestUpdateFindings(), createOutput(), createProviderFailure() (+28 more)
 
 ### Community 2 - "Community 2"
 Cohesion: 0.15
-Nodes (27): buildDiscoveryIndex(), buildGeneratedDoc(), buildKeyFolderIndex(), buildTestIndex(), buildValidationGuide(), buildValidationMap(), collectFolderFacts(), collectRouteGroups() (+19 more)
+Nodes (31): collectHarnessOnboardingErrors(), collectMarkdownLinkErrors(), collectMissingRequiredLinkErrors(), collectPackageGuideLinkErrors(), collectPackagesRouterLinkErrors(), collectReadmeLinkErrors(), collectReferencedPathErrors(), collectRuntimeScenarioDocSyncErrors() (+23 more)
 
 ### Community 3 - "Community 3"
-Cohesion: 0.16
-Nodes (25): asArray(), asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), assignOrDelete(), asString() (+17 more)
+Cohesion: 0.15
+Nodes (27): buildDiscoveryIndex(), buildGeneratedDoc(), buildKeyFolderIndex(), buildTestIndex(), buildValidationGuide(), buildValidationMap(), collectFolderFacts(), collectRouteGroups() (+19 more)
 
 ### Community 4 - "Community 4"
-Cohesion: 0.17
-Nodes (26): buildFinding(), buildHumanReport(), collectHarnessSafetySignalFindings(), collectHarnessScriptTestUpdateFindings(), createOutput(), createProviderFailure(), createReducedSignalFinding(), createRuntimeFailure() (+18 more)
+Cohesion: 0.16
+Nodes (25): asArray(), asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), assignOrDelete(), asString() (+17 more)
 
 ### Community 5 - "Community 5"
 Cohesion: 0.13
@@ -7289,6 +7289,8 @@ _Questions this graph is uniquely positioned to answer:_
 
 - **Should `Community 0` be split into smaller, more focused modules?**
   _Cohesion score 0.09 - nodes in this community are weakly interconnected._
+- **Should `Community 1` be split into smaller, more focused modules?**
+  _Cohesion score 0.13 - nodes in this community are weakly interconnected._
 - **Should `Community 5` be split into smaller, more focused modules?**
   _Cohesion score 0.13 - nodes in this community are weakly interconnected._
 - **Should `Community 9` be split into smaller, more focused modules?**

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -1401,7 +1401,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_storeconfigv2_ts",
-      "community": 3
+      "community": 4
     },
     {
       "label": "isPlainObject()",
@@ -1409,7 +1409,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L53",
       "id": "storeconfigv2_isplainobject",
-      "community": 3
+      "community": 4
     },
     {
       "label": "asRecord()",
@@ -1417,7 +1417,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L57",
       "id": "storeconfigv2_asrecord",
-      "community": 3
+      "community": 4
     },
     {
       "label": "asNumber()",
@@ -1425,7 +1425,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L61",
       "id": "storeconfigv2_asnumber",
-      "community": 3
+      "community": 4
     },
     {
       "label": "asString()",
@@ -1433,7 +1433,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L65",
       "id": "storeconfigv2_asstring",
-      "community": 3
+      "community": 4
     },
     {
       "label": "asBoolean()",
@@ -1441,7 +1441,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L69",
       "id": "storeconfigv2_asboolean",
-      "community": 3
+      "community": 4
     },
     {
       "label": "asArray()",
@@ -1449,7 +1449,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L77",
       "id": "storeconfigv2_asarray",
-      "community": 3
+      "community": 4
     },
     {
       "label": "asOptionalArray()",
@@ -1457,7 +1457,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L90",
       "id": "storeconfigv2_asoptionalarray",
-      "community": 3
+      "community": 4
     },
     {
       "label": "firstDefined()",
@@ -1465,7 +1465,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L101",
       "id": "storeconfigv2_firstdefined",
-      "community": 3
+      "community": 4
     },
     {
       "label": "mapPromotion()",
@@ -1473,7 +1473,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L111",
       "id": "storeconfigv2_mappromotion",
-      "community": 3
+      "community": 4
     },
     {
       "label": "mapStreamReel()",
@@ -1481,7 +1481,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L115",
       "id": "storeconfigv2_mapstreamreel",
-      "community": 3
+      "community": 4
     },
     {
       "label": "normalizeWaiveDeliveryFees()",
@@ -1489,7 +1489,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L135",
       "id": "storeconfigv2_normalizewaivedeliveryfees",
-      "community": 3
+      "community": 4
     },
     {
       "label": "cleanUndefined()",
@@ -1497,7 +1497,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L153",
       "id": "storeconfigv2_cleanundefined",
-      "community": 3
+      "community": 4
     },
     {
       "label": "asMtnMomoSetupStatus()",
@@ -1505,7 +1505,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L165",
       "id": "storeconfigv2_asmtnmomosetupstatus",
-      "community": 3
+      "community": 4
     },
     {
       "label": "hasMtnMomoReceivingAccountDetails()",
@@ -1513,7 +1513,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L178",
       "id": "storeconfigv2_hasmtnmomoreceivingaccountdetails",
-      "community": 3
+      "community": 4
     },
     {
       "label": "mapMtnMomoReceivingAccount()",
@@ -1521,7 +1521,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L191",
       "id": "storeconfigv2_mapmtnmomoreceivingaccount",
-      "community": 3
+      "community": 4
     },
     {
       "label": "normalizeMtnMomoReceivingAccounts()",
@@ -1529,7 +1529,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L214",
       "id": "storeconfigv2_normalizemtnmomoreceivingaccounts",
-      "community": 3
+      "community": 4
     },
     {
       "label": "toV2Config()",
@@ -1537,7 +1537,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L231",
       "id": "storeconfigv2_tov2config",
-      "community": 3
+      "community": 4
     },
     {
       "label": "normalizeStoreConfig()",
@@ -1545,7 +1545,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L474",
       "id": "storeconfigv2_normalizestoreconfig",
-      "community": 3
+      "community": 4
     },
     {
       "label": "deepMerge()",
@@ -1553,7 +1553,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L478",
       "id": "storeconfigv2_deepmerge",
-      "community": 3
+      "community": 4
     },
     {
       "label": "patchV2Config()",
@@ -1561,7 +1561,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L498",
       "id": "storeconfigv2_patchv2config",
-      "community": 3
+      "community": 4
     },
     {
       "label": "assignOrDelete()",
@@ -1569,7 +1569,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L507",
       "id": "storeconfigv2_assignordelete",
-      "community": 3
+      "community": 4
     },
     {
       "label": "mirrorLegacyKeys()",
@@ -1577,7 +1577,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L520",
       "id": "storeconfigv2_mirrorlegacykeys",
-      "community": 3
+      "community": 4
     },
     {
       "label": "getUnknownStoreConfigRootKeys()",
@@ -1585,7 +1585,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L591",
       "id": "storeconfigv2_getunknownstoreconfigrootkeys",
-      "community": 3
+      "community": 4
     },
     {
       "label": "isStoreCheckoutDisabled()",
@@ -1593,7 +1593,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L597",
       "id": "storeconfigv2_isstorecheckoutdisabled",
-      "community": 3
+      "community": 4
     },
     {
       "label": "removeLegacyRootKeysFromConfig()",
@@ -1601,7 +1601,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L606",
       "id": "storeconfigv2_removelegacyrootkeysfromconfig",
-      "community": 3
+      "community": 4
     },
     {
       "label": "isLegacyRootKey()",
@@ -1609,7 +1609,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L623",
       "id": "storeconfigv2_islegacyrootkey",
-      "community": 3
+      "community": 4
     },
     {
       "label": "isV2RootKey()",
@@ -1617,7 +1617,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.ts",
       "source_location": "L627",
       "id": "storeconfigv2_isv2rootkey",
-      "community": 3
+      "community": 4
     },
     {
       "label": "stores.ts",
@@ -20337,7 +20337,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L1",
       "id": "scripts_harness_check_ts",
-      "community": 1
+      "community": 2
     },
     {
       "label": "normalizeRepoPath()",
@@ -20345,7 +20345,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L39",
       "id": "harness_check_normalizerepopath",
-      "community": 1
+      "community": 2
     },
     {
       "label": "stripLinkDecorations()",
@@ -20353,7 +20353,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L43",
       "id": "harness_check_striplinkdecorations",
-      "community": 1
+      "community": 2
     },
     {
       "label": "toRelativeLinkTarget()",
@@ -20361,7 +20361,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L47",
       "id": "harness_check_torelativelinktarget",
-      "community": 1
+      "community": 2
     },
     {
       "label": "collectMissingRequiredLinkErrors()",
@@ -20369,7 +20369,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L55",
       "id": "harness_check_collectmissingrequiredlinkerrors",
-      "community": 1
+      "community": 2
     },
     {
       "label": "isRelativeLink()",
@@ -20377,7 +20377,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L72",
       "id": "harness_check_isrelativelink",
-      "community": 1
+      "community": 2
     },
     {
       "label": "fileExists()",
@@ -20385,7 +20385,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L80",
       "id": "harness_check_fileexists",
-      "community": 1
+      "community": 2
     },
     {
       "label": "hasAnyHarnessDocs()",
@@ -20393,7 +20393,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L89",
       "id": "harness_check_hasanyharnessdocs",
-      "community": 1
+      "community": 2
     },
     {
       "label": "isEnforcedHarnessApp()",
@@ -20401,7 +20401,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L105",
       "id": "harness_check_isenforcedharnessapp",
-      "community": 1
+      "community": 2
     },
     {
       "label": "sortUniqueEntries()",
@@ -20409,7 +20409,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L116",
       "id": "harness_check_sortuniqueentries",
-      "community": 1
+      "community": 2
     },
     {
       "label": "formatScenarioList()",
@@ -20417,7 +20417,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L122",
       "id": "harness_check_formatscenariolist",
-      "community": 1
+      "community": 2
     },
     {
       "label": "isRuntimeScenarioName()",
@@ -20425,7 +20425,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L126",
       "id": "harness_check_isruntimescenarioname",
-      "community": 1
+      "community": 2
     },
     {
       "label": "extractRuntimeScenarioSection()",
@@ -20433,7 +20433,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L134",
       "id": "harness_check_extractruntimescenariosection",
-      "community": 1
+      "community": 2
     },
     {
       "label": "collectRuntimeScenarioDocSyncErrors()",
@@ -20441,7 +20441,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L156",
       "id": "harness_check_collectruntimescenariodocsyncerrors",
-      "community": 1
+      "community": 2
     },
     {
       "label": "collectMarkdownLinkErrors()",
@@ -20449,7 +20449,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L215",
       "id": "harness_check_collectmarkdownlinkerrors",
-      "community": 1
+      "community": 2
     },
     {
       "label": "extractInlineCode()",
@@ -20457,7 +20457,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L244",
       "id": "harness_check_extractinlinecode",
-      "community": 1
+      "community": 2
     },
     {
       "label": "normalizePathReference()",
@@ -20465,7 +20465,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L250",
       "id": "harness_check_normalizepathreference",
-      "community": 1
+      "community": 2
     },
     {
       "label": "isLikelyPathReference()",
@@ -20473,7 +20473,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L263",
       "id": "harness_check_islikelypathreference",
-      "community": 1
+      "community": 2
     },
     {
       "label": "resolvePathReference()",
@@ -20481,7 +20481,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L288",
       "id": "harness_check_resolvepathreference",
-      "community": 1
+      "community": 2
     },
     {
       "label": "collectReferencedPathErrors()",
@@ -20489,7 +20489,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L314",
       "id": "harness_check_collectreferencedpatherrors",
-      "community": 1
+      "community": 2
     },
     {
       "label": "readPackageConfig()",
@@ -20497,7 +20497,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L349",
       "id": "harness_check_readpackageconfig",
-      "community": 1
+      "community": 2
     },
     {
       "label": "listWorkspacePackageDirs()",
@@ -20505,7 +20505,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L377",
       "id": "harness_check_listworkspacepackagedirs",
-      "community": 1
+      "community": 2
     },
     {
       "label": "collectHarnessOnboardingErrors()",
@@ -20513,7 +20513,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L400",
       "id": "harness_check_collectharnessonboardingerrors",
-      "community": 1
+      "community": 2
     },
     {
       "label": "extractTestScriptFromCommand()",
@@ -20521,7 +20521,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L431",
       "id": "harness_check_extracttestscriptfromcommand",
-      "community": 1
+      "community": 2
     },
     {
       "label": "walkFiles()",
@@ -20529,7 +20529,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L463",
       "id": "harness_check_walkfiles",
-      "community": 1
+      "community": 2
     },
     {
       "label": "collectServiceDocumentedSurfaces()",
@@ -20537,7 +20537,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L483",
       "id": "harness_check_collectservicedocumentedsurfaces",
-      "community": 1
+      "community": 2
     },
     {
       "label": "collectTestSurfaceRoots()",
@@ -20545,7 +20545,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L508",
       "id": "harness_check_collecttestsurfaceroots",
-      "community": 1
+      "community": 2
     },
     {
       "label": "collectTestingDocErrors()",
@@ -20553,7 +20553,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L555",
       "id": "harness_check_collecttestingdocerrors",
-      "community": 1
+      "community": 2
     },
     {
       "label": "collectReadmeLinkErrors()",
@@ -20561,7 +20561,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L608",
       "id": "harness_check_collectreadmelinkerrors",
-      "community": 1
+      "community": 2
     },
     {
       "label": "collectPackagesRouterLinkErrors()",
@@ -20569,7 +20569,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L620",
       "id": "harness_check_collectpackagesrouterlinkerrors",
-      "community": 1
+      "community": 2
     },
     {
       "label": "collectPackageGuideLinkErrors()",
@@ -20577,7 +20577,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L644",
       "id": "harness_check_collectpackageguidelinkerrors",
-      "community": 1
+      "community": 2
     },
     {
       "label": "validateHarnessDocs()",
@@ -20585,7 +20585,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L666",
       "id": "harness_check_validateharnessdocs",
-      "community": 1
+      "community": 2
     },
     {
       "label": "runHarnessCheck()",
@@ -20593,7 +20593,7 @@
       "source_file": "scripts/harness-check.ts",
       "source_location": "L825",
       "id": "harness_check_runharnesscheck",
-      "community": 1
+      "community": 2
     },
     {
       "label": "harness-generate.test.ts",
@@ -20625,7 +20625,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L1",
       "id": "scripts_harness_generate_ts",
-      "community": 2
+      "community": 3
     },
     {
       "label": "normalizeRepoPath()",
@@ -20633,7 +20633,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L24",
       "id": "harness_generate_normalizerepopath",
-      "community": 2
+      "community": 3
     },
     {
       "label": "shouldSkipGeneratedEntry()",
@@ -20641,7 +20641,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L28",
       "id": "harness_generate_shouldskipgeneratedentry",
-      "community": 2
+      "community": 3
     },
     {
       "label": "fileExists()",
@@ -20649,7 +20649,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L32",
       "id": "harness_generate_fileexists",
-      "community": 2
+      "community": 3
     },
     {
       "label": "walkFiles()",
@@ -20657,7 +20657,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L41",
       "id": "harness_generate_walkfiles",
-      "community": 2
+      "community": 3
     },
     {
       "label": "readPackageConfig()",
@@ -20665,7 +20665,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L63",
       "id": "harness_generate_readpackageconfig",
-      "community": 2
+      "community": 3
     },
     {
       "label": "toDocPath()",
@@ -20673,7 +20673,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L81",
       "id": "harness_generate_todocpath",
-      "community": 2
+      "community": 3
     },
     {
       "label": "formatMarkdownLink()",
@@ -20681,7 +20681,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L85",
       "id": "harness_generate_formatmarkdownlink",
-      "community": 2
+      "community": 3
     },
     {
       "label": "headingFromSegment()",
@@ -20689,7 +20689,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L89",
       "id": "harness_generate_headingfromsegment",
-      "community": 2
+      "community": 3
     },
     {
       "label": "summarizeChildren()",
@@ -20697,7 +20697,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L97",
       "id": "harness_generate_summarizechildren",
-      "community": 2
+      "community": 3
     },
     {
       "label": "isWithinFolder()",
@@ -20705,7 +20705,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L105",
       "id": "harness_generate_iswithinfolder",
-      "community": 2
+      "community": 3
     },
     {
       "label": "toPackageRelativeGeneratedDocPaths()",
@@ -20713,7 +20713,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L116",
       "id": "harness_generate_topackagerelativegenerateddocpaths",
-      "community": 2
+      "community": 3
     },
     {
       "label": "collectRouteGroups()",
@@ -20721,7 +20721,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L126",
       "id": "harness_generate_collectroutegroups",
-      "community": 2
+      "community": 3
     },
     {
       "label": "collectServiceDocumentedEntries()",
@@ -20729,7 +20729,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L152",
       "id": "harness_generate_collectservicedocumentedentries",
-      "community": 2
+      "community": 3
     },
     {
       "label": "collectServiceEntryGroups()",
@@ -20737,7 +20737,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L177",
       "id": "harness_generate_collectserviceentrygroups",
-      "community": 2
+      "community": 3
     },
     {
       "label": "collectTestFiles()",
@@ -20745,7 +20745,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L196",
       "id": "harness_generate_collecttestfiles",
-      "community": 2
+      "community": 3
     },
     {
       "label": "collectTestSurfaceRoots()",
@@ -20753,7 +20753,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L226",
       "id": "harness_generate_collecttestsurfaceroots",
-      "community": 2
+      "community": 3
     },
     {
       "label": "collectFolderFacts()",
@@ -20761,7 +20761,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L272",
       "id": "harness_generate_collectfolderfacts",
-      "community": 2
+      "community": 3
     },
     {
       "label": "formatScriptCommand()",
@@ -20769,7 +20769,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L316",
       "id": "harness_generate_formatscriptcommand",
-      "community": 2
+      "community": 3
     },
     {
       "label": "toRepoValidationPath()",
@@ -20777,7 +20777,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L326",
       "id": "harness_generate_torepovalidationpath",
-      "community": 2
+      "community": 3
     },
     {
       "label": "slugifyTitle()",
@@ -20785,7 +20785,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L331",
       "id": "harness_generate_slugifytitle",
-      "community": 2
+      "community": 3
     },
     {
       "label": "formatValidationCommandForDoc()",
@@ -20793,7 +20793,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L338",
       "id": "harness_generate_formatvalidationcommandfordoc",
-      "community": 2
+      "community": 3
     },
     {
       "label": "toGeneratedValidationMap()",
@@ -20801,7 +20801,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L347",
       "id": "harness_generate_togeneratedvalidationmap",
-      "community": 2
+      "community": 3
     },
     {
       "label": "buildGeneratedDoc()",
@@ -20809,7 +20809,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L376",
       "id": "harness_generate_buildgenerateddoc",
-      "community": 2
+      "community": 3
     },
     {
       "label": "buildDiscoveryIndex()",
@@ -20817,7 +20817,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L386",
       "id": "harness_generate_builddiscoveryindex",
-      "community": 2
+      "community": 3
     },
     {
       "label": "buildTestIndex()",
@@ -20825,7 +20825,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L421",
       "id": "harness_generate_buildtestindex",
-      "community": 2
+      "community": 3
     },
     {
       "label": "buildKeyFolderIndex()",
@@ -20833,7 +20833,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L478",
       "id": "harness_generate_buildkeyfolderindex",
-      "community": 2
+      "community": 3
     },
     {
       "label": "buildValidationGuide()",
@@ -20841,7 +20841,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L511",
       "id": "harness_generate_buildvalidationguide",
-      "community": 2
+      "community": 3
     },
     {
       "label": "buildValidationMap()",
@@ -20849,7 +20849,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L553",
       "id": "harness_generate_buildvalidationmap",
-      "community": 2
+      "community": 3
     },
     {
       "label": "generateHarnessDocs()",
@@ -20857,7 +20857,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L560",
       "id": "harness_generate_generateharnessdocs",
-      "community": 2
+      "community": 3
     },
     {
       "label": "writeGeneratedHarnessDocs()",
@@ -20865,7 +20865,7 @@
       "source_file": "scripts/harness-generate.ts",
       "source_location": "L590",
       "id": "harness_generate_writegeneratedharnessdocs",
-      "community": 2
+      "community": 3
     },
     {
       "label": "harness-inferential-review.test.ts",
@@ -20897,223 +20897,303 @@
       "source_file": "scripts/harness-inferential-review.ts",
       "source_location": "L1",
       "id": "scripts_harness_inferential_review_ts",
-      "community": 4
+      "community": 1
     },
     {
       "label": "normalizeRepoPath()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L79",
+      "source_location": "L107",
       "id": "harness_inferential_review_normalizerepopath",
-      "community": 4
+      "community": 1
     },
     {
       "label": "sortUnique()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L83",
+      "source_location": "L111",
       "id": "harness_inferential_review_sortunique",
-      "community": 4
+      "community": 1
     },
     {
       "label": "fileExists()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L89",
+      "source_location": "L117",
       "id": "harness_inferential_review_fileexists",
-      "community": 4
+      "community": 1
     },
     {
       "label": "readUtf8OrNull()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L98",
+      "source_location": "L126",
       "id": "harness_inferential_review_readutf8ornull",
-      "community": 4
+      "community": 1
     },
     {
       "label": "runCommand()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L112",
+      "source_location": "L140",
       "id": "harness_inferential_review_runcommand",
-      "community": 4
+      "community": 1
     },
     {
       "label": "getChangedFilesForInferentialReview()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L139",
+      "source_location": "L167",
       "id": "harness_inferential_review_getchangedfilesforinferentialreview",
-      "community": 4
+      "community": 1
     },
     {
       "label": "isHarnessCriticalFile()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L203",
+      "source_location": "L231",
       "id": "harness_inferential_review_isharnesscriticalfile",
-      "community": 4
+      "community": 1
     },
     {
       "label": "buildFinding()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L228",
+      "source_location": "L256",
       "id": "harness_inferential_review_buildfinding",
-      "community": 4
+      "community": 1
     },
     {
       "label": "includesCaseInsensitive()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L246",
+      "source_location": "L274",
       "id": "harness_inferential_review_includescaseinsensitive",
-      "community": 4
+      "community": 1
     },
     {
       "label": "slugifyForFindingId()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L250",
+      "source_location": "L278",
       "id": "harness_inferential_review_slugifyforfindingid",
-      "community": 4
+      "community": 1
     },
     {
       "label": "isHarnessScriptSourceFile()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L257",
+      "source_location": "L285",
       "id": "harness_inferential_review_isharnessscriptsourcefile",
-      "community": 4
+      "community": 1
     },
     {
       "label": "toHarnessScriptTestPath()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L262",
+      "source_location": "L290",
       "id": "harness_inferential_review_toharnessscripttestpath",
-      "community": 4
+      "community": 1
     },
     {
       "label": "formatMissingSignals()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L266",
+      "source_location": "L294",
       "id": "harness_inferential_review_formatmissingsignals",
-      "community": 4
+      "community": 1
     },
     {
       "label": "createReducedSignalFinding()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L270",
+      "source_location": "L298",
       "id": "harness_inferential_review_createreducedsignalfinding",
-      "community": 4
+      "community": 1
     },
     {
       "label": "collectHarnessScriptTestUpdateFindings()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L287",
+      "source_location": "L315",
       "id": "harness_inferential_review_collectharnessscripttestupdatefindings",
-      "community": 4
+      "community": 1
     },
     {
       "label": "collectHarnessSafetySignalFindings()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L324",
+      "source_location": "L352",
       "id": "harness_inferential_review_collectharnesssafetysignalfindings",
-      "community": 4
+      "community": 1
     },
     {
       "label": "runDeterministicSemanticAnalysis()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L420",
+      "source_location": "L448",
       "id": "harness_inferential_review_rundeterministicsemanticanalysis",
-      "community": 4
+      "community": 1
+    },
+    {
+      "label": "resolveSemanticMode()",
+      "file_type": "code",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L467",
+      "id": "harness_inferential_review_resolvesemanticmode",
+      "community": 1
+    },
+    {
+      "label": "buildShadowSummary()",
+      "file_type": "code",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L476",
+      "id": "harness_inferential_review_buildshadowsummary",
+      "community": 1
+    },
+    {
+      "label": "truncateForPrompt()",
+      "file_type": "code",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L482",
+      "id": "harness_inferential_review_truncateforprompt",
+      "community": 1
+    },
+    {
+      "label": "buildSemanticPrompt()",
+      "file_type": "code",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L490",
+      "id": "harness_inferential_review_buildsemanticprompt",
+      "community": 1
+    },
+    {
+      "label": "extractTextFromAnthropicResponse()",
+      "file_type": "code",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L518",
+      "id": "harness_inferential_review_extracttextfromanthropicresponse",
+      "community": 1
+    },
+    {
+      "label": "extractJsonPayload()",
+      "file_type": "code",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L544",
+      "id": "harness_inferential_review_extractjsonpayload",
+      "community": 1
+    },
+    {
+      "label": "normalizeSemanticFinding()",
+      "file_type": "code",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L564",
+      "id": "harness_inferential_review_normalizesemanticfinding",
+      "community": 1
+    },
+    {
+      "label": "parseSemanticResponse()",
+      "file_type": "code",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L613",
+      "id": "harness_inferential_review_parsesemanticresponse",
+      "community": 1
+    },
+    {
+      "label": "runAnthropicSemanticAnalysis()",
+      "file_type": "code",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L636",
+      "id": "harness_inferential_review_runanthropicsemanticanalysis",
+      "community": 1
     },
     {
       "label": "runDeterministicInferentialProvider()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L439",
+      "source_location": "L675",
       "id": "harness_inferential_review_rundeterministicinferentialprovider",
-      "community": 4
+      "community": 1
     },
     {
       "label": "sortFindings()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L591",
+      "source_location": "L827",
       "id": "harness_inferential_review_sortfindings",
-      "community": 4
+      "community": 1
     },
     {
       "label": "formatStatusLabel()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L610",
+      "source_location": "L846",
       "id": "harness_inferential_review_formatstatuslabel",
-      "community": 4
+      "community": 1
     },
     {
       "label": "buildHumanReport()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L623",
+      "source_location": "L859",
       "id": "harness_inferential_review_buildhumanreport",
-      "community": 4
+      "community": 1
     },
     {
       "label": "writeMachineOutput()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L666",
+      "source_location": "L929",
       "id": "harness_inferential_review_writemachineoutput",
-      "community": 4
+      "community": 1
     },
     {
       "label": "createOutput()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L676",
+      "source_location": "L939",
       "id": "harness_inferential_review_createoutput",
-      "community": 4
+      "community": 1
+    },
+    {
+      "label": "createShadowOutput()",
+      "file_type": "code",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L968",
+      "id": "harness_inferential_review_createshadowoutput",
+      "community": 1
     },
     {
       "label": "createProviderFailure()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L701",
+      "source_location": "L986",
       "id": "harness_inferential_review_createproviderfailure",
-      "community": 4
+      "community": 1
     },
     {
       "label": "createRuntimeFailure()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L728",
+      "source_location": "L1015",
       "id": "harness_inferential_review_createruntimefailure",
-      "community": 4
+      "community": 1
     },
     {
       "label": "runHarnessInferentialReview()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L755",
+      "source_location": "L1044",
       "id": "harness_inferential_review_runharnessinferentialreview",
-      "community": 4
+      "community": 1
     },
     {
       "label": "parseCliArgs()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L930",
+      "source_location": "L1267",
       "id": "harness_inferential_review_parsecliargs",
-      "community": 4
+      "community": 1
     },
     {
       "label": "harness-janitor.test.ts",
@@ -46569,7 +46649,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L79",
+      "source_location": "L107",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_normalizerepopath",
@@ -46581,7 +46661,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L83",
+      "source_location": "L111",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_sortunique",
@@ -46593,7 +46673,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L89",
+      "source_location": "L117",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_fileexists",
@@ -46605,7 +46685,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L98",
+      "source_location": "L126",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_readutf8ornull",
@@ -46617,7 +46697,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L112",
+      "source_location": "L140",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_runcommand",
@@ -46629,7 +46709,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L139",
+      "source_location": "L167",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_getchangedfilesforinferentialreview",
@@ -46641,7 +46721,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L203",
+      "source_location": "L231",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_isharnesscriticalfile",
@@ -46653,7 +46733,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L228",
+      "source_location": "L256",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_buildfinding",
@@ -46665,7 +46745,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L246",
+      "source_location": "L274",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_includescaseinsensitive",
@@ -46677,7 +46757,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L250",
+      "source_location": "L278",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_slugifyforfindingid",
@@ -46689,7 +46769,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L257",
+      "source_location": "L285",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_isharnessscriptsourcefile",
@@ -46701,7 +46781,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L262",
+      "source_location": "L290",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_toharnessscripttestpath",
@@ -46713,7 +46793,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L266",
+      "source_location": "L294",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_formatmissingsignals",
@@ -46725,7 +46805,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L270",
+      "source_location": "L298",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_createreducedsignalfinding",
@@ -46737,7 +46817,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L287",
+      "source_location": "L315",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_collectharnessscripttestupdatefindings",
@@ -46749,7 +46829,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L324",
+      "source_location": "L352",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_collectharnesssafetysignalfindings",
@@ -46761,7 +46841,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L420",
+      "source_location": "L448",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_rundeterministicsemanticanalysis",
@@ -46773,7 +46853,115 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L439",
+      "source_location": "L467",
+      "weight": 1.0,
+      "_src": "scripts_harness_inferential_review_ts",
+      "_tgt": "harness_inferential_review_resolvesemanticmode",
+      "source": "scripts_harness_inferential_review_ts",
+      "target": "harness_inferential_review_resolvesemanticmode",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L476",
+      "weight": 1.0,
+      "_src": "scripts_harness_inferential_review_ts",
+      "_tgt": "harness_inferential_review_buildshadowsummary",
+      "source": "scripts_harness_inferential_review_ts",
+      "target": "harness_inferential_review_buildshadowsummary",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L482",
+      "weight": 1.0,
+      "_src": "scripts_harness_inferential_review_ts",
+      "_tgt": "harness_inferential_review_truncateforprompt",
+      "source": "scripts_harness_inferential_review_ts",
+      "target": "harness_inferential_review_truncateforprompt",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L490",
+      "weight": 1.0,
+      "_src": "scripts_harness_inferential_review_ts",
+      "_tgt": "harness_inferential_review_buildsemanticprompt",
+      "source": "scripts_harness_inferential_review_ts",
+      "target": "harness_inferential_review_buildsemanticprompt",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L518",
+      "weight": 1.0,
+      "_src": "scripts_harness_inferential_review_ts",
+      "_tgt": "harness_inferential_review_extracttextfromanthropicresponse",
+      "source": "scripts_harness_inferential_review_ts",
+      "target": "harness_inferential_review_extracttextfromanthropicresponse",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L544",
+      "weight": 1.0,
+      "_src": "scripts_harness_inferential_review_ts",
+      "_tgt": "harness_inferential_review_extractjsonpayload",
+      "source": "scripts_harness_inferential_review_ts",
+      "target": "harness_inferential_review_extractjsonpayload",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L564",
+      "weight": 1.0,
+      "_src": "scripts_harness_inferential_review_ts",
+      "_tgt": "harness_inferential_review_normalizesemanticfinding",
+      "source": "scripts_harness_inferential_review_ts",
+      "target": "harness_inferential_review_normalizesemanticfinding",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L613",
+      "weight": 1.0,
+      "_src": "scripts_harness_inferential_review_ts",
+      "_tgt": "harness_inferential_review_parsesemanticresponse",
+      "source": "scripts_harness_inferential_review_ts",
+      "target": "harness_inferential_review_parsesemanticresponse",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L636",
+      "weight": 1.0,
+      "_src": "scripts_harness_inferential_review_ts",
+      "_tgt": "harness_inferential_review_runanthropicsemanticanalysis",
+      "source": "scripts_harness_inferential_review_ts",
+      "target": "harness_inferential_review_runanthropicsemanticanalysis",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L675",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_rundeterministicinferentialprovider",
@@ -46785,7 +46973,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L591",
+      "source_location": "L827",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_sortfindings",
@@ -46797,7 +46985,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L610",
+      "source_location": "L846",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_formatstatuslabel",
@@ -46809,7 +46997,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L623",
+      "source_location": "L859",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_buildhumanreport",
@@ -46821,7 +47009,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L666",
+      "source_location": "L929",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_writemachineoutput",
@@ -46833,7 +47021,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L676",
+      "source_location": "L939",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_createoutput",
@@ -46845,7 +47033,19 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L701",
+      "source_location": "L968",
+      "weight": 1.0,
+      "_src": "scripts_harness_inferential_review_ts",
+      "_tgt": "harness_inferential_review_createshadowoutput",
+      "source": "scripts_harness_inferential_review_ts",
+      "target": "harness_inferential_review_createshadowoutput",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L986",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_createproviderfailure",
@@ -46857,7 +47057,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L728",
+      "source_location": "L1015",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_createruntimefailure",
@@ -46869,7 +47069,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L755",
+      "source_location": "L1044",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_runharnessinferentialreview",
@@ -46881,7 +47081,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L930",
+      "source_location": "L1267",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_parsecliargs",
@@ -46893,7 +47093,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L204",
+      "source_location": "L232",
       "weight": 1.0,
       "_src": "harness_inferential_review_isharnesscriticalfile",
       "_tgt": "harness_inferential_review_normalizerepopath",
@@ -46905,7 +47105,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L251",
+      "source_location": "L279",
       "weight": 1.0,
       "_src": "harness_inferential_review_slugifyforfindingid",
       "_tgt": "harness_inferential_review_normalizerepopath",
@@ -46917,7 +47117,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L258",
+      "source_location": "L286",
       "weight": 1.0,
       "_src": "harness_inferential_review_isharnessscriptsourcefile",
       "_tgt": "harness_inferential_review_normalizerepopath",
@@ -46929,7 +47129,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L263",
+      "source_location": "L291",
       "weight": 1.0,
       "_src": "harness_inferential_review_toharnessscripttestpath",
       "_tgt": "harness_inferential_review_normalizerepopath",
@@ -46941,7 +47141,19 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L196",
+      "source_location": "L588",
+      "weight": 1.0,
+      "_src": "harness_inferential_review_normalizesemanticfinding",
+      "_tgt": "harness_inferential_review_normalizerepopath",
+      "source": "harness_inferential_review_normalizerepopath",
+      "target": "harness_inferential_review_normalizesemanticfinding",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L224",
       "weight": 1.0,
       "_src": "harness_inferential_review_getchangedfilesforinferentialreview",
       "_tgt": "harness_inferential_review_sortunique",
@@ -46953,7 +47165,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L291",
+      "source_location": "L319",
       "weight": 1.0,
       "_src": "harness_inferential_review_collectharnessscripttestupdatefindings",
       "_tgt": "harness_inferential_review_sortunique",
@@ -46965,7 +47177,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L328",
+      "source_location": "L356",
       "weight": 1.0,
       "_src": "harness_inferential_review_collectharnesssafetysignalfindings",
       "_tgt": "harness_inferential_review_sortunique",
@@ -46977,7 +47189,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L694",
+      "source_location": "L960",
       "weight": 1.0,
       "_src": "harness_inferential_review_createoutput",
       "_tgt": "harness_inferential_review_sortunique",
@@ -46989,7 +47201,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L777",
+      "source_location": "L1069",
       "weight": 1.0,
       "_src": "harness_inferential_review_runharnessinferentialreview",
       "_tgt": "harness_inferential_review_sortunique",
@@ -47001,7 +47213,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L99",
+      "source_location": "L127",
       "weight": 1.0,
       "_src": "harness_inferential_review_readutf8ornull",
       "_tgt": "harness_inferential_review_fileexists",
@@ -47013,7 +47225,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L304",
+      "source_location": "L332",
       "weight": 1.0,
       "_src": "harness_inferential_review_collectharnessscripttestupdatefindings",
       "_tgt": "harness_inferential_review_fileexists",
@@ -47025,7 +47237,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L393",
+      "source_location": "L421",
       "weight": 1.0,
       "_src": "harness_inferential_review_collectharnesssafetysignalfindings",
       "_tgt": "harness_inferential_review_readutf8ornull",
@@ -47037,7 +47249,19 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L457",
+      "source_location": "L494",
+      "weight": 1.0,
+      "_src": "harness_inferential_review_buildsemanticprompt",
+      "_tgt": "harness_inferential_review_readutf8ornull",
+      "source": "harness_inferential_review_readutf8ornull",
+      "target": "harness_inferential_review_buildsemanticprompt",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L693",
       "weight": 1.0,
       "_src": "harness_inferential_review_rundeterministicinferentialprovider",
       "_tgt": "harness_inferential_review_readutf8ornull",
@@ -47049,7 +47273,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L143",
+      "source_location": "L171",
       "weight": 1.0,
       "_src": "harness_inferential_review_getchangedfilesforinferentialreview",
       "_tgt": "harness_inferential_review_runcommand",
@@ -47061,7 +47285,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L277",
+      "source_location": "L305",
       "weight": 1.0,
       "_src": "harness_inferential_review_createreducedsignalfinding",
       "_tgt": "harness_inferential_review_buildfinding",
@@ -47073,7 +47297,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L306",
+      "source_location": "L334",
       "weight": 1.0,
       "_src": "harness_inferential_review_collectharnessscripttestupdatefindings",
       "_tgt": "harness_inferential_review_buildfinding",
@@ -47085,7 +47309,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L460",
+      "source_location": "L696",
       "weight": 1.0,
       "_src": "harness_inferential_review_rundeterministicinferentialprovider",
       "_tgt": "harness_inferential_review_buildfinding",
@@ -47097,7 +47321,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L492",
+      "source_location": "L728",
       "weight": 1.0,
       "_src": "harness_inferential_review_rundeterministicinferentialprovider",
       "_tgt": "harness_inferential_review_includescaseinsensitive",
@@ -47109,7 +47333,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L278",
+      "source_location": "L306",
       "weight": 1.0,
       "_src": "harness_inferential_review_createreducedsignalfinding",
       "_tgt": "harness_inferential_review_slugifyforfindingid",
@@ -47121,7 +47345,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L307",
+      "source_location": "L335",
       "weight": 1.0,
       "_src": "harness_inferential_review_collectharnessscripttestupdatefindings",
       "_tgt": "harness_inferential_review_slugifyforfindingid",
@@ -47133,7 +47357,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L295",
+      "source_location": "L323",
       "weight": 1.0,
       "_src": "harness_inferential_review_collectharnessscripttestupdatefindings",
       "_tgt": "harness_inferential_review_isharnessscriptsourcefile",
@@ -47145,7 +47369,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L299",
+      "source_location": "L327",
       "weight": 1.0,
       "_src": "harness_inferential_review_collectharnessscripttestupdatefindings",
       "_tgt": "harness_inferential_review_toharnessscripttestpath",
@@ -47157,7 +47381,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L282",
+      "source_location": "L310",
       "weight": 1.0,
       "_src": "harness_inferential_review_createreducedsignalfinding",
       "_tgt": "harness_inferential_review_formatmissingsignals",
@@ -47169,7 +47393,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L407",
+      "source_location": "L435",
       "weight": 1.0,
       "_src": "harness_inferential_review_collectharnesssafetysignalfindings",
       "_tgt": "harness_inferential_review_createreducedsignalfinding",
@@ -47181,7 +47405,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L424",
+      "source_location": "L452",
       "weight": 1.0,
       "_src": "harness_inferential_review_rundeterministicsemanticanalysis",
       "_tgt": "harness_inferential_review_collectharnessscripttestupdatefindings",
@@ -47193,7 +47417,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L428",
+      "source_location": "L456",
       "weight": 1.0,
       "_src": "harness_inferential_review_rundeterministicsemanticanalysis",
       "_tgt": "harness_inferential_review_collectharnesssafetysignalfindings",
@@ -47205,7 +47429,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L435",
+      "source_location": "L463",
       "weight": 1.0,
       "_src": "harness_inferential_review_rundeterministicsemanticanalysis",
       "_tgt": "harness_inferential_review_sortfindings",
@@ -47217,7 +47441,127 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L587",
+      "source_location": "L1139",
+      "weight": 1.0,
+      "_src": "harness_inferential_review_runharnessinferentialreview",
+      "_tgt": "harness_inferential_review_rundeterministicsemanticanalysis",
+      "source": "harness_inferential_review_rundeterministicsemanticanalysis",
+      "target": "harness_inferential_review_runharnessinferentialreview",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L1052",
+      "weight": 1.0,
+      "_src": "harness_inferential_review_runharnessinferentialreview",
+      "_tgt": "harness_inferential_review_resolvesemanticmode",
+      "source": "harness_inferential_review_resolvesemanticmode",
+      "target": "harness_inferential_review_runharnessinferentialreview",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L628",
+      "weight": 1.0,
+      "_src": "harness_inferential_review_parsesemanticresponse",
+      "_tgt": "harness_inferential_review_buildshadowsummary",
+      "source": "harness_inferential_review_buildshadowsummary",
+      "target": "harness_inferential_review_parsesemanticresponse",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L1195",
+      "weight": 1.0,
+      "_src": "harness_inferential_review_runharnessinferentialreview",
+      "_tgt": "harness_inferential_review_buildshadowsummary",
+      "source": "harness_inferential_review_buildshadowsummary",
+      "target": "harness_inferential_review_runharnessinferentialreview",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L499",
+      "weight": 1.0,
+      "_src": "harness_inferential_review_buildsemanticprompt",
+      "_tgt": "harness_inferential_review_truncateforprompt",
+      "source": "harness_inferential_review_truncateforprompt",
+      "target": "harness_inferential_review_buildsemanticprompt",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L655",
+      "weight": 1.0,
+      "_src": "harness_inferential_review_runanthropicsemanticanalysis",
+      "_tgt": "harness_inferential_review_buildsemanticprompt",
+      "source": "harness_inferential_review_buildsemanticprompt",
+      "target": "harness_inferential_review_runanthropicsemanticanalysis",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L664",
+      "weight": 1.0,
+      "_src": "harness_inferential_review_runanthropicsemanticanalysis",
+      "_tgt": "harness_inferential_review_extracttextfromanthropicresponse",
+      "source": "harness_inferential_review_extracttextfromanthropicresponse",
+      "target": "harness_inferential_review_runanthropicsemanticanalysis",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L614",
+      "weight": 1.0,
+      "_src": "harness_inferential_review_parsesemanticresponse",
+      "_tgt": "harness_inferential_review_extractjsonpayload",
+      "source": "harness_inferential_review_extractjsonpayload",
+      "target": "harness_inferential_review_parsesemanticresponse",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L632",
+      "weight": 1.0,
+      "_src": "harness_inferential_review_parsesemanticresponse",
+      "_tgt": "harness_inferential_review_sortfindings",
+      "source": "harness_inferential_review_parsesemanticresponse",
+      "target": "harness_inferential_review_sortfindings",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L665",
+      "weight": 1.0,
+      "_src": "harness_inferential_review_runanthropicsemanticanalysis",
+      "_tgt": "harness_inferential_review_parsesemanticresponse",
+      "source": "harness_inferential_review_parsesemanticresponse",
+      "target": "harness_inferential_review_runanthropicsemanticanalysis",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L823",
       "weight": 1.0,
       "_src": "harness_inferential_review_rundeterministicinferentialprovider",
       "_tgt": "harness_inferential_review_sortfindings",
@@ -47229,7 +47573,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L696",
+      "source_location": "L962",
       "weight": 1.0,
       "_src": "harness_inferential_review_createoutput",
       "_tgt": "harness_inferential_review_sortfindings",
@@ -47241,7 +47585,19 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L850",
+      "source_location": "L981",
+      "weight": 1.0,
+      "_src": "harness_inferential_review_createshadowoutput",
+      "_tgt": "harness_inferential_review_sortfindings",
+      "source": "harness_inferential_review_sortfindings",
+      "target": "harness_inferential_review_createshadowoutput",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L1145",
       "weight": 1.0,
       "_src": "harness_inferential_review_runharnessinferentialreview",
       "_tgt": "harness_inferential_review_sortfindings",
@@ -47253,7 +47609,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L628",
+      "source_location": "L864",
       "weight": 1.0,
       "_src": "harness_inferential_review_buildhumanreport",
       "_tgt": "harness_inferential_review_formatstatuslabel",
@@ -47265,7 +47621,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L788",
+      "source_location": "L1081",
       "weight": 1.0,
       "_src": "harness_inferential_review_runharnessinferentialreview",
       "_tgt": "harness_inferential_review_buildhumanreport",
@@ -47277,7 +47633,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L789",
+      "source_location": "L1082",
       "weight": 1.0,
       "_src": "harness_inferential_review_runharnessinferentialreview",
       "_tgt": "harness_inferential_review_writemachineoutput",
@@ -47289,7 +47645,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L708",
+      "source_location": "L994",
       "weight": 1.0,
       "_src": "harness_inferential_review_createproviderfailure",
       "_tgt": "harness_inferential_review_createoutput",
@@ -47301,7 +47657,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L735",
+      "source_location": "L1023",
       "weight": 1.0,
       "_src": "harness_inferential_review_createruntimefailure",
       "_tgt": "harness_inferential_review_createoutput",
@@ -47313,7 +47669,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L799",
+      "source_location": "L1092",
       "weight": 1.0,
       "_src": "harness_inferential_review_runharnessinferentialreview",
       "_tgt": "harness_inferential_review_createoutput",
@@ -47325,7 +47681,19 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L829",
+      "source_location": "L1189",
+      "weight": 1.0,
+      "_src": "harness_inferential_review_runharnessinferentialreview",
+      "_tgt": "harness_inferential_review_createshadowoutput",
+      "source": "harness_inferential_review_createshadowoutput",
+      "target": "harness_inferential_review_runharnessinferentialreview",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L1123",
       "weight": 1.0,
       "_src": "harness_inferential_review_runharnessinferentialreview",
       "_tgt": "harness_inferential_review_createproviderfailure",
@@ -47337,7 +47705,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L781",
+      "source_location": "L1073",
       "weight": 1.0,
       "_src": "harness_inferential_review_runharnessinferentialreview",
       "_tgt": "harness_inferential_review_createruntimefailure",

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,17 +8,17 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1198
-- Graph nodes: 2769
-- Graph edges: 2289
+- Graph nodes: 2779
+- Graph edges: 2313
 - Communities: 1113
 
 ## Graph Hotspots
 - `storefrontJourneyEvents.ts` (45 edges, Community 0) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 0) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `harness-check.ts` (32 edges, Community 1) - [`scripts/harness-check.ts`](../../scripts/harness-check.ts)
-- `harness-generate.ts` (30 edges, Community 2) - [`scripts/harness-generate.ts`](../../scripts/harness-generate.ts)
-- `harness-inferential-review.ts` (27 edges, Community 4) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
-- `storeConfigV2.ts` (27 edges, Community 3) - [`packages/athena-webapp/convex/inventory/storeConfigV2.ts`](../../packages/athena-webapp/convex/inventory/storeConfigV2.ts)
+- `harness-inferential-review.ts` (37 edges, Community 1) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
+- `harness-check.ts` (32 edges, Community 2) - [`scripts/harness-check.ts`](../../scripts/harness-check.ts)
+- `harness-generate.ts` (30 edges, Community 3) - [`scripts/harness-generate.ts`](../../scripts/harness-generate.ts)
+- `storeConfigV2.ts` (27 edges, Community 4) - [`packages/athena-webapp/convex/inventory/storeConfigV2.ts`](../../packages/athena-webapp/convex/inventory/storeConfigV2.ts)
 - `harness-behavior.ts` (24 edges, Community 5) - [`scripts/harness-behavior.ts`](../../scripts/harness-behavior.ts)
 - `harness-self-review.ts` (24 edges, Community 6) - [`scripts/harness-self-review.ts`](../../scripts/harness-self-review.ts)
 

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -17,7 +17,7 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 - [validation-map.json](../../../packages/athena-webapp/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `storeConfigV2.ts` (27 edges, Community 3) - [`packages/athena-webapp/convex/inventory/storeConfigV2.ts`](../../../packages/athena-webapp/convex/inventory/storeConfigV2.ts)
+- `storeConfigV2.ts` (27 edges, Community 4) - [`packages/athena-webapp/convex/inventory/storeConfigV2.ts`](../../../packages/athena-webapp/convex/inventory/storeConfigV2.ts)
 - `ProductStock.tsx` (19 edges, Community 9) - [`packages/athena-webapp/src/components/add-product/ProductStock.tsx`](../../../packages/athena-webapp/src/components/add-product/ProductStock.tsx)
 - `checkoutSession.ts` (17 edges, Community 11) - [`packages/athena-webapp/convex/storeFront/checkoutSession.ts`](../../../packages/athena-webapp/convex/storeFront/checkoutSession.ts)
 - `DataTableViewOptions()` (16 edges, Community 13) - [`packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx`](../../../packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx)

--- a/scripts/harness-inferential-review.test.ts
+++ b/scripts/harness-inferential-review.test.ts
@@ -189,8 +189,49 @@ describe("runHarnessInferentialReview", () => {
 
     expect(result.exitCode).toBe(0);
     expect(result.machine.status).toBe("pass");
+    expect(result.machine.reviewMode).toBe("deterministic-only");
     expect(result.machine.findings).toEqual([]);
     expect(result.humanReport).toContain("No actionable inferential findings.");
+  });
+
+  it("records semantic shadow findings without changing the blocking result", async () => {
+    const rootDir = await createFixtureRepo();
+
+    const result = await runHarnessInferentialReview(rootDir, {
+      getChangedFiles: async () => ["package.json"],
+      runSemanticAnalysis: async () => ({
+        providerName: "semantic-shadow-stub",
+        findings: [
+          {
+            id: "semantic-doc-gap",
+            severity: "low",
+            title: "Semantic doc gap",
+            filePath: "package.json",
+            rationale: "The semantic reviewer found a likely docs mismatch.",
+            remediation: "Document the new wiring in the testing guide.",
+          },
+        ],
+      }),
+      semanticMode: "shadow",
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.machine.status).toBe("pass");
+    expect(result.machine.reviewMode).toBe("semantic-shadow");
+    expect(result.machine.findings).toEqual([]);
+    expect(result.machine.errors).toEqual([]);
+    expect(result.machine.shadow).toMatchObject({
+      status: "fail",
+      providerName: "semantic-shadow-stub",
+      findings: [
+        {
+          id: "semantic-doc-gap",
+          severity: "low",
+          filePath: "package.json",
+        },
+      ],
+    });
   });
 
   it("returns deterministic actionable runtime/provider failure output", async () => {
@@ -215,26 +256,29 @@ describe("runHarnessInferentialReview", () => {
     expect(result.humanReport).toContain("Confirm provider configuration and connectivity");
   });
 
-  it("returns deterministic runtime failure output when semantic analysis throws", async () => {
+  it("records semantic shadow errors without making the command blocking", async () => {
     const rootDir = await createFixtureRepo();
 
     const result = await runHarnessInferentialReview(rootDir, {
-      getChangedFiles: async () => ["scripts/harness-inferential-review.ts"],
+      getChangedFiles: async () => ["package.json"],
       runSemanticAnalysis: async () => {
         throw new Error("semantic parse failure");
       },
+      semanticMode: "shadow",
       nowIso: () => "2026-04-12T05:00:00.000Z",
     });
 
-    expect(result.exitCode).toBe(1);
-    expect(result.machine.status).toBe("error");
-    expect(result.machine.errors).toMatchObject([
+    expect(result.exitCode).toBe(0);
+    expect(result.machine.status).toBe("pass");
+    expect(result.machine.errors).toEqual([]);
+    expect(result.machine.shadow?.errors).toMatchObject([
       {
         code: "INFERENTIAL_RUNTIME_FAILURE",
       },
     ]);
-    expect(result.humanReport).toContain("Semantic analysis failed");
-    expect(result.humanReport).toContain("Inspect the runtime error output");
+    expect(result.machine.shadow?.status).toBe("error");
+    expect(result.humanReport).toContain("Shadow semantic review");
+    expect(result.humanReport).toContain("semantic parse failure");
   });
 
   it("is explicit and clean when no harness-critical files are in scope", async () => {
@@ -251,17 +295,42 @@ describe("runHarnessInferentialReview", () => {
     expect(result.humanReport).toContain("No harness-critical files are in scope.");
   });
 
-  it("writes machine-readable output via the default artifact path", async () => {
+  it("writes machine-readable output with additive shadow data via the default artifact path", async () => {
     const rootDir = await createFixtureRepo();
 
     const result = await runHarnessInferentialReview(rootDir, {
-      getChangedFiles: async () => ["README.md"],
+      getChangedFiles: async () => ["package.json"],
+      semanticMode: "shadow",
+      runSemanticAnalysis: async () => ({
+        providerName: "semantic-shadow-stub",
+        findings: [
+          {
+            id: "semantic-doc-gap",
+            severity: "low",
+            title: "Semantic doc gap",
+            filePath: "package.json",
+            rationale: "The semantic reviewer found a likely docs mismatch.",
+            remediation: "Document the new wiring in the testing guide.",
+          },
+        ],
+      }),
       nowIso: () => "2026-04-12T05:00:00.000Z",
     });
 
     const saved = JSON.parse(
       await readFile(path.join(rootDir, result.machineOutputPath), "utf8")
-    ) as { status: string };
-    expect(saved.status).toBe("skipped");
+    ) as {
+      status: string;
+      providerName: string;
+      reviewMode?: string;
+      shadow?: { providerName: string; status: string };
+    };
+    expect(saved.status).toBe("pass");
+    expect(saved.providerName).toBe("deterministic-policy-v1");
+    expect(saved.reviewMode).toBe("semantic-shadow");
+    expect(saved.shadow).toMatchObject({
+      providerName: "semantic-shadow-stub",
+      status: "fail",
+    });
   });
 });

--- a/scripts/harness-inferential-review.ts
+++ b/scripts/harness-inferential-review.ts
@@ -1,9 +1,15 @@
+import Anthropic from "@anthropic-ai/sdk";
 import { access, mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 const DEFAULT_BASE_REF = "origin/main";
 const DEFAULT_MACHINE_OUTPUT_PATH =
   "artifacts/harness-inferential-review/latest.json";
+const DEFAULT_SEMANTIC_MODE = "off";
+const DEFAULT_SEMANTIC_PROVIDER_MODEL = "claude-3-5-haiku-20241022";
+const DEFAULT_SEMANTIC_PROVIDER_NAME = "anthropic-shadow-v1";
+const MAX_PROMPT_TARGET_FILES = 6;
+const MAX_PROMPT_FILE_CHARS = 6000;
 
 type InferentialSeverity = "high" | "medium" | "low";
 
@@ -23,10 +29,22 @@ type InferentialError = {
 };
 
 type InferentialStatus = "pass" | "fail" | "error" | "skipped";
+type InferentialReviewMode = "deterministic-only" | "semantic-shadow";
+type InferentialShadowMode = "off" | "shadow";
+
+type InferentialShadowMachineOutput = {
+  generatedAt: string;
+  status: InferentialStatus;
+  summary: string;
+  providerName: string;
+  findings: InferentialFinding[];
+  errors: InferentialError[];
+};
 
 type InferentialMachineOutput = {
   version: "1.0";
   generatedAt: string;
+  reviewMode: InferentialReviewMode;
   baseRef: string;
   status: InferentialStatus;
   summary: string;
@@ -35,6 +53,7 @@ type InferentialMachineOutput = {
   targetFiles: string[];
   findings: InferentialFinding[];
   errors: InferentialError[];
+  shadow?: InferentialShadowMachineOutput;
 };
 
 type InferentialProviderInput = {
@@ -49,8 +68,16 @@ type InferentialProviderResult = {
   findings: InferentialFinding[];
 };
 
-type InferentialSemanticAnalysisResult = {
+type InferentialDeterministicAnalysisResult = {
   findings: InferentialFinding[];
+};
+
+type InferentialSemanticAnalysisResult = {
+  providerName: string;
+  findings: InferentialFinding[];
+  summary?: string;
+  status?: InferentialStatus;
+  errors?: InferentialError[];
 };
 
 type InferentialReviewLogger = Pick<Console, "log" | "error">;
@@ -61,6 +88,7 @@ type InferentialReviewOptions = {
   runProvider?: (
     input: InferentialProviderInput
   ) => Promise<InferentialProviderResult>;
+  semanticMode?: InferentialShadowMode;
   runSemanticAnalysis?: (
     input: InferentialProviderInput
   ) => Promise<InferentialSemanticAnalysisResult>;
@@ -419,7 +447,7 @@ async function collectHarnessSafetySignalFindings(
 
 async function runDeterministicSemanticAnalysis(
   input: InferentialProviderInput
-): Promise<InferentialSemanticAnalysisResult> {
+): Promise<InferentialDeterministicAnalysisResult> {
   const findings = [
     ...(await collectHarnessScriptTestUpdateFindings(
       input.rootDir,
@@ -433,6 +461,214 @@ async function runDeterministicSemanticAnalysis(
 
   return {
     findings: sortFindings(findings),
+  };
+}
+
+function resolveSemanticMode(
+  optionMode?: InferentialShadowMode
+): InferentialShadowMode {
+  const rawMode =
+    optionMode ?? process.env.HARNESS_INFERENTIAL_SEMANTIC_MODE ?? DEFAULT_SEMANTIC_MODE;
+
+  return rawMode === "shadow" ? "shadow" : "off";
+}
+
+function buildShadowSummary(findings: InferentialFinding[]) {
+  return findings.length > 0
+    ? `Shadow semantic review found ${findings.length} possible issue(s).`
+    : "Shadow semantic review found no semantic issues.";
+}
+
+function truncateForPrompt(contents: string) {
+  if (contents.length <= MAX_PROMPT_FILE_CHARS) {
+    return contents;
+  }
+
+  return `${contents.slice(0, MAX_PROMPT_FILE_CHARS)}\n...[truncated]`;
+}
+
+async function buildSemanticPrompt(input: InferentialProviderInput) {
+  const fileSections: string[] = [];
+
+  for (const filePath of input.targetFiles.slice(0, MAX_PROMPT_TARGET_FILES)) {
+    const contents = await readUtf8OrNull(path.join(input.rootDir, filePath));
+    fileSections.push(
+      [
+        `FILE: ${filePath}`,
+        "CONTENT:",
+        contents ? truncateForPrompt(contents) : "[missing]",
+      ].join("\n")
+    );
+  }
+
+  return [
+    "You are reviewing Athena harness-critical files in semantic shadow mode.",
+    "Return JSON only with this exact shape:",
+    '{"summary":"string","findings":[{"id":"string","severity":"high|medium|low","title":"string","filePath":"string","rationale":"string","remediation":"string"}]}',
+    "Only report likely semantic or operational issues that a deterministic rule might miss.",
+    "If there are no likely issues, return {\"summary\":\"No semantic issues detected.\",\"findings\":[]}.",
+    `Base ref: ${input.baseRef}`,
+    `Changed files (${input.changedFiles.length}): ${input.changedFiles.join(", ")}`,
+    `Target files (${input.targetFiles.length}): ${input.targetFiles.join(", ")}`,
+    "",
+    fileSections.join("\n\n"),
+  ].join("\n");
+}
+
+function extractTextFromAnthropicResponse(content: unknown) {
+  if (!Array.isArray(content)) {
+    return String(content ?? "");
+  }
+
+  return content
+    .map((entry) => {
+      if (typeof entry === "string") {
+        return entry;
+      }
+
+      if (
+        typeof entry === "object" &&
+        entry !== null &&
+        "type" in entry &&
+        "text" in entry &&
+        (entry as { type?: string }).type === "text"
+      ) {
+        return String((entry as { text?: string }).text ?? "");
+      }
+
+      return "";
+    })
+    .join("\n");
+}
+
+function extractJsonPayload(responseText: string) {
+  const trimmed = responseText.trim();
+  if (trimmed.startsWith("{") && trimmed.endsWith("}")) {
+    return trimmed;
+  }
+
+  const fencedMatch = trimmed.match(/```(?:json)?\s*([\s\S]+?)```/i);
+  if (fencedMatch?.[1]) {
+    return fencedMatch[1].trim();
+  }
+
+  const firstBrace = trimmed.indexOf("{");
+  const lastBrace = trimmed.lastIndexOf("}");
+  if (firstBrace !== -1 && lastBrace !== -1 && lastBrace > firstBrace) {
+    return trimmed.slice(firstBrace, lastBrace + 1);
+  }
+
+  throw new Error("Semantic provider response did not include JSON output.");
+}
+
+function normalizeSemanticFinding(
+  value: unknown
+): InferentialFinding | null {
+  if (typeof value !== "object" || value === null) {
+    return null;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  const id =
+    typeof candidate.id === "string" && candidate.id.trim()
+      ? candidate.id.trim()
+      : null;
+  const severity =
+    candidate.severity === "high" ||
+    candidate.severity === "medium" ||
+    candidate.severity === "low"
+      ? candidate.severity
+      : null;
+  const title =
+    typeof candidate.title === "string" && candidate.title.trim()
+      ? candidate.title.trim()
+      : null;
+  const filePath =
+    typeof candidate.filePath === "string" && candidate.filePath.trim()
+      ? normalizeRepoPath(candidate.filePath)
+      : null;
+  const rationale =
+    typeof candidate.rationale === "string" && candidate.rationale.trim()
+      ? candidate.rationale.trim()
+      : null;
+  const remediation =
+    typeof candidate.remediation === "string" && candidate.remediation.trim()
+      ? candidate.remediation.trim()
+      : null;
+
+  if (!id || !severity || !title || !filePath || !rationale || !remediation) {
+    return null;
+  }
+
+  return {
+    id,
+    severity,
+    title,
+    filePath,
+    rationale,
+    remediation,
+  };
+}
+
+function parseSemanticResponse(responseText: string) {
+  const parsed = JSON.parse(extractJsonPayload(responseText)) as {
+    summary?: unknown;
+    findings?: unknown;
+  };
+
+  const findings = Array.isArray(parsed.findings)
+    ? parsed.findings
+        .map((finding) => normalizeSemanticFinding(finding))
+        .filter((finding): finding is InferentialFinding => finding !== null)
+    : [];
+
+  const summary =
+    typeof parsed.summary === "string" && parsed.summary.trim()
+      ? parsed.summary.trim()
+      : buildShadowSummary(findings);
+
+  return {
+    summary,
+    findings: sortFindings(findings),
+  };
+}
+
+async function runAnthropicSemanticAnalysis(
+  input: InferentialProviderInput
+): Promise<InferentialSemanticAnalysisResult> {
+  const model =
+    process.env.HARNESS_INFERENTIAL_ANTHROPIC_MODEL?.trim() ||
+    DEFAULT_SEMANTIC_PROVIDER_MODEL;
+  const providerName = `${DEFAULT_SEMANTIC_PROVIDER_NAME}:${model}`;
+  const apiKey = process.env.ANTHROPIC_API_KEY?.trim();
+
+  if (!apiKey) {
+    return {
+      providerName,
+      status: "skipped",
+      summary:
+        "Shadow semantic review skipped because ANTHROPIC_API_KEY is not configured.",
+      findings: [],
+    };
+  }
+
+  const prompt = await buildSemanticPrompt(input);
+  const anthropic = new Anthropic({ apiKey });
+  const completion = await anthropic.messages.create({
+    model,
+    max_tokens: 1200,
+    temperature: 0,
+    messages: [{ role: "user", content: prompt }],
+  });
+
+  const responseText = extractTextFromAnthropicResponse(completion.content);
+  const parsed = parseSemanticResponse(responseText);
+
+  return {
+    providerName,
+    status: parsed.findings.length > 0 ? "fail" : "pass",
+    summary: parsed.summary,
+    findings: parsed.findings,
   };
 }
 
@@ -626,6 +862,7 @@ function buildHumanReport(output: InferentialMachineOutput) {
   lines.push("# Harness Inferential Review");
   lines.push("");
   lines.push(`Status: ${formatStatusLabel(output.status)}`);
+  lines.push(`Review mode: ${output.reviewMode}`);
   lines.push(`Provider: ${output.providerName}`);
   lines.push(`Base ref: ${output.baseRef}`);
   lines.push(`Changed files: ${output.changedFiles.length}`);
@@ -660,6 +897,32 @@ function buildHumanReport(output: InferentialMachineOutput) {
     lines.push("");
   }
 
+  if (output.shadow) {
+    lines.push("Shadow semantic review:");
+    lines.push(`- Status: ${formatStatusLabel(output.shadow.status)}`);
+    lines.push(`- Provider: ${output.shadow.providerName}`);
+    lines.push(`- Summary: ${output.shadow.summary}`);
+
+    if (output.shadow.findings.length > 0) {
+      for (const finding of output.shadow.findings) {
+        lines.push(
+          `- [${finding.severity.toUpperCase()}] ${finding.title} (${finding.filePath})`
+        );
+        lines.push(`  Rationale: ${finding.rationale}`);
+        lines.push(`  Remediation: ${finding.remediation}`);
+      }
+    }
+
+    if (output.shadow.errors.length > 0) {
+      for (const error of output.shadow.errors) {
+        lines.push(`- ${error.code}: ${error.message}`);
+        lines.push(`  Remediation: ${error.remediation}`);
+      }
+    }
+
+    lines.push("");
+  }
+
   return lines.join("\n");
 }
 
@@ -683,16 +946,38 @@ function createOutput(params: {
   errors?: InferentialError[];
   providerName: string;
   generatedAt: string;
+  reviewMode?: InferentialReviewMode;
+  shadow?: InferentialShadowMachineOutput;
 }): InferentialMachineOutput {
   return {
     version: "1.0",
     generatedAt: params.generatedAt,
+    reviewMode: params.reviewMode ?? "deterministic-only",
     baseRef: params.baseRef,
     status: params.status,
     summary: params.summary,
     providerName: params.providerName,
     changedFiles: sortUnique(params.changedFiles),
     targetFiles: sortUnique(params.targetFiles),
+    findings: sortFindings(params.findings ?? []),
+    errors: params.errors ?? [],
+    shadow: params.shadow,
+  };
+}
+
+function createShadowOutput(params: {
+  status: InferentialStatus;
+  summary: string;
+  providerName: string;
+  generatedAt: string;
+  findings?: InferentialFinding[];
+  errors?: InferentialError[];
+}): InferentialShadowMachineOutput {
+  return {
+    generatedAt: params.generatedAt,
+    status: params.status,
+    summary: params.summary,
+    providerName: params.providerName,
     findings: sortFindings(params.findings ?? []),
     errors: params.errors ?? [],
   };
@@ -703,7 +988,8 @@ function createProviderFailure(
   baseRef: string,
   changedFiles: string[],
   targetFiles: string[],
-  generatedAt: string
+  generatedAt: string,
+  reviewMode: InferentialReviewMode
 ): InferentialMachineOutput {
   return createOutput({
     status: "error",
@@ -714,6 +1000,7 @@ function createProviderFailure(
     targetFiles,
     providerName: "deterministic-policy-v1",
     generatedAt,
+    reviewMode,
     errors: [
       {
         code: "INFERENTIAL_PROVIDER_FAILURE",
@@ -730,7 +1017,8 @@ function createRuntimeFailure(
   baseRef: string,
   changedFiles: string[],
   targetFiles: string[],
-  generatedAt: string
+  generatedAt: string,
+  reviewMode: InferentialReviewMode
 ): InferentialMachineOutput {
   return createOutput({
     status: "error",
@@ -741,6 +1029,7 @@ function createRuntimeFailure(
     targetFiles,
     providerName: "deterministic-policy-v1",
     generatedAt,
+    reviewMode,
     errors: [
       {
         code: "INFERENTIAL_RUNTIME_FAILURE",
@@ -760,6 +1049,9 @@ export async function runHarnessInferentialReview(
   const machineOutputPath =
     options.machineOutputPath ?? DEFAULT_MACHINE_OUTPUT_PATH;
   const nowIso = options.nowIso ?? (() => new Date().toISOString());
+  const semanticMode = resolveSemanticMode(options.semanticMode);
+  const reviewMode: InferentialReviewMode =
+    semanticMode === "shadow" ? "semantic-shadow" : "deterministic-only";
   const logger = options.logger ?? console;
 
   const getChangedFiles =
@@ -767,7 +1059,7 @@ export async function runHarnessInferentialReview(
   const runProvider =
     options.runProvider ?? runDeterministicInferentialProvider;
   const runSemanticAnalysis =
-    options.runSemanticAnalysis ?? runDeterministicSemanticAnalysis;
+    options.runSemanticAnalysis ?? runAnthropicSemanticAnalysis;
 
   let changedFiles: string[] = [];
   let targetFiles: string[] = [];
@@ -783,7 +1075,8 @@ export async function runHarnessInferentialReview(
       baseRef,
       changedFiles,
       targetFiles,
-      nowIso()
+      nowIso(),
+      reviewMode
     );
     const humanReport = buildHumanReport(machine);
     await writeMachineOutput(rootDir, machineOutputPath, machine);
@@ -804,6 +1097,7 @@ export async function runHarnessInferentialReview(
       targetFiles,
       providerName: "deterministic-policy-v1",
       generatedAt: nowIso(),
+      reviewMode,
     });
     const humanReport = buildHumanReport(machine);
     await writeMachineOutput(rootDir, machineOutputPath, machine);
@@ -831,7 +1125,8 @@ export async function runHarnessInferentialReview(
       baseRef,
       changedFiles,
       targetFiles,
-      nowIso()
+      nowIso(),
+      reviewMode
     );
   }
 
@@ -841,7 +1136,7 @@ export async function runHarnessInferentialReview(
     }
 
     try {
-      const semanticResult = await runSemanticAnalysis({
+      const deterministicResult = await runDeterministicSemanticAnalysis({
         rootDir,
         baseRef,
         changedFiles,
@@ -849,7 +1144,7 @@ export async function runHarnessInferentialReview(
       });
       const findings = sortFindings([
         ...providerResult.findings,
-        ...semanticResult.findings,
+        ...deterministicResult.findings,
       ]);
       machine = createOutput({
         status: findings.length > 0 ? "fail" : "pass",
@@ -863,21 +1158,62 @@ export async function runHarnessInferentialReview(
         providerName: providerResult.providerName,
         findings,
         generatedAt: nowIso(),
+        reviewMode,
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       machine = createRuntimeFailure(
-        `Semantic analysis failed: ${message}`,
+        `Deterministic inferential analysis failed: ${message}`,
         baseRef,
         changedFiles,
         targetFiles,
-        nowIso()
+        nowIso(),
+        reviewMode
       );
     }
   }
 
   if (!machine) {
     throw new Error("Inferential review did not produce machine output.");
+  }
+
+  if (semanticMode === "shadow" && machine.status !== "error") {
+    try {
+      const semanticResult = await runSemanticAnalysis({
+        rootDir,
+        baseRef,
+        changedFiles,
+        targetFiles,
+      });
+      const shadowFindings = sortFindings(semanticResult.findings);
+      machine.shadow = createShadowOutput({
+        generatedAt: nowIso(),
+        providerName: semanticResult.providerName,
+        status:
+          semanticResult.status ??
+          (shadowFindings.length > 0 ? "fail" : "pass"),
+        summary: semanticResult.summary ?? buildShadowSummary(shadowFindings),
+        findings: shadowFindings,
+        errors: semanticResult.errors ?? [],
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      machine.shadow = createShadowOutput({
+        generatedAt: nowIso(),
+        providerName: DEFAULT_SEMANTIC_PROVIDER_NAME,
+        status: "error",
+        summary:
+          "Shadow semantic review failed, but deterministic inferential review remains authoritative.",
+        errors: [
+          {
+            code: "INFERENTIAL_RUNTIME_FAILURE",
+            message: `Semantic analysis failed: ${message}`,
+            remediation:
+              "Inspect the shadow semantic provider output or configuration, then rerun `bun run harness:inferential-review`.",
+          },
+        ],
+      });
+    }
   }
 
   const humanReport = buildHumanReport(machine);
@@ -891,7 +1227,8 @@ export async function runHarnessInferentialReview(
       baseRef,
       changedFiles,
       targetFiles,
-      nowIso()
+      nowIso(),
+      reviewMode
     );
     const runtimeReport = buildHumanReport(machine);
     await writeMachineOutput(rootDir, machineOutputPath, machine);


### PR DESCRIPTION
## Summary
- add a semantic shadow-mode lane to `harness:inferential-review` while preserving deterministic blocking behavior
- expose additive shadow-lane status/findings/errors in human and machine output
- add inferential-review tests for shadow findings, shadow failures, and additive artifact compatibility

## Why
- we need to collect semantic-review signal without making merges depend on a new provider path yet
- this keeps the current deterministic inferential gate intact while starting the shadow-mode rollout
- graphify artifacts stay fresh so agent navigation remains in sync with the code change

## Validation
- `bun test scripts/harness-inferential-review.test.ts`
- `HARNESS_INFERENTIAL_SEMANTIC_MODE=shadow bun run harness:inferential-review`
- `bun run graphify:rebuild`
- `bun run pr:athena`
- internal review: APPROVED (`critical_count=0`, `important_count=0`, `minor_count=0`)

https://linear.app/v26-labs/issue/V26-225/add-semantic-shadow-mode-lane-to-harness-inferential-review