### PR TITLE
[V26-226]: persist inferential and runtime trend history

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 2787 nodes · 2333 edges · 1113 communities detected
+- 2788 nodes · 2334 edges · 1113 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1212,15 +1212,15 @@ Nodes (13): compareSnapshots(), fileExists(), formatArtifactList(), formatDetail
 
 ### Community 15 - "Community 15"
 Cohesion: 0.21
-Nodes (14): CheckoutSessionError, createCheckoutSession(), defaultCheckoutActionMessage(), getActiveCheckoutSession(), getBaseUrl(), getCheckoutActionErrorMessage(), getCheckoutErrorMessageFromPayload(), getCheckoutSession() (+6 more)
+Nodes (14): buildNumericTrendStats(), buildRegressionWarnings(), buildRuntimeTrendOutput(), buildScenarioTrend(), collectHarnessRuntimeTrends(), formatMs(), formatPercent(), parseHarnessBehaviorReportLines() (+6 more)
 
 ### Community 16 - "Community 16"
-Cohesion: 0.2
-Nodes (9): collectCommandsForChangedFiles(), fileExists(), hasAnyHarnessDocs(), loadReviewTarget(), loadReviewTargets(), matchesPathPrefix(), normalizeBehaviorScenarioName(), normalizeRepoPath() (+1 more)
+Cohesion: 0.21
+Nodes (14): CheckoutSessionError, createCheckoutSession(), defaultCheckoutActionMessage(), getActiveCheckoutSession(), getBaseUrl(), getCheckoutActionErrorMessage(), getCheckoutErrorMessageFromPayload(), getCheckoutSession() (+6 more)
 
 ### Community 17 - "Community 17"
-Cohesion: 0.23
-Nodes (14): buildNumericTrendStats(), buildRegressionWarnings(), buildRuntimeTrendOutput(), buildScenarioTrend(), collectHarnessRuntimeTrends(), formatMs(), formatPercent(), parseHarnessBehaviorReportLines() (+6 more)
+Cohesion: 0.2
+Nodes (9): collectCommandsForChangedFiles(), fileExists(), hasAnyHarnessDocs(), loadReviewTarget(), loadReviewTargets(), matchesPathPrefix(), normalizeBehaviorScenarioName(), normalizeRepoPath() (+1 more)
 
 ### Community 18 - "Community 18"
 Cohesion: 0.13
@@ -1275,20 +1275,20 @@ Cohesion: 0.36
 Nodes (8): collectAllPages(), createTransactionFromSessionHandler(), listCompletedTransactionsForDay(), listProductSkusByProductId(), listSessionItems(), listStoreProducts(), listStoreSkus(), listTransactionItems()
 
 ### Community 31 - "Community 31"
+Cohesion: 0.31
+Nodes (5): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getPotentialPoints()
+
+### Community 32 - "Community 32"
 Cohesion: 0.29
 Nodes (6): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile()
 
-### Community 32 - "Community 32"
+### Community 33 - "Community 33"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 33 - "Community 33"
+### Community 34 - "Community 34"
 Cohesion: 0.38
 Nodes (9): awardPointsForGuestOrders(), awardPointsForPastOrder(), getBaseUrl(), getEligiblePastOrders(), getOrderRewardPoints(), getPointHistory(), getRewardTiers(), getUserPoints() (+1 more)
-
-### Community 34 - "Community 34"
-Cohesion: 0.31
-Nodes (5): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getPotentialPoints()
 
 ### Community 35 - "Community 35"
 Cohesion: 0.28
@@ -1363,16 +1363,16 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 53 - "Community 53"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
-
-### Community 54 - "Community 54"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
-### Community 55 - "Community 55"
+### Community 54 - "Community 54"
 Cohesion: 0.29
 Nodes (0):
+
+### Community 55 - "Community 55"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
 
 ### Community 56 - "Community 56"
 Cohesion: 0.52
@@ -1427,16 +1427,16 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 69 - "Community 69"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 70 - "Community 70"
-Cohesion: 0.4
-Nodes (2): useBulkOperations(), validateOperationValue()
-
-### Community 71 - "Community 71"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 71 - "Community 71"
+Cohesion: 0.4
+Nodes (2): useBulkOperations(), validateOperationValue()
 
 ### Community 72 - "Community 72"
 Cohesion: 0.33
@@ -1451,28 +1451,28 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 75 - "Community 75"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 76 - "Community 76"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 77 - "Community 77"
-Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 78 - "Community 78"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
 ### Community 79 - "Community 79"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 80 - "Community 80"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 81 - "Community 81"
 Cohesion: 0.53

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 2779 nodes · 2313 edges · 1113 communities detected
+- 2787 nodes · 2333 edges · 1113 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1131,10 +1131,10 @@
 4. `DataTableColumnHeader()` - 14 edges
 5. `toV2Config()` - 13 edges
 6. `validateHarnessDocs()` - 13 edges
-7. `getBaseUrl()` - 12 edges
-8. `fileExists()` - 12 edges
-9. `runHarnessInferentialReview()` - 12 edges
-10. `OrdersTableToolbarProvider()` - 9 edges
+7. `runHarnessInferentialReview()` - 13 edges
+8. `getBaseUrl()` - 12 edges
+9. `fileExists()` - 12 edges
+10. `collectHarnessScorecard()` - 11 edges
 
 ## Surprising Connections (you probably didn't know these)
 - `getAmountPaidForOrder()` --calls--> `getDiscountValue()`  [EXTRACTED]
@@ -1155,8 +1155,8 @@ Cohesion: 0.09
 Nodes (45): compactContext(), createAuthEntryViewedEvent(), createAuthRequestStartedEvent(), createAuthVerificationSucceededEvent(), createAuthVerificationViewedEvent(), createBagAddSucceededEvent(), createBagMoveToSavedEvent(), createBagRemoveSucceededEvent() (+37 more)
 
 ### Community 1 - "Community 1"
-Cohesion: 0.13
-Nodes (36): buildFinding(), buildHumanReport(), buildSemanticPrompt(), buildShadowSummary(), collectHarnessSafetySignalFindings(), collectHarnessScriptTestUpdateFindings(), createOutput(), createProviderFailure() (+28 more)
+Cohesion: 0.12
+Nodes (38): buildFinding(), buildHumanReport(), buildSemanticPrompt(), buildShadowSummary(), collectHarnessSafetySignalFindings(), collectHarnessScriptTestUpdateFindings(), createOutput(), createProviderFailure() (+30 more)
 
 ### Community 2 - "Community 2"
 Cohesion: 0.15
@@ -1175,16 +1175,16 @@ Cohesion: 0.13
 Nodes (22): asRegExp(), collectLatencyDiagnostics(), collectRuntimeSignalDiagnostics(), collectRuntimeSignalMatches(), consumeLines(), escapeRegExp(), formatAssertionDiagnostics(), formatError() (+14 more)
 
 ### Community 6 - "Community 6"
+Cohesion: 0.16
+Nodes (20): buildDocumentationStatus(), buildEmptyHistoryMetric(), buildGraphifyStatus(), buildSummary(), collectHarnessScorecard(), countMissingSnippets(), createFileSystem(), extractScenarioNames() (+12 more)
+
+### Community 7 - "Community 7"
 Cohesion: 0.15
 Nodes (19): appendListSection(), buildMarkdownBundle(), collectCoverage(), evaluateGraphifyFreshness(), fileExists(), formatValidationCommand(), getChangedFilesFromGit(), isLocalGeneratedArtifactPath() (+11 more)
 
-### Community 7 - "Community 7"
+### Community 8 - "Community 8"
 Cohesion: 0.27
 Nodes (20): asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), asString(), cleanUndefined(), firstDefined() (+12 more)
-
-### Community 8 - "Community 8"
-Cohesion: 0.18
-Nodes (16): buildDocumentationStatus(), buildGraphifyStatus(), buildSummary(), collectHarnessScorecard(), countMissingSnippets(), createFileSystem(), extractScenarioNames(), extractScenarioSection() (+8 more)
 
 ### Community 9 - "Community 9"
 Cohesion: 0.11
@@ -1219,16 +1219,16 @@ Cohesion: 0.2
 Nodes (9): collectCommandsForChangedFiles(), fileExists(), hasAnyHarnessDocs(), loadReviewTarget(), loadReviewTargets(), matchesPathPrefix(), normalizeBehaviorScenarioName(), normalizeRepoPath() (+1 more)
 
 ### Community 17 - "Community 17"
+Cohesion: 0.23
+Nodes (14): buildNumericTrendStats(), buildRegressionWarnings(), buildRuntimeTrendOutput(), buildScenarioTrend(), collectHarnessRuntimeTrends(), formatMs(), formatPercent(), parseHarnessBehaviorReportLines() (+6 more)
+
+### Community 18 - "Community 18"
 Cohesion: 0.13
 Nodes (1): DataTableColumnHeader()
 
-### Community 18 - "Community 18"
+### Community 19 - "Community 19"
 Cohesion: 0.28
 Nodes (12): addGroupedError(), collectLiveSurfaceEntries(), fileExists(), formatGroupedErrors(), hasAnyHarnessDocs(), inferGroupFromError(), loadAuditTarget(), matchesPathPrefix() (+4 more)
-
-### Community 19 - "Community 19"
-Cohesion: 0.24
-Nodes (13): buildNumericTrendStats(), buildRegressionWarnings(), buildRuntimeTrendOutput(), buildScenarioTrend(), collectHarnessRuntimeTrends(), formatMs(), formatPercent(), parseHarnessBehaviorReportLines() (+5 more)
 
 ### Community 20 - "Community 20"
 Cohesion: 0.18
@@ -1275,20 +1275,20 @@ Cohesion: 0.36
 Nodes (8): collectAllPages(), createTransactionFromSessionHandler(), listCompletedTransactionsForDay(), listProductSkusByProductId(), listSessionItems(), listStoreProducts(), listStoreSkus(), listTransactionItems()
 
 ### Community 31 - "Community 31"
-Cohesion: 0.31
-Nodes (5): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getPotentialPoints()
-
-### Community 32 - "Community 32"
 Cohesion: 0.29
 Nodes (6): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile()
 
-### Community 33 - "Community 33"
+### Community 32 - "Community 32"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 34 - "Community 34"
+### Community 33 - "Community 33"
 Cohesion: 0.38
 Nodes (9): awardPointsForGuestOrders(), awardPointsForPastOrder(), getBaseUrl(), getEligiblePastOrders(), getOrderRewardPoints(), getPointHistory(), getRewardTiers(), getUserPoints() (+1 more)
+
+### Community 34 - "Community 34"
+Cohesion: 0.31
+Nodes (5): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getPotentialPoints()
 
 ### Community 35 - "Community 35"
 Cohesion: 0.28
@@ -1427,16 +1427,16 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 69 - "Community 69"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
-
-### Community 70 - "Community 70"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 71 - "Community 71"
+### Community 70 - "Community 70"
 Cohesion: 0.4
 Nodes (2): useBulkOperations(), validateOperationValue()
+
+### Community 71 - "Community 71"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 72 - "Community 72"
 Cohesion: 0.33
@@ -1451,28 +1451,28 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 75 - "Community 75"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 76 - "Community 76"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 77 - "Community 77"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 78 - "Community 78"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 78 - "Community 78"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 79 - "Community 79"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 80 - "Community 80"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 81 - "Community 81"
 Cohesion: 0.53
@@ -7290,12 +7290,12 @@ _Questions this graph is uniquely positioned to answer:_
 - **Should `Community 0` be split into smaller, more focused modules?**
   _Cohesion score 0.09 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**
-  _Cohesion score 0.13 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.12 - nodes in this community are weakly interconnected._
 - **Should `Community 5` be split into smaller, more focused modules?**
   _Cohesion score 0.13 - nodes in this community are weakly interconnected._
 - **Should `Community 9` be split into smaller, more focused modules?**
   _Cohesion score 0.11 - nodes in this community are weakly interconnected._
 - **Should `Community 13` be split into smaller, more focused modules?**
   _Cohesion score 0.12 - nodes in this community are weakly interconnected._
-- **Should `Community 17` be split into smaller, more focused modules?**
+- **Should `Community 18` be split into smaller, more focused modules?**
   _Cohesion score 0.13 - nodes in this community are weakly interconnected._

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -1649,7 +1649,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_utils_ts",
-      "community": 31
+      "community": 34
     },
     {
       "label": "getDiscountValue()",
@@ -1657,7 +1657,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L17",
       "id": "utils_getdiscountvalue",
-      "community": 31
+      "community": 34
     },
     {
       "label": "getProductDiscountValue()",
@@ -1665,7 +1665,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
       "source_location": "L75",
       "id": "utils_getproductdiscountvalue",
-      "community": 31
+      "community": 34
     },
     {
       "label": "getOrderAmount()",
@@ -1673,7 +1673,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L51",
       "id": "utils_getorderamount",
-      "community": 31
+      "community": 34
     },
     {
       "label": "formatDeliveryAddress()",
@@ -1681,7 +1681,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L74",
       "id": "utils_formatdeliveryaddress",
-      "community": 31
+      "community": 34
     },
     {
       "label": "currency.test.ts",
@@ -4417,7 +4417,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_column_header_tsx",
-      "community": 17
+      "community": 18
     },
     {
       "label": "DataTableColumnHeader()",
@@ -4425,7 +4425,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-column-header.tsx",
       "source_location": "L20",
       "id": "data_table_column_header_datatablecolumnheader",
-      "community": 17
+      "community": 18
     },
     {
       "label": "data-table-faceted-filter.tsx",
@@ -4873,7 +4873,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_column_header_tsx",
-      "community": 17
+      "community": 18
     },
     {
       "label": "data-table-faceted-filter.tsx",
@@ -4937,7 +4937,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_column_header_tsx",
-      "community": 17
+      "community": 18
     },
     {
       "label": "data-table-pagination.tsx",
@@ -4977,7 +4977,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_column_header_tsx",
-      "community": 17
+      "community": 18
     },
     {
       "label": "data-table-pagination.tsx",
@@ -5017,7 +5017,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_column_header_tsx",
-      "community": 17
+      "community": 18
     },
     {
       "label": "data-table-faceted-filter.tsx",
@@ -5089,7 +5089,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/users-table/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_column_header_tsx",
-      "community": 17
+      "community": 18
     },
     {
       "label": "data-table-pagination.tsx",
@@ -5321,7 +5321,7 @@
       "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_column_header_tsx",
-      "community": 17
+      "community": 18
     },
     {
       "label": "data-table-faceted-filter.tsx",
@@ -5561,7 +5561,7 @@
       "source_file": "packages/athena-webapp/src/components/base/table/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_base_table_data_table_column_header_tsx",
-      "community": 17
+      "community": 18
     },
     {
       "label": "data-table-faceted-filter.tsx",
@@ -5769,7 +5769,7 @@
       "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_column_header_tsx",
-      "community": 17
+      "community": 18
     },
     {
       "label": "data-table-pagination.tsx",
@@ -6081,7 +6081,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_heroheaderimageuploader_tsx",
-      "community": 32
+      "community": 31
     },
     {
       "label": "validateFile()",
@@ -6089,7 +6089,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L50",
       "id": "heroheaderimageuploader_validatefile",
-      "community": 32
+      "community": 31
     },
     {
       "label": "uploadImage()",
@@ -6097,7 +6097,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L67",
       "id": "heroheaderimageuploader_uploadimage",
-      "community": 32
+      "community": 31
     },
     {
       "label": "resetEditState()",
@@ -6105,7 +6105,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L95",
       "id": "heroheaderimageuploader_reseteditstate",
-      "community": 32
+      "community": 31
     },
     {
       "label": "handleEditClick()",
@@ -6113,7 +6113,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L108",
       "id": "heroheaderimageuploader_handleeditclick",
-      "community": 32
+      "community": 31
     },
     {
       "label": "handleFileSelect()",
@@ -6121,7 +6121,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L113",
       "id": "heroheaderimageuploader_handlefileselect",
-      "community": 32
+      "community": 31
     },
     {
       "label": "handleUpload()",
@@ -6129,7 +6129,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L127",
       "id": "heroheaderimageuploader_handleupload",
-      "community": 32
+      "community": 31
     },
     {
       "label": "handleRevert()",
@@ -6137,7 +6137,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L163",
       "id": "heroheaderimageuploader_handlerevert",
-      "community": 32
+      "community": 31
     },
     {
       "label": "EditModeButtons()",
@@ -6145,7 +6145,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L179",
       "id": "heroheaderimageuploader_editmodebuttons",
-      "community": 32
+      "community": 31
     },
     {
       "label": "ViewModeButton()",
@@ -6153,7 +6153,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L205",
       "id": "heroheaderimageuploader_viewmodebutton",
-      "community": 32
+      "community": 31
     },
     {
       "label": "HeroSectionTabs.tsx",
@@ -6697,7 +6697,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_column_header_tsx",
-      "community": 17
+      "community": 18
     },
     {
       "label": "data-table-faceted-filter.tsx",
@@ -6857,7 +6857,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_utils_ts",
-      "community": 31
+      "community": 34
     },
     {
       "label": "getOrderState()",
@@ -6865,7 +6865,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
       "source_location": "L1",
       "id": "utils_getorderstate",
-      "community": 31
+      "community": 34
     },
     {
       "label": "getAmountPaidForOrder()",
@@ -6873,7 +6873,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
       "source_location": "L108",
       "id": "utils_getamountpaidfororder",
-      "community": 31
+      "community": 34
     },
     {
       "label": "index.tsx",
@@ -6905,7 +6905,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_column_header_tsx",
-      "community": 17
+      "community": 18
     },
     {
       "label": "data-table-faceted-filter.tsx",
@@ -6985,7 +6985,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_column_header_tsx",
-      "community": 17
+      "community": 18
     },
     {
       "label": "data-table-faceted-filter.tsx",
@@ -8633,7 +8633,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_column_header_tsx",
-      "community": 17
+      "community": 18
     },
     {
       "label": "data-table-faceted-filter.tsx",
@@ -9529,7 +9529,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "community": 69
+      "community": 80
     },
     {
       "label": "onDrop()",
@@ -9537,7 +9537,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L20",
       "id": "image_uploader_ondrop",
-      "community": 69
+      "community": 80
     },
     {
       "label": "removeImage()",
@@ -9545,7 +9545,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L31",
       "id": "image_uploader_removeimage",
-      "community": 69
+      "community": 80
     },
     {
       "label": "unmarkForDeletion()",
@@ -9553,7 +9553,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L46",
       "id": "image_uploader_unmarkfordeletion",
-      "community": 69
+      "community": 80
     },
     {
       "label": "onDragEnd()",
@@ -9561,7 +9561,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L100",
       "id": "image_uploader_ondragend",
-      "community": 69
+      "community": 80
     },
     {
       "label": "input-otp.tsx",
@@ -9857,7 +9857,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
-      "community": 70
+      "community": 69
     },
     {
       "label": "useSidebar()",
@@ -9865,7 +9865,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L45",
       "id": "sidebar_usesidebar",
-      "community": 70
+      "community": 69
     },
     {
       "label": "handleKeyDown()",
@@ -9873,7 +9873,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L105",
       "id": "sidebar_handlekeydown",
-      "community": 70
+      "community": 69
     },
     {
       "label": "cn()",
@@ -9881,7 +9881,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L147",
       "id": "sidebar_cn",
-      "community": 70
+      "community": 69
     },
     {
       "label": "handleOnHover()",
@@ -9889,7 +9889,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L224",
       "id": "sidebar_handleonhover",
-      "community": 70
+      "community": 69
     },
     {
       "label": "handleOnMouseLeave()",
@@ -9897,7 +9897,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L228",
       "id": "sidebar_handleonmouseleave",
-      "community": 70
+      "community": 69
     },
     {
       "label": "skeleton.tsx",
@@ -10121,7 +10121,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-column-header.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_column_header_tsx",
-      "community": 17
+      "community": 18
     },
     {
       "label": "data-table-faceted-filter.tsx",
@@ -10817,7 +10817,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
-      "community": 71
+      "community": 70
     },
     {
       "label": "applyOperation()",
@@ -10825,7 +10825,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L56",
       "id": "usebulkoperations_applyoperation",
-      "community": 71
+      "community": 70
     },
     {
       "label": "calculatePriceWithFee()",
@@ -10833,7 +10833,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L87",
       "id": "usebulkoperations_calculatepricewithfee",
-      "community": 71
+      "community": 70
     },
     {
       "label": "computePreview()",
@@ -10841,7 +10841,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L101",
       "id": "usebulkoperations_computepreview",
-      "community": 71
+      "community": 70
     },
     {
       "label": "validateOperationValue()",
@@ -10849,7 +10849,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L139",
       "id": "usebulkoperations_validateoperationvalue",
-      "community": 71
+      "community": 70
     },
     {
       "label": "useBulkOperations()",
@@ -10857,7 +10857,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L158",
       "id": "usebulkoperations_usebulkoperations",
-      "community": 71
+      "community": 70
     },
     {
       "label": "useCartOperations.ts",
@@ -10961,7 +10961,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
-      "community": 72
+      "community": 71
     },
     {
       "label": "useExpenseStoreSessions()",
@@ -10969,7 +10969,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L7",
       "id": "useexpensesessions_useexpensestoresessions",
-      "community": 72
+      "community": 71
     },
     {
       "label": "useExpenseSession()",
@@ -10977,7 +10977,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L23",
       "id": "useexpensesessions_useexpensesession",
-      "community": 72
+      "community": 71
     },
     {
       "label": "useExpenseActiveSession()",
@@ -10985,7 +10985,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L33",
       "id": "useexpensesessions_useexpenseactivesession",
-      "community": 72
+      "community": 71
     },
     {
       "label": "useExpenseSessionCreate()",
@@ -10993,7 +10993,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L48",
       "id": "useexpensesessions_useexpensesessioncreate",
-      "community": 72
+      "community": 71
     },
     {
       "label": "useExpenseSessionUpdate()",
@@ -11001,7 +11001,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L85",
       "id": "useexpensesessions_useexpensesessionupdate",
-      "community": 72
+      "community": 71
     },
     {
       "label": "useGetActiveProduct.ts",
@@ -11217,7 +11217,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_useposcustomers_ts",
-      "community": 73
+      "community": 72
     },
     {
       "label": "usePOSCustomerSearch()",
@@ -11225,7 +11225,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L7",
       "id": "useposcustomers_useposcustomersearch",
-      "community": 73
+      "community": 72
     },
     {
       "label": "usePOSCustomer()",
@@ -11233,7 +11233,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L18",
       "id": "useposcustomers_useposcustomer",
-      "community": 73
+      "community": 72
     },
     {
       "label": "usePOSCustomerCreate()",
@@ -11241,7 +11241,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L26",
       "id": "useposcustomers_useposcustomercreate",
-      "community": 73
+      "community": 72
     },
     {
       "label": "usePOSCustomerUpdate()",
@@ -11249,7 +11249,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L57",
       "id": "useposcustomers_useposcustomerupdate",
-      "community": 73
+      "community": 72
     },
     {
       "label": "usePOSCustomerTransactions()",
@@ -11257,7 +11257,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L90",
       "id": "useposcustomers_useposcustomertransactions",
-      "community": 73
+      "community": 72
     },
     {
       "label": "usePOSOperations.ts",
@@ -11585,7 +11585,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
-      "community": 74
+      "community": 73
     },
     {
       "label": "getCustomerJourneyStage()",
@@ -11593,7 +11593,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L36",
       "id": "behaviorutils_getcustomerjourneystage",
-      "community": 74
+      "community": 73
     },
     {
       "label": "calculateRiskIndicators()",
@@ -11601,7 +11601,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L71",
       "id": "behaviorutils_calculateriskindicators",
-      "community": 74
+      "community": 73
     },
     {
       "label": "calculateEngagementMetrics()",
@@ -11609,7 +11609,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L173",
       "id": "behaviorutils_calculateengagementmetrics",
-      "community": 74
+      "community": 73
     },
     {
       "label": "getActivityPriority()",
@@ -11617,7 +11617,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L251",
       "id": "behaviorutils_getactivitypriority",
-      "community": 74
+      "community": 73
     },
     {
       "label": "getJourneyStageInfo()",
@@ -11625,7 +11625,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L277",
       "id": "behaviorutils_getjourneystageinfo",
-      "community": 74
+      "community": 73
     },
     {
       "label": "browserFingerprint.ts",
@@ -12033,7 +12033,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
-      "community": 75
+      "community": 74
     },
     {
       "label": "handlePOSOperation()",
@@ -12041,7 +12041,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L171",
       "id": "toastservice_handleposoperation",
-      "community": 75
+      "community": 74
     },
     {
       "label": "showValidationError()",
@@ -12049,7 +12049,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L293",
       "id": "toastservice_showvalidationerror",
-      "community": 75
+      "community": 74
     },
     {
       "label": "showInventoryError()",
@@ -12057,7 +12057,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L302",
       "id": "toastservice_showinventoryerror",
-      "community": 75
+      "community": 74
     },
     {
       "label": "showSessionExpiredError()",
@@ -12065,7 +12065,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L312",
       "id": "toastservice_showsessionexpirederror",
-      "community": 75
+      "community": 74
     },
     {
       "label": "showNoActiveSessionError()",
@@ -12073,7 +12073,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L319",
       "id": "toastservice_shownoactivesessionerror",
-      "community": 75
+      "community": 74
     },
     {
       "label": "transactionUtils.ts",
@@ -12321,7 +12321,7 @@
       "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_storeconfig_ts",
-      "community": 7
+      "community": 8
     },
     {
       "label": "asRecord()",
@@ -12329,7 +12329,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L103",
       "id": "storeconfig_asrecord",
-      "community": 7
+      "community": 8
     },
     {
       "label": "asString()",
@@ -12337,7 +12337,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L111",
       "id": "storeconfig_asstring",
-      "community": 7
+      "community": 8
     },
     {
       "label": "asNumber()",
@@ -12345,7 +12345,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L114",
       "id": "storeconfig_asnumber",
-      "community": 7
+      "community": 8
     },
     {
       "label": "asBoolean()",
@@ -12353,7 +12353,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L117",
       "id": "storeconfig_asboolean",
-      "community": 7
+      "community": 8
     },
     {
       "label": "asOptionalArray()",
@@ -12361,7 +12361,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L132",
       "id": "storeconfig_asoptionalarray",
-      "community": 7
+      "community": 8
     },
     {
       "label": "firstDefined()",
@@ -12369,7 +12369,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L120",
       "id": "storeconfig_firstdefined",
-      "community": 7
+      "community": 8
     },
     {
       "label": "cleanUndefined()",
@@ -12377,7 +12377,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L143",
       "id": "storeconfig_cleanundefined",
-      "community": 7
+      "community": 8
     },
     {
       "label": "asMtnMomoSetupStatus()",
@@ -12385,7 +12385,7 @@
       "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L80",
       "id": "storeconfig_asmtnmomosetupstatus",
-      "community": 7
+      "community": 8
     },
     {
       "label": "hasMtnMomoReceivingAccountDetails()",
@@ -12393,7 +12393,7 @@
       "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L93",
       "id": "storeconfig_hasmtnmomoreceivingaccountdetails",
-      "community": 7
+      "community": 8
     },
     {
       "label": "mapMtnMomoReceivingAccount()",
@@ -12401,7 +12401,7 @@
       "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L106",
       "id": "storeconfig_mapmtnmomoreceivingaccount",
-      "community": 7
+      "community": 8
     },
     {
       "label": "normalizeMtnMomoReceivingAccounts()",
@@ -12409,7 +12409,7 @@
       "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L126",
       "id": "storeconfig_normalizemtnmomoreceivingaccounts",
-      "community": 7
+      "community": 8
     },
     {
       "label": "getRawConfig()",
@@ -12417,7 +12417,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L196",
       "id": "storeconfig_getrawconfig",
-      "community": 7
+      "community": 8
     },
     {
       "label": "mapStreamReel()",
@@ -12425,7 +12425,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L155",
       "id": "storeconfig_mapstreamreel",
-      "community": 7
+      "community": 8
     },
     {
       "label": "mapPromotion()",
@@ -12433,7 +12433,7 @@
       "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L172",
       "id": "storeconfig_mappromotion",
-      "community": 7
+      "community": 8
     },
     {
       "label": "normalizeWaiveDeliveryFees()",
@@ -12441,7 +12441,7 @@
       "source_file": "packages/athena-webapp/src/lib/storeConfig.ts",
       "source_location": "L177",
       "id": "storeconfig_normalizewaivedeliveryfees",
-      "community": 7
+      "community": 8
     },
     {
       "label": "getStoreConfigV2()",
@@ -12449,7 +12449,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L208",
       "id": "storeconfig_getstoreconfigv2",
-      "community": 7
+      "community": 8
     },
     {
       "label": "timelineUtils.ts",
@@ -13089,7 +13089,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
-      "community": 76
+      "community": 75
     },
     {
       "label": "OrganizationSettings()",
@@ -13097,7 +13097,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L24",
       "id": "organizationsettingsview_organizationsettings",
-      "community": 76
+      "community": 75
     },
     {
       "label": "saveStoreChanges()",
@@ -13105,7 +13105,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L71",
       "id": "organizationsettingsview_savestorechanges",
-      "community": 76
+      "community": 75
     },
     {
       "label": "onSubmit()",
@@ -13113,7 +13113,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L105",
       "id": "organizationsettingsview_onsubmit",
-      "community": 76
+      "community": 75
     },
     {
       "label": "handleDeleteStore()",
@@ -13121,7 +13121,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L156",
       "id": "organizationsettingsview_handledeletestore",
-      "community": 76
+      "community": 75
     },
     {
       "label": "Navigation()",
@@ -13129,7 +13129,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L198",
       "id": "organizationsettingsview_navigation",
-      "community": 76
+      "community": 75
     },
     {
       "label": "OrganizationsSettingsAccordion.tsx",
@@ -13153,7 +13153,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
-      "community": 77
+      "community": 76
     },
     {
       "label": "StoreSettings()",
@@ -13161,7 +13161,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L28",
       "id": "storesettingsview_storesettings",
-      "community": 77
+      "community": 76
     },
     {
       "label": "saveStoreChanges()",
@@ -13169,7 +13169,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L82",
       "id": "storesettingsview_savestorechanges",
-      "community": 77
+      "community": 76
     },
     {
       "label": "onSubmit()",
@@ -13177,7 +13177,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L116",
       "id": "storesettingsview_onsubmit",
-      "community": 77
+      "community": 76
     },
     {
       "label": "handleDeleteStore()",
@@ -13185,7 +13185,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L167",
       "id": "storesettingsview_handledeletestore",
-      "community": 77
+      "community": 76
     },
     {
       "label": "handleDeleteAllProductsInStore()",
@@ -13193,7 +13193,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L232",
       "id": "storesettingsview_handledeleteallproductsinstore",
-      "community": 77
+      "community": 76
     },
     {
       "label": "StoresSettingsAccordion.tsx",
@@ -13345,7 +13345,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_tests_pos_simple_test_ts",
-      "community": 33
+      "community": 32
     },
     {
       "label": "generateTransactionNumber()",
@@ -13353,7 +13353,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L38",
       "id": "simple_test_generatetransactionnumber",
-      "community": 33
+      "community": 32
     },
     {
       "label": "validateInventory()",
@@ -13361,7 +13361,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L77",
       "id": "simple_test_validateinventory",
-      "community": 33
+      "community": 32
     },
     {
       "label": "validateInventoryWithAggregation()",
@@ -13369,7 +13369,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L130",
       "id": "simple_test_validateinventorywithaggregation",
-      "community": 33
+      "community": 32
     },
     {
       "label": "formatCurrency()",
@@ -13377,7 +13377,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L173",
       "id": "simple_test_formatcurrency",
-      "community": 33
+      "community": 32
     },
     {
       "label": "formatPaymentMethod()",
@@ -13385,7 +13385,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L201",
       "id": "simple_test_formatpaymentmethod",
-      "community": 33
+      "community": 32
     },
     {
       "label": "formatReceiptDate()",
@@ -13393,7 +13393,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L225",
       "id": "simple_test_formatreceiptdate",
-      "community": 33
+      "community": 32
     },
     {
       "label": "addToCart()",
@@ -13401,7 +13401,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L249",
       "id": "simple_test_addtocart",
-      "community": 33
+      "community": 32
     },
     {
       "label": "removeFromCart()",
@@ -13409,7 +13409,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L288",
       "id": "simple_test_removefromcart",
-      "community": 33
+      "community": 32
     },
     {
       "label": "updateQuantity()",
@@ -13417,7 +13417,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L311",
       "id": "simple_test_updatequantity",
-      "community": 33
+      "community": 32
     },
     {
       "label": "usePrint.test.ts",
@@ -14097,7 +14097,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_promocodes_ts",
-      "community": 78
+      "community": 77
     },
     {
       "label": "getBaseUrl()",
@@ -14105,7 +14105,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L4",
       "id": "promocodes_getbaseurl",
-      "community": 78
+      "community": 77
     },
     {
       "label": "redeemPromoCode()",
@@ -14113,7 +14113,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L6",
       "id": "promocodes_redeempromocode",
-      "community": 78
+      "community": 77
     },
     {
       "label": "getPromoCodes()",
@@ -14121,7 +14121,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L34",
       "id": "promocodes_getpromocodes",
-      "community": 78
+      "community": 77
     },
     {
       "label": "getPromoCodeItems()",
@@ -14129,7 +14129,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L49",
       "id": "promocodes_getpromocodeitems",
-      "community": 78
+      "community": 77
     },
     {
       "label": "getRedeemedPromoCodes()",
@@ -14137,7 +14137,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L74",
       "id": "promocodes_getredeemedpromocodes",
-      "community": 78
+      "community": 77
     },
     {
       "label": "reviews.ts",
@@ -14249,7 +14249,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_rewards_ts",
-      "community": 34
+      "community": 33
     },
     {
       "label": "getBaseUrl()",
@@ -14257,7 +14257,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L3",
       "id": "rewards_getbaseurl",
-      "community": 34
+      "community": 33
     },
     {
       "label": "getUserPoints()",
@@ -14265,7 +14265,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L54",
       "id": "rewards_getuserpoints",
-      "community": 34
+      "community": 33
     },
     {
       "label": "getPointHistory()",
@@ -14273,7 +14273,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L71",
       "id": "rewards_getpointhistory",
-      "community": 34
+      "community": 33
     },
     {
       "label": "getRewardTiers()",
@@ -14281,7 +14281,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L90",
       "id": "rewards_getrewardtiers",
-      "community": 34
+      "community": 33
     },
     {
       "label": "redeemRewardPoints()",
@@ -14289,7 +14289,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L107",
       "id": "rewards_redeemrewardpoints",
-      "community": 34
+      "community": 33
     },
     {
       "label": "getEligiblePastOrders()",
@@ -14297,7 +14297,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L129",
       "id": "rewards_geteligiblepastorders",
-      "community": 34
+      "community": 33
     },
     {
       "label": "awardPointsForPastOrder()",
@@ -14305,7 +14305,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L151",
       "id": "rewards_awardpointsforpastorder",
-      "community": 34
+      "community": 33
     },
     {
       "label": "getOrderRewardPoints()",
@@ -14313,7 +14313,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L175",
       "id": "rewards_getorderrewardpoints",
-      "community": 34
+      "community": 33
     },
     {
       "label": "awardPointsForGuestOrders()",
@@ -14321,7 +14321,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L198",
       "id": "rewards_awardpointsforguestorders",
-      "community": 34
+      "community": 33
     },
     {
       "label": "savedBag.ts",
@@ -14769,7 +14769,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
-      "community": 79
+      "community": 78
     },
     {
       "label": "EnteredBillingAddressDetails()",
@@ -14777,7 +14777,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L102",
       "id": "billingdetails_enteredbillingaddressdetails",
-      "community": 79
+      "community": 78
     },
     {
       "label": "onSubmit()",
@@ -14785,7 +14785,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L150",
       "id": "billingdetails_onsubmit",
-      "community": 79
+      "community": 78
     },
     {
       "label": "toggleSameAsDelivery()",
@@ -14793,7 +14793,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L155",
       "id": "billingdetails_togglesameasdelivery",
-      "community": 79
+      "community": 78
     },
     {
       "label": "clearForm()",
@@ -14801,7 +14801,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L173",
       "id": "billingdetails_clearform",
-      "community": 79
+      "community": 78
     },
     {
       "label": "handleUseBillingAddressOnFile()",
@@ -14809,7 +14809,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L201",
       "id": "billingdetails_handleusebillingaddressonfile",
-      "community": 79
+      "community": 78
     },
     {
       "label": "BillingDetailsSection.tsx",
@@ -15273,7 +15273,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
-      "community": 31
+      "community": 34
     },
     {
       "label": "getPotentialPoints()",
@@ -15281,7 +15281,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L107",
       "id": "utils_getpotentialpoints",
-      "community": 31
+      "community": 34
     },
     {
       "label": "FadeIn.tsx",
@@ -16305,7 +16305,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
-      "community": 80
+      "community": 79
     },
     {
       "label": "CheckoutExpired()",
@@ -16313,7 +16313,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L9",
       "id": "checkoutexpired_checkoutexpired",
-      "community": 80
+      "community": 79
     },
     {
       "label": "NoCheckoutSession()",
@@ -16321,7 +16321,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L33",
       "id": "checkoutexpired_nocheckoutsession",
-      "community": 80
+      "community": 79
     },
     {
       "label": "CheckoutSessionNotFound()",
@@ -16329,7 +16329,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L54",
       "id": "checkoutexpired_checkoutsessionnotfound",
-      "community": 80
+      "community": 79
     },
     {
       "label": "CheckoutSessionGeneric()",
@@ -16337,7 +16337,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L73",
       "id": "checkoutexpired_checkoutsessiongeneric",
-      "community": 80
+      "community": 79
     },
     {
       "label": "handleSendEmail()",
@@ -16345,7 +16345,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L98",
       "id": "checkoutexpired_handlesendemail",
-      "community": 80
+      "community": 79
     },
     {
       "label": "empty-state.tsx",
@@ -16625,7 +16625,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "community": 69
+      "community": 80
     },
     {
       "label": "image-with-fallback.tsx",
@@ -18041,7 +18041,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_storeconfig_ts",
-      "community": 7
+      "community": 8
     },
     {
       "label": "mapPromo()",
@@ -18049,7 +18049,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L172",
       "id": "storeconfig_mappromo",
-      "community": 7
+      "community": 8
     },
     {
       "label": "isStoreReadOnlyMode()",
@@ -18057,7 +18057,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L461",
       "id": "storeconfig_isstorereadonlymode",
-      "community": 7
+      "community": 8
     },
     {
       "label": "isStoreMaintenanceMode()",
@@ -18065,7 +18065,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L465",
       "id": "storeconfig_isstoremaintenancemode",
-      "community": 7
+      "community": 8
     },
     {
       "label": "getStoreFallbackImageUrl()",
@@ -18073,7 +18073,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storeConfig.ts",
       "source_location": "L479",
       "id": "storeconfig_getstorefallbackimageurl",
-      "community": 7
+      "community": 8
     },
     {
       "label": "storefrontFailureObservability.test.ts",
@@ -19833,7 +19833,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L1",
       "id": "scripts_harness_audit_ts",
-      "community": 18
+      "community": 19
     },
     {
       "label": "normalizeRepoPath()",
@@ -19841,7 +19841,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L39",
       "id": "harness_audit_normalizerepopath",
-      "community": 18
+      "community": 19
     },
     {
       "label": "matchesPathPrefix()",
@@ -19849,7 +19849,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L43",
       "id": "harness_audit_matchespathprefix",
-      "community": 18
+      "community": 19
     },
     {
       "label": "fileExists()",
@@ -19857,7 +19857,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L57",
       "id": "harness_audit_fileexists",
-      "community": 18
+      "community": 19
     },
     {
       "label": "hasAnyHarnessDocs()",
@@ -19865,7 +19865,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L66",
       "id": "harness_audit_hasanyharnessdocs",
-      "community": 18
+      "community": 19
     },
     {
       "label": "readJsonFile()",
@@ -19873,7 +19873,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L86",
       "id": "harness_audit_readjsonfile",
-      "community": 18
+      "community": 19
     },
     {
       "label": "normalizeValidationCommand()",
@@ -19881,7 +19881,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L90",
       "id": "harness_audit_normalizevalidationcommand",
-      "community": 18
+      "community": 19
     },
     {
       "label": "normalizeBehaviorScenarioName()",
@@ -19889,7 +19889,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L98",
       "id": "harness_audit_normalizebehaviorscenarioname",
-      "community": 18
+      "community": 19
     },
     {
       "label": "addGroupedError()",
@@ -19897,7 +19897,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L102",
       "id": "harness_audit_addgroupederror",
-      "community": 18
+      "community": 19
     },
     {
       "label": "inferGroupFromError()",
@@ -19905,7 +19905,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L116",
       "id": "harness_audit_infergroupfromerror",
-      "community": 18
+      "community": 19
     },
     {
       "label": "shouldSkipSurfaceEntry()",
@@ -19913,7 +19913,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L121",
       "id": "harness_audit_shouldskipsurfaceentry",
-      "community": 18
+      "community": 19
     },
     {
       "label": "collectLiveSurfaceEntries()",
@@ -19921,7 +19921,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L135",
       "id": "harness_audit_collectlivesurfaceentries",
-      "community": 18
+      "community": 19
     },
     {
       "label": "loadAuditTarget()",
@@ -19929,7 +19929,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L164",
       "id": "harness_audit_loadaudittarget",
-      "community": 18
+      "community": 19
     },
     {
       "label": "formatGroupedErrors()",
@@ -19937,7 +19937,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L341",
       "id": "harness_audit_formatgroupederrors",
-      "community": 18
+      "community": 19
     },
     {
       "label": "runHarnessAudit()",
@@ -19945,7 +19945,7 @@
       "source_file": "scripts/harness-audit.ts",
       "source_location": "L356",
       "id": "harness_audit_runharnessaudit",
-      "community": 18
+      "community": 19
     },
     {
       "label": "athena-runtime-app.ts",
@@ -20903,7 +20903,7 @@
       "label": "normalizeRepoPath()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L107",
+      "source_location": "L108",
       "id": "harness_inferential_review_normalizerepopath",
       "community": 1
     },
@@ -20911,7 +20911,7 @@
       "label": "sortUnique()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L111",
+      "source_location": "L112",
       "id": "harness_inferential_review_sortunique",
       "community": 1
     },
@@ -20919,7 +20919,7 @@
       "label": "fileExists()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L117",
+      "source_location": "L118",
       "id": "harness_inferential_review_fileexists",
       "community": 1
     },
@@ -20927,7 +20927,7 @@
       "label": "readUtf8OrNull()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L126",
+      "source_location": "L127",
       "id": "harness_inferential_review_readutf8ornull",
       "community": 1
     },
@@ -20935,7 +20935,7 @@
       "label": "runCommand()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L140",
+      "source_location": "L141",
       "id": "harness_inferential_review_runcommand",
       "community": 1
     },
@@ -20943,7 +20943,7 @@
       "label": "getChangedFilesForInferentialReview()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L167",
+      "source_location": "L168",
       "id": "harness_inferential_review_getchangedfilesforinferentialreview",
       "community": 1
     },
@@ -20951,7 +20951,7 @@
       "label": "isHarnessCriticalFile()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L231",
+      "source_location": "L232",
       "id": "harness_inferential_review_isharnesscriticalfile",
       "community": 1
     },
@@ -20959,7 +20959,7 @@
       "label": "buildFinding()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L256",
+      "source_location": "L257",
       "id": "harness_inferential_review_buildfinding",
       "community": 1
     },
@@ -20967,7 +20967,7 @@
       "label": "includesCaseInsensitive()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L274",
+      "source_location": "L275",
       "id": "harness_inferential_review_includescaseinsensitive",
       "community": 1
     },
@@ -20975,7 +20975,7 @@
       "label": "slugifyForFindingId()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L278",
+      "source_location": "L279",
       "id": "harness_inferential_review_slugifyforfindingid",
       "community": 1
     },
@@ -20983,7 +20983,7 @@
       "label": "isHarnessScriptSourceFile()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L285",
+      "source_location": "L286",
       "id": "harness_inferential_review_isharnessscriptsourcefile",
       "community": 1
     },
@@ -20991,7 +20991,7 @@
       "label": "toHarnessScriptTestPath()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L290",
+      "source_location": "L291",
       "id": "harness_inferential_review_toharnessscripttestpath",
       "community": 1
     },
@@ -20999,7 +20999,7 @@
       "label": "formatMissingSignals()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L294",
+      "source_location": "L295",
       "id": "harness_inferential_review_formatmissingsignals",
       "community": 1
     },
@@ -21007,7 +21007,7 @@
       "label": "createReducedSignalFinding()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L298",
+      "source_location": "L299",
       "id": "harness_inferential_review_createreducedsignalfinding",
       "community": 1
     },
@@ -21015,7 +21015,7 @@
       "label": "collectHarnessScriptTestUpdateFindings()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L315",
+      "source_location": "L316",
       "id": "harness_inferential_review_collectharnessscripttestupdatefindings",
       "community": 1
     },
@@ -21023,7 +21023,7 @@
       "label": "collectHarnessSafetySignalFindings()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L352",
+      "source_location": "L353",
       "id": "harness_inferential_review_collectharnesssafetysignalfindings",
       "community": 1
     },
@@ -21031,7 +21031,7 @@
       "label": "runDeterministicSemanticAnalysis()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L448",
+      "source_location": "L449",
       "id": "harness_inferential_review_rundeterministicsemanticanalysis",
       "community": 1
     },
@@ -21039,7 +21039,7 @@
       "label": "resolveSemanticMode()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L467",
+      "source_location": "L468",
       "id": "harness_inferential_review_resolvesemanticmode",
       "community": 1
     },
@@ -21047,7 +21047,7 @@
       "label": "buildShadowSummary()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L476",
+      "source_location": "L477",
       "id": "harness_inferential_review_buildshadowsummary",
       "community": 1
     },
@@ -21055,7 +21055,7 @@
       "label": "truncateForPrompt()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L482",
+      "source_location": "L483",
       "id": "harness_inferential_review_truncateforprompt",
       "community": 1
     },
@@ -21063,7 +21063,7 @@
       "label": "buildSemanticPrompt()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L490",
+      "source_location": "L491",
       "id": "harness_inferential_review_buildsemanticprompt",
       "community": 1
     },
@@ -21071,7 +21071,7 @@
       "label": "extractTextFromAnthropicResponse()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L518",
+      "source_location": "L519",
       "id": "harness_inferential_review_extracttextfromanthropicresponse",
       "community": 1
     },
@@ -21079,7 +21079,7 @@
       "label": "extractJsonPayload()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L544",
+      "source_location": "L545",
       "id": "harness_inferential_review_extractjsonpayload",
       "community": 1
     },
@@ -21087,7 +21087,7 @@
       "label": "normalizeSemanticFinding()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L564",
+      "source_location": "L565",
       "id": "harness_inferential_review_normalizesemanticfinding",
       "community": 1
     },
@@ -21095,7 +21095,7 @@
       "label": "parseSemanticResponse()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L613",
+      "source_location": "L614",
       "id": "harness_inferential_review_parsesemanticresponse",
       "community": 1
     },
@@ -21103,7 +21103,7 @@
       "label": "runAnthropicSemanticAnalysis()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L636",
+      "source_location": "L637",
       "id": "harness_inferential_review_runanthropicsemanticanalysis",
       "community": 1
     },
@@ -21111,7 +21111,7 @@
       "label": "runDeterministicInferentialProvider()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L675",
+      "source_location": "L676",
       "id": "harness_inferential_review_rundeterministicinferentialprovider",
       "community": 1
     },
@@ -21119,7 +21119,7 @@
       "label": "sortFindings()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L827",
+      "source_location": "L828",
       "id": "harness_inferential_review_sortfindings",
       "community": 1
     },
@@ -21127,7 +21127,7 @@
       "label": "formatStatusLabel()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L846",
+      "source_location": "L847",
       "id": "harness_inferential_review_formatstatuslabel",
       "community": 1
     },
@@ -21135,7 +21135,7 @@
       "label": "buildHumanReport()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L859",
+      "source_location": "L860",
       "id": "harness_inferential_review_buildhumanreport",
       "community": 1
     },
@@ -21143,15 +21143,31 @@
       "label": "writeMachineOutput()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L929",
+      "source_location": "L930",
       "id": "harness_inferential_review_writemachineoutput",
+      "community": 1
+    },
+    {
+      "label": "toHistoryFileStamp()",
+      "file_type": "code",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L940",
+      "id": "harness_inferential_review_tohistoryfilestamp",
+      "community": 1
+    },
+    {
+      "label": "writeHistorySnapshot()",
+      "file_type": "code",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L944",
+      "id": "harness_inferential_review_writehistorysnapshot",
       "community": 1
     },
     {
       "label": "createOutput()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L939",
+      "source_location": "L960",
       "id": "harness_inferential_review_createoutput",
       "community": 1
     },
@@ -21159,7 +21175,7 @@
       "label": "createShadowOutput()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L968",
+      "source_location": "L989",
       "id": "harness_inferential_review_createshadowoutput",
       "community": 1
     },
@@ -21167,7 +21183,7 @@
       "label": "createProviderFailure()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L986",
+      "source_location": "L1007",
       "id": "harness_inferential_review_createproviderfailure",
       "community": 1
     },
@@ -21175,7 +21191,7 @@
       "label": "createRuntimeFailure()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1015",
+      "source_location": "L1036",
       "id": "harness_inferential_review_createruntimefailure",
       "community": 1
     },
@@ -21183,7 +21199,7 @@
       "label": "runHarnessInferentialReview()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1044",
+      "source_location": "L1065",
       "id": "harness_inferential_review_runharnessinferentialreview",
       "community": 1
     },
@@ -21191,7 +21207,7 @@
       "label": "parseCliArgs()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1267",
+      "source_location": "L1312",
       "id": "harness_inferential_review_parsecliargs",
       "community": 1
     },
@@ -21567,7 +21583,7 @@
       "label": "buildReportLine()",
       "file_type": "code",
       "source_file": "scripts/harness-runtime-trends.test.ts",
-      "source_location": "L5",
+      "source_location": "L14",
       "id": "harness_runtime_trends_test_buildreportline",
       "community": 570
     },
@@ -21577,119 +21593,127 @@
       "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L1",
       "id": "scripts_harness_runtime_trends_ts",
-      "community": 19
+      "community": 17
+    },
+    {
+      "label": "toHistoryFileStamp()",
+      "file_type": "code",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L110",
+      "id": "harness_runtime_trends_tohistoryfilestamp",
+      "community": 17
     },
     {
       "label": "splitInputLines()",
       "file_type": "code",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L109",
+      "source_location": "L114",
       "id": "harness_runtime_trends_splitinputlines",
-      "community": 19
+      "community": 17
     },
     {
       "label": "sortUnique()",
       "file_type": "code",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L115",
+      "source_location": "L120",
       "id": "harness_runtime_trends_sortunique",
-      "community": 19
+      "community": 17
     },
     {
       "label": "isHarnessBehaviorScenarioReport()",
       "file_type": "code",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L121",
+      "source_location": "L126",
       "id": "harness_runtime_trends_isharnessbehaviorscenarioreport",
-      "community": 19
+      "community": 17
     },
     {
       "label": "parseHarnessBehaviorReportLines()",
       "file_type": "code",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L139",
+      "source_location": "L144",
       "id": "harness_runtime_trends_parseharnessbehaviorreportlines",
-      "community": 19
+      "community": 17
     },
     {
       "label": "percentile()",
       "file_type": "code",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L181",
+      "source_location": "L186",
       "id": "harness_runtime_trends_percentile",
-      "community": 19
+      "community": 17
     },
     {
       "label": "buildNumericTrendStats()",
       "file_type": "code",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L192",
+      "source_location": "L197",
       "id": "harness_runtime_trends_buildnumerictrendstats",
-      "community": 19
+      "community": 17
     },
     {
       "label": "sortCountEntries()",
       "file_type": "code",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L217",
+      "source_location": "L222",
       "id": "harness_runtime_trends_sortcountentries",
-      "community": 19
+      "community": 17
     },
     {
       "label": "formatPercent()",
       "file_type": "code",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L223",
+      "source_location": "L228",
       "id": "harness_runtime_trends_formatpercent",
-      "community": 19
+      "community": 17
     },
     {
       "label": "formatMs()",
       "file_type": "code",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L227",
+      "source_location": "L232",
       "id": "harness_runtime_trends_formatms",
-      "community": 19
+      "community": 17
     },
     {
       "label": "buildScenarioTrend()",
       "file_type": "code",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L231",
+      "source_location": "L236",
       "id": "harness_runtime_trends_buildscenariotrend",
-      "community": 19
+      "community": 17
     },
     {
       "label": "buildRegressionWarnings()",
       "file_type": "code",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L327",
+      "source_location": "L332",
       "id": "harness_runtime_trends_buildregressionwarnings",
-      "community": 19
+      "community": 17
     },
     {
       "label": "buildRuntimeTrendOutput()",
       "file_type": "code",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L399",
+      "source_location": "L404",
       "id": "harness_runtime_trends_buildruntimetrendoutput",
-      "community": 19
+      "community": 17
     },
     {
       "label": "collectHarnessRuntimeTrends()",
       "file_type": "code",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L463",
+      "source_location": "L468",
       "id": "harness_runtime_trends_collectharnessruntimetrends",
-      "community": 19
+      "community": 17
     },
     {
       "label": "runHarnessRuntimeTrends()",
       "file_type": "code",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L471",
+      "source_location": "L476",
       "id": "harness_runtime_trends_runharnessruntimetrends",
-      "community": 19
+      "community": 17
     },
     {
       "label": "harness-scorecard.test.ts",
@@ -21721,167 +21745,207 @@
       "source_file": "scripts/harness-scorecard.ts",
       "source_location": "L1",
       "id": "scripts_harness_scorecard_ts",
-      "community": 8
+      "community": 6
     },
     {
       "label": "normalizeRepoPath()",
       "file_type": "code",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L136",
+      "source_location": "L189",
       "id": "harness_scorecard_normalizerepopath",
-      "community": 8
+      "community": 6
     },
     {
       "label": "sortUnique()",
       "file_type": "code",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L140",
+      "source_location": "L193",
       "id": "harness_scorecard_sortunique",
-      "community": 8
+      "community": 6
     },
     {
       "label": "isRuntimeScenarioName()",
       "file_type": "code",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L146",
+      "source_location": "L199",
       "id": "harness_scorecard_isruntimescenarioname",
-      "community": 8
+      "community": 6
     },
     {
       "label": "fileExists()",
       "file_type": "code",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L150",
+      "source_location": "L203",
       "id": "harness_scorecard_fileexists",
-      "community": 8
+      "community": 6
     },
     {
       "label": "readJsonFile()",
       "file_type": "code",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L159",
+      "source_location": "L212",
       "id": "harness_scorecard_readjsonfile",
-      "community": 8
+      "community": 6
+    },
+    {
+      "label": "listDirectory()",
+      "file_type": "code",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L216",
+      "id": "harness_scorecard_listdirectory",
+      "community": 6
     },
     {
       "label": "readTextFile()",
       "file_type": "code",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L163",
+      "source_location": "L220",
       "id": "harness_scorecard_readtextfile",
-      "community": 8
+      "community": 6
     },
     {
       "label": "createFileSystem()",
       "file_type": "code",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L167",
+      "source_location": "L224",
       "id": "harness_scorecard_createfilesystem",
-      "community": 8
+      "community": 6
     },
     {
       "label": "extractScenarioSection()",
       "file_type": "code",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L175",
+      "source_location": "L233",
       "id": "harness_scorecard_extractscenariosection",
-      "community": 8
+      "community": 6
     },
     {
       "label": "extractScenarioNames()",
       "file_type": "code",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L197",
+      "source_location": "L255",
       "id": "harness_scorecard_extractscenarionames",
-      "community": 8
+      "community": 6
     },
     {
       "label": "countMissingSnippets()",
       "file_type": "code",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L210",
+      "source_location": "L268",
       "id": "harness_scorecard_countmissingsnippets",
-      "community": 8
+      "community": 6
     },
     {
       "label": "buildDocumentationStatus()",
       "file_type": "code",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L217",
+      "source_location": "L275",
       "id": "harness_scorecard_builddocumentationstatus",
-      "community": 8
+      "community": 6
     },
     {
       "label": "buildGraphifyStatus()",
       "file_type": "code",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L241",
+      "source_location": "L299",
       "id": "harness_scorecard_buildgraphifystatus",
-      "community": 8
+      "community": 6
     },
     {
       "label": "buildSummary()",
       "file_type": "code",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L253",
+      "source_location": "L311",
       "id": "harness_scorecard_buildsummary",
-      "community": 8
+      "community": 6
     },
     {
       "label": "hasAnyHarnessDocs()",
       "file_type": "code",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L304",
+      "source_location": "L374",
       "id": "harness_scorecard_hasanyharnessdocs",
-      "community": 8
+      "community": 6
     },
     {
       "label": "inspectAppDocumentation()",
       "file_type": "code",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L321",
+      "source_location": "L391",
       "id": "harness_scorecard_inspectappdocumentation",
-      "community": 8
+      "community": 6
     },
     {
       "label": "getDocumentedScenarioExpectations()",
       "file_type": "code",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L385",
+      "source_location": "L455",
       "id": "harness_scorecard_getdocumentedscenarioexpectations",
-      "community": 8
+      "community": 6
     },
     {
       "label": "inspectInferentialArtifact()",
       "file_type": "code",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L398",
+      "source_location": "L468",
       "id": "harness_scorecard_inspectinferentialartifact",
-      "community": 8
+      "community": 6
+    },
+    {
+      "label": "buildEmptyHistoryMetric()",
+      "file_type": "code",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L554",
+      "id": "harness_scorecard_buildemptyhistorymetric",
+      "community": 6
+    },
+    {
+      "label": "inspectInferentialHistory()",
+      "file_type": "code",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L564",
+      "id": "harness_scorecard_inspectinferentialhistory",
+      "community": 6
+    },
+    {
+      "label": "inspectRuntimeTrendArtifact()",
+      "file_type": "code",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L616",
+      "id": "harness_scorecard_inspectruntimetrendartifact",
+      "community": 6
+    },
+    {
+      "label": "inspectRuntimeTrendHistory()",
+      "file_type": "code",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L659",
+      "id": "harness_scorecard_inspectruntimetrendhistory",
+      "community": 6
     },
     {
       "label": "inspectGraphifyArtifacts()",
       "file_type": "code",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L444",
+      "source_location": "L709",
       "id": "harness_scorecard_inspectgraphifyartifacts",
-      "community": 8
+      "community": 6
     },
     {
       "label": "collectHarnessScorecard()",
       "file_type": "code",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L472",
+      "source_location": "L737",
       "id": "harness_scorecard_collectharnessscorecard",
-      "community": 8
+      "community": 6
     },
     {
       "label": "runHarnessScorecard()",
       "file_type": "code",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L558",
+      "source_location": "L827",
       "id": "harness_scorecard_runharnessscorecard",
-      "community": 8
+      "community": 6
     },
     {
       "label": "harness-self-review.test.ts",
@@ -21913,7 +21977,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L1",
       "id": "scripts_harness_self_review_ts",
-      "community": 6
+      "community": 7
     },
     {
       "label": "normalizeRepoPath()",
@@ -21921,7 +21985,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L90",
       "id": "harness_self_review_normalizerepopath",
-      "community": 6
+      "community": 7
     },
     {
       "label": "sortUniquePaths()",
@@ -21929,7 +21993,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L94",
       "id": "harness_self_review_sortuniquepaths",
-      "community": 6
+      "community": 7
     },
     {
       "label": "matchesPathPrefix()",
@@ -21937,7 +22001,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L100",
       "id": "harness_self_review_matchespathprefix",
-      "community": 6
+      "community": 7
     },
     {
       "label": "normalizeValidationCommand()",
@@ -21945,7 +22009,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L114",
       "id": "harness_self_review_normalizevalidationcommand",
-      "community": 6
+      "community": 7
     },
     {
       "label": "normalizeBehaviorScenarioName()",
@@ -21953,7 +22017,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L122",
       "id": "harness_self_review_normalizebehaviorscenarioname",
-      "community": 6
+      "community": 7
     },
     {
       "label": "formatValidationCommand()",
@@ -21961,7 +22025,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L126",
       "id": "harness_self_review_formatvalidationcommand",
-      "community": 6
+      "community": 7
     },
     {
       "label": "quoteCode()",
@@ -21969,7 +22033,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L134",
       "id": "harness_self_review_quotecode",
-      "community": 6
+      "community": 7
     },
     {
       "label": "fileExists()",
@@ -21977,7 +22041,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L138",
       "id": "harness_self_review_fileexists",
-      "community": 6
+      "community": 7
     },
     {
       "label": "readJsonFile()",
@@ -21985,7 +22049,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L147",
       "id": "harness_self_review_readjsonfile",
-      "community": 6
+      "community": 7
     },
     {
       "label": "runCommand()",
@@ -21993,7 +22057,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L151",
       "id": "harness_self_review_runcommand",
-      "community": 6
+      "community": 7
     },
     {
       "label": "getChangedFilesFromGit()",
@@ -22001,7 +22065,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L171",
       "id": "harness_self_review_getchangedfilesfromgit",
-      "community": 6
+      "community": 7
     },
     {
       "label": "parseRuntimeScenarios()",
@@ -22009,7 +22073,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L235",
       "id": "harness_self_review_parseruntimescenarios",
-      "community": 6
+      "community": 7
     },
     {
       "label": "loadSelfReviewTarget()",
@@ -22017,7 +22081,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L241",
       "id": "harness_self_review_loadselfreviewtarget",
-      "community": 6
+      "community": 7
     },
     {
       "label": "loadSelfReviewTargets()",
@@ -22025,7 +22089,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L373",
       "id": "harness_self_review_loadselfreviewtargets",
-      "community": 6
+      "community": 7
     },
     {
       "label": "collectCoverage()",
@@ -22033,7 +22097,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L392",
       "id": "harness_self_review_collectcoverage",
-      "community": 6
+      "community": 7
     },
     {
       "label": "isLikelyCodeOrConfig()",
@@ -22041,7 +22105,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L470",
       "id": "harness_self_review_islikelycodeorconfig",
-      "community": 6
+      "community": 7
     },
     {
       "label": "isWorktreeMetadataPath()",
@@ -22049,7 +22113,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L491",
       "id": "harness_self_review_isworktreemetadatapath",
-      "community": 6
+      "community": 7
     },
     {
       "label": "isLocalGeneratedArtifactPath()",
@@ -22057,7 +22121,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L500",
       "id": "harness_self_review_islocalgeneratedartifactpath",
-      "community": 6
+      "community": 7
     },
     {
       "label": "evaluateGraphifyFreshness()",
@@ -22065,7 +22129,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L509",
       "id": "harness_self_review_evaluategraphifyfreshness",
-      "community": 6
+      "community": 7
     },
     {
       "label": "runQuietHarnessCheck()",
@@ -22073,7 +22137,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L577",
       "id": "harness_self_review_runquietharnesscheck",
-      "community": 6
+      "community": 7
     },
     {
       "label": "appendListSection()",
@@ -22081,7 +22145,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L586",
       "id": "harness_self_review_appendlistsection",
-      "community": 6
+      "community": 7
     },
     {
       "label": "buildMarkdownBundle()",
@@ -22089,7 +22153,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L605",
       "id": "harness_self_review_buildmarkdownbundle",
-      "community": 6
+      "community": 7
     },
     {
       "label": "parseCliArguments()",
@@ -22097,7 +22161,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L762",
       "id": "harness_self_review_parsecliarguments",
-      "community": 6
+      "community": 7
     },
     {
       "label": "runHarnessSelfReview()",
@@ -22105,7 +22169,7 @@
       "source_file": "scripts/harness-self-review.ts",
       "source_location": "L811",
       "id": "harness_self_review_runharnessselfreview",
-      "community": 6
+      "community": 7
     },
     {
       "label": "harness-test.test.ts",
@@ -46649,7 +46713,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L107",
+      "source_location": "L108",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_normalizerepopath",
@@ -46661,7 +46725,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L111",
+      "source_location": "L112",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_sortunique",
@@ -46673,7 +46737,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L117",
+      "source_location": "L118",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_fileexists",
@@ -46685,7 +46749,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L126",
+      "source_location": "L127",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_readutf8ornull",
@@ -46697,7 +46761,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L140",
+      "source_location": "L141",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_runcommand",
@@ -46709,7 +46773,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L167",
+      "source_location": "L168",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_getchangedfilesforinferentialreview",
@@ -46721,7 +46785,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L231",
+      "source_location": "L232",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_isharnesscriticalfile",
@@ -46733,7 +46797,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L256",
+      "source_location": "L257",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_buildfinding",
@@ -46745,7 +46809,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L274",
+      "source_location": "L275",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_includescaseinsensitive",
@@ -46757,7 +46821,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L278",
+      "source_location": "L279",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_slugifyforfindingid",
@@ -46769,7 +46833,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L285",
+      "source_location": "L286",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_isharnessscriptsourcefile",
@@ -46781,7 +46845,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L290",
+      "source_location": "L291",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_toharnessscripttestpath",
@@ -46793,7 +46857,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L294",
+      "source_location": "L295",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_formatmissingsignals",
@@ -46805,7 +46869,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L298",
+      "source_location": "L299",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_createreducedsignalfinding",
@@ -46817,7 +46881,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L315",
+      "source_location": "L316",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_collectharnessscripttestupdatefindings",
@@ -46829,7 +46893,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L352",
+      "source_location": "L353",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_collectharnesssafetysignalfindings",
@@ -46841,7 +46905,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L448",
+      "source_location": "L449",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_rundeterministicsemanticanalysis",
@@ -46853,7 +46917,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L467",
+      "source_location": "L468",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_resolvesemanticmode",
@@ -46865,7 +46929,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L476",
+      "source_location": "L477",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_buildshadowsummary",
@@ -46877,7 +46941,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L482",
+      "source_location": "L483",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_truncateforprompt",
@@ -46889,7 +46953,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L490",
+      "source_location": "L491",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_buildsemanticprompt",
@@ -46901,7 +46965,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L518",
+      "source_location": "L519",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_extracttextfromanthropicresponse",
@@ -46913,7 +46977,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L544",
+      "source_location": "L545",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_extractjsonpayload",
@@ -46925,7 +46989,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L564",
+      "source_location": "L565",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_normalizesemanticfinding",
@@ -46937,7 +47001,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L613",
+      "source_location": "L614",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_parsesemanticresponse",
@@ -46949,7 +47013,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L636",
+      "source_location": "L637",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_runanthropicsemanticanalysis",
@@ -46961,7 +47025,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L675",
+      "source_location": "L676",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_rundeterministicinferentialprovider",
@@ -46973,7 +47037,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L827",
+      "source_location": "L828",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_sortfindings",
@@ -46985,7 +47049,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L846",
+      "source_location": "L847",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_formatstatuslabel",
@@ -46997,7 +47061,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L859",
+      "source_location": "L860",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_buildhumanreport",
@@ -47009,7 +47073,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L929",
+      "source_location": "L930",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_writemachineoutput",
@@ -47021,7 +47085,31 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L939",
+      "source_location": "L940",
+      "weight": 1.0,
+      "_src": "scripts_harness_inferential_review_ts",
+      "_tgt": "harness_inferential_review_tohistoryfilestamp",
+      "source": "scripts_harness_inferential_review_ts",
+      "target": "harness_inferential_review_tohistoryfilestamp",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L944",
+      "weight": 1.0,
+      "_src": "scripts_harness_inferential_review_ts",
+      "_tgt": "harness_inferential_review_writehistorysnapshot",
+      "source": "scripts_harness_inferential_review_ts",
+      "target": "harness_inferential_review_writehistorysnapshot",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L960",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_createoutput",
@@ -47033,7 +47121,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L968",
+      "source_location": "L989",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_createshadowoutput",
@@ -47045,7 +47133,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L986",
+      "source_location": "L1007",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_createproviderfailure",
@@ -47057,7 +47145,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1015",
+      "source_location": "L1036",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_createruntimefailure",
@@ -47069,7 +47157,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1044",
+      "source_location": "L1065",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_runharnessinferentialreview",
@@ -47081,7 +47169,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1267",
+      "source_location": "L1312",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_parsecliargs",
@@ -47093,7 +47181,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L232",
+      "source_location": "L233",
       "weight": 1.0,
       "_src": "harness_inferential_review_isharnesscriticalfile",
       "_tgt": "harness_inferential_review_normalizerepopath",
@@ -47105,7 +47193,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L279",
+      "source_location": "L280",
       "weight": 1.0,
       "_src": "harness_inferential_review_slugifyforfindingid",
       "_tgt": "harness_inferential_review_normalizerepopath",
@@ -47117,7 +47205,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L286",
+      "source_location": "L287",
       "weight": 1.0,
       "_src": "harness_inferential_review_isharnessscriptsourcefile",
       "_tgt": "harness_inferential_review_normalizerepopath",
@@ -47129,7 +47217,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L291",
+      "source_location": "L292",
       "weight": 1.0,
       "_src": "harness_inferential_review_toharnessscripttestpath",
       "_tgt": "harness_inferential_review_normalizerepopath",
@@ -47141,7 +47229,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L588",
+      "source_location": "L589",
       "weight": 1.0,
       "_src": "harness_inferential_review_normalizesemanticfinding",
       "_tgt": "harness_inferential_review_normalizerepopath",
@@ -47153,7 +47241,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L224",
+      "source_location": "L225",
       "weight": 1.0,
       "_src": "harness_inferential_review_getchangedfilesforinferentialreview",
       "_tgt": "harness_inferential_review_sortunique",
@@ -47165,7 +47253,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L319",
+      "source_location": "L320",
       "weight": 1.0,
       "_src": "harness_inferential_review_collectharnessscripttestupdatefindings",
       "_tgt": "harness_inferential_review_sortunique",
@@ -47177,7 +47265,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L356",
+      "source_location": "L357",
       "weight": 1.0,
       "_src": "harness_inferential_review_collectharnesssafetysignalfindings",
       "_tgt": "harness_inferential_review_sortunique",
@@ -47189,7 +47277,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L960",
+      "source_location": "L981",
       "weight": 1.0,
       "_src": "harness_inferential_review_createoutput",
       "_tgt": "harness_inferential_review_sortunique",
@@ -47201,7 +47289,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1069",
+      "source_location": "L1090",
       "weight": 1.0,
       "_src": "harness_inferential_review_runharnessinferentialreview",
       "_tgt": "harness_inferential_review_sortunique",
@@ -47213,7 +47301,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L127",
+      "source_location": "L128",
       "weight": 1.0,
       "_src": "harness_inferential_review_readutf8ornull",
       "_tgt": "harness_inferential_review_fileexists",
@@ -47225,7 +47313,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L332",
+      "source_location": "L333",
       "weight": 1.0,
       "_src": "harness_inferential_review_collectharnessscripttestupdatefindings",
       "_tgt": "harness_inferential_review_fileexists",
@@ -47237,7 +47325,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L421",
+      "source_location": "L422",
       "weight": 1.0,
       "_src": "harness_inferential_review_collectharnesssafetysignalfindings",
       "_tgt": "harness_inferential_review_readutf8ornull",
@@ -47249,7 +47337,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L494",
+      "source_location": "L495",
       "weight": 1.0,
       "_src": "harness_inferential_review_buildsemanticprompt",
       "_tgt": "harness_inferential_review_readutf8ornull",
@@ -47261,7 +47349,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L693",
+      "source_location": "L694",
       "weight": 1.0,
       "_src": "harness_inferential_review_rundeterministicinferentialprovider",
       "_tgt": "harness_inferential_review_readutf8ornull",
@@ -47273,7 +47361,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L171",
+      "source_location": "L172",
       "weight": 1.0,
       "_src": "harness_inferential_review_getchangedfilesforinferentialreview",
       "_tgt": "harness_inferential_review_runcommand",
@@ -47285,7 +47373,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L305",
+      "source_location": "L306",
       "weight": 1.0,
       "_src": "harness_inferential_review_createreducedsignalfinding",
       "_tgt": "harness_inferential_review_buildfinding",
@@ -47297,7 +47385,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L334",
+      "source_location": "L335",
       "weight": 1.0,
       "_src": "harness_inferential_review_collectharnessscripttestupdatefindings",
       "_tgt": "harness_inferential_review_buildfinding",
@@ -47309,7 +47397,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L696",
+      "source_location": "L697",
       "weight": 1.0,
       "_src": "harness_inferential_review_rundeterministicinferentialprovider",
       "_tgt": "harness_inferential_review_buildfinding",
@@ -47321,7 +47409,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L728",
+      "source_location": "L729",
       "weight": 1.0,
       "_src": "harness_inferential_review_rundeterministicinferentialprovider",
       "_tgt": "harness_inferential_review_includescaseinsensitive",
@@ -47333,7 +47421,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L306",
+      "source_location": "L307",
       "weight": 1.0,
       "_src": "harness_inferential_review_createreducedsignalfinding",
       "_tgt": "harness_inferential_review_slugifyforfindingid",
@@ -47345,7 +47433,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L335",
+      "source_location": "L336",
       "weight": 1.0,
       "_src": "harness_inferential_review_collectharnessscripttestupdatefindings",
       "_tgt": "harness_inferential_review_slugifyforfindingid",
@@ -47357,7 +47445,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L323",
+      "source_location": "L324",
       "weight": 1.0,
       "_src": "harness_inferential_review_collectharnessscripttestupdatefindings",
       "_tgt": "harness_inferential_review_isharnessscriptsourcefile",
@@ -47369,7 +47457,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L327",
+      "source_location": "L328",
       "weight": 1.0,
       "_src": "harness_inferential_review_collectharnessscripttestupdatefindings",
       "_tgt": "harness_inferential_review_toharnessscripttestpath",
@@ -47381,7 +47469,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L310",
+      "source_location": "L311",
       "weight": 1.0,
       "_src": "harness_inferential_review_createreducedsignalfinding",
       "_tgt": "harness_inferential_review_formatmissingsignals",
@@ -47393,7 +47481,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L435",
+      "source_location": "L436",
       "weight": 1.0,
       "_src": "harness_inferential_review_collectharnesssafetysignalfindings",
       "_tgt": "harness_inferential_review_createreducedsignalfinding",
@@ -47405,7 +47493,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L452",
+      "source_location": "L453",
       "weight": 1.0,
       "_src": "harness_inferential_review_rundeterministicsemanticanalysis",
       "_tgt": "harness_inferential_review_collectharnessscripttestupdatefindings",
@@ -47417,7 +47505,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L456",
+      "source_location": "L457",
       "weight": 1.0,
       "_src": "harness_inferential_review_rundeterministicsemanticanalysis",
       "_tgt": "harness_inferential_review_collectharnesssafetysignalfindings",
@@ -47429,7 +47517,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L463",
+      "source_location": "L464",
       "weight": 1.0,
       "_src": "harness_inferential_review_rundeterministicsemanticanalysis",
       "_tgt": "harness_inferential_review_sortfindings",
@@ -47441,7 +47529,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1139",
+      "source_location": "L1160",
       "weight": 1.0,
       "_src": "harness_inferential_review_runharnessinferentialreview",
       "_tgt": "harness_inferential_review_rundeterministicsemanticanalysis",
@@ -47453,7 +47541,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1052",
+      "source_location": "L1073",
       "weight": 1.0,
       "_src": "harness_inferential_review_runharnessinferentialreview",
       "_tgt": "harness_inferential_review_resolvesemanticmode",
@@ -47465,7 +47553,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L628",
+      "source_location": "L629",
       "weight": 1.0,
       "_src": "harness_inferential_review_parsesemanticresponse",
       "_tgt": "harness_inferential_review_buildshadowsummary",
@@ -47477,7 +47565,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1195",
+      "source_location": "L1216",
       "weight": 1.0,
       "_src": "harness_inferential_review_runharnessinferentialreview",
       "_tgt": "harness_inferential_review_buildshadowsummary",
@@ -47489,7 +47577,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L499",
+      "source_location": "L500",
       "weight": 1.0,
       "_src": "harness_inferential_review_buildsemanticprompt",
       "_tgt": "harness_inferential_review_truncateforprompt",
@@ -47501,7 +47589,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L655",
+      "source_location": "L656",
       "weight": 1.0,
       "_src": "harness_inferential_review_runanthropicsemanticanalysis",
       "_tgt": "harness_inferential_review_buildsemanticprompt",
@@ -47513,7 +47601,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L664",
+      "source_location": "L665",
       "weight": 1.0,
       "_src": "harness_inferential_review_runanthropicsemanticanalysis",
       "_tgt": "harness_inferential_review_extracttextfromanthropicresponse",
@@ -47525,7 +47613,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L614",
+      "source_location": "L615",
       "weight": 1.0,
       "_src": "harness_inferential_review_parsesemanticresponse",
       "_tgt": "harness_inferential_review_extractjsonpayload",
@@ -47537,7 +47625,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L632",
+      "source_location": "L633",
       "weight": 1.0,
       "_src": "harness_inferential_review_parsesemanticresponse",
       "_tgt": "harness_inferential_review_sortfindings",
@@ -47549,7 +47637,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L665",
+      "source_location": "L666",
       "weight": 1.0,
       "_src": "harness_inferential_review_runanthropicsemanticanalysis",
       "_tgt": "harness_inferential_review_parsesemanticresponse",
@@ -47561,7 +47649,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L823",
+      "source_location": "L824",
       "weight": 1.0,
       "_src": "harness_inferential_review_rundeterministicinferentialprovider",
       "_tgt": "harness_inferential_review_sortfindings",
@@ -47573,7 +47661,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L962",
+      "source_location": "L983",
       "weight": 1.0,
       "_src": "harness_inferential_review_createoutput",
       "_tgt": "harness_inferential_review_sortfindings",
@@ -47585,7 +47673,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L981",
+      "source_location": "L1002",
       "weight": 1.0,
       "_src": "harness_inferential_review_createshadowoutput",
       "_tgt": "harness_inferential_review_sortfindings",
@@ -47597,7 +47685,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1145",
+      "source_location": "L1166",
       "weight": 1.0,
       "_src": "harness_inferential_review_runharnessinferentialreview",
       "_tgt": "harness_inferential_review_sortfindings",
@@ -47609,7 +47697,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L864",
+      "source_location": "L865",
       "weight": 1.0,
       "_src": "harness_inferential_review_buildhumanreport",
       "_tgt": "harness_inferential_review_formatstatuslabel",
@@ -47621,7 +47709,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1081",
+      "source_location": "L1102",
       "weight": 1.0,
       "_src": "harness_inferential_review_runharnessinferentialreview",
       "_tgt": "harness_inferential_review_buildhumanreport",
@@ -47633,7 +47721,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1082",
+      "source_location": "L1103",
       "weight": 1.0,
       "_src": "harness_inferential_review_runharnessinferentialreview",
       "_tgt": "harness_inferential_review_writemachineoutput",
@@ -47645,7 +47733,31 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L994",
+      "source_location": "L953",
+      "weight": 1.0,
+      "_src": "harness_inferential_review_writehistorysnapshot",
+      "_tgt": "harness_inferential_review_tohistoryfilestamp",
+      "source": "harness_inferential_review_tohistoryfilestamp",
+      "target": "harness_inferential_review_writehistorysnapshot",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L1266",
+      "weight": 1.0,
+      "_src": "harness_inferential_review_runharnessinferentialreview",
+      "_tgt": "harness_inferential_review_writehistorysnapshot",
+      "source": "harness_inferential_review_writehistorysnapshot",
+      "target": "harness_inferential_review_runharnessinferentialreview",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L1015",
       "weight": 1.0,
       "_src": "harness_inferential_review_createproviderfailure",
       "_tgt": "harness_inferential_review_createoutput",
@@ -47657,7 +47769,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1023",
+      "source_location": "L1044",
       "weight": 1.0,
       "_src": "harness_inferential_review_createruntimefailure",
       "_tgt": "harness_inferential_review_createoutput",
@@ -47669,7 +47781,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1092",
+      "source_location": "L1113",
       "weight": 1.0,
       "_src": "harness_inferential_review_runharnessinferentialreview",
       "_tgt": "harness_inferential_review_createoutput",
@@ -47681,7 +47793,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1189",
+      "source_location": "L1210",
       "weight": 1.0,
       "_src": "harness_inferential_review_runharnessinferentialreview",
       "_tgt": "harness_inferential_review_createshadowoutput",
@@ -47693,7 +47805,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1123",
+      "source_location": "L1144",
       "weight": 1.0,
       "_src": "harness_inferential_review_runharnessinferentialreview",
       "_tgt": "harness_inferential_review_createproviderfailure",
@@ -47705,7 +47817,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1073",
+      "source_location": "L1094",
       "weight": 1.0,
       "_src": "harness_inferential_review_runharnessinferentialreview",
       "_tgt": "harness_inferential_review_createruntimefailure",
@@ -48461,7 +48573,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.test.ts",
-      "source_location": "L5",
+      "source_location": "L14",
       "weight": 1.0,
       "_src": "scripts_harness_runtime_trends_test_ts",
       "_tgt": "harness_runtime_trends_test_buildreportline",
@@ -48473,7 +48585,19 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L109",
+      "source_location": "L110",
+      "weight": 1.0,
+      "_src": "scripts_harness_runtime_trends_ts",
+      "_tgt": "harness_runtime_trends_tohistoryfilestamp",
+      "source": "scripts_harness_runtime_trends_ts",
+      "target": "harness_runtime_trends_tohistoryfilestamp",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L114",
       "weight": 1.0,
       "_src": "scripts_harness_runtime_trends_ts",
       "_tgt": "harness_runtime_trends_splitinputlines",
@@ -48485,7 +48609,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L115",
+      "source_location": "L120",
       "weight": 1.0,
       "_src": "scripts_harness_runtime_trends_ts",
       "_tgt": "harness_runtime_trends_sortunique",
@@ -48497,7 +48621,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L121",
+      "source_location": "L126",
       "weight": 1.0,
       "_src": "scripts_harness_runtime_trends_ts",
       "_tgt": "harness_runtime_trends_isharnessbehaviorscenarioreport",
@@ -48509,7 +48633,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L139",
+      "source_location": "L144",
       "weight": 1.0,
       "_src": "scripts_harness_runtime_trends_ts",
       "_tgt": "harness_runtime_trends_parseharnessbehaviorreportlines",
@@ -48521,7 +48645,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L181",
+      "source_location": "L186",
       "weight": 1.0,
       "_src": "scripts_harness_runtime_trends_ts",
       "_tgt": "harness_runtime_trends_percentile",
@@ -48533,7 +48657,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L192",
+      "source_location": "L197",
       "weight": 1.0,
       "_src": "scripts_harness_runtime_trends_ts",
       "_tgt": "harness_runtime_trends_buildnumerictrendstats",
@@ -48545,7 +48669,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L217",
+      "source_location": "L222",
       "weight": 1.0,
       "_src": "scripts_harness_runtime_trends_ts",
       "_tgt": "harness_runtime_trends_sortcountentries",
@@ -48557,7 +48681,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L223",
+      "source_location": "L228",
       "weight": 1.0,
       "_src": "scripts_harness_runtime_trends_ts",
       "_tgt": "harness_runtime_trends_formatpercent",
@@ -48569,7 +48693,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L227",
+      "source_location": "L232",
       "weight": 1.0,
       "_src": "scripts_harness_runtime_trends_ts",
       "_tgt": "harness_runtime_trends_formatms",
@@ -48581,7 +48705,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L231",
+      "source_location": "L236",
       "weight": 1.0,
       "_src": "scripts_harness_runtime_trends_ts",
       "_tgt": "harness_runtime_trends_buildscenariotrend",
@@ -48593,7 +48717,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L327",
+      "source_location": "L332",
       "weight": 1.0,
       "_src": "scripts_harness_runtime_trends_ts",
       "_tgt": "harness_runtime_trends_buildregressionwarnings",
@@ -48605,7 +48729,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L399",
+      "source_location": "L404",
       "weight": 1.0,
       "_src": "scripts_harness_runtime_trends_ts",
       "_tgt": "harness_runtime_trends_buildruntimetrendoutput",
@@ -48617,7 +48741,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L463",
+      "source_location": "L468",
       "weight": 1.0,
       "_src": "scripts_harness_runtime_trends_ts",
       "_tgt": "harness_runtime_trends_collectharnessruntimetrends",
@@ -48629,7 +48753,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L471",
+      "source_location": "L476",
       "weight": 1.0,
       "_src": "scripts_harness_runtime_trends_ts",
       "_tgt": "harness_runtime_trends_runharnessruntimetrends",
@@ -48641,7 +48765,19 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L140",
+      "source_location": "L492",
+      "weight": 1.0,
+      "_src": "harness_runtime_trends_runharnessruntimetrends",
+      "_tgt": "harness_runtime_trends_tohistoryfilestamp",
+      "source": "harness_runtime_trends_tohistoryfilestamp",
+      "target": "harness_runtime_trends_runharnessruntimetrends",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L145",
       "weight": 1.0,
       "_src": "harness_runtime_trends_parseharnessbehaviorreportlines",
       "_tgt": "harness_runtime_trends_splitinputlines",
@@ -48653,7 +48789,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L240",
+      "source_location": "L245",
       "weight": 1.0,
       "_src": "harness_runtime_trends_buildscenariotrend",
       "_tgt": "harness_runtime_trends_sortunique",
@@ -48665,7 +48801,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L418",
+      "source_location": "L423",
       "weight": 1.0,
       "_src": "harness_runtime_trends_buildruntimetrendoutput",
       "_tgt": "harness_runtime_trends_sortunique",
@@ -48677,7 +48813,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L467",
+      "source_location": "L472",
       "weight": 1.0,
       "_src": "harness_runtime_trends_collectharnessruntimetrends",
       "_tgt": "harness_runtime_trends_parseharnessbehaviorreportlines",
@@ -48689,7 +48825,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L212",
+      "source_location": "L217",
       "weight": 1.0,
       "_src": "harness_runtime_trends_buildnumerictrendstats",
       "_tgt": "harness_runtime_trends_percentile",
@@ -48701,7 +48837,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L236",
+      "source_location": "L241",
       "weight": 1.0,
       "_src": "harness_runtime_trends_buildscenariotrend",
       "_tgt": "harness_runtime_trends_buildnumerictrendstats",
@@ -48713,7 +48849,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L316",
+      "source_location": "L321",
       "weight": 1.0,
       "_src": "harness_runtime_trends_buildscenariotrend",
       "_tgt": "harness_runtime_trends_sortcountentries",
@@ -48725,7 +48861,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L343",
+      "source_location": "L348",
       "weight": 1.0,
       "_src": "harness_runtime_trends_buildregressionwarnings",
       "_tgt": "harness_runtime_trends_formatpercent",
@@ -48737,7 +48873,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L362",
+      "source_location": "L367",
       "weight": 1.0,
       "_src": "harness_runtime_trends_buildregressionwarnings",
       "_tgt": "harness_runtime_trends_formatms",
@@ -48749,7 +48885,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L468",
+      "source_location": "L473",
       "weight": 1.0,
       "_src": "harness_runtime_trends_collectharnessruntimetrends",
       "_tgt": "harness_runtime_trends_buildruntimetrendoutput",
@@ -48761,7 +48897,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L476",
+      "source_location": "L481",
       "weight": 1.0,
       "_src": "harness_runtime_trends_runharnessruntimetrends",
       "_tgt": "harness_runtime_trends_collectharnessruntimetrends",
@@ -48809,7 +48945,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L136",
+      "source_location": "L189",
       "weight": 1.0,
       "_src": "scripts_harness_scorecard_ts",
       "_tgt": "harness_scorecard_normalizerepopath",
@@ -48821,7 +48957,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L140",
+      "source_location": "L193",
       "weight": 1.0,
       "_src": "scripts_harness_scorecard_ts",
       "_tgt": "harness_scorecard_sortunique",
@@ -48833,7 +48969,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L146",
+      "source_location": "L199",
       "weight": 1.0,
       "_src": "scripts_harness_scorecard_ts",
       "_tgt": "harness_scorecard_isruntimescenarioname",
@@ -48845,7 +48981,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L150",
+      "source_location": "L203",
       "weight": 1.0,
       "_src": "scripts_harness_scorecard_ts",
       "_tgt": "harness_scorecard_fileexists",
@@ -48857,7 +48993,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L159",
+      "source_location": "L212",
       "weight": 1.0,
       "_src": "scripts_harness_scorecard_ts",
       "_tgt": "harness_scorecard_readjsonfile",
@@ -48869,7 +49005,19 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L163",
+      "source_location": "L216",
+      "weight": 1.0,
+      "_src": "scripts_harness_scorecard_ts",
+      "_tgt": "harness_scorecard_listdirectory",
+      "source": "scripts_harness_scorecard_ts",
+      "target": "harness_scorecard_listdirectory",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L220",
       "weight": 1.0,
       "_src": "scripts_harness_scorecard_ts",
       "_tgt": "harness_scorecard_readtextfile",
@@ -48881,7 +49029,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L167",
+      "source_location": "L224",
       "weight": 1.0,
       "_src": "scripts_harness_scorecard_ts",
       "_tgt": "harness_scorecard_createfilesystem",
@@ -48893,7 +49041,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L175",
+      "source_location": "L233",
       "weight": 1.0,
       "_src": "scripts_harness_scorecard_ts",
       "_tgt": "harness_scorecard_extractscenariosection",
@@ -48905,7 +49053,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L197",
+      "source_location": "L255",
       "weight": 1.0,
       "_src": "scripts_harness_scorecard_ts",
       "_tgt": "harness_scorecard_extractscenarionames",
@@ -48917,7 +49065,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L210",
+      "source_location": "L268",
       "weight": 1.0,
       "_src": "scripts_harness_scorecard_ts",
       "_tgt": "harness_scorecard_countmissingsnippets",
@@ -48929,7 +49077,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L217",
+      "source_location": "L275",
       "weight": 1.0,
       "_src": "scripts_harness_scorecard_ts",
       "_tgt": "harness_scorecard_builddocumentationstatus",
@@ -48941,7 +49089,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L241",
+      "source_location": "L299",
       "weight": 1.0,
       "_src": "scripts_harness_scorecard_ts",
       "_tgt": "harness_scorecard_buildgraphifystatus",
@@ -48953,7 +49101,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L253",
+      "source_location": "L311",
       "weight": 1.0,
       "_src": "scripts_harness_scorecard_ts",
       "_tgt": "harness_scorecard_buildsummary",
@@ -48965,7 +49113,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L304",
+      "source_location": "L374",
       "weight": 1.0,
       "_src": "scripts_harness_scorecard_ts",
       "_tgt": "harness_scorecard_hasanyharnessdocs",
@@ -48977,7 +49125,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L321",
+      "source_location": "L391",
       "weight": 1.0,
       "_src": "scripts_harness_scorecard_ts",
       "_tgt": "harness_scorecard_inspectappdocumentation",
@@ -48989,7 +49137,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L385",
+      "source_location": "L455",
       "weight": 1.0,
       "_src": "scripts_harness_scorecard_ts",
       "_tgt": "harness_scorecard_getdocumentedscenarioexpectations",
@@ -49001,7 +49149,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L398",
+      "source_location": "L468",
       "weight": 1.0,
       "_src": "scripts_harness_scorecard_ts",
       "_tgt": "harness_scorecard_inspectinferentialartifact",
@@ -49013,7 +49161,55 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L444",
+      "source_location": "L554",
+      "weight": 1.0,
+      "_src": "scripts_harness_scorecard_ts",
+      "_tgt": "harness_scorecard_buildemptyhistorymetric",
+      "source": "scripts_harness_scorecard_ts",
+      "target": "harness_scorecard_buildemptyhistorymetric",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L564",
+      "weight": 1.0,
+      "_src": "scripts_harness_scorecard_ts",
+      "_tgt": "harness_scorecard_inspectinferentialhistory",
+      "source": "scripts_harness_scorecard_ts",
+      "target": "harness_scorecard_inspectinferentialhistory",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L616",
+      "weight": 1.0,
+      "_src": "scripts_harness_scorecard_ts",
+      "_tgt": "harness_scorecard_inspectruntimetrendartifact",
+      "source": "scripts_harness_scorecard_ts",
+      "target": "harness_scorecard_inspectruntimetrendartifact",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L659",
+      "weight": 1.0,
+      "_src": "scripts_harness_scorecard_ts",
+      "_tgt": "harness_scorecard_inspectruntimetrendhistory",
+      "source": "scripts_harness_scorecard_ts",
+      "target": "harness_scorecard_inspectruntimetrendhistory",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L709",
       "weight": 1.0,
       "_src": "scripts_harness_scorecard_ts",
       "_tgt": "harness_scorecard_inspectgraphifyartifacts",
@@ -49025,7 +49221,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L472",
+      "source_location": "L737",
       "weight": 1.0,
       "_src": "scripts_harness_scorecard_ts",
       "_tgt": "harness_scorecard_collectharnessscorecard",
@@ -49037,7 +49233,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L558",
+      "source_location": "L827",
       "weight": 1.0,
       "_src": "scripts_harness_scorecard_ts",
       "_tgt": "harness_scorecard_runharnessscorecard",
@@ -49049,7 +49245,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L203",
+      "source_location": "L261",
       "weight": 1.0,
       "_src": "harness_scorecard_extractscenarionames",
       "_tgt": "harness_scorecard_sortunique",
@@ -49061,7 +49257,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L389",
+      "source_location": "L459",
       "weight": 1.0,
       "_src": "harness_scorecard_getdocumentedscenarioexpectations",
       "_tgt": "harness_scorecard_sortunique",
@@ -49073,7 +49269,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L479",
+      "source_location": "L744",
       "weight": 1.0,
       "_src": "harness_scorecard_collectharnessscorecard",
       "_tgt": "harness_scorecard_sortunique",
@@ -49085,7 +49281,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L313",
+      "source_location": "L383",
       "weight": 1.0,
       "_src": "harness_scorecard_hasanyharnessdocs",
       "_tgt": "harness_scorecard_fileexists",
@@ -49097,7 +49293,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L329",
+      "source_location": "L399",
       "weight": 1.0,
       "_src": "harness_scorecard_inspectappdocumentation",
       "_tgt": "harness_scorecard_fileexists",
@@ -49109,7 +49305,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L403",
+      "source_location": "L473",
       "weight": 1.0,
       "_src": "harness_scorecard_inspectinferentialartifact",
       "_tgt": "harness_scorecard_fileexists",
@@ -49121,7 +49317,43 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L448",
+      "source_location": "L570",
+      "weight": 1.0,
+      "_src": "harness_scorecard_inspectinferentialhistory",
+      "_tgt": "harness_scorecard_fileexists",
+      "source": "harness_scorecard_fileexists",
+      "target": "harness_scorecard_inspectinferentialhistory",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L624",
+      "weight": 1.0,
+      "_src": "harness_scorecard_inspectruntimetrendartifact",
+      "_tgt": "harness_scorecard_fileexists",
+      "source": "harness_scorecard_fileexists",
+      "target": "harness_scorecard_inspectruntimetrendartifact",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L665",
+      "weight": 1.0,
+      "_src": "harness_scorecard_inspectruntimetrendhistory",
+      "_tgt": "harness_scorecard_fileexists",
+      "source": "harness_scorecard_fileexists",
+      "target": "harness_scorecard_inspectruntimetrendhistory",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L713",
       "weight": 1.0,
       "_src": "harness_scorecard_inspectgraphifyartifacts",
       "_tgt": "harness_scorecard_fileexists",
@@ -49133,7 +49365,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L476",
+      "source_location": "L741",
       "weight": 1.0,
       "_src": "harness_scorecard_collectharnessscorecard",
       "_tgt": "harness_scorecard_createfilesystem",
@@ -49145,7 +49377,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L198",
+      "source_location": "L256",
       "weight": 1.0,
       "_src": "harness_scorecard_extractscenarionames",
       "_tgt": "harness_scorecard_extractscenariosection",
@@ -49157,7 +49389,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L339",
+      "source_location": "L409",
       "weight": 1.0,
       "_src": "harness_scorecard_inspectappdocumentation",
       "_tgt": "harness_scorecard_extractscenarionames",
@@ -49169,7 +49401,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L336",
+      "source_location": "L406",
       "weight": 1.0,
       "_src": "harness_scorecard_inspectappdocumentation",
       "_tgt": "harness_scorecard_countmissingsnippets",
@@ -49181,7 +49413,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L361",
+      "source_location": "L431",
       "weight": 1.0,
       "_src": "harness_scorecard_inspectappdocumentation",
       "_tgt": "harness_scorecard_builddocumentationstatus",
@@ -49193,7 +49425,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L452",
+      "source_location": "L717",
       "weight": 1.0,
       "_src": "harness_scorecard_inspectgraphifyartifacts",
       "_tgt": "harness_scorecard_buildgraphifystatus",
@@ -49205,7 +49437,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L543",
+      "source_location": "L811",
       "weight": 1.0,
       "_src": "harness_scorecard_collectharnessscorecard",
       "_tgt": "harness_scorecard_buildsummary",
@@ -49217,7 +49449,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L485",
+      "source_location": "L750",
       "weight": 1.0,
       "_src": "harness_scorecard_collectharnessscorecard",
       "_tgt": "harness_scorecard_hasanyharnessdocs",
@@ -49229,7 +49461,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L540",
+      "source_location": "L805",
       "weight": 1.0,
       "_src": "harness_scorecard_collectharnessscorecard",
       "_tgt": "harness_scorecard_inspectinferentialartifact",
@@ -49241,7 +49473,79 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L541",
+      "source_location": "L572",
+      "weight": 1.0,
+      "_src": "harness_scorecard_inspectinferentialhistory",
+      "_tgt": "harness_scorecard_buildemptyhistorymetric",
+      "source": "harness_scorecard_buildemptyhistorymetric",
+      "target": "harness_scorecard_inspectinferentialhistory",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L636",
+      "weight": 1.0,
+      "_src": "harness_scorecard_inspectruntimetrendartifact",
+      "_tgt": "harness_scorecard_buildemptyhistorymetric",
+      "source": "harness_scorecard_buildemptyhistorymetric",
+      "target": "harness_scorecard_inspectruntimetrendartifact",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L667",
+      "weight": 1.0,
+      "_src": "harness_scorecard_inspectruntimetrendhistory",
+      "_tgt": "harness_scorecard_buildemptyhistorymetric",
+      "source": "harness_scorecard_buildemptyhistorymetric",
+      "target": "harness_scorecard_inspectruntimetrendhistory",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L806",
+      "weight": 1.0,
+      "_src": "harness_scorecard_collectharnessscorecard",
+      "_tgt": "harness_scorecard_inspectinferentialhistory",
+      "source": "harness_scorecard_inspectinferentialhistory",
+      "target": "harness_scorecard_collectharnessscorecard",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L807",
+      "weight": 1.0,
+      "_src": "harness_scorecard_collectharnessscorecard",
+      "_tgt": "harness_scorecard_inspectruntimetrendartifact",
+      "source": "harness_scorecard_inspectruntimetrendartifact",
+      "target": "harness_scorecard_collectharnessscorecard",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L808",
+      "weight": 1.0,
+      "_src": "harness_scorecard_collectharnessscorecard",
+      "_tgt": "harness_scorecard_inspectruntimetrendhistory",
+      "source": "harness_scorecard_inspectruntimetrendhistory",
+      "target": "harness_scorecard_collectharnessscorecard",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L809",
       "weight": 1.0,
       "_src": "harness_scorecard_collectharnessscorecard",
       "_tgt": "harness_scorecard_inspectgraphifyartifacts",
@@ -49253,7 +49557,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L562",
+      "source_location": "L831",
       "weight": 1.0,
       "_src": "harness_scorecard_runharnessscorecard",
       "_tgt": "harness_scorecard_collectharnessscorecard",

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -1649,7 +1649,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_utils_ts",
-      "community": 34
+      "community": 31
     },
     {
       "label": "getDiscountValue()",
@@ -1657,7 +1657,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L17",
       "id": "utils_getdiscountvalue",
-      "community": 34
+      "community": 31
     },
     {
       "label": "getProductDiscountValue()",
@@ -1665,7 +1665,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
       "source_location": "L75",
       "id": "utils_getproductdiscountvalue",
-      "community": 34
+      "community": 31
     },
     {
       "label": "getOrderAmount()",
@@ -1673,7 +1673,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L51",
       "id": "utils_getorderamount",
-      "community": 34
+      "community": 31
     },
     {
       "label": "formatDeliveryAddress()",
@@ -1681,7 +1681,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L74",
       "id": "utils_formatdeliveryaddress",
-      "community": 34
+      "community": 31
     },
     {
       "label": "currency.test.ts",
@@ -6081,7 +6081,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_heroheaderimageuploader_tsx",
-      "community": 31
+      "community": 32
     },
     {
       "label": "validateFile()",
@@ -6089,7 +6089,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L50",
       "id": "heroheaderimageuploader_validatefile",
-      "community": 31
+      "community": 32
     },
     {
       "label": "uploadImage()",
@@ -6097,7 +6097,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L67",
       "id": "heroheaderimageuploader_uploadimage",
-      "community": 31
+      "community": 32
     },
     {
       "label": "resetEditState()",
@@ -6105,7 +6105,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L95",
       "id": "heroheaderimageuploader_reseteditstate",
-      "community": 31
+      "community": 32
     },
     {
       "label": "handleEditClick()",
@@ -6113,7 +6113,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L108",
       "id": "heroheaderimageuploader_handleeditclick",
-      "community": 31
+      "community": 32
     },
     {
       "label": "handleFileSelect()",
@@ -6121,7 +6121,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L113",
       "id": "heroheaderimageuploader_handlefileselect",
-      "community": 31
+      "community": 32
     },
     {
       "label": "handleUpload()",
@@ -6129,7 +6129,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L127",
       "id": "heroheaderimageuploader_handleupload",
-      "community": 31
+      "community": 32
     },
     {
       "label": "handleRevert()",
@@ -6137,7 +6137,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L163",
       "id": "heroheaderimageuploader_handlerevert",
-      "community": 31
+      "community": 32
     },
     {
       "label": "EditModeButtons()",
@@ -6145,7 +6145,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L179",
       "id": "heroheaderimageuploader_editmodebuttons",
-      "community": 31
+      "community": 32
     },
     {
       "label": "ViewModeButton()",
@@ -6153,7 +6153,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L205",
       "id": "heroheaderimageuploader_viewmodebutton",
-      "community": 31
+      "community": 32
     },
     {
       "label": "HeroSectionTabs.tsx",
@@ -6857,7 +6857,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_utils_ts",
-      "community": 34
+      "community": 31
     },
     {
       "label": "getOrderState()",
@@ -6865,7 +6865,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
       "source_location": "L1",
       "id": "utils_getorderstate",
-      "community": 34
+      "community": 31
     },
     {
       "label": "getAmountPaidForOrder()",
@@ -6873,7 +6873,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
       "source_location": "L108",
       "id": "utils_getamountpaidfororder",
-      "community": 34
+      "community": 31
     },
     {
       "label": "index.tsx",
@@ -9529,7 +9529,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "community": 80
+      "community": 69
     },
     {
       "label": "onDrop()",
@@ -9537,7 +9537,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L20",
       "id": "image_uploader_ondrop",
-      "community": 80
+      "community": 69
     },
     {
       "label": "removeImage()",
@@ -9545,7 +9545,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L31",
       "id": "image_uploader_removeimage",
-      "community": 80
+      "community": 69
     },
     {
       "label": "unmarkForDeletion()",
@@ -9553,7 +9553,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L46",
       "id": "image_uploader_unmarkfordeletion",
-      "community": 80
+      "community": 69
     },
     {
       "label": "onDragEnd()",
@@ -9561,7 +9561,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L100",
       "id": "image_uploader_ondragend",
-      "community": 80
+      "community": 69
     },
     {
       "label": "input-otp.tsx",
@@ -9857,7 +9857,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
-      "community": 69
+      "community": 70
     },
     {
       "label": "useSidebar()",
@@ -9865,7 +9865,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L45",
       "id": "sidebar_usesidebar",
-      "community": 69
+      "community": 70
     },
     {
       "label": "handleKeyDown()",
@@ -9873,7 +9873,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L105",
       "id": "sidebar_handlekeydown",
-      "community": 69
+      "community": 70
     },
     {
       "label": "cn()",
@@ -9881,7 +9881,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L147",
       "id": "sidebar_cn",
-      "community": 69
+      "community": 70
     },
     {
       "label": "handleOnHover()",
@@ -9889,7 +9889,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L224",
       "id": "sidebar_handleonhover",
-      "community": 69
+      "community": 70
     },
     {
       "label": "handleOnMouseLeave()",
@@ -9897,7 +9897,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L228",
       "id": "sidebar_handleonmouseleave",
-      "community": 69
+      "community": 70
     },
     {
       "label": "skeleton.tsx",
@@ -10817,7 +10817,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
-      "community": 70
+      "community": 71
     },
     {
       "label": "applyOperation()",
@@ -10825,7 +10825,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L56",
       "id": "usebulkoperations_applyoperation",
-      "community": 70
+      "community": 71
     },
     {
       "label": "calculatePriceWithFee()",
@@ -10833,7 +10833,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L87",
       "id": "usebulkoperations_calculatepricewithfee",
-      "community": 70
+      "community": 71
     },
     {
       "label": "computePreview()",
@@ -10841,7 +10841,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L101",
       "id": "usebulkoperations_computepreview",
-      "community": 70
+      "community": 71
     },
     {
       "label": "validateOperationValue()",
@@ -10849,7 +10849,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L139",
       "id": "usebulkoperations_validateoperationvalue",
-      "community": 70
+      "community": 71
     },
     {
       "label": "useBulkOperations()",
@@ -10857,7 +10857,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L158",
       "id": "usebulkoperations_usebulkoperations",
-      "community": 70
+      "community": 71
     },
     {
       "label": "useCartOperations.ts",
@@ -10961,7 +10961,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
-      "community": 71
+      "community": 72
     },
     {
       "label": "useExpenseStoreSessions()",
@@ -10969,7 +10969,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L7",
       "id": "useexpensesessions_useexpensestoresessions",
-      "community": 71
+      "community": 72
     },
     {
       "label": "useExpenseSession()",
@@ -10977,7 +10977,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L23",
       "id": "useexpensesessions_useexpensesession",
-      "community": 71
+      "community": 72
     },
     {
       "label": "useExpenseActiveSession()",
@@ -10985,7 +10985,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L33",
       "id": "useexpensesessions_useexpenseactivesession",
-      "community": 71
+      "community": 72
     },
     {
       "label": "useExpenseSessionCreate()",
@@ -10993,7 +10993,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L48",
       "id": "useexpensesessions_useexpensesessioncreate",
-      "community": 71
+      "community": 72
     },
     {
       "label": "useExpenseSessionUpdate()",
@@ -11001,7 +11001,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L85",
       "id": "useexpensesessions_useexpensesessionupdate",
-      "community": 71
+      "community": 72
     },
     {
       "label": "useGetActiveProduct.ts",
@@ -11217,7 +11217,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_useposcustomers_ts",
-      "community": 72
+      "community": 73
     },
     {
       "label": "usePOSCustomerSearch()",
@@ -11225,7 +11225,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L7",
       "id": "useposcustomers_useposcustomersearch",
-      "community": 72
+      "community": 73
     },
     {
       "label": "usePOSCustomer()",
@@ -11233,7 +11233,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L18",
       "id": "useposcustomers_useposcustomer",
-      "community": 72
+      "community": 73
     },
     {
       "label": "usePOSCustomerCreate()",
@@ -11241,7 +11241,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L26",
       "id": "useposcustomers_useposcustomercreate",
-      "community": 72
+      "community": 73
     },
     {
       "label": "usePOSCustomerUpdate()",
@@ -11249,7 +11249,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L57",
       "id": "useposcustomers_useposcustomerupdate",
-      "community": 72
+      "community": 73
     },
     {
       "label": "usePOSCustomerTransactions()",
@@ -11257,7 +11257,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L90",
       "id": "useposcustomers_useposcustomertransactions",
-      "community": 72
+      "community": 73
     },
     {
       "label": "usePOSOperations.ts",
@@ -11585,7 +11585,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
-      "community": 73
+      "community": 74
     },
     {
       "label": "getCustomerJourneyStage()",
@@ -11593,7 +11593,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L36",
       "id": "behaviorutils_getcustomerjourneystage",
-      "community": 73
+      "community": 74
     },
     {
       "label": "calculateRiskIndicators()",
@@ -11601,7 +11601,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L71",
       "id": "behaviorutils_calculateriskindicators",
-      "community": 73
+      "community": 74
     },
     {
       "label": "calculateEngagementMetrics()",
@@ -11609,7 +11609,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L173",
       "id": "behaviorutils_calculateengagementmetrics",
-      "community": 73
+      "community": 74
     },
     {
       "label": "getActivityPriority()",
@@ -11617,7 +11617,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L251",
       "id": "behaviorutils_getactivitypriority",
-      "community": 73
+      "community": 74
     },
     {
       "label": "getJourneyStageInfo()",
@@ -11625,7 +11625,7 @@
       "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L277",
       "id": "behaviorutils_getjourneystageinfo",
-      "community": 73
+      "community": 74
     },
     {
       "label": "browserFingerprint.ts",
@@ -12033,7 +12033,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
-      "community": 74
+      "community": 75
     },
     {
       "label": "handlePOSOperation()",
@@ -12041,7 +12041,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L171",
       "id": "toastservice_handleposoperation",
-      "community": 74
+      "community": 75
     },
     {
       "label": "showValidationError()",
@@ -12049,7 +12049,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L293",
       "id": "toastservice_showvalidationerror",
-      "community": 74
+      "community": 75
     },
     {
       "label": "showInventoryError()",
@@ -12057,7 +12057,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L302",
       "id": "toastservice_showinventoryerror",
-      "community": 74
+      "community": 75
     },
     {
       "label": "showSessionExpiredError()",
@@ -12065,7 +12065,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L312",
       "id": "toastservice_showsessionexpirederror",
-      "community": 74
+      "community": 75
     },
     {
       "label": "showNoActiveSessionError()",
@@ -12073,7 +12073,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L319",
       "id": "toastservice_shownoactivesessionerror",
-      "community": 74
+      "community": 75
     },
     {
       "label": "transactionUtils.ts",
@@ -12233,7 +12233,7 @@
       "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "community": 53
+      "community": 55
     },
     {
       "label": "getProductName()",
@@ -12241,7 +12241,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L18",
       "id": "productutils_getproductname",
-      "community": 53
+      "community": 55
     },
     {
       "label": "sortProduct()",
@@ -12249,7 +12249,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L66",
       "id": "productutils_sortproduct",
-      "community": 53
+      "community": 55
     },
     {
       "label": "category.ts",
@@ -13089,7 +13089,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
-      "community": 75
+      "community": 76
     },
     {
       "label": "OrganizationSettings()",
@@ -13097,7 +13097,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L24",
       "id": "organizationsettingsview_organizationsettings",
-      "community": 75
+      "community": 76
     },
     {
       "label": "saveStoreChanges()",
@@ -13105,7 +13105,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L71",
       "id": "organizationsettingsview_savestorechanges",
-      "community": 75
+      "community": 76
     },
     {
       "label": "onSubmit()",
@@ -13113,7 +13113,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L105",
       "id": "organizationsettingsview_onsubmit",
-      "community": 75
+      "community": 76
     },
     {
       "label": "handleDeleteStore()",
@@ -13121,7 +13121,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L156",
       "id": "organizationsettingsview_handledeletestore",
-      "community": 75
+      "community": 76
     },
     {
       "label": "Navigation()",
@@ -13129,7 +13129,7 @@
       "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L198",
       "id": "organizationsettingsview_navigation",
-      "community": 75
+      "community": 76
     },
     {
       "label": "OrganizationsSettingsAccordion.tsx",
@@ -13153,7 +13153,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
-      "community": 76
+      "community": 77
     },
     {
       "label": "StoreSettings()",
@@ -13161,7 +13161,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L28",
       "id": "storesettingsview_storesettings",
-      "community": 76
+      "community": 77
     },
     {
       "label": "saveStoreChanges()",
@@ -13169,7 +13169,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L82",
       "id": "storesettingsview_savestorechanges",
-      "community": 76
+      "community": 77
     },
     {
       "label": "onSubmit()",
@@ -13177,7 +13177,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L116",
       "id": "storesettingsview_onsubmit",
-      "community": 76
+      "community": 77
     },
     {
       "label": "handleDeleteStore()",
@@ -13185,7 +13185,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L167",
       "id": "storesettingsview_handledeletestore",
-      "community": 76
+      "community": 77
     },
     {
       "label": "handleDeleteAllProductsInStore()",
@@ -13193,7 +13193,7 @@
       "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
       "source_location": "L232",
       "id": "storesettingsview_handledeleteallproductsinstore",
-      "community": 76
+      "community": 77
     },
     {
       "label": "StoresSettingsAccordion.tsx",
@@ -13345,7 +13345,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_tests_pos_simple_test_ts",
-      "community": 32
+      "community": 33
     },
     {
       "label": "generateTransactionNumber()",
@@ -13353,7 +13353,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L38",
       "id": "simple_test_generatetransactionnumber",
-      "community": 32
+      "community": 33
     },
     {
       "label": "validateInventory()",
@@ -13361,7 +13361,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L77",
       "id": "simple_test_validateinventory",
-      "community": 32
+      "community": 33
     },
     {
       "label": "validateInventoryWithAggregation()",
@@ -13369,7 +13369,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L130",
       "id": "simple_test_validateinventorywithaggregation",
-      "community": 32
+      "community": 33
     },
     {
       "label": "formatCurrency()",
@@ -13377,7 +13377,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L173",
       "id": "simple_test_formatcurrency",
-      "community": 32
+      "community": 33
     },
     {
       "label": "formatPaymentMethod()",
@@ -13385,7 +13385,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L201",
       "id": "simple_test_formatpaymentmethod",
-      "community": 32
+      "community": 33
     },
     {
       "label": "formatReceiptDate()",
@@ -13393,7 +13393,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L225",
       "id": "simple_test_formatreceiptdate",
-      "community": 32
+      "community": 33
     },
     {
       "label": "addToCart()",
@@ -13401,7 +13401,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L249",
       "id": "simple_test_addtocart",
-      "community": 32
+      "community": 33
     },
     {
       "label": "removeFromCart()",
@@ -13409,7 +13409,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L288",
       "id": "simple_test_removefromcart",
-      "community": 32
+      "community": 33
     },
     {
       "label": "updateQuantity()",
@@ -13417,7 +13417,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L311",
       "id": "simple_test_updatequantity",
-      "community": 32
+      "community": 33
     },
     {
       "label": "usePrint.test.ts",
@@ -13769,7 +13769,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_checkoutsession_ts",
-      "community": 15
+      "community": 16
     },
     {
       "label": "getBaseUrl()",
@@ -13777,7 +13777,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L5",
       "id": "checkoutsession_getbaseurl",
-      "community": 15
+      "community": 16
     },
     {
       "label": "CheckoutSessionError",
@@ -13785,7 +13785,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L64",
       "id": "checkoutsession_checkoutsessionerror",
-      "community": 15
+      "community": 16
     },
     {
       "label": ".constructor()",
@@ -13793,7 +13793,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L69",
       "id": "checkoutsession_checkoutsessionerror_constructor",
-      "community": 15
+      "community": 16
     },
     {
       "label": "isRecord()",
@@ -13801,7 +13801,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L78",
       "id": "checkoutsession_isrecord",
-      "community": 15
+      "community": 16
     },
     {
       "label": "parseJson()",
@@ -13809,7 +13809,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L81",
       "id": "checkoutsession_parsejson",
-      "community": 15
+      "community": 16
     },
     {
       "label": "getCheckoutErrorMessageFromPayload()",
@@ -13817,7 +13817,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L98",
       "id": "checkoutsession_getcheckouterrormessagefrompayload",
-      "community": 15
+      "community": 16
     },
     {
       "label": "parseCheckoutResponse()",
@@ -13825,7 +13825,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L115",
       "id": "checkoutsession_parsecheckoutresponse",
-      "community": 15
+      "community": 16
     },
     {
       "label": "defaultCheckoutActionMessage()",
@@ -13833,7 +13833,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L135",
       "id": "checkoutsession_defaultcheckoutactionmessage",
-      "community": 15
+      "community": 16
     },
     {
       "label": "getCheckoutActionErrorMessage()",
@@ -13841,7 +13841,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L147",
       "id": "checkoutsession_getcheckoutactionerrormessage",
-      "community": 15
+      "community": 16
     },
     {
       "label": "createCheckoutSession()",
@@ -13849,7 +13849,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L184",
       "id": "checkoutsession_createcheckoutsession",
-      "community": 15
+      "community": 16
     },
     {
       "label": "getActiveCheckoutSession()",
@@ -13857,7 +13857,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L204",
       "id": "checkoutsession_getactivecheckoutsession",
-      "community": 15
+      "community": 16
     },
     {
       "label": "getPendingCheckoutSessions()",
@@ -13865,7 +13865,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L215",
       "id": "checkoutsession_getpendingcheckoutsessions",
-      "community": 15
+      "community": 16
     },
     {
       "label": "getCheckoutSession()",
@@ -13873,7 +13873,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L226",
       "id": "checkoutsession_getcheckoutsession",
-      "community": 15
+      "community": 16
     },
     {
       "label": "updateCheckoutSession()",
@@ -13881,7 +13881,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L239",
       "id": "checkoutsession_updatecheckoutsession",
-      "community": 15
+      "community": 16
     },
     {
       "label": "verifyCheckoutSessionPayment()",
@@ -13889,7 +13889,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L274",
       "id": "checkoutsession_verifycheckoutsessionpayment",
-      "community": 15
+      "community": 16
     },
     {
       "label": "color.ts",
@@ -14097,7 +14097,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_promocodes_ts",
-      "community": 77
+      "community": 78
     },
     {
       "label": "getBaseUrl()",
@@ -14105,7 +14105,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L4",
       "id": "promocodes_getbaseurl",
-      "community": 77
+      "community": 78
     },
     {
       "label": "redeemPromoCode()",
@@ -14113,7 +14113,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L6",
       "id": "promocodes_redeempromocode",
-      "community": 77
+      "community": 78
     },
     {
       "label": "getPromoCodes()",
@@ -14121,7 +14121,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L34",
       "id": "promocodes_getpromocodes",
-      "community": 77
+      "community": 78
     },
     {
       "label": "getPromoCodeItems()",
@@ -14129,7 +14129,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L49",
       "id": "promocodes_getpromocodeitems",
-      "community": 77
+      "community": 78
     },
     {
       "label": "getRedeemedPromoCodes()",
@@ -14137,7 +14137,7 @@
       "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L74",
       "id": "promocodes_getredeemedpromocodes",
-      "community": 77
+      "community": 78
     },
     {
       "label": "reviews.ts",
@@ -14249,7 +14249,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_rewards_ts",
-      "community": 33
+      "community": 34
     },
     {
       "label": "getBaseUrl()",
@@ -14257,7 +14257,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L3",
       "id": "rewards_getbaseurl",
-      "community": 33
+      "community": 34
     },
     {
       "label": "getUserPoints()",
@@ -14265,7 +14265,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L54",
       "id": "rewards_getuserpoints",
-      "community": 33
+      "community": 34
     },
     {
       "label": "getPointHistory()",
@@ -14273,7 +14273,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L71",
       "id": "rewards_getpointhistory",
-      "community": 33
+      "community": 34
     },
     {
       "label": "getRewardTiers()",
@@ -14281,7 +14281,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L90",
       "id": "rewards_getrewardtiers",
-      "community": 33
+      "community": 34
     },
     {
       "label": "redeemRewardPoints()",
@@ -14289,7 +14289,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L107",
       "id": "rewards_redeemrewardpoints",
-      "community": 33
+      "community": 34
     },
     {
       "label": "getEligiblePastOrders()",
@@ -14297,7 +14297,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L129",
       "id": "rewards_geteligiblepastorders",
-      "community": 33
+      "community": 34
     },
     {
       "label": "awardPointsForPastOrder()",
@@ -14305,7 +14305,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L151",
       "id": "rewards_awardpointsforpastorder",
-      "community": 33
+      "community": 34
     },
     {
       "label": "getOrderRewardPoints()",
@@ -14313,7 +14313,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L175",
       "id": "rewards_getorderrewardpoints",
-      "community": 33
+      "community": 34
     },
     {
       "label": "awardPointsForGuestOrders()",
@@ -14321,7 +14321,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L198",
       "id": "rewards_awardpointsforguestorders",
-      "community": 33
+      "community": 34
     },
     {
       "label": "savedBag.ts",
@@ -14329,7 +14329,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_savedbag_ts",
-      "community": 54
+      "community": 53
     },
     {
       "label": "getBaseUrl()",
@@ -14337,7 +14337,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L8",
       "id": "savedbag_getbaseurl",
-      "community": 54
+      "community": 53
     },
     {
       "label": "getActiveSavedBag()",
@@ -14345,7 +14345,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L10",
       "id": "savedbag_getactivesavedbag",
-      "community": 54
+      "community": 53
     },
     {
       "label": "addItemToSavedBag()",
@@ -14353,7 +14353,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L25",
       "id": "savedbag_additemtosavedbag",
-      "community": 54
+      "community": 53
     },
     {
       "label": "updateSavedBagItem()",
@@ -14361,7 +14361,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L61",
       "id": "savedbag_updatesavedbagitem",
-      "community": 54
+      "community": 53
     },
     {
       "label": "removeItemFromSavedBag()",
@@ -14369,7 +14369,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L91",
       "id": "savedbag_removeitemfromsavedbag",
-      "community": 54
+      "community": 53
     },
     {
       "label": "updateSavedBagOwner()",
@@ -14377,7 +14377,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L109",
       "id": "savedbag_updatesavedbagowner",
-      "community": 54
+      "community": 53
     },
     {
       "label": "storeFrontUser.ts",
@@ -14769,7 +14769,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
-      "community": 78
+      "community": 79
     },
     {
       "label": "EnteredBillingAddressDetails()",
@@ -14777,7 +14777,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L102",
       "id": "billingdetails_enteredbillingaddressdetails",
-      "community": 78
+      "community": 79
     },
     {
       "label": "onSubmit()",
@@ -14785,7 +14785,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L150",
       "id": "billingdetails_onsubmit",
-      "community": 78
+      "community": 79
     },
     {
       "label": "toggleSameAsDelivery()",
@@ -14793,7 +14793,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L155",
       "id": "billingdetails_togglesameasdelivery",
-      "community": 78
+      "community": 79
     },
     {
       "label": "clearForm()",
@@ -14801,7 +14801,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L173",
       "id": "billingdetails_clearform",
-      "community": 78
+      "community": 79
     },
     {
       "label": "handleUseBillingAddressOnFile()",
@@ -14809,7 +14809,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L201",
       "id": "billingdetails_handleusebillingaddressonfile",
-      "community": 78
+      "community": 79
     },
     {
       "label": "BillingDetailsSection.tsx",
@@ -15273,7 +15273,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
-      "community": 34
+      "community": 31
     },
     {
       "label": "getPotentialPoints()",
@@ -15281,7 +15281,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L107",
       "id": "utils_getpotentialpoints",
-      "community": 34
+      "community": 31
     },
     {
       "label": "FadeIn.tsx",
@@ -16233,7 +16233,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_tsx",
-      "community": 55
+      "community": 54
     },
     {
       "label": "PendingItem()",
@@ -16241,7 +16241,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L62",
       "id": "shoppingbag_pendingitem",
-      "community": 55
+      "community": 54
     },
     {
       "label": "handleOnCheckoutClick()",
@@ -16249,7 +16249,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L476",
       "id": "shoppingbag_handleoncheckoutclick",
-      "community": 55
+      "community": 54
     },
     {
       "label": "handleClickOnDiscountCode()",
@@ -16257,7 +16257,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L525",
       "id": "shoppingbag_handleclickondiscountcode",
-      "community": 55
+      "community": 54
     },
     {
       "label": "isSkuUnavailable()",
@@ -16265,7 +16265,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L537",
       "id": "shoppingbag_isskuunavailable",
-      "community": 55
+      "community": 54
     },
     {
       "label": "handleMoveToSaved()",
@@ -16273,7 +16273,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L552",
       "id": "shoppingbag_handlemovetosaved",
-      "community": 55
+      "community": 54
     },
     {
       "label": "handleDeleteItem()",
@@ -16281,7 +16281,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L566",
       "id": "shoppingbag_handledeleteitem",
-      "community": 55
+      "community": 54
     },
     {
       "label": "CheckoutUnavailable.tsx",
@@ -16305,7 +16305,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
-      "community": 79
+      "community": 80
     },
     {
       "label": "CheckoutExpired()",
@@ -16313,7 +16313,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L9",
       "id": "checkoutexpired_checkoutexpired",
-      "community": 79
+      "community": 80
     },
     {
       "label": "NoCheckoutSession()",
@@ -16321,7 +16321,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L33",
       "id": "checkoutexpired_nocheckoutsession",
-      "community": 79
+      "community": 80
     },
     {
       "label": "CheckoutSessionNotFound()",
@@ -16329,7 +16329,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L54",
       "id": "checkoutexpired_checkoutsessionnotfound",
-      "community": 79
+      "community": 80
     },
     {
       "label": "CheckoutSessionGeneric()",
@@ -16337,7 +16337,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L73",
       "id": "checkoutexpired_checkoutsessiongeneric",
-      "community": 79
+      "community": 80
     },
     {
       "label": "handleSendEmail()",
@@ -16345,7 +16345,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L98",
       "id": "checkoutexpired_handlesendemail",
-      "community": 79
+      "community": 80
     },
     {
       "label": "empty-state.tsx",
@@ -16625,7 +16625,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "community": 80
+      "community": 69
     },
     {
       "label": "image-with-fallback.tsx",
@@ -17721,7 +17721,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "community": 53
+      "community": 55
     },
     {
       "label": "isSoldOut()",
@@ -17729,7 +17729,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L45",
       "id": "productutils_issoldout",
-      "community": 53
+      "community": 55
     },
     {
       "label": "hasLowStock()",
@@ -17737,7 +17737,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L52",
       "id": "productutils_haslowstock",
-      "community": 53
+      "community": 55
     },
     {
       "label": "sortSkusByLength()",
@@ -17745,7 +17745,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L62",
       "id": "productutils_sortskusbylength",
-      "community": 53
+      "community": 55
     },
     {
       "label": "bag.ts",
@@ -20879,7 +20879,7 @@
       "label": "write()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.test.ts",
-      "source_location": "L10",
+      "source_location": "L13",
       "id": "harness_inferential_review_test_write",
       "community": 269
     },
@@ -20887,7 +20887,7 @@
       "label": "createFixtureRepo()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.test.ts",
-      "source_location": "L16",
+      "source_location": "L19",
       "id": "harness_inferential_review_test_createfixturerepo",
       "community": 269
     },
@@ -21204,11 +21204,11 @@
       "community": 1
     },
     {
-      "label": "parseCliArgs()",
+      "label": "parseHarnessInferentialReviewArgs()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1312",
-      "id": "harness_inferential_review_parsecliargs",
+      "source_location": "L1313",
+      "id": "harness_inferential_review_parseharnessinferentialreviewargs",
       "community": 1
     },
     {
@@ -21449,7 +21449,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L1",
       "id": "scripts_harness_review_ts",
-      "community": 16
+      "community": 17
     },
     {
       "label": "normalizeRepoPath()",
@@ -21457,7 +21457,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L44",
       "id": "harness_review_normalizerepopath",
-      "community": 16
+      "community": 17
     },
     {
       "label": "matchesPathPrefix()",
@@ -21465,7 +21465,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L48",
       "id": "harness_review_matchespathprefix",
-      "community": 16
+      "community": 17
     },
     {
       "label": "normalizeValidationCommand()",
@@ -21473,7 +21473,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L62",
       "id": "harness_review_normalizevalidationcommand",
-      "community": 16
+      "community": 17
     },
     {
       "label": "normalizeBehaviorScenarioName()",
@@ -21481,7 +21481,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L70",
       "id": "harness_review_normalizebehaviorscenarioname",
-      "community": 16
+      "community": 17
     },
     {
       "label": "fileExists()",
@@ -21489,7 +21489,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L74",
       "id": "harness_review_fileexists",
-      "community": 16
+      "community": 17
     },
     {
       "label": "hasAnyHarnessDocs()",
@@ -21497,7 +21497,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L83",
       "id": "harness_review_hasanyharnessdocs",
-      "community": 16
+      "community": 17
     },
     {
       "label": "readJsonFile()",
@@ -21505,7 +21505,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L103",
       "id": "harness_review_readjsonfile",
-      "community": 16
+      "community": 17
     },
     {
       "label": "loadReviewTarget()",
@@ -21513,7 +21513,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L107",
       "id": "harness_review_loadreviewtarget",
-      "community": 16
+      "community": 17
     },
     {
       "label": "loadReviewTargets()",
@@ -21521,7 +21521,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L244",
       "id": "harness_review_loadreviewtargets",
-      "community": 16
+      "community": 17
     },
     {
       "label": "collectCommandsForChangedFiles()",
@@ -21529,7 +21529,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L277",
       "id": "harness_review_collectcommandsforchangedfiles",
-      "community": 16
+      "community": 17
     },
     {
       "label": "getChangedFilesFromGit()",
@@ -21537,7 +21537,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L362",
       "id": "harness_review_getchangedfilesfromgit",
-      "community": 16
+      "community": 17
     },
     {
       "label": "runPackageScript()",
@@ -21545,7 +21545,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L400",
       "id": "harness_review_runpackagescript",
-      "community": 16
+      "community": 17
     },
     {
       "label": "runRawCommand()",
@@ -21553,7 +21553,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L414",
       "id": "harness_review_runrawcommand",
-      "community": 16
+      "community": 17
     },
     {
       "label": "runHarnessBehaviorScenario()",
@@ -21561,7 +21561,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L427",
       "id": "harness_review_runharnessbehaviorscenario",
-      "community": 16
+      "community": 17
     },
     {
       "label": "runHarnessReview()",
@@ -21569,7 +21569,7 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L441",
       "id": "harness_review_runharnessreview",
-      "community": 16
+      "community": 17
     },
     {
       "label": "harness-runtime-trends.test.ts",
@@ -21583,7 +21583,7 @@
       "label": "buildReportLine()",
       "file_type": "code",
       "source_file": "scripts/harness-runtime-trends.test.ts",
-      "source_location": "L14",
+      "source_location": "L15",
       "id": "harness_runtime_trends_test_buildreportline",
       "community": 570
     },
@@ -21593,127 +21593,135 @@
       "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L1",
       "id": "scripts_harness_runtime_trends_ts",
-      "community": 17
+      "community": 15
     },
     {
       "label": "toHistoryFileStamp()",
       "file_type": "code",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L110",
+      "source_location": "L115",
       "id": "harness_runtime_trends_tohistoryfilestamp",
-      "community": 17
+      "community": 15
     },
     {
       "label": "splitInputLines()",
       "file_type": "code",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L114",
+      "source_location": "L119",
       "id": "harness_runtime_trends_splitinputlines",
-      "community": 17
+      "community": 15
     },
     {
       "label": "sortUnique()",
       "file_type": "code",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L120",
+      "source_location": "L125",
       "id": "harness_runtime_trends_sortunique",
-      "community": 17
+      "community": 15
     },
     {
       "label": "isHarnessBehaviorScenarioReport()",
       "file_type": "code",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L126",
+      "source_location": "L131",
       "id": "harness_runtime_trends_isharnessbehaviorscenarioreport",
-      "community": 17
+      "community": 15
     },
     {
       "label": "parseHarnessBehaviorReportLines()",
       "file_type": "code",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L144",
+      "source_location": "L149",
       "id": "harness_runtime_trends_parseharnessbehaviorreportlines",
-      "community": 17
+      "community": 15
     },
     {
       "label": "percentile()",
       "file_type": "code",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L186",
+      "source_location": "L191",
       "id": "harness_runtime_trends_percentile",
-      "community": 17
+      "community": 15
     },
     {
       "label": "buildNumericTrendStats()",
       "file_type": "code",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L197",
+      "source_location": "L202",
       "id": "harness_runtime_trends_buildnumerictrendstats",
-      "community": 17
+      "community": 15
     },
     {
       "label": "sortCountEntries()",
       "file_type": "code",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L222",
+      "source_location": "L227",
       "id": "harness_runtime_trends_sortcountentries",
-      "community": 17
+      "community": 15
     },
     {
       "label": "formatPercent()",
       "file_type": "code",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L228",
+      "source_location": "L233",
       "id": "harness_runtime_trends_formatpercent",
-      "community": 17
+      "community": 15
     },
     {
       "label": "formatMs()",
       "file_type": "code",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L232",
+      "source_location": "L237",
       "id": "harness_runtime_trends_formatms",
-      "community": 17
+      "community": 15
     },
     {
       "label": "buildScenarioTrend()",
       "file_type": "code",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L236",
+      "source_location": "L241",
       "id": "harness_runtime_trends_buildscenariotrend",
-      "community": 17
+      "community": 15
     },
     {
       "label": "buildRegressionWarnings()",
       "file_type": "code",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L332",
+      "source_location": "L337",
       "id": "harness_runtime_trends_buildregressionwarnings",
-      "community": 17
+      "community": 15
     },
     {
       "label": "buildRuntimeTrendOutput()",
       "file_type": "code",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L404",
+      "source_location": "L409",
       "id": "harness_runtime_trends_buildruntimetrendoutput",
-      "community": 17
+      "community": 15
     },
     {
       "label": "collectHarnessRuntimeTrends()",
       "file_type": "code",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L468",
+      "source_location": "L473",
       "id": "harness_runtime_trends_collectharnessruntimetrends",
-      "community": 17
+      "community": 15
     },
     {
       "label": "runHarnessRuntimeTrends()",
       "file_type": "code",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L476",
+      "source_location": "L481",
       "id": "harness_runtime_trends_runharnessruntimetrends",
-      "community": 17
+      "community": 15
+    },
+    {
+      "label": "parseHarnessRuntimeTrendsArgs()",
+      "file_type": "code",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L509",
+      "id": "harness_runtime_trends_parseharnessruntimetrendsargs",
+      "community": 15
     },
     {
       "label": "harness-scorecard.test.ts",
@@ -46677,7 +46685,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.test.ts",
-      "source_location": "L10",
+      "source_location": "L13",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_test_ts",
       "_tgt": "harness_inferential_review_test_write",
@@ -46689,7 +46697,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.test.ts",
-      "source_location": "L16",
+      "source_location": "L19",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_test_ts",
       "_tgt": "harness_inferential_review_test_createfixturerepo",
@@ -46701,7 +46709,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.test.ts",
-      "source_location": "L22",
+      "source_location": "L25",
       "weight": 1.0,
       "_src": "harness_inferential_review_test_createfixturerepo",
       "_tgt": "harness_inferential_review_test_write",
@@ -47169,12 +47177,12 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1312",
+      "source_location": "L1313",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
-      "_tgt": "harness_inferential_review_parsecliargs",
+      "_tgt": "harness_inferential_review_parseharnessinferentialreviewargs",
       "source": "scripts_harness_inferential_review_ts",
-      "target": "harness_inferential_review_parsecliargs",
+      "target": "harness_inferential_review_parseharnessinferentialreviewargs",
       "confidence_score": 1.0
     },
     {
@@ -48573,7 +48581,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.test.ts",
-      "source_location": "L14",
+      "source_location": "L15",
       "weight": 1.0,
       "_src": "scripts_harness_runtime_trends_test_ts",
       "_tgt": "harness_runtime_trends_test_buildreportline",
@@ -48585,7 +48593,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L110",
+      "source_location": "L115",
       "weight": 1.0,
       "_src": "scripts_harness_runtime_trends_ts",
       "_tgt": "harness_runtime_trends_tohistoryfilestamp",
@@ -48597,7 +48605,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L114",
+      "source_location": "L119",
       "weight": 1.0,
       "_src": "scripts_harness_runtime_trends_ts",
       "_tgt": "harness_runtime_trends_splitinputlines",
@@ -48609,7 +48617,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L120",
+      "source_location": "L125",
       "weight": 1.0,
       "_src": "scripts_harness_runtime_trends_ts",
       "_tgt": "harness_runtime_trends_sortunique",
@@ -48621,7 +48629,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L126",
+      "source_location": "L131",
       "weight": 1.0,
       "_src": "scripts_harness_runtime_trends_ts",
       "_tgt": "harness_runtime_trends_isharnessbehaviorscenarioreport",
@@ -48633,7 +48641,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L144",
+      "source_location": "L149",
       "weight": 1.0,
       "_src": "scripts_harness_runtime_trends_ts",
       "_tgt": "harness_runtime_trends_parseharnessbehaviorreportlines",
@@ -48645,7 +48653,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L186",
+      "source_location": "L191",
       "weight": 1.0,
       "_src": "scripts_harness_runtime_trends_ts",
       "_tgt": "harness_runtime_trends_percentile",
@@ -48657,7 +48665,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L197",
+      "source_location": "L202",
       "weight": 1.0,
       "_src": "scripts_harness_runtime_trends_ts",
       "_tgt": "harness_runtime_trends_buildnumerictrendstats",
@@ -48669,7 +48677,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L222",
+      "source_location": "L227",
       "weight": 1.0,
       "_src": "scripts_harness_runtime_trends_ts",
       "_tgt": "harness_runtime_trends_sortcountentries",
@@ -48681,7 +48689,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L228",
+      "source_location": "L233",
       "weight": 1.0,
       "_src": "scripts_harness_runtime_trends_ts",
       "_tgt": "harness_runtime_trends_formatpercent",
@@ -48693,7 +48701,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L232",
+      "source_location": "L237",
       "weight": 1.0,
       "_src": "scripts_harness_runtime_trends_ts",
       "_tgt": "harness_runtime_trends_formatms",
@@ -48705,7 +48713,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L236",
+      "source_location": "L241",
       "weight": 1.0,
       "_src": "scripts_harness_runtime_trends_ts",
       "_tgt": "harness_runtime_trends_buildscenariotrend",
@@ -48717,7 +48725,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L332",
+      "source_location": "L337",
       "weight": 1.0,
       "_src": "scripts_harness_runtime_trends_ts",
       "_tgt": "harness_runtime_trends_buildregressionwarnings",
@@ -48729,7 +48737,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L404",
+      "source_location": "L409",
       "weight": 1.0,
       "_src": "scripts_harness_runtime_trends_ts",
       "_tgt": "harness_runtime_trends_buildruntimetrendoutput",
@@ -48741,7 +48749,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L468",
+      "source_location": "L473",
       "weight": 1.0,
       "_src": "scripts_harness_runtime_trends_ts",
       "_tgt": "harness_runtime_trends_collectharnessruntimetrends",
@@ -48753,7 +48761,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L476",
+      "source_location": "L481",
       "weight": 1.0,
       "_src": "scripts_harness_runtime_trends_ts",
       "_tgt": "harness_runtime_trends_runharnessruntimetrends",
@@ -48762,10 +48770,22 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-runtime-trends.ts",
+      "source_location": "L509",
+      "weight": 1.0,
+      "_src": "scripts_harness_runtime_trends_ts",
+      "_tgt": "harness_runtime_trends_parseharnessruntimetrendsargs",
+      "source": "scripts_harness_runtime_trends_ts",
+      "target": "harness_runtime_trends_parseharnessruntimetrendsargs",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L492",
+      "source_location": "L497",
       "weight": 1.0,
       "_src": "harness_runtime_trends_runharnessruntimetrends",
       "_tgt": "harness_runtime_trends_tohistoryfilestamp",
@@ -48777,7 +48797,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L145",
+      "source_location": "L150",
       "weight": 1.0,
       "_src": "harness_runtime_trends_parseharnessbehaviorreportlines",
       "_tgt": "harness_runtime_trends_splitinputlines",
@@ -48789,7 +48809,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L245",
+      "source_location": "L250",
       "weight": 1.0,
       "_src": "harness_runtime_trends_buildscenariotrend",
       "_tgt": "harness_runtime_trends_sortunique",
@@ -48801,7 +48821,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L423",
+      "source_location": "L428",
       "weight": 1.0,
       "_src": "harness_runtime_trends_buildruntimetrendoutput",
       "_tgt": "harness_runtime_trends_sortunique",
@@ -48813,7 +48833,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L472",
+      "source_location": "L477",
       "weight": 1.0,
       "_src": "harness_runtime_trends_collectharnessruntimetrends",
       "_tgt": "harness_runtime_trends_parseharnessbehaviorreportlines",
@@ -48825,7 +48845,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L217",
+      "source_location": "L222",
       "weight": 1.0,
       "_src": "harness_runtime_trends_buildnumerictrendstats",
       "_tgt": "harness_runtime_trends_percentile",
@@ -48837,7 +48857,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L241",
+      "source_location": "L246",
       "weight": 1.0,
       "_src": "harness_runtime_trends_buildscenariotrend",
       "_tgt": "harness_runtime_trends_buildnumerictrendstats",
@@ -48849,7 +48869,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L321",
+      "source_location": "L326",
       "weight": 1.0,
       "_src": "harness_runtime_trends_buildscenariotrend",
       "_tgt": "harness_runtime_trends_sortcountentries",
@@ -48861,7 +48881,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L348",
+      "source_location": "L353",
       "weight": 1.0,
       "_src": "harness_runtime_trends_buildregressionwarnings",
       "_tgt": "harness_runtime_trends_formatpercent",
@@ -48873,7 +48893,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L367",
+      "source_location": "L372",
       "weight": 1.0,
       "_src": "harness_runtime_trends_buildregressionwarnings",
       "_tgt": "harness_runtime_trends_formatms",
@@ -48885,7 +48905,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L473",
+      "source_location": "L478",
       "weight": 1.0,
       "_src": "harness_runtime_trends_collectharnessruntimetrends",
       "_tgt": "harness_runtime_trends_buildruntimetrendoutput",
@@ -48897,7 +48917,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-runtime-trends.ts",
-      "source_location": "L481",
+      "source_location": "L486",
       "weight": 1.0,
       "_src": "harness_runtime_trends_runharnessruntimetrends",
       "_tgt": "harness_runtime_trends_collectharnessruntimetrends",

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1198
-- Graph nodes: 2787
-- Graph edges: 2333
+- Graph nodes: 2788
+- Graph edges: 2334
 - Communities: 1113
 
 ## Graph Hotspots

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,19 +8,19 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1198
-- Graph nodes: 2779
-- Graph edges: 2313
+- Graph nodes: 2787
+- Graph edges: 2333
 - Communities: 1113
 
 ## Graph Hotspots
 - `storefrontJourneyEvents.ts` (45 edges, Community 0) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 0) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `harness-inferential-review.ts` (37 edges, Community 1) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
+- `harness-inferential-review.ts` (39 edges, Community 1) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
 - `harness-check.ts` (32 edges, Community 2) - [`scripts/harness-check.ts`](../../scripts/harness-check.ts)
 - `harness-generate.ts` (30 edges, Community 3) - [`scripts/harness-generate.ts`](../../scripts/harness-generate.ts)
 - `storeConfigV2.ts` (27 edges, Community 4) - [`packages/athena-webapp/convex/inventory/storeConfigV2.ts`](../../packages/athena-webapp/convex/inventory/storeConfigV2.ts)
+- `harness-scorecard.ts` (25 edges, Community 6) - [`scripts/harness-scorecard.ts`](../../scripts/harness-scorecard.ts)
 - `harness-behavior.ts` (24 edges, Community 5) - [`scripts/harness-behavior.ts`](../../scripts/harness-behavior.ts)
-- `harness-self-review.ts` (24 edges, Community 6) - [`scripts/harness-self-review.ts`](../../scripts/harness-self-review.ts)
 
 ## Registered Packages
 - [Athena Webapp](packages/athena-webapp.md)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -21,7 +21,7 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 - `ProductStock.tsx` (19 edges, Community 9) - [`packages/athena-webapp/src/components/add-product/ProductStock.tsx`](../../../packages/athena-webapp/src/components/add-product/ProductStock.tsx)
 - `checkoutSession.ts` (17 edges, Community 11) - [`packages/athena-webapp/convex/storeFront/checkoutSession.ts`](../../../packages/athena-webapp/convex/storeFront/checkoutSession.ts)
 - `DataTableViewOptions()` (16 edges, Community 13) - [`packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx`](../../../packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx)
-- `storeConfig.ts` (16 edges, Community 7) - [`packages/athena-webapp/src/lib/storeConfig.ts`](../../../packages/athena-webapp/src/lib/storeConfig.ts)
+- `storeConfig.ts` (16 edges, Community 8) - [`packages/athena-webapp/src/lib/storeConfig.ts`](../../../packages/athena-webapp/src/lib/storeConfig.ts)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -20,7 +20,7 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 - `storefrontJourneyEvents.ts` (45 edges, Community 0) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 0) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `getStoreConfigV2()` (17 edges, Community 8) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
-- `checkoutSession.ts` (14 edges, Community 15) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
+- `checkoutSession.ts` (14 edges, Community 16) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
 - `storeConfig.ts` (14 edges, Community 8) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 
 ## Navigation

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -19,9 +19,9 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 ## Graph Hotspots
 - `storefrontJourneyEvents.ts` (45 edges, Community 0) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 0) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `getStoreConfigV2()` (17 edges, Community 7) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+- `getStoreConfigV2()` (17 edges, Community 8) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 - `checkoutSession.ts` (14 edges, Community 15) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
-- `storeConfig.ts` (14 edges, Community 7) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+- `storeConfig.ts` (14 edges, Community 8) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/scripts/harness-inferential-review.test.ts
+++ b/scripts/harness-inferential-review.test.ts
@@ -333,4 +333,40 @@ describe("runHarnessInferentialReview", () => {
       status: "fail",
     });
   });
+
+  it("writes a timestamped inferential history snapshot when persistence is enabled", async () => {
+    const rootDir = await createFixtureRepo();
+
+    await runHarnessInferentialReview(rootDir, {
+      getChangedFiles: async () => ["package.json"],
+      semanticMode: "shadow",
+      persistHistory: true,
+      runSemanticAnalysis: async () => ({
+        providerName: "semantic-shadow-stub",
+        findings: [],
+      }),
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    const historySnapshot = JSON.parse(
+      await readFile(
+        path.join(
+          rootDir,
+          "artifacts/harness-inferential-review/history/2026-04-12T05-00-00-000Z.json"
+        ),
+        "utf8"
+      )
+    ) as {
+      status: string;
+      reviewMode?: string;
+      shadow?: { providerName: string; status: string };
+    };
+
+    expect(historySnapshot.status).toBe("pass");
+    expect(historySnapshot.reviewMode).toBe("semantic-shadow");
+    expect(historySnapshot.shadow).toMatchObject({
+      providerName: "semantic-shadow-stub",
+      status: "pass",
+    });
+  });
 });

--- a/scripts/harness-inferential-review.test.ts
+++ b/scripts/harness-inferential-review.test.ts
@@ -3,7 +3,10 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { runHarnessInferentialReview } from "./harness-inferential-review";
+import {
+  parseHarnessInferentialReviewArgs,
+  runHarnessInferentialReview,
+} from "./harness-inferential-review";
 
 const tempRoots: string[] = [];
 
@@ -367,6 +370,18 @@ describe("runHarnessInferentialReview", () => {
     expect(historySnapshot.shadow).toMatchObject({
       providerName: "semantic-shadow-stub",
       status: "pass",
+    });
+  });
+});
+
+describe("parseHarnessInferentialReviewArgs", () => {
+  it("accepts --persist-history", () => {
+    expect(
+      parseHarnessInferentialReviewArgs(["--base", "origin/main", "--persist-history"])
+    ).toMatchObject({
+      baseRef: "origin/main",
+      persistHistory: true,
+      help: false,
     });
   });
 });

--- a/scripts/harness-inferential-review.ts
+++ b/scripts/harness-inferential-review.ts
@@ -89,6 +89,7 @@ type InferentialReviewOptions = {
     input: InferentialProviderInput
   ) => Promise<InferentialProviderResult>;
   semanticMode?: InferentialShadowMode;
+  persistHistory?: boolean;
   runSemanticAnalysis?: (
     input: InferentialProviderInput
   ) => Promise<InferentialSemanticAnalysisResult>;
@@ -936,6 +937,26 @@ async function writeMachineOutput(
   await writeFile(`${absoluteOutputPath}`, `${JSON.stringify(output, null, 2)}\n`);
 }
 
+function toHistoryFileStamp(generatedAt: string) {
+  return generatedAt.replaceAll(":", "-").replaceAll(".", "-");
+}
+
+async function writeHistorySnapshot(
+  rootDir: string,
+  machineOutputPath: string,
+  output: InferentialMachineOutput
+) {
+  const absoluteHistoryPath = path.join(
+    rootDir,
+    path.dirname(machineOutputPath),
+    "history",
+    `${toHistoryFileStamp(output.generatedAt)}.json`
+  );
+
+  await mkdir(path.dirname(absoluteHistoryPath), { recursive: true });
+  await writeFile(absoluteHistoryPath, `${JSON.stringify(output, null, 2)}\n`);
+}
+
 function createOutput(params: {
   status: InferentialStatus;
   summary: string;
@@ -1238,6 +1259,30 @@ export async function runHarnessInferentialReview(
       machine,
       machineOutputPath,
     };
+  }
+
+  if (options.persistHistory) {
+    try {
+      await writeHistorySnapshot(rootDir, machineOutputPath, machine);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      machine = createRuntimeFailure(
+        `Unable to write inferential history snapshot: ${message}`,
+        baseRef,
+        changedFiles,
+        targetFiles,
+        nowIso(),
+        reviewMode
+      );
+      const runtimeReport = buildHumanReport(machine);
+      await writeMachineOutput(rootDir, machineOutputPath, machine);
+      return {
+        exitCode: 1,
+        humanReport: runtimeReport,
+        machine,
+        machineOutputPath,
+      };
+    }
   }
 
   if (machine.status === "fail" || machine.status === "error") {

--- a/scripts/harness-inferential-review.ts
+++ b/scripts/harness-inferential-review.ts
@@ -1306,11 +1306,13 @@ export async function runHarnessInferentialReview(
 
 type ParsedCliArgs = {
   baseRef: string;
+  persistHistory: boolean;
   help: boolean;
 };
 
-function parseCliArgs(argv: string[]): ParsedCliArgs {
+export function parseHarnessInferentialReviewArgs(argv: string[]): ParsedCliArgs {
   let baseRef = DEFAULT_BASE_REF;
+  let persistHistory = false;
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -1322,8 +1324,14 @@ function parseCliArgs(argv: string[]): ParsedCliArgs {
     if (arg === "--help" || arg === "-h") {
       return {
         baseRef,
+        persistHistory,
         help: true,
       };
+    }
+
+    if (arg === "--persist-history") {
+      persistHistory = true;
+      continue;
     }
 
     if (arg === "--base") {
@@ -1356,22 +1364,24 @@ function parseCliArgs(argv: string[]): ParsedCliArgs {
 
   return {
     baseRef,
+    persistHistory,
     help: false,
   };
 }
 
 if (import.meta.main) {
   try {
-    const parsed = parseCliArgs(Bun.argv.slice(2));
+    const parsed = parseHarnessInferentialReviewArgs(Bun.argv.slice(2));
     if (parsed.help) {
       console.log(
-        "Usage: bun run harness:inferential-review [--base <ref>]"
+        "Usage: bun run harness:inferential-review [--base <ref>] [--persist-history]"
       );
       process.exit(0);
     }
 
     const result = await runHarnessInferentialReview(process.cwd(), {
       baseRef: parsed.baseRef,
+      persistHistory: parsed.persistHistory,
     });
     console.log(result.humanReport);
     console.log(`Machine output: ${result.machineOutputPath}`);

--- a/scripts/harness-runtime-trends.test.ts
+++ b/scripts/harness-runtime-trends.test.ts
@@ -1,10 +1,27 @@
-import { describe, expect, it } from "vitest";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
 
-import { collectHarnessRuntimeTrends, parseHarnessBehaviorReportLines } from "./harness-runtime-trends";
+import {
+  collectHarnessRuntimeTrends,
+  parseHarnessBehaviorReportLines,
+  runHarnessRuntimeTrends,
+} from "./harness-runtime-trends";
+
+const tempRoots: string[] = [];
 
 function buildReportLine(report: Record<string, unknown>) {
   return `[harness:behavior:report] ${JSON.stringify(report)}`;
 }
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((rootDir) =>
+      rm(rootDir, { recursive: true, force: true })
+    )
+  );
+});
 
 describe("parseHarnessBehaviorReportLines", () => {
   it("extracts reports and keeps malformed report lines as parse errors", () => {
@@ -247,5 +264,51 @@ describe("collectHarnessRuntimeTrends", () => {
           'Scenario "sample-runtime-smoke" average total duration 2500ms exceeds the warning threshold 1500ms.',
       },
     ]);
+  });
+
+  it("writes latest and timestamped runtime-trend history snapshots when persistence is enabled", async () => {
+    const rootDir = await mkdtemp(
+      path.join(tmpdir(), "athena-harness-runtime-trends-")
+    );
+    tempRoots.push(rootDir);
+
+    const result = await runHarnessRuntimeTrends(
+      rootDir,
+      [
+        buildReportLine({
+          scenarioName: "sample-runtime-smoke",
+          status: "passed",
+          totalDurationMs: 1000,
+          phaseDurations: [{ phase: "boot", durationMs: 100 }],
+          runtimeSignals: [],
+          diagnostics: [],
+        }),
+      ],
+      {
+        nowIso: () => "2026-04-12T05:00:00.000Z",
+        persistHistory: true,
+      }
+    );
+
+    expect(result.outputPath).toBe("artifacts/harness-behavior/trends/latest.json");
+
+    const latest = JSON.parse(
+      await readFile(
+        path.join(rootDir, "artifacts/harness-behavior/trends/latest.json"),
+        "utf8"
+      )
+    ) as { summary: { reportCount: number } };
+    const historySnapshot = JSON.parse(
+      await readFile(
+        path.join(
+          rootDir,
+          "artifacts/harness-behavior/trends/history/2026-04-12T05-00-00-000Z.json"
+        ),
+        "utf8"
+      )
+    ) as { summary: { reportCount: number } };
+
+    expect(latest.summary.reportCount).toBe(1);
+    expect(historySnapshot.summary.reportCount).toBe(1);
   });
 });

--- a/scripts/harness-runtime-trends.test.ts
+++ b/scripts/harness-runtime-trends.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import {
   collectHarnessRuntimeTrends,
+  parseHarnessRuntimeTrendsArgs,
   parseHarnessBehaviorReportLines,
   runHarnessRuntimeTrends,
 } from "./harness-runtime-trends";
@@ -310,5 +311,14 @@ describe("collectHarnessRuntimeTrends", () => {
 
     expect(latest.summary.reportCount).toBe(1);
     expect(historySnapshot.summary.reportCount).toBe(1);
+  });
+});
+
+describe("parseHarnessRuntimeTrendsArgs", () => {
+  it("accepts --persist-history", () => {
+    expect(parseHarnessRuntimeTrendsArgs(["--persist-history"])).toMatchObject({
+      persistHistory: true,
+      help: false,
+    });
   });
 });

--- a/scripts/harness-runtime-trends.ts
+++ b/scripts/harness-runtime-trends.ts
@@ -107,6 +107,11 @@ type HarnessRuntimeTrendRunResult = {
   outputPath: string;
 };
 
+type ParsedHarnessRuntimeTrendsArgs = {
+  persistHistory: boolean;
+  help: boolean;
+};
+
 function toHistoryFileStamp(generatedAt: string) {
   return generatedAt.replaceAll(":", "-").replaceAll(".", "-");
 }
@@ -501,8 +506,49 @@ export async function runHarnessRuntimeTrends(
   };
 }
 
+export function parseHarnessRuntimeTrendsArgs(
+  argv: string[]
+): ParsedHarnessRuntimeTrendsArgs {
+  let persistHistory = false;
+
+  for (const arg of argv) {
+    if (!arg) {
+      continue;
+    }
+
+    if (arg === "--help" || arg === "-h") {
+      return {
+        persistHistory,
+        help: true,
+      };
+    }
+
+    if (arg === "--persist-history") {
+      persistHistory = true;
+      continue;
+    }
+
+    throw new Error(
+      `Unknown argument: ${arg}. Usage: bun run harness:runtime-trends [--persist-history]`
+    );
+  }
+
+  return {
+    persistHistory,
+    help: false,
+  };
+}
+
 if (import.meta.main) {
+  const parsed = parseHarnessRuntimeTrendsArgs(Bun.argv.slice(2));
+  if (parsed.help) {
+    console.log("Usage: bun run harness:runtime-trends [--persist-history]");
+    process.exit(0);
+  }
+
   const input = await new Response(Bun.stdin).text();
-  const result = await runHarnessRuntimeTrends(process.cwd(), input);
+  const result = await runHarnessRuntimeTrends(process.cwd(), input, {
+    persistHistory: parsed.persistHistory,
+  });
   console.log(JSON.stringify(result.output, null, 2));
 }

--- a/scripts/harness-runtime-trends.ts
+++ b/scripts/harness-runtime-trends.ts
@@ -99,12 +99,17 @@ type HarnessRuntimeTrendOptions = {
   nowIso?: () => string;
   thresholds?: HarnessRuntimeTrendThresholds;
   logger?: HarnessRuntimeTrendLogger;
+  persistHistory?: boolean;
 };
 
 type HarnessRuntimeTrendRunResult = {
   output: HarnessRuntimeTrendsOutput;
   outputPath: string;
 };
+
+function toHistoryFileStamp(generatedAt: string) {
+  return generatedAt.replaceAll(":", "-").replaceAll(".", "-");
+}
 
 function splitInputLines(source: string | readonly string[]) {
   return typeof source === "string"
@@ -478,6 +483,18 @@ export async function runHarnessRuntimeTrends(
   const absoluteOutputPath = path.join(rootDir, outputPath);
   await mkdir(path.dirname(absoluteOutputPath), { recursive: true });
   await writeFile(absoluteOutputPath, `${JSON.stringify(output, null, 2)}\n`);
+
+  if (options.persistHistory) {
+    const absoluteHistoryPath = path.join(
+      rootDir,
+      path.dirname(outputPath),
+      "history",
+      `${toHistoryFileStamp(output.generatedAt)}.json`
+    );
+    await mkdir(path.dirname(absoluteHistoryPath), { recursive: true });
+    await writeFile(absoluteHistoryPath, `${JSON.stringify(output, null, 2)}\n`);
+  }
+
   return {
     output,
     outputPath,
@@ -486,6 +503,6 @@ export async function runHarnessRuntimeTrends(
 
 if (import.meta.main) {
   const input = await new Response(Bun.stdin).text();
-  const result = collectHarnessRuntimeTrends(input);
-  console.log(JSON.stringify(result, null, 2));
+  const result = await runHarnessRuntimeTrends(process.cwd(), input);
+  console.log(JSON.stringify(result.output, null, 2));
 }

--- a/scripts/harness-scorecard.test.ts
+++ b/scripts/harness-scorecard.test.ts
@@ -160,6 +160,7 @@ async function createFixtureRepo(includeArtifacts: boolean) {
         {
           version: "1.0",
           generatedAt: "2026-04-12T04:55:00.000Z",
+          reviewMode: "semantic-shadow",
           baseRef: "origin/main",
           status: "skipped",
           summary: "No harness-critical files are in scope. Inferential review skipped.",
@@ -168,6 +169,148 @@ async function createFixtureRepo(includeArtifacts: boolean) {
           targetFiles: [],
           findings: [],
           errors: [],
+          shadow: {
+            generatedAt: "2026-04-12T04:55:00.000Z",
+            status: "skipped",
+            summary:
+              "Shadow semantic review skipped because ANTHROPIC_API_KEY is not configured.",
+            providerName: "semantic-shadow-stub",
+            findings: [],
+            errors: [],
+          },
+        },
+        null,
+        2
+      ),
+      rootDir
+    );
+    await write(
+      "artifacts/harness-inferential-review/history/2026-04-11T05-00-00-000Z.json",
+      JSON.stringify(
+        {
+          version: "1.0",
+          generatedAt: "2026-04-11T05:00:00.000Z",
+          reviewMode: "semantic-shadow",
+          baseRef: "origin/main",
+          status: "pass",
+          summary: "Inferential review completed with no actionable findings.",
+          providerName: "deterministic-policy-v1",
+          changedFiles: ["scripts/harness-scorecard.ts"],
+          targetFiles: ["scripts/harness-scorecard.ts"],
+          findings: [],
+          errors: [],
+          shadow: {
+            generatedAt: "2026-04-11T05:00:00.000Z",
+            status: "pass",
+            summary: "Shadow semantic review found no semantic issues.",
+            providerName: "semantic-shadow-stub",
+            findings: [],
+            errors: [],
+          },
+        },
+        null,
+        2
+      ),
+      rootDir
+    );
+    await write(
+      "artifacts/harness-inferential-review/history/2026-04-12T04-55-00-000Z.json",
+      JSON.stringify(
+        {
+          version: "1.0",
+          generatedAt: "2026-04-12T04:55:00.000Z",
+          reviewMode: "semantic-shadow",
+          baseRef: "origin/main",
+          status: "skipped",
+          summary: "No harness-critical files are in scope. Inferential review skipped.",
+          providerName: "deterministic-policy-v1",
+          changedFiles: ["README.md"],
+          targetFiles: [],
+          findings: [],
+          errors: [],
+          shadow: {
+            generatedAt: "2026-04-12T04:55:00.000Z",
+            status: "skipped",
+            summary:
+              "Shadow semantic review skipped because ANTHROPIC_API_KEY is not configured.",
+            providerName: "semantic-shadow-stub",
+            findings: [],
+            errors: [],
+          },
+        },
+        null,
+        2
+      ),
+      rootDir
+    );
+
+    await write(
+      "artifacts/harness-behavior/trends/latest.json",
+      JSON.stringify(
+        {
+          version: "1.0",
+          generatedAt: "2026-04-12T04:58:00.000Z",
+          parseErrors: [],
+          scenarios: [
+            {
+              scenarioName: "sample-runtime-smoke",
+              reportCount: 1,
+              passCount: 1,
+              failCount: 0,
+              passRate: 1,
+              totalDurationMs: {
+                count: 1,
+                minMs: 1000,
+                maxMs: 1000,
+                averageMs: 1000,
+                p50Ms: 1000,
+                p90Ms: 1000,
+              },
+              phaseDurations: [],
+              runtimeSignals: {
+                totalCount: 0,
+                belowMinCount: 0,
+                aboveMaxCount: 0,
+                withinBoundsCount: 0,
+              },
+              failurePhases: [],
+              diagnostics: [],
+            },
+          ],
+          summary: {
+            reportCount: 1,
+            scenarioCount: 1,
+            passCount: 1,
+            failCount: 0,
+            parseErrorCount: 0,
+            status: "healthy",
+            note: "1 parsed reports across 1 scenarios. 0 parse errors. 0 regression warnings.",
+            regressions: [],
+          },
+        },
+        null,
+        2
+      ),
+      rootDir
+    );
+    await write(
+      "artifacts/harness-behavior/trends/history/2026-04-12T04-58-00-000Z.json",
+      JSON.stringify(
+        {
+          version: "1.0",
+          generatedAt: "2026-04-12T04:58:00.000Z",
+          parseErrors: [],
+          scenarios: [],
+          summary: {
+            reportCount: 1,
+            scenarioCount: 1,
+            passCount: 1,
+            failCount: 0,
+            parseErrorCount: 0,
+            status: "healthy",
+            note: "history sample",
+            regressions: [],
+          },
         },
         null,
         2
@@ -213,6 +356,7 @@ describe("collectHarnessScorecard", () => {
       "registry",
       "documentation",
       "inferential",
+      "runtimeTrends",
       "graphify",
     ]);
     expect(first.metrics.registry.definition).toContain("onboarding states");
@@ -236,7 +380,28 @@ describe("collectHarnessScorecard", () => {
     expect(first.metrics.documentation.healthyAppCount).toBe(3);
     expect(first.metrics.documentation.degradedAppCount).toBe(0);
     expect(first.metrics.inferential.status).toBe("skipped");
+    expect(first.metrics.inferential.reviewMode).toBe("semantic-shadow");
+    expect(first.metrics.inferential.shadow).toMatchObject({
+      status: "skipped",
+      providerName: "semantic-shadow-stub",
+    });
     expect(first.metrics.inferential.findingCount).toBe(0);
+    expect(first.metrics.inferential.history).toMatchObject({
+      present: true,
+      sampleCount: 2,
+      parseErrorCount: 0,
+    });
+    expect(first.metrics.runtimeTrends).toMatchObject({
+      present: true,
+      status: "healthy",
+      reportCount: 1,
+      scenarioCount: 1,
+    });
+    expect(first.metrics.runtimeTrends.history).toMatchObject({
+      present: true,
+      sampleCount: 1,
+      parseErrorCount: 0,
+    });
     expect(first.metrics.graphify.status).toBe("paired");
     expect(first.metrics.graphify.reportPresent).toBe(true);
     expect(first.metrics.graphify.graphPresent).toBe(true);
@@ -250,8 +415,99 @@ describe("collectHarnessScorecard", () => {
     });
 
     expect(result.metrics.inferential.status).toBe("missing");
+    expect(result.metrics.runtimeTrends.status).toBe("missing");
     expect(result.metrics.graphify.status).toBe("missing");
     expect(result.summary.status).toBe("degraded");
     expect(result.summary.missingSignals).toBeGreaterThan(0);
+  });
+
+  it("surfaces malformed history and repeated shadow provider errors without crashing", async () => {
+    const rootDir = await createFixtureRepo(true);
+
+    await write(
+      "artifacts/harness-inferential-review/history/2026-04-12T05-10-00-000Z.json",
+      "not-json\n",
+      rootDir
+    );
+    await write(
+      "artifacts/harness-inferential-review/history/2026-04-12T05-15-00-000Z.json",
+      JSON.stringify(
+        {
+          version: "1.0",
+          generatedAt: "2026-04-12T05:15:00.000Z",
+          reviewMode: "semantic-shadow",
+          baseRef: "origin/main",
+          status: "pass",
+          summary: "Inferential review completed with no actionable findings.",
+          providerName: "deterministic-policy-v1",
+          changedFiles: ["scripts/harness-scorecard.ts"],
+          targetFiles: ["scripts/harness-scorecard.ts"],
+          findings: [],
+          errors: [],
+          shadow: {
+            generatedAt: "2026-04-12T05:15:00.000Z",
+            status: "error",
+            summary:
+              "Shadow semantic review failed, but deterministic inferential review remains authoritative.",
+            providerName: "semantic-shadow-stub",
+            findings: [],
+            errors: [
+              {
+                code: "INFERENTIAL_RUNTIME_FAILURE",
+                message: "provider timeout",
+                remediation: "retry",
+              },
+            ],
+          },
+        },
+        null,
+        2
+      ),
+      rootDir
+    );
+    await write(
+      "artifacts/harness-inferential-review/history/2026-04-12T05-20-00-000Z.json",
+      JSON.stringify(
+        {
+          version: "1.0",
+          generatedAt: "2026-04-12T05:20:00.000Z",
+          reviewMode: "semantic-shadow",
+          baseRef: "origin/main",
+          status: "pass",
+          summary: "Inferential review completed with no actionable findings.",
+          providerName: "deterministic-policy-v1",
+          changedFiles: ["scripts/harness-scorecard.ts"],
+          targetFiles: ["scripts/harness-scorecard.ts"],
+          findings: [],
+          errors: [],
+          shadow: {
+            generatedAt: "2026-04-12T05:20:00.000Z",
+            status: "error",
+            summary:
+              "Shadow semantic review failed, but deterministic inferential review remains authoritative.",
+            providerName: "semantic-shadow-stub",
+            findings: [],
+            errors: [
+              {
+                code: "INFERENTIAL_RUNTIME_FAILURE",
+                message: "provider timeout",
+                remediation: "retry",
+              },
+            ],
+          },
+        },
+        null,
+        2
+      ),
+      rootDir
+    );
+
+    const result = await collectHarnessScorecard(rootDir, {
+      nowIso: () => "2026-04-12T05:30:00.000Z",
+    });
+
+    expect(result.metrics.inferential.history.parseErrorCount).toBe(1);
+    expect(result.metrics.inferential.history.shadowErrorCount).toBeGreaterThanOrEqual(2);
+    expect(result.summary.status).toBe("mixed");
   });
 });

--- a/scripts/harness-scorecard.ts
+++ b/scripts/harness-scorecard.ts
@@ -1,4 +1,4 @@
-import { access, mkdir, readFile, writeFile } from "node:fs/promises";
+import { access, mkdir, readFile, readdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 import {
@@ -30,6 +30,7 @@ type ScorecardLogger = Pick<Console, "log" | "error">;
 
 type ScorecardFileSystem = {
   fileExists: (filePath: string) => Promise<boolean>;
+  listDir: (directoryPath: string) => Promise<string[]>;
   readText: (filePath: string) => Promise<string>;
   readJson: <T>(filePath: string) => Promise<T>;
 };
@@ -37,6 +38,7 @@ type ScorecardFileSystem = {
 type HarnessInferentialArtifact = {
   version?: string;
   generatedAt?: string;
+  reviewMode?: string;
   baseRef?: string;
   status?: ArtifactStatus;
   summary?: string;
@@ -45,6 +47,37 @@ type HarnessInferentialArtifact = {
   targetFiles?: string[];
   findings?: unknown[];
   errors?: unknown[];
+  shadow?: {
+    generatedAt?: string;
+    status?: ArtifactStatus;
+    summary?: string;
+    providerName?: string;
+    findings?: unknown[];
+    errors?: unknown[];
+  };
+};
+
+type HarnessRuntimeTrendsArtifact = {
+  version?: string;
+  generatedAt?: string;
+  scenarios?: Array<{ scenarioName?: string }>;
+  summary?: {
+    reportCount?: number;
+    scenarioCount?: number;
+    status?: ArtifactStatus;
+    regressions?: unknown[];
+  };
+};
+
+type HarnessScorecardHistoryMetric = {
+  directoryPath: string;
+  present: boolean;
+  sampleCount: number;
+  latestGeneratedAt: string | null;
+  parseErrorCount: number;
+  shadowErrorCount?: number;
+  shadowErrorRate?: number | null;
+  degradedSampleCount?: number;
 };
 
 type HarnessScorecardAppDocumentationMetric = {
@@ -94,6 +127,7 @@ type HarnessScorecardOutput = {
       artifactPath: string;
       present: boolean;
       status: ArtifactStatus | "missing";
+      reviewMode: string | null;
       baseRef: string | null;
       generatedAt: string | null;
       summary: string;
@@ -101,6 +135,25 @@ type HarnessScorecardOutput = {
       errorCount: number;
       changedFileCount: number;
       targetFileCount: number;
+      shadow: {
+        present: boolean;
+        status: ArtifactStatus | "missing";
+        providerName: string | null;
+        findingCount: number;
+        errorCount: number;
+      };
+      history: HarnessScorecardHistoryMetric;
+    };
+    runtimeTrends: {
+      definition: string;
+      artifactPath: string;
+      present: boolean;
+      status: ArtifactStatus | "missing";
+      generatedAt: string | null;
+      reportCount: number;
+      scenarioCount: number;
+      regressionCount: number;
+      history: HarnessScorecardHistoryMetric;
     };
     graphify: {
       definition: string;
@@ -160,6 +213,10 @@ async function readJsonFile<T>(filePath: string) {
   return JSON.parse(await readFile(filePath, "utf8")) as T;
 }
 
+async function listDirectory(directoryPath: string) {
+  return readdir(directoryPath);
+}
+
 async function readTextFile(filePath: string) {
   return readFile(filePath, "utf8");
 }
@@ -167,6 +224,7 @@ async function readTextFile(filePath: string) {
 function createFileSystem(overrides?: Partial<ScorecardFileSystem>): ScorecardFileSystem {
   return {
     fileExists: overrides?.fileExists ?? fileExists,
+    listDir: overrides?.listDir ?? listDirectory,
     readText: overrides?.readText ?? readTextFile,
     readJson: overrides?.readJson ?? readJsonFile,
   };
@@ -253,19 +311,26 @@ function buildGraphifyStatus(reportPresent: boolean, graphPresent: boolean) {
 function buildSummary(
   documentation: HarnessScorecardOutput["metrics"]["documentation"],
   inferential: HarnessScorecardOutput["metrics"]["inferential"],
+  runtimeTrends: HarnessScorecardOutput["metrics"]["runtimeTrends"],
   graphify: HarnessScorecardOutput["metrics"]["graphify"]
 ): HarnessScorecardOutput["summary"] {
   const healthySignals =
     documentation.healthyAppCount +
     (inferential.status === "missing" ? 0 : 1) +
+    (runtimeTrends.status === "missing" ? 0 : 1) +
     (graphify.status === "paired" ? 1 : 0);
   const degradedSignals =
     documentation.degradedAppCount +
     (inferential.status === "fail" || inferential.status === "error" ? 1 : 0) +
+    ((inferential.history.shadowErrorCount ?? 0) >= 2 ? 1 : 0) +
+    (inferential.history.parseErrorCount > 0 ? 1 : 0) +
+    (runtimeTrends.status === "mixed" || runtimeTrends.status === "degraded" ? 1 : 0) +
+    (runtimeTrends.history.parseErrorCount > 0 ? 1 : 0) +
     (graphify.status === "partial" ? 1 : 0);
   const missingSignals =
     documentation.missingAppCount +
     (inferential.status === "missing" ? 1 : 0) +
+    (runtimeTrends.status === "missing" ? 1 : 0) +
     (graphify.status === "missing" ? 1 : 0);
 
   let status: ScorecardStatus = "healthy";
@@ -283,6 +348,11 @@ function buildSummary(
     inferential.status === "missing"
       ? "Inferential artifact missing."
       : `Inferential artifact ${inferential.status}.`
+  );
+  noteParts.push(
+    runtimeTrends.status === "missing"
+      ? "Runtime trend artifact missing."
+      : `Runtime trend artifact ${runtimeTrends.status}.`
   );
   noteParts.push(
     graphify.status === "paired"
@@ -408,6 +478,7 @@ async function inspectInferentialArtifact(rootDir: string, fsApi: ScorecardFileS
       artifactPath: "artifacts/harness-inferential-review/latest.json",
       present: false,
       status: "missing" as const,
+      reviewMode: null,
       baseRef: null,
       generatedAt: null,
       summary: "Inferential artifact not found.",
@@ -415,6 +486,22 @@ async function inspectInferentialArtifact(rootDir: string, fsApi: ScorecardFileS
       errorCount: 0,
       changedFileCount: 0,
       targetFileCount: 0,
+      shadow: {
+        present: false,
+        status: "missing" as const,
+        providerName: null,
+        findingCount: 0,
+        errorCount: 0,
+      },
+      history: {
+        directoryPath: "artifacts/harness-inferential-review/history",
+        present: false,
+        sampleCount: 0,
+        latestGeneratedAt: null,
+        parseErrorCount: 0,
+        shadowErrorCount: 0,
+        shadowErrorRate: null,
+      },
     };
   }
 
@@ -423,6 +510,12 @@ async function inspectInferentialArtifact(rootDir: string, fsApi: ScorecardFileS
   const targetFiles = Array.isArray(artifact.targetFiles) ? artifact.targetFiles : [];
   const findings = Array.isArray(artifact.findings) ? artifact.findings : [];
   const errors = Array.isArray(artifact.errors) ? artifact.errors : [];
+  const shadowFindings = Array.isArray(artifact.shadow?.findings)
+    ? artifact.shadow?.findings
+    : [];
+  const shadowErrors = Array.isArray(artifact.shadow?.errors)
+    ? artifact.shadow?.errors
+    : [];
 
   return {
     definition:
@@ -430,6 +523,7 @@ async function inspectInferentialArtifact(rootDir: string, fsApi: ScorecardFileS
     artifactPath: "artifacts/harness-inferential-review/latest.json",
     present: true,
     status: artifact.status ?? "missing",
+    reviewMode: artifact.reviewMode ?? null,
     baseRef: artifact.baseRef ?? null,
     generatedAt: artifact.generatedAt ?? null,
     summary:
@@ -438,6 +532,177 @@ async function inspectInferentialArtifact(rootDir: string, fsApi: ScorecardFileS
     errorCount: errors.length,
     changedFileCount: changedFiles.length,
     targetFileCount: targetFiles.length,
+    shadow: {
+      present: artifact.shadow !== undefined,
+      status: artifact.shadow?.status ?? "missing",
+      providerName: artifact.shadow?.providerName ?? null,
+      findingCount: shadowFindings.length,
+      errorCount: shadowErrors.length,
+    },
+    history: {
+      directoryPath: "artifacts/harness-inferential-review/history",
+      present: false,
+      sampleCount: 0,
+      latestGeneratedAt: null,
+      parseErrorCount: 0,
+      shadowErrorCount: 0,
+      shadowErrorRate: null,
+    },
+  };
+}
+
+function buildEmptyHistoryMetric(directoryPath: string): HarnessScorecardHistoryMetric {
+  return {
+    directoryPath,
+    present: false,
+    sampleCount: 0,
+    latestGeneratedAt: null,
+    parseErrorCount: 0,
+  };
+}
+
+async function inspectInferentialHistory(
+  rootDir: string,
+  fsApi: ScorecardFileSystem
+) {
+  const directoryPath = "artifacts/harness-inferential-review/history";
+  const absoluteDirectoryPath = path.join(rootDir, directoryPath);
+  if (!(await fsApi.fileExists(absoluteDirectoryPath))) {
+    return {
+      ...buildEmptyHistoryMetric(directoryPath),
+      shadowErrorCount: 0,
+      shadowErrorRate: null,
+    };
+  }
+
+  const entries = (await fsApi.listDir(absoluteDirectoryPath))
+    .filter((entry) => entry.endsWith(".json"))
+    .sort((left, right) => left.localeCompare(right));
+
+  let parseErrorCount = 0;
+  let shadowErrorCount = 0;
+  let sampleCount = 0;
+  let latestGeneratedAt: string | null = null;
+
+  for (const entry of entries) {
+    try {
+      const artifact = await fsApi.readJson<HarnessInferentialArtifact>(
+        path.join(absoluteDirectoryPath, entry)
+      );
+      sampleCount += 1;
+      latestGeneratedAt = artifact.generatedAt ?? latestGeneratedAt;
+      const shadowErrors = Array.isArray(artifact.shadow?.errors)
+        ? artifact.shadow?.errors
+        : [];
+      if ((artifact.shadow?.status === "error") || shadowErrors.length > 0) {
+        shadowErrorCount += 1;
+      }
+    } catch {
+      parseErrorCount += 1;
+    }
+  }
+
+  return {
+    directoryPath,
+    present: true,
+    sampleCount,
+    latestGeneratedAt,
+    parseErrorCount,
+    shadowErrorCount,
+    shadowErrorRate: sampleCount > 0 ? shadowErrorCount / sampleCount : null,
+  };
+}
+
+async function inspectRuntimeTrendArtifact(
+  rootDir: string,
+  fsApi: ScorecardFileSystem
+) {
+  const artifactPath = path.join(
+    rootDir,
+    "artifacts/harness-behavior/trends/latest.json"
+  );
+  const present = await fsApi.fileExists(artifactPath);
+  if (!present) {
+    return {
+      definition:
+        "Latest runtime trend artifact state from artifacts/harness-behavior/trends/latest.json.",
+      artifactPath: "artifacts/harness-behavior/trends/latest.json",
+      present: false,
+      status: "missing" as const,
+      generatedAt: null,
+      reportCount: 0,
+      scenarioCount: 0,
+      regressionCount: 0,
+      history: buildEmptyHistoryMetric("artifacts/harness-behavior/trends/history"),
+    };
+  }
+
+  const artifact = await fsApi.readJson<HarnessRuntimeTrendsArtifact>(artifactPath);
+  const regressions = Array.isArray(artifact.summary?.regressions)
+    ? artifact.summary?.regressions
+    : [];
+
+  return {
+    definition:
+      "Latest runtime trend artifact state from artifacts/harness-behavior/trends/latest.json.",
+    artifactPath: "artifacts/harness-behavior/trends/latest.json",
+    present: true,
+    status: artifact.summary?.status ?? "missing",
+    generatedAt: artifact.generatedAt ?? null,
+    reportCount: artifact.summary?.reportCount ?? 0,
+    scenarioCount: artifact.summary?.scenarioCount ?? 0,
+    regressionCount: regressions.length,
+    history: buildEmptyHistoryMetric("artifacts/harness-behavior/trends/history"),
+  };
+}
+
+async function inspectRuntimeTrendHistory(
+  rootDir: string,
+  fsApi: ScorecardFileSystem
+) {
+  const directoryPath = "artifacts/harness-behavior/trends/history";
+  const absoluteDirectoryPath = path.join(rootDir, directoryPath);
+  if (!(await fsApi.fileExists(absoluteDirectoryPath))) {
+    return {
+      ...buildEmptyHistoryMetric(directoryPath),
+      degradedSampleCount: 0,
+    };
+  }
+
+  const entries = (await fsApi.listDir(absoluteDirectoryPath))
+    .filter((entry) => entry.endsWith(".json"))
+    .sort((left, right) => left.localeCompare(right));
+
+  let parseErrorCount = 0;
+  let degradedSampleCount = 0;
+  let sampleCount = 0;
+  let latestGeneratedAt: string | null = null;
+
+  for (const entry of entries) {
+    try {
+      const artifact = await fsApi.readJson<HarnessRuntimeTrendsArtifact>(
+        path.join(absoluteDirectoryPath, entry)
+      );
+      sampleCount += 1;
+      latestGeneratedAt = artifact.generatedAt ?? latestGeneratedAt;
+      if (
+        artifact.summary?.status === "mixed" ||
+        artifact.summary?.status === "degraded"
+      ) {
+        degradedSampleCount += 1;
+      }
+    } catch {
+      parseErrorCount += 1;
+    }
+  }
+
+  return {
+    directoryPath,
+    present: true,
+    sampleCount,
+    latestGeneratedAt,
+    parseErrorCount,
+    degradedSampleCount,
   };
 }
 
@@ -538,9 +803,12 @@ export async function collectHarnessScorecard(
   };
 
   const inferential = await inspectInferentialArtifact(rootDir, fsApi, generatedAt);
+  inferential.history = await inspectInferentialHistory(rootDir, fsApi);
+  const runtimeTrends = await inspectRuntimeTrendArtifact(rootDir, fsApi);
+  runtimeTrends.history = await inspectRuntimeTrendHistory(rootDir, fsApi);
   const graphify = await inspectGraphifyArtifacts(rootDir, fsApi);
 
-  const summary = buildSummary(documentation, inferential, graphify);
+  const summary = buildSummary(documentation, inferential, runtimeTrends, graphify);
 
   return {
     version: "1.0",
@@ -549,6 +817,7 @@ export async function collectHarnessScorecard(
       registry,
       documentation,
       inferential,
+      runtimeTrends,
       graphify,
     },
     summary,


### PR DESCRIPTION
## Summary
- add `--persist-history` CLI support to `harness:inferential-review` and `harness:runtime-trends`, with parser coverage for both entrypoints
- persist timestamped inferential and runtime-trend history snapshots alongside latest artifacts and extend `harness:scorecard` to summarize history health
- keep the graphify navigation artifacts fresh after the harness changes

## Why
- shadow-mode semantic review is only useful if we can accumulate stable telemetry over time instead of inspecting one latest artifact
- the scorecard needs to surface history presence, parse-health, and shadow-provider stability before we wire the shadow lane into CI
- CLI-level persistence makes the new history path usable in CI and local collection, not just through programmatic calls

## Validation
- `bun test scripts/harness-inferential-review.test.ts scripts/harness-runtime-trends.test.ts scripts/harness-scorecard.test.ts`
- `bun run harness:inferential-review --persist-history`
- `printf '[harness:behavior:report] {"scenarioName":"sample-runtime-smoke","status":"passed","totalDurationMs":1200,"phaseDurations":[],"runtimeSignals":[],"diagnostics":[]}' | bun run harness:runtime-trends --persist-history`
- `bun run graphify:rebuild`
- `bun run pr:athena`
- `bun run harness:behavior --scenario sample-runtime-smoke --record-video`
- `git diff --check`

https://linear.app/v26-labs/issue/V26-226/persist-inferential-and-runtime-trend-history-and-extend-the-harness
