### PR TITLE
[V26-228]: enforce base-aware harness review

### DIFF
--- a/.github/workflows/athena-pr-tests.yml
+++ b/.github/workflows/athena-pr-tests.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Run harness self-review
         run: bun run harness:self-review --base origin/main
 
+      - name: Run harness review
+        run: bun run harness:review --base origin/main
+
       - name: Check harness docs
         run: bun run harness:check
 

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 2788 nodes · 2334 edges · 1113 communities detected
+- 2800 nodes · 2358 edges · 1113 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1151,12 +1151,12 @@
 ## Communities
 
 ### Community 0 - "Community 0"
-Cohesion: 0.09
-Nodes (45): compactContext(), createAuthEntryViewedEvent(), createAuthRequestStartedEvent(), createAuthVerificationSucceededEvent(), createAuthVerificationViewedEvent(), createBagAddSucceededEvent(), createBagMoveToSavedEvent(), createBagRemoveSucceededEvent() (+37 more)
+Cohesion: 0.1
+Nodes (45): buildFinding(), buildHumanReport(), buildSemanticPrompt(), buildShadowSummary(), buildShellCommandPattern(), collectHarnessSafetySignalFindings(), collectHarnessScriptTestUpdateFindings(), createOutput() (+37 more)
 
 ### Community 1 - "Community 1"
-Cohesion: 0.12
-Nodes (38): buildFinding(), buildHumanReport(), buildSemanticPrompt(), buildShadowSummary(), collectHarnessSafetySignalFindings(), collectHarnessScriptTestUpdateFindings(), createOutput(), createProviderFailure() (+30 more)
+Cohesion: 0.09
+Nodes (45): compactContext(), createAuthEntryViewedEvent(), createAuthRequestStartedEvent(), createAuthVerificationSucceededEvent(), createAuthVerificationViewedEvent(), createBagAddSucceededEvent(), createBagMoveToSavedEvent(), createBagRemoveSucceededEvent() (+37 more)
 
 ### Community 2 - "Community 2"
 Cohesion: 0.15
@@ -1195,32 +1195,32 @@ Cohesion: 0.15
 Nodes (10): capitalizeFirstLetter(), capitalizeWords(), cn(), currencyFormatter(), formatDate(), getErrorForField(), getProductName(), getRelativeTime() (+2 more)
 
 ### Community 11 - "Community 11"
+Cohesion: 0.17
+Nodes (12): collectCommandsForChangedFiles(), fileExists(), getChangedFilesForHarnessReview(), hasAnyHarnessDocs(), loadReviewTarget(), loadReviewTargets(), matchesPathPrefix(), normalizeBehaviorScenarioName() (+4 more)
+
+### Community 12 - "Community 12"
 Cohesion: 0.16
 Nodes (9): checkIfItemsHaveChanged(), createOnlineOrder(), findBestValuePromoCode(), handleExistingSession(), handleOrderCreation(), handlePlaceOrder(), listSessionItems(), updateExistingSession() (+1 more)
 
-### Community 12 - "Community 12"
+### Community 13 - "Community 13"
 Cohesion: 0.22
 Nodes (16): buildDegreeIndex(), buildHotspotLines(), buildPackagePage(), buildRootIndexPage(), collectRepoCodeFiles(), compareHotspots(), countCommunities(), fileExists() (+8 more)
 
-### Community 13 - "Community 13"
+### Community 14 - "Community 14"
 Cohesion: 0.12
 Nodes (1): DataTableViewOptions()
 
-### Community 14 - "Community 14"
+### Community 15 - "Community 15"
 Cohesion: 0.19
 Nodes (13): compareSnapshots(), fileExists(), formatArtifactList(), formatDetailLines(), formatError(), formatHarnessJanitorReport(), readUtf8OrNull(), runCheckStep() (+5 more)
 
-### Community 15 - "Community 15"
+### Community 16 - "Community 16"
 Cohesion: 0.21
 Nodes (14): buildNumericTrendStats(), buildRegressionWarnings(), buildRuntimeTrendOutput(), buildScenarioTrend(), collectHarnessRuntimeTrends(), formatMs(), formatPercent(), parseHarnessBehaviorReportLines() (+6 more)
 
-### Community 16 - "Community 16"
+### Community 17 - "Community 17"
 Cohesion: 0.21
 Nodes (14): CheckoutSessionError, createCheckoutSession(), defaultCheckoutActionMessage(), getActiveCheckoutSession(), getBaseUrl(), getCheckoutActionErrorMessage(), getCheckoutErrorMessageFromPayload(), getCheckoutSession() (+6 more)
-
-### Community 17 - "Community 17"
-Cohesion: 0.2
-Nodes (9): collectCommandsForChangedFiles(), fileExists(), hasAnyHarnessDocs(), loadReviewTarget(), loadReviewTargets(), matchesPathPrefix(), normalizeBehaviorScenarioName(), normalizeRepoPath() (+1 more)
 
 ### Community 18 - "Community 18"
 Cohesion: 0.13
@@ -1275,20 +1275,20 @@ Cohesion: 0.36
 Nodes (8): collectAllPages(), createTransactionFromSessionHandler(), listCompletedTransactionsForDay(), listProductSkusByProductId(), listSessionItems(), listStoreProducts(), listStoreSkus(), listTransactionItems()
 
 ### Community 31 - "Community 31"
-Cohesion: 0.31
-Nodes (5): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getPotentialPoints()
-
-### Community 32 - "Community 32"
 Cohesion: 0.29
 Nodes (6): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile()
 
-### Community 33 - "Community 33"
+### Community 32 - "Community 32"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 34 - "Community 34"
+### Community 33 - "Community 33"
 Cohesion: 0.38
 Nodes (9): awardPointsForGuestOrders(), awardPointsForPastOrder(), getBaseUrl(), getEligiblePastOrders(), getOrderRewardPoints(), getPointHistory(), getRewardTiers(), getUserPoints() (+1 more)
+
+### Community 34 - "Community 34"
+Cohesion: 0.31
+Nodes (5): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getPotentialPoints()
 
 ### Community 35 - "Community 35"
 Cohesion: 0.28
@@ -1312,11 +1312,11 @@ Nodes (1): Logger
 
 ### Community 40 - "Community 40"
 Cohesion: 0.43
-Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
+Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 41 - "Community 41"
 Cohesion: 0.43
-Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
+Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
 ### Community 42 - "Community 42"
 Cohesion: 0.25
@@ -1363,16 +1363,16 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 53 - "Community 53"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
+
+### Community 54 - "Community 54"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
-### Community 54 - "Community 54"
+### Community 55 - "Community 55"
 Cohesion: 0.29
 Nodes (0):
-
-### Community 55 - "Community 55"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
 
 ### Community 56 - "Community 56"
 Cohesion: 0.52
@@ -1383,40 +1383,40 @@ Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
 ### Community 58 - "Community 58"
-Cohesion: 0.33
-Nodes (1): ValkeyClient
+Cohesion: 0.38
+Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
 ### Community 59 - "Community 59"
 Cohesion: 0.33
-Nodes (0):
+Nodes (1): ValkeyClient
 
 ### Community 60 - "Community 60"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 61 - "Community 61"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
-### Community 61 - "Community 61"
+### Community 62 - "Community 62"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 62 - "Community 62"
+### Community 63 - "Community 63"
 Cohesion: 0.47
 Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
 
-### Community 63 - "Community 63"
+### Community 64 - "Community 64"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 64 - "Community 64"
+### Community 65 - "Community 65"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
-### Community 65 - "Community 65"
+### Community 66 - "Community 66"
 Cohesion: 0.4
 Nodes (2): buildUsername(), normalizeNameSegment()
-
-### Community 66 - "Community 66"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 67 - "Community 67"
 Cohesion: 0.33
@@ -1427,8 +1427,8 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 69 - "Community 69"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 70 - "Community 70"
 Cohesion: 0.33
@@ -1475,20 +1475,20 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 81 - "Community 81"
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+
+### Community 82 - "Community 82"
 Cohesion: 0.53
 Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
-### Community 82 - "Community 82"
+### Community 83 - "Community 83"
 Cohesion: 0.47
 Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
-### Community 83 - "Community 83"
+### Community 84 - "Community 84"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
-
-### Community 84 - "Community 84"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 85 - "Community 85"
 Cohesion: 0.4
@@ -1503,24 +1503,24 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 88 - "Community 88"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 89 - "Community 89"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 89 - "Community 89"
+### Community 90 - "Community 90"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 90 - "Community 90"
-Cohesion: 0.6
-Nodes (3): getNonEmptyString(), isFailureStatus(), normalizeEvent()
 
 ### Community 91 - "Community 91"
 Cohesion: 0.6
-Nodes (3): createOffer(), isDuplicate(), updateStoreFrontActorEmail()
+Nodes (3): getNonEmptyString(), isFailureStatus(), normalizeEvent()
 
 ### Community 92 - "Community 92"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (3): createOffer(), isDuplicate(), updateStoreFrontActorEmail()
 
 ### Community 93 - "Community 93"
 Cohesion: 0.4
@@ -1535,12 +1535,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 96 - "Community 96"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
-
-### Community 97 - "Community 97"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 97 - "Community 97"
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 98 - "Community 98"
 Cohesion: 0.4
@@ -1552,11 +1552,11 @@ Nodes (0):
 
 ### Community 100 - "Community 100"
 Cohesion: 0.4
-Nodes (1): Header()
+Nodes (0):
 
 ### Community 101 - "Community 101"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): Header()
 
 ### Community 102 - "Community 102"
 Cohesion: 0.4
@@ -1575,16 +1575,16 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 106 - "Community 106"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 107 - "Community 107"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 107 - "Community 107"
-Cohesion: 0.4
-Nodes (1): MockImage
-
 ### Community 108 - "Community 108"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): MockImage
 
 ### Community 109 - "Community 109"
 Cohesion: 0.4
@@ -1599,32 +1599,32 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 112 - "Community 112"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
-
-### Community 113 - "Community 113"
-Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
-
-### Community 114 - "Community 114"
-Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
-
-### Community 115 - "Community 115"
 Cohesion: 0.4
 Nodes (0):
 
+### Community 113 - "Community 113"
+Cohesion: 0.7
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
+
+### Community 114 - "Community 114"
+Cohesion: 0.7
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+
+### Community 115 - "Community 115"
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+
 ### Community 116 - "Community 116"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 117 - "Community 117"
 Cohesion: 0.7
 Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
-### Community 117 - "Community 117"
+### Community 118 - "Community 118"
 Cohesion: 0.6
 Nodes (4): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), trackStorefrontEvent()
-
-### Community 118 - "Community 118"
-Cohesion: 0.5
-Nodes (2): createFixtureRepo(), write()
 
 ### Community 119 - "Community 119"
 Cohesion: 0.4
@@ -7288,14 +7288,14 @@ Nodes (0):
 _Questions this graph is uniquely positioned to answer:_
 
 - **Should `Community 0` be split into smaller, more focused modules?**
-  _Cohesion score 0.09 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.1 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**
-  _Cohesion score 0.12 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.09 - nodes in this community are weakly interconnected._
 - **Should `Community 5` be split into smaller, more focused modules?**
   _Cohesion score 0.13 - nodes in this community are weakly interconnected._
 - **Should `Community 9` be split into smaller, more focused modules?**
   _Cohesion score 0.11 - nodes in this community are weakly interconnected._
-- **Should `Community 13` be split into smaller, more focused modules?**
+- **Should `Community 14` be split into smaller, more focused modules?**
   _Cohesion score 0.12 - nodes in this community are weakly interconnected._
 - **Should `Community 18` be split into smaller, more focused modules?**
   _Cohesion score 0.13 - nodes in this community are weakly interconnected._

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -73,7 +73,7 @@
       "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_cache_index_ts",
-      "community": 58
+      "community": 59
     },
     {
       "label": "ValkeyClient",
@@ -81,7 +81,7 @@
       "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L4",
       "id": "index_valkeyclient",
-      "community": 58
+      "community": 59
     },
     {
       "label": ".constructor()",
@@ -89,7 +89,7 @@
       "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L11",
       "id": "index_valkeyclient_constructor",
-      "community": 58
+      "community": 59
     },
     {
       "label": ".get()",
@@ -97,7 +97,7 @@
       "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L20",
       "id": "index_valkeyclient_get",
-      "community": 58
+      "community": 59
     },
     {
       "label": ".set()",
@@ -105,7 +105,7 @@
       "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L48",
       "id": "index_valkeyclient_set",
-      "community": 58
+      "community": 59
     },
     {
       "label": ".invalidate()",
@@ -113,7 +113,7 @@
       "source_file": "packages/athena-webapp/convex/cache/index.ts",
       "source_location": "L75",
       "id": "index_valkeyclient_invalidate",
-      "community": 58
+      "community": 59
     },
     {
       "label": "r2.ts",
@@ -121,7 +121,7 @@
       "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_cloudflare_r2_ts",
-      "community": 84
+      "community": 85
     },
     {
       "label": "uploadFileToR2()",
@@ -129,7 +129,7 @@
       "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
       "source_location": "L21",
       "id": "r2_uploadfiletor2",
-      "community": 84
+      "community": 85
     },
     {
       "label": "deleteFileInR2()",
@@ -137,7 +137,7 @@
       "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
       "source_location": "L40",
       "id": "r2_deletefileinr2",
-      "community": 84
+      "community": 85
     },
     {
       "label": "deleteDirectoryInR2()",
@@ -145,7 +145,7 @@
       "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
       "source_location": "L62",
       "id": "r2_deletedirectoryinr2",
-      "community": 84
+      "community": 85
     },
     {
       "label": "listItemsInR2Directory()",
@@ -153,7 +153,7 @@
       "source_file": "packages/athena-webapp/convex/cloudflare/r2.ts",
       "source_location": "L106",
       "id": "r2_listitemsinr2directory",
-      "community": 84
+      "community": 85
     },
     {
       "label": "stream.ts",
@@ -545,7 +545,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_ts",
-      "community": 59
+      "community": 60
     },
     {
       "label": "hasValidPositiveQuantity()",
@@ -553,7 +553,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
       "source_location": "L27",
       "id": "security_hasvalidpositivequantity",
-      "community": 59
+      "community": 60
     },
     {
       "label": "isAuthorizedResourceOwner()",
@@ -561,7 +561,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
       "source_location": "L31",
       "id": "security_isauthorizedresourceowner",
-      "community": 59
+      "community": 60
     },
     {
       "label": "buildCanonicalCheckoutProducts()",
@@ -569,7 +569,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
       "source_location": "L42",
       "id": "security_buildcanonicalcheckoutproducts",
-      "community": 59
+      "community": 60
     },
     {
       "label": "isAmountTampered()",
@@ -577,7 +577,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
       "source_location": "L65",
       "id": "security_isamounttampered",
-      "community": 59
+      "community": 60
     },
     {
       "label": "isDuplicateChargeSuccess()",
@@ -585,7 +585,7 @@
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/security.ts",
       "source_location": "L76",
       "id": "security_isduplicatechargesuccess",
-      "community": 59
+      "community": 60
     },
     {
       "label": "storefront.ts",
@@ -833,7 +833,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionvalidation_ts",
-      "community": 85
+      "community": 86
     },
     {
       "label": "validateExpenseSessionExists()",
@@ -841,7 +841,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
       "source_location": "L19",
       "id": "expensesessionvalidation_validateexpensesessionexists",
-      "community": 85
+      "community": 86
     },
     {
       "label": "validateExpenseSessionActive()",
@@ -849,7 +849,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
       "source_location": "L39",
       "id": "expensesessionvalidation_validateexpensesessionactive",
-      "community": 85
+      "community": 86
     },
     {
       "label": "validateExpenseSessionModifiable()",
@@ -857,7 +857,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
       "source_location": "L92",
       "id": "expensesessionvalidation_validateexpensesessionmodifiable",
-      "community": 85
+      "community": 86
     },
     {
       "label": "validateExpenseItemBelongsToSession()",
@@ -865,7 +865,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/helpers/expenseSessionValidation.ts",
       "source_location": "L135",
       "id": "expensesessionvalidation_validateexpenseitembelongstosession",
-      "community": 85
+      "community": 86
     },
     {
       "label": "inventoryHolds.ts",
@@ -1257,7 +1257,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_possessions_ts",
-      "community": 86
+      "community": 87
     },
     {
       "label": "buildNextSessionNumber()",
@@ -1265,7 +1265,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
       "source_location": "L34",
       "id": "possessions_buildnextsessionnumber",
-      "community": 86
+      "community": 87
     },
     {
       "label": "loadPosSessionItems()",
@@ -1273,7 +1273,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
       "source_location": "L45",
       "id": "possessions_loadpossessionitems",
-      "community": 86
+      "community": 87
     },
     {
       "label": "listPosSessionsByStatusBefore()",
@@ -1281,7 +1281,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
       "source_location": "L67",
       "id": "possessions_listpossessionsbystatusbefore",
-      "community": 86
+      "community": 87
     },
     {
       "label": "listPosSessionsForStoreStatus()",
@@ -1289,7 +1289,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/posSessions.ts",
       "source_location": "L93",
       "id": "possessions_listpossessionsforstorestatus",
-      "community": 86
+      "community": 87
     },
     {
       "label": "posTerminal.ts",
@@ -1321,7 +1321,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/products.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_products_ts",
-      "community": 87
+      "community": 88
     },
     {
       "label": "generateSKU()",
@@ -1329,7 +1329,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/products.ts",
       "source_location": "L18",
       "id": "products_generatesku",
-      "community": 87
+      "community": 88
     },
     {
       "label": "generateBarcode()",
@@ -1337,7 +1337,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/products.ts",
       "source_location": "L42",
       "id": "products_generatebarcode",
-      "community": 87
+      "community": 88
     },
     {
       "label": "calculateTotalInventoryCount()",
@@ -1345,7 +1345,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/products.ts",
       "source_location": "L65",
       "id": "products_calculatetotalinventorycount",
-      "community": 87
+      "community": 88
     },
     {
       "label": "calculateTotalAvailableCount()",
@@ -1353,7 +1353,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/products.ts",
       "source_location": "L70",
       "id": "products_calculatetotalavailablecount",
-      "community": 87
+      "community": 88
     },
     {
       "label": "promoCode.ts",
@@ -1649,7 +1649,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_inventory_utils_ts",
-      "community": 31
+      "community": 34
     },
     {
       "label": "getDiscountValue()",
@@ -1657,7 +1657,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L17",
       "id": "utils_getdiscountvalue",
-      "community": 31
+      "community": 34
     },
     {
       "label": "getProductDiscountValue()",
@@ -1665,7 +1665,7 @@
       "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
       "source_location": "L75",
       "id": "utils_getproductdiscountvalue",
-      "community": 31
+      "community": 34
     },
     {
       "label": "getOrderAmount()",
@@ -1673,7 +1673,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L51",
       "id": "utils_getorderamount",
-      "community": 31
+      "community": 34
     },
     {
       "label": "formatDeliveryAddress()",
@@ -1681,7 +1681,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L74",
       "id": "utils_formatdeliveryaddress",
-      "community": 31
+      "community": 34
     },
     {
       "label": "currency.test.ts",
@@ -1809,7 +1809,7 @@
       "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_mailersend_index_tsx",
-      "community": 41
+      "community": 40
     },
     {
       "label": "sendVerificationCode()",
@@ -1817,7 +1817,7 @@
       "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L3",
       "id": "index_sendverificationcode",
-      "community": 41
+      "community": 40
     },
     {
       "label": "sendOrderEmail()",
@@ -1825,7 +1825,7 @@
       "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L43",
       "id": "index_sendorderemail",
-      "community": 41
+      "community": 40
     },
     {
       "label": "sendNewOrderEmail()",
@@ -1833,7 +1833,7 @@
       "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L117",
       "id": "index_sendneworderemail",
-      "community": 41
+      "community": 40
     },
     {
       "label": "sendFeedbackRequestEmail()",
@@ -1841,7 +1841,7 @@
       "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L167",
       "id": "index_sendfeedbackrequestemail",
-      "community": 41
+      "community": 40
     },
     {
       "label": "sendDiscountCodeEmail()",
@@ -1849,7 +1849,7 @@
       "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L255",
       "id": "index_senddiscountcodeemail",
-      "community": 41
+      "community": 40
     },
     {
       "label": "sendDiscountReminderEmail()",
@@ -1857,7 +1857,7 @@
       "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L334",
       "id": "index_senddiscountreminderemail",
-      "community": 41
+      "community": 40
     },
     {
       "label": "migrateAmountsToPesewas.ts",
@@ -1977,7 +1977,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_mtn_config_ts",
-      "community": 40
+      "community": 41
     },
     {
       "label": "toEnvSegment()",
@@ -1985,7 +1985,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L29",
       "id": "config_toenvsegment",
-      "community": 40
+      "community": 41
     },
     {
       "label": "buildMtnCollectionsLookupPrefixes()",
@@ -1993,7 +1993,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L43",
       "id": "config_buildmtncollectionslookupprefixes",
-      "community": 40
+      "community": 41
     },
     {
       "label": "readScopedValue()",
@@ -2001,7 +2001,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L56",
       "id": "config_readscopedvalue",
-      "community": 40
+      "community": 41
     },
     {
       "label": "isTargetEnvironment()",
@@ -2009,7 +2009,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L67",
       "id": "config_istargetenvironment",
-      "community": 40
+      "community": 41
     },
     {
       "label": "resolveConfigForPrefix()",
@@ -2017,7 +2017,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L73",
       "id": "config_resolveconfigforprefix",
-      "community": 40
+      "community": 41
     },
     {
       "label": "resolveMtnCollectionsConfigFromEnv()",
@@ -2025,7 +2025,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L108",
       "id": "config_resolvemtncollectionsconfigfromenv",
-      "community": 40
+      "community": 41
     },
     {
       "label": "buildMtnCollectionsCallbackUrl()",
@@ -2033,7 +2033,7 @@
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L135",
       "id": "config_buildmtncollectionscallbackurl",
-      "community": 40
+      "community": 41
     },
     {
       "label": "foundation.test.ts",
@@ -2553,7 +2553,7 @@
       "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
-      "community": 41
+      "community": 40
     },
     {
       "label": "orderEmailService.ts",
@@ -2561,7 +2561,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_services_orderemailservice_ts",
-      "community": 60
+      "community": 61
     },
     {
       "label": "shouldSendToAdmins()",
@@ -2569,7 +2569,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L42",
       "id": "orderemailservice_shouldsendtoadmins",
-      "community": 60
+      "community": 61
     },
     {
       "label": "buildOrderStatusMessage()",
@@ -2577,7 +2577,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L49",
       "id": "orderemailservice_buildorderstatusmessage",
-      "community": 60
+      "community": 61
     },
     {
       "label": "buildPickupDetails()",
@@ -2585,7 +2585,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L77",
       "id": "orderemailservice_buildpickupdetails",
-      "community": 60
+      "community": 61
     },
     {
       "label": "sendPODOrderEmails()",
@@ -2593,7 +2593,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L96",
       "id": "orderemailservice_sendpodorderemails",
-      "community": 60
+      "community": 61
     },
     {
       "label": "sendPaymentVerificationEmails()",
@@ -2601,7 +2601,7 @@
       "source_file": "packages/athena-webapp/convex/services/orderEmailService.ts",
       "source_location": "L217",
       "id": "orderemailservice_sendpaymentverificationemails",
-      "community": 60
+      "community": 61
     },
     {
       "label": "paystackService.ts",
@@ -2609,7 +2609,7 @@
       "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_services_paystackservice_ts",
-      "community": 88
+      "community": 89
     },
     {
       "label": "getPaystackHeaders()",
@@ -2617,7 +2617,7 @@
       "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
       "source_location": "L11",
       "id": "paystackservice_getpaystackheaders",
-      "community": 88
+      "community": 89
     },
     {
       "label": "initializeTransaction()",
@@ -2625,7 +2625,7 @@
       "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
       "source_location": "L21",
       "id": "paystackservice_initializetransaction",
-      "community": 88
+      "community": 89
     },
     {
       "label": "verifyTransaction()",
@@ -2633,7 +2633,7 @@
       "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
       "source_location": "L65",
       "id": "paystackservice_verifytransaction",
-      "community": 88
+      "community": 89
     },
     {
       "label": "initiateRefund()",
@@ -2641,7 +2641,7 @@
       "source_file": "packages/athena-webapp/convex/services/paystackService.ts",
       "source_location": "L87",
       "id": "paystackservice_initiaterefund",
-      "community": 88
+      "community": 89
     },
     {
       "label": "analytics.ts",
@@ -2649,7 +2649,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_analytics_ts",
-      "community": 61
+      "community": 62
     },
     {
       "label": "extractPromoCodeId()",
@@ -2657,7 +2657,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L18",
       "id": "analytics_extractpromocodeid",
-      "community": 61
+      "community": 62
     },
     {
       "label": "getAnalyticsByStoreQuery()",
@@ -2665,7 +2665,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L28",
       "id": "analytics_getanalyticsbystorequery",
-      "community": 61
+      "community": 62
     },
     {
       "label": "getCompletedOrdersQuery()",
@@ -2673,7 +2673,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L59",
       "id": "analytics_getcompletedordersquery",
-      "community": 61
+      "community": 62
     },
     {
       "label": "getAnalyticsByStoreAndActionQuery()",
@@ -2681,7 +2681,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L97",
       "id": "analytics_getanalyticsbystoreandactionquery",
-      "community": 61
+      "community": 62
     },
     {
       "label": "getSkuMapForProducts()",
@@ -2689,7 +2689,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/analytics.ts",
       "source_location": "L132",
       "id": "analytics_getskumapforproducts",
-      "community": 61
+      "community": 62
     },
     {
       "label": "auth.ts",
@@ -2729,7 +2729,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_checkoutsession_ts",
-      "community": 11
+      "community": 12
     },
     {
       "label": "listSessionItems()",
@@ -2737,7 +2737,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L40",
       "id": "checkoutsession_listsessionitems",
-      "community": 11
+      "community": 12
     },
     {
       "label": "checkIfItemsHaveChanged()",
@@ -2745,7 +2745,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L50",
       "id": "checkoutsession_checkifitemshavechanged",
-      "community": 11
+      "community": 12
     },
     {
       "label": "createPatchObject()",
@@ -2753,7 +2753,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L651",
       "id": "checkoutsession_createpatchobject",
-      "community": 11
+      "community": 12
     },
     {
       "label": "handlePlaceOrder()",
@@ -2761,7 +2761,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L698",
       "id": "checkoutsession_handleplaceorder",
-      "community": 11
+      "community": 12
     },
     {
       "label": "handleOrderCreation()",
@@ -2769,7 +2769,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L734",
       "id": "checkoutsession_handleordercreation",
-      "community": 11
+      "community": 12
     },
     {
       "label": "createOnlineOrder()",
@@ -2777,7 +2777,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L765",
       "id": "checkoutsession_createonlineorder",
-      "community": 11
+      "community": 12
     },
     {
       "label": "retrieveActiveCheckoutSession()",
@@ -2785,7 +2785,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L951",
       "id": "checkoutsession_retrieveactivecheckoutsession",
-      "community": 11
+      "community": 12
     },
     {
       "label": "fetchProductSkus()",
@@ -2793,7 +2793,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L979",
       "id": "checkoutsession_fetchproductskus",
-      "community": 11
+      "community": 12
     },
     {
       "label": "checkAdjustedAvailability()",
@@ -2801,7 +2801,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L990",
       "id": "checkoutsession_checkadjustedavailability",
-      "community": 11
+      "community": 12
     },
     {
       "label": "updateExistingSession()",
@@ -2809,7 +2809,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1020",
       "id": "checkoutsession_updateexistingsession",
-      "community": 11
+      "community": 12
     },
     {
       "label": "createSessionItems()",
@@ -2817,7 +2817,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1102",
       "id": "checkoutsession_createsessionitems",
-      "community": 11
+      "community": 12
     },
     {
       "label": "updateProductAvailability()",
@@ -2825,7 +2825,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1123",
       "id": "checkoutsession_updateproductavailability",
-      "community": 11
+      "community": 12
     },
     {
       "label": "updateAvailability()",
@@ -2833,7 +2833,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1140",
       "id": "checkoutsession_updateavailability",
-      "community": 11
+      "community": 12
     },
     {
       "label": "handleExistingSession()",
@@ -2841,7 +2841,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1161",
       "id": "checkoutsession_handleexistingsession",
-      "community": 11
+      "community": 12
     },
     {
       "label": "validateExistingDiscount()",
@@ -2849,7 +2849,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1321",
       "id": "checkoutsession_validateexistingdiscount",
-      "community": 11
+      "community": 12
     },
     {
       "label": "calculatePromoCodeValue()",
@@ -2857,7 +2857,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1447",
       "id": "checkoutsession_calculatepromocodevalue",
-      "community": 11
+      "community": 12
     },
     {
       "label": "findBestValuePromoCode()",
@@ -2865,7 +2865,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.ts",
       "source_location": "L1495",
       "id": "checkoutsession_findbestvaluepromocode",
-      "community": 11
+      "community": 12
     },
     {
       "label": "commerceQueryIndexes.test.ts",
@@ -2913,7 +2913,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_ts",
-      "community": 89
+      "community": 90
     },
     {
       "label": "getTimeFilterForRange()",
@@ -2921,7 +2921,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
       "source_location": "L11",
       "id": "customerbehaviortimeline_gettimefilterforrange",
-      "community": 89
+      "community": 90
     },
     {
       "label": "getCustomerAnalyticsQuery()",
@@ -2929,7 +2929,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
       "source_location": "L26",
       "id": "customerbehaviortimeline_getcustomeranalyticsquery",
-      "community": 89
+      "community": 90
     },
     {
       "label": "getTimelineUserData()",
@@ -2937,7 +2937,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
       "source_location": "L42",
       "id": "customerbehaviortimeline_gettimelineuserdata",
-      "community": 89
+      "community": 90
     },
     {
       "label": "getProductInfoMaps()",
@@ -2945,7 +2945,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.ts",
       "source_location": "L66",
       "id": "customerbehaviortimeline_getproductinfomaps",
-      "community": 89
+      "community": 90
     },
     {
       "label": "customerObservabilityTimeline.test.ts",
@@ -2969,7 +2969,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_customerobservabilitytimelinedata_ts",
-      "community": 90
+      "community": 91
     },
     {
       "label": "getNonEmptyString()",
@@ -2977,7 +2977,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L64",
       "id": "customerobservabilitytimelinedata_getnonemptystring",
-      "community": 90
+      "community": 91
     },
     {
       "label": "isFailureStatus()",
@@ -2985,7 +2985,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L68",
       "id": "customerobservabilitytimelinedata_isfailurestatus",
-      "community": 90
+      "community": 91
     },
     {
       "label": "normalizeEvent()",
@@ -2993,7 +2993,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L72",
       "id": "customerobservabilitytimelinedata_normalizeevent",
-      "community": 90
+      "community": 91
     },
     {
       "label": "buildCustomerObservabilityTimeline()",
@@ -3001,7 +3001,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L118",
       "id": "customerobservabilitytimelinedata_buildcustomerobservabilitytimeline",
-      "community": 90
+      "community": 91
     },
     {
       "label": "guest.ts",
@@ -3057,7 +3057,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_helpers_onlineorder_ts",
-      "community": 62
+      "community": 63
     },
     {
       "label": "generateOrderNumber()",
@@ -3065,7 +3065,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
       "source_location": "L8",
       "id": "onlineorder_generateordernumber",
-      "community": 62
+      "community": 63
     },
     {
       "label": "findOrderByExternalReference()",
@@ -3073,7 +3073,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
       "source_location": "L15",
       "id": "onlineorder_findorderbyexternalreference",
-      "community": 62
+      "community": 63
     },
     {
       "label": "clearBagItems()",
@@ -3081,7 +3081,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
       "source_location": "L27",
       "id": "onlineorder_clearbagitems",
-      "community": 62
+      "community": 63
     },
     {
       "label": "returnOrderItemsToStock()",
@@ -3089,7 +3089,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
       "source_location": "L39",
       "id": "onlineorder_returnorderitemstostock",
-      "community": 62
+      "community": 63
     },
     {
       "label": "createOrderFromCheckoutSession()",
@@ -3097,7 +3097,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/onlineOrder.ts",
       "source_location": "L75",
       "id": "onlineorder_createorderfromcheckoutsession",
-      "community": 62
+      "community": 63
     },
     {
       "label": "orderUpdateEmails.ts",
@@ -3217,7 +3217,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_offers_ts",
-      "community": 91
+      "community": 92
     },
     {
       "label": "isDuplicate()",
@@ -3225,7 +3225,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
       "source_location": "L36",
       "id": "offers_isduplicate",
-      "community": 91
+      "community": 92
     },
     {
       "label": "updateStoreFrontActorEmail()",
@@ -3233,7 +3233,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
       "source_location": "L59",
       "id": "offers_updatestorefrontactoremail",
-      "community": 91
+      "community": 92
     },
     {
       "label": "createOffer()",
@@ -3241,7 +3241,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
       "source_location": "L88",
       "id": "offers_createoffer",
-      "community": 91
+      "community": 92
     },
     {
       "label": "getUpsellProducts()",
@@ -3249,7 +3249,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
       "source_location": "L685",
       "id": "offers_getupsellproducts",
-      "community": 91
+      "community": 92
     },
     {
       "label": "onlineOrder.ts",
@@ -3577,7 +3577,7 @@
       "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_navbar_tsx",
-      "community": 92
+      "community": 93
     },
     {
       "label": "SettingsHeader()",
@@ -3585,7 +3585,7 @@
       "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
       "source_location": "L20",
       "id": "navbar_settingsheader",
-      "community": 92
+      "community": 93
     },
     {
       "label": "AppHeader()",
@@ -3593,7 +3593,7 @@
       "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
       "source_location": "L61",
       "id": "navbar_appheader",
-      "community": 92
+      "community": 93
     },
     {
       "label": "Header()",
@@ -3601,7 +3601,7 @@
       "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
       "source_location": "L75",
       "id": "navbar_header",
-      "community": 92
+      "community": 93
     },
     {
       "label": "Navbar()",
@@ -3609,7 +3609,7 @@
       "source_file": "packages/athena-webapp/src/components/Navbar.tsx",
       "source_location": "L116",
       "id": "navbar_navbar",
-      "community": 92
+      "community": 93
     },
     {
       "label": "OrganizationView.tsx",
@@ -4001,7 +4001,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_productcategorization_tsx",
-      "community": 93
+      "community": 94
     },
     {
       "label": "handleClose()",
@@ -4009,7 +4009,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
       "source_location": "L203",
       "id": "productcategorization_handleclose",
-      "community": 93
+      "community": 94
     },
     {
       "label": "setInitialSelectedOption()",
@@ -4017,7 +4017,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
       "source_location": "L230",
       "id": "productcategorization_setinitialselectedoption",
-      "community": 93
+      "community": 94
     },
     {
       "label": "handleProductVisibility()",
@@ -4025,7 +4025,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
       "source_location": "L243",
       "id": "productcategorization_handleproductvisibility",
-      "community": 93
+      "community": 94
     },
     {
       "label": "getProductName()",
@@ -4033,7 +4033,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductCategorization.tsx",
       "source_location": "L286",
       "id": "productcategorization_getproductname",
-      "community": 93
+      "community": 94
     },
     {
       "label": "ProductDetails.tsx",
@@ -4473,7 +4473,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_tsx",
-      "community": 63
+      "community": 64
     },
     {
       "label": "DataTableToolbar()",
@@ -4481,7 +4481,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
       "source_location": "L23",
       "id": "data_table_toolbar_datatabletoolbar",
-      "community": 63
+      "community": 64
     },
     {
       "label": "data-table-view-options.tsx",
@@ -4489,7 +4489,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-view-options.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_view_options_tsx",
-      "community": 13
+      "community": 14
     },
     {
       "label": "DataTableViewOptions()",
@@ -4497,7 +4497,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
       "source_location": "L18",
       "id": "data_table_view_options_datatableviewoptions",
-      "community": 13
+      "community": 14
     },
     {
       "label": "data-table.tsx",
@@ -4825,7 +4825,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-view-options.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_view_options_tsx",
-      "community": 13
+      "community": 14
     },
     {
       "label": "data-table.tsx",
@@ -4841,7 +4841,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/selectable-data-provider.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
-      "community": 64
+      "community": 65
     },
     {
       "label": "SelectedProductsProvider()",
@@ -4849,7 +4849,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
       "source_location": "L16",
       "id": "selectable_data_provider_selectedproductsprovider",
-      "community": 64
+      "community": 65
     },
     {
       "label": "useSelectedProducts()",
@@ -4857,7 +4857,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
       "source_location": "L37",
       "id": "selectable_data_provider_useselectedproducts",
-      "community": 64
+      "community": 65
     },
     {
       "label": "columns.tsx",
@@ -4913,7 +4913,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-view-options.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_view_options_tsx",
-      "community": 13
+      "community": 14
     },
     {
       "label": "data-table.tsx",
@@ -5049,7 +5049,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_tsx",
-      "community": 63
+      "community": 64
     },
     {
       "label": "data-table-view-options.tsx",
@@ -5057,7 +5057,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-view-options.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_view_options_tsx",
-      "community": 13
+      "community": 14
     },
     {
       "label": "data-table.tsx",
@@ -5241,7 +5241,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-view-options.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_view_options_tsx",
-      "community": 13
+      "community": 14
     },
     {
       "label": "data-table.tsx",
@@ -5353,7 +5353,7 @@
       "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-view-options.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_view_options_tsx",
-      "community": 13
+      "community": 14
     },
     {
       "label": "data-table.tsx",
@@ -5377,7 +5377,7 @@
       "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_assets_index_tsx",
-      "community": 100
+      "community": 101
     },
     {
       "label": "Header()",
@@ -5385,7 +5385,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
       "source_location": "L42",
       "id": "index_header",
-      "community": 100
+      "community": 101
     },
     {
       "label": "FeesView()",
@@ -5393,7 +5393,7 @@
       "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
       "source_location": "L29",
       "id": "index_feesview",
-      "community": 100
+      "community": 101
     },
     {
       "label": "Auth.tsx",
@@ -5521,7 +5521,7 @@
       "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-view-options.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_view_options_tsx",
-      "community": 13
+      "community": 14
     },
     {
       "label": "data-table.tsx",
@@ -5537,7 +5537,7 @@
       "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/selectable-data-provider.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
-      "community": 64
+      "community": 65
     },
     {
       "label": "columns.tsx",
@@ -5593,7 +5593,7 @@
       "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_tsx",
-      "community": 63
+      "community": 64
     },
     {
       "label": "data-table-view-options.tsx",
@@ -5601,7 +5601,7 @@
       "source_file": "packages/athena-webapp/src/components/base/table/data-table-view-options.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_base_table_data_table_view_options_tsx",
-      "community": 13
+      "community": 14
     },
     {
       "label": "data-table.tsx",
@@ -5673,7 +5673,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_cashiers_cashiermanagement_tsx",
-      "community": 65
+      "community": 66
     },
     {
       "label": "normalizeNameSegment()",
@@ -5681,7 +5681,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L42",
       "id": "cashiermanagement_normalizenamesegment",
-      "community": 65
+      "community": 66
     },
     {
       "label": "buildUsername()",
@@ -5689,7 +5689,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L50",
       "id": "cashiermanagement_buildusername",
-      "community": 65
+      "community": 66
     },
     {
       "label": "handleSubmit()",
@@ -5697,7 +5697,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L109",
       "id": "cashiermanagement_handlesubmit",
-      "community": 65
+      "community": 66
     },
     {
       "label": "handlePinKeyDown()",
@@ -5705,7 +5705,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L169",
       "id": "cashiermanagement_handlepinkeydown",
-      "community": 65
+      "community": 66
     },
     {
       "label": "handleDelete()",
@@ -5713,7 +5713,7 @@
       "source_file": "packages/athena-webapp/src/components/cashiers/CashierManagement.tsx",
       "source_location": "L320",
       "id": "cashiermanagement_handledelete",
-      "community": 65
+      "community": 66
     },
     {
       "label": "index.tsx",
@@ -5825,7 +5825,7 @@
       "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
-      "community": 94
+      "community": 95
     },
     {
       "label": "getPeriodRange()",
@@ -5833,7 +5833,7 @@
       "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
       "source_location": "L20",
       "id": "dashboard_getperiodrange",
-      "community": 94
+      "community": 95
     },
     {
       "label": "LoadingSection()",
@@ -5841,7 +5841,7 @@
       "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
       "source_location": "L50",
       "id": "dashboard_loadingsection",
-      "community": 94
+      "community": 95
     },
     {
       "label": "renderSalesSection()",
@@ -5849,7 +5849,7 @@
       "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
       "source_location": "L322",
       "id": "dashboard_rendersalessection",
-      "community": 94
+      "community": 95
     },
     {
       "label": "renderProductsSection()",
@@ -5857,7 +5857,7 @@
       "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
       "source_location": "L342",
       "id": "dashboard_renderproductssection",
-      "community": 94
+      "community": 95
     },
     {
       "label": "MetricCard.tsx",
@@ -5953,7 +5953,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_bannermessageeditor_tsx",
-      "community": 66
+      "community": 67
     },
     {
       "label": "handleSave()",
@@ -5961,7 +5961,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L46",
       "id": "bannermessageeditor_handlesave",
-      "community": 66
+      "community": 67
     },
     {
       "label": "handleClear()",
@@ -5969,7 +5969,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L66",
       "id": "bannermessageeditor_handleclear",
-      "community": 66
+      "community": 67
     },
     {
       "label": "handleActiveToggle()",
@@ -5977,7 +5977,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L91",
       "id": "bannermessageeditor_handleactivetoggle",
-      "community": 66
+      "community": 67
     },
     {
       "label": "handleCountdownChange()",
@@ -5985,7 +5985,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L113",
       "id": "bannermessageeditor_handlecountdownchange",
-      "community": 66
+      "community": 67
     },
     {
       "label": "getCountdownStatus()",
@@ -5993,7 +5993,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L123",
       "id": "bannermessageeditor_getcountdownstatus",
-      "community": 66
+      "community": 67
     },
     {
       "label": "BestSellers.tsx",
@@ -6081,7 +6081,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_heroheaderimageuploader_tsx",
-      "community": 32
+      "community": 31
     },
     {
       "label": "validateFile()",
@@ -6089,7 +6089,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L50",
       "id": "heroheaderimageuploader_validatefile",
-      "community": 32
+      "community": 31
     },
     {
       "label": "uploadImage()",
@@ -6097,7 +6097,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L67",
       "id": "heroheaderimageuploader_uploadimage",
-      "community": 32
+      "community": 31
     },
     {
       "label": "resetEditState()",
@@ -6105,7 +6105,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L95",
       "id": "heroheaderimageuploader_reseteditstate",
-      "community": 32
+      "community": 31
     },
     {
       "label": "handleEditClick()",
@@ -6113,7 +6113,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L108",
       "id": "heroheaderimageuploader_handleeditclick",
-      "community": 32
+      "community": 31
     },
     {
       "label": "handleFileSelect()",
@@ -6121,7 +6121,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L113",
       "id": "heroheaderimageuploader_handlefileselect",
-      "community": 32
+      "community": 31
     },
     {
       "label": "handleUpload()",
@@ -6129,7 +6129,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L127",
       "id": "heroheaderimageuploader_handleupload",
-      "community": 32
+      "community": 31
     },
     {
       "label": "handleRevert()",
@@ -6137,7 +6137,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L163",
       "id": "heroheaderimageuploader_handlerevert",
-      "community": 32
+      "community": 31
     },
     {
       "label": "EditModeButtons()",
@@ -6145,7 +6145,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L179",
       "id": "heroheaderimageuploader_editmodebuttons",
-      "community": 32
+      "community": 31
     },
     {
       "label": "ViewModeButton()",
@@ -6153,7 +6153,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L205",
       "id": "heroheaderimageuploader_viewmodebutton",
-      "community": 32
+      "community": 31
     },
     {
       "label": "HeroSectionTabs.tsx",
@@ -6161,7 +6161,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
-      "community": 95
+      "community": 96
     },
     {
       "label": "handleImageUpdate()",
@@ -6169,7 +6169,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
       "source_location": "L57",
       "id": "herosectiontabs_handleimageupdate",
-      "community": 95
+      "community": 96
     },
     {
       "label": "handleDisplayTypeChange()",
@@ -6177,7 +6177,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
       "source_location": "L61",
       "id": "herosectiontabs_handledisplaytypechange",
-      "community": 95
+      "community": 96
     },
     {
       "label": "handleOverlayToggle()",
@@ -6185,7 +6185,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
       "source_location": "L98",
       "id": "herosectiontabs_handleoverlaytoggle",
-      "community": 95
+      "community": 96
     },
     {
       "label": "handleTextToggle()",
@@ -6193,7 +6193,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
       "source_location": "L134",
       "id": "herosectiontabs_handletexttoggle",
-      "community": 95
+      "community": 96
     },
     {
       "label": "Home.tsx",
@@ -6265,7 +6265,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
-      "community": 96
+      "community": 97
     },
     {
       "label": "formatFileSize()",
@@ -6273,7 +6273,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
       "source_location": "L38",
       "id": "reeluploader_formatfilesize",
-      "community": 96
+      "community": 97
     },
     {
       "label": "validateFile()",
@@ -6281,7 +6281,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
       "source_location": "L43",
       "id": "reeluploader_validatefile",
-      "community": 96
+      "community": 97
     },
     {
       "label": "handleFileSelect()",
@@ -6289,7 +6289,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
       "source_location": "L64",
       "id": "reeluploader_handlefileselect",
-      "community": 96
+      "community": 97
     },
     {
       "label": "handleUpload()",
@@ -6297,7 +6297,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
       "source_location": "L135",
       "id": "reeluploader_handleupload",
-      "community": 96
+      "community": 97
     },
     {
       "label": "ShopLook.tsx",
@@ -6401,7 +6401,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
-      "community": 97
+      "community": 98
     },
     {
       "label": "isRefundAction()",
@@ -6409,7 +6409,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
       "source_location": "L50",
       "id": "activityview_isrefundaction",
-      "community": 97
+      "community": 98
     },
     {
       "label": "isTransitionAction()",
@@ -6417,7 +6417,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
       "source_location": "L53",
       "id": "activityview_istransitionaction",
-      "community": 97
+      "community": 98
     },
     {
       "label": "isCreatedAction()",
@@ -6425,7 +6425,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
       "source_location": "L58",
       "id": "activityview_iscreatedaction",
-      "community": 97
+      "community": 98
     },
     {
       "label": "isFeedbackRequestAction()",
@@ -6433,7 +6433,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
       "source_location": "L63",
       "id": "activityview_isfeedbackrequestaction",
-      "community": 97
+      "community": 98
     },
     {
       "label": "CustomerDetailsView.tsx",
@@ -6473,7 +6473,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
-      "community": 98
+      "community": 99
     },
     {
       "label": "VerifiedBadge()",
@@ -6481,7 +6481,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
       "source_location": "L41",
       "id": "orderdetailsview_verifiedbadge",
-      "community": 98
+      "community": 99
     },
     {
       "label": "fetchTransactions()",
@@ -6489,7 +6489,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
       "source_location": "L136",
       "id": "orderdetailsview_fetchtransactions",
-      "community": 98
+      "community": 99
     },
     {
       "label": "handleMarkAsVerified()",
@@ -6497,7 +6497,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
       "source_location": "L173",
       "id": "orderdetailsview_handlemarkasverified",
-      "community": 98
+      "community": 99
     },
     {
       "label": "handleMarkPaymentCollected()",
@@ -6505,7 +6505,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
       "source_location": "L187",
       "id": "orderdetailsview_handlemarkpaymentcollected",
-      "community": 98
+      "community": 99
     },
     {
       "label": "OrderItemsView.tsx",
@@ -6513,7 +6513,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
-      "community": 99
+      "community": 100
     },
     {
       "label": "handleUpdateOrderItem()",
@@ -6521,7 +6521,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
       "source_location": "L47",
       "id": "orderitemsview_handleupdateorderitem",
-      "community": 99
+      "community": 100
     },
     {
       "label": "handleReturnItemToStock()",
@@ -6529,7 +6529,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
       "source_location": "L61",
       "id": "orderitemsview_handlereturnitemtostock",
-      "community": 99
+      "community": 100
     },
     {
       "label": "handleRequestFeedback()",
@@ -6537,7 +6537,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
       "source_location": "L77",
       "id": "orderitemsview_handlerequestfeedback",
-      "community": 99
+      "community": 100
     },
     {
       "label": "handleRestockAll()",
@@ -6545,7 +6545,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
       "source_location": "L295",
       "id": "orderitemsview_handlerestockall",
-      "community": 99
+      "community": 100
     },
     {
       "label": "OrderMetricsPanel.tsx",
@@ -6745,7 +6745,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-view-options.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_view_options_tsx",
-      "community": 13
+      "community": 14
     },
     {
       "label": "data-table.tsx",
@@ -6857,7 +6857,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_utils_ts",
-      "community": 31
+      "community": 34
     },
     {
       "label": "getOrderState()",
@@ -6865,7 +6865,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
       "source_location": "L1",
       "id": "utils_getorderstate",
-      "community": 31
+      "community": 34
     },
     {
       "label": "getAmountPaidForOrder()",
@@ -6873,7 +6873,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
       "source_location": "L108",
       "id": "utils_getamountpaidfororder",
-      "community": 31
+      "community": 34
     },
     {
       "label": "index.tsx",
@@ -6881,7 +6881,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
-      "community": 100
+      "community": 101
     },
     {
       "label": "onSubmit()",
@@ -6889,7 +6889,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
       "source_location": "L105",
       "id": "index_onsubmit",
-      "community": 100
+      "community": 101
     },
     {
       "label": "constants.ts",
@@ -6945,7 +6945,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-view-options.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_view_options_tsx",
-      "community": 13
+      "community": 14
     },
     {
       "label": "data-table.tsx",
@@ -7025,7 +7025,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-view-options.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_view_options_tsx",
-      "community": 13
+      "community": 14
     },
     {
       "label": "data-table.tsx",
@@ -7329,7 +7329,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_paymentview_tsx",
-      "community": 101
+      "community": 102
     },
     {
       "label": "handleAddPayment()",
@@ -7337,7 +7337,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
       "source_location": "L178",
       "id": "paymentview_handleaddpayment",
-      "community": 101
+      "community": 102
     },
     {
       "label": "handleClearAll()",
@@ -7345,7 +7345,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
       "source_location": "L219",
       "id": "paymentview_handleclearall",
-      "community": 101
+      "community": 102
     },
     {
       "label": "handleAmountChange()",
@@ -7353,7 +7353,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
       "source_location": "L224",
       "id": "paymentview_handleamountchange",
-      "community": 101
+      "community": 102
     },
     {
       "label": "handleAmountBlur()",
@@ -7361,7 +7361,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
       "source_location": "L253",
       "id": "paymentview_handleamountblur",
-      "community": 101
+      "community": 102
     },
     {
       "label": "PaymentsAddedList.tsx",
@@ -7369,7 +7369,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_tsx",
-      "community": 67
+      "community": 68
     },
     {
       "label": "getPaymentMethodLabel()",
@@ -7377,7 +7377,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L18",
       "id": "paymentsaddedlist_getpaymentmethodlabel",
-      "community": 67
+      "community": 68
     },
     {
       "label": "handleStartEdit()",
@@ -7385,7 +7385,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L57",
       "id": "paymentsaddedlist_handlestartedit",
-      "community": 67
+      "community": 68
     },
     {
       "label": "handleSaveEdit()",
@@ -7393,7 +7393,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L62",
       "id": "paymentsaddedlist_handlesaveedit",
-      "community": 67
+      "community": 68
     },
     {
       "label": "handleCancelEdit()",
@@ -7401,7 +7401,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L93",
       "id": "paymentsaddedlist_handlecanceledit",
-      "community": 67
+      "community": 68
     },
     {
       "label": "handleRemovePayment()",
@@ -7409,7 +7409,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L98",
       "id": "paymentsaddedlist_handleremovepayment",
-      "community": 67
+      "community": 68
     },
     {
       "label": "PinInput.tsx",
@@ -7553,7 +7553,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_sessionmanager_tsx",
-      "community": 102
+      "community": 103
     },
     {
       "label": "onHoldConfirm()",
@@ -7561,7 +7561,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
       "source_location": "L72",
       "id": "sessionmanager_onholdconfirm",
-      "community": 102
+      "community": 103
     },
     {
       "label": "onResumeSession()",
@@ -7569,7 +7569,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
       "source_location": "L77",
       "id": "sessionmanager_onresumesession",
-      "community": 102
+      "community": 103
     },
     {
       "label": "onVoidConfirm()",
@@ -7577,7 +7577,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
       "source_location": "L90",
       "id": "sessionmanager_onvoidconfirm",
-      "community": 102
+      "community": 103
     },
     {
       "label": "onNewSessionClick()",
@@ -7585,7 +7585,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
       "source_location": "L96",
       "id": "sessionmanager_onnewsessionclick",
-      "community": 102
+      "community": 103
     },
     {
       "label": "TotalsDisplay.tsx",
@@ -8209,7 +8209,7 @@
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-view-options.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_view_options_tsx",
-      "community": 13
+      "community": 14
     },
     {
       "label": "data-table.tsx",
@@ -8297,7 +8297,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeview_tsx",
-      "community": 103
+      "community": 104
     },
     {
       "label": "handleAddPromoCode()",
@@ -8305,7 +8305,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
       "source_location": "L146",
       "id": "promocodeview_handleaddpromocode",
-      "community": 103
+      "community": 104
     },
     {
       "label": "handleUpdatePromoCode()",
@@ -8313,7 +8313,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
       "source_location": "L213",
       "id": "promocodeview_handleupdatepromocode",
-      "community": 103
+      "community": 104
     },
     {
       "label": "updateHomepageDiscountCode()",
@@ -8321,7 +8321,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
       "source_location": "L299",
       "id": "promocodeview_updatehomepagediscountcode",
-      "community": 103
+      "community": 104
     },
     {
       "label": "updateLeaveAReviewDiscountCode()",
@@ -8329,7 +8329,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
       "source_location": "L351",
       "id": "promocodeview_updateleaveareviewdiscountcode",
-      "community": 103
+      "community": 104
     },
     {
       "label": "PromoCodes.tsx",
@@ -8593,7 +8593,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-view-options.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_view_options_tsx",
-      "community": 13
+      "community": 14
     },
     {
       "label": "data-table.tsx",
@@ -8609,7 +8609,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/selectable-data-provider.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
-      "community": 64
+      "community": 65
     },
     {
       "label": "columns.tsx",
@@ -8665,7 +8665,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_tsx",
-      "community": 63
+      "community": 64
     },
     {
       "label": "data-table-view-options.tsx",
@@ -8673,7 +8673,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-view-options.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_view_options_tsx",
-      "community": 13
+      "community": 14
     },
     {
       "label": "data-table.tsx",
@@ -8777,7 +8777,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_reviews_reviewsview_tsx",
-      "community": 68
+      "community": 69
     },
     {
       "label": "Header()",
@@ -8785,7 +8785,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L13",
       "id": "reviewsview_header",
-      "community": 68
+      "community": 69
     },
     {
       "label": "handleApprove()",
@@ -8793,7 +8793,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L42",
       "id": "reviewsview_handleapprove",
-      "community": 68
+      "community": 69
     },
     {
       "label": "handleReject()",
@@ -8801,7 +8801,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L58",
       "id": "reviewsview_handlereject",
-      "community": 68
+      "community": 69
     },
     {
       "label": "handlePublish()",
@@ -8809,7 +8809,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L74",
       "id": "reviewsview_handlepublish",
-      "community": 68
+      "community": 69
     },
     {
       "label": "handleUnpublish()",
@@ -8817,7 +8817,7 @@
       "source_file": "packages/athena-webapp/src/components/reviews/ReviewsView.tsx",
       "source_location": "L90",
       "id": "reviewsview_handleunpublish",
-      "community": 68
+      "community": 69
     },
     {
       "label": "empty-state.tsx",
@@ -9529,7 +9529,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "community": 69
+      "community": 81
     },
     {
       "label": "onDrop()",
@@ -9537,7 +9537,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L20",
       "id": "image_uploader_ondrop",
-      "community": 69
+      "community": 81
     },
     {
       "label": "removeImage()",
@@ -9545,7 +9545,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L31",
       "id": "image_uploader_removeimage",
-      "community": 69
+      "community": 81
     },
     {
       "label": "unmarkForDeletion()",
@@ -9553,7 +9553,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L46",
       "id": "image_uploader_unmarkfordeletion",
-      "community": 69
+      "community": 81
     },
     {
       "label": "onDragEnd()",
@@ -9561,7 +9561,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L100",
       "id": "image_uploader_ondragend",
-      "community": 69
+      "community": 81
     },
     {
       "label": "input-otp.tsx",
@@ -9657,7 +9657,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_example_tsx",
-      "community": 104
+      "community": 105
     },
     {
       "label": "BasicModalExample()",
@@ -9665,7 +9665,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
       "source_location": "L7",
       "id": "custom_modal_example_basicmodalexample",
-      "community": 104
+      "community": 105
     },
     {
       "label": "CustomPositionModalExample()",
@@ -9673,7 +9673,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
       "source_location": "L44",
       "id": "custom_modal_example_custompositionmodalexample",
-      "community": 104
+      "community": 105
     },
     {
       "label": "CustomCloseButtonExample()",
@@ -9681,7 +9681,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
       "source_location": "L69",
       "id": "custom_modal_example_customclosebuttonexample",
-      "community": 104
+      "community": 105
     },
     {
       "label": "FullScreenModalExample()",
@@ -9689,7 +9689,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
       "source_location": "L103",
       "id": "custom_modal_example_fullscreenmodalexample",
-      "community": 104
+      "community": 105
     },
     {
       "label": "custom-modal.tsx",
@@ -10153,7 +10153,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_tsx",
-      "community": 63
+      "community": 64
     },
     {
       "label": "data-table-view-options.tsx",
@@ -10161,7 +10161,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-view-options.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_view_options_tsx",
-      "community": 13
+      "community": 14
     },
     {
       "label": "data-table.tsx",
@@ -10249,7 +10249,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_view_options_tsx",
-      "community": 13
+      "community": 14
     },
     {
       "label": "data-table.tsx",
@@ -10265,7 +10265,7 @@
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/selectable-data-provider.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
-      "community": 64
+      "community": 65
     },
     {
       "label": "ActivitySummaryCards.tsx",
@@ -11289,7 +11289,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
-      "community": 105
+      "community": 106
     },
     {
       "label": "usePOSProductSearch()",
@@ -11297,7 +11297,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L10",
       "id": "useposproducts_useposproductsearch",
-      "community": 105
+      "community": 106
     },
     {
       "label": "usePOSBarcodeSearch()",
@@ -11305,7 +11305,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L30",
       "id": "useposproducts_useposbarcodesearch",
-      "community": 105
+      "community": 106
     },
     {
       "label": "usePOSProductIdSearch()",
@@ -11313,7 +11313,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L41",
       "id": "useposproducts_useposproductidsearch",
-      "community": 105
+      "community": 106
     },
     {
       "label": "usePOSTransactionComplete()",
@@ -11321,7 +11321,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L100",
       "id": "useposproducts_usepostransactioncomplete",
-      "community": 105
+      "community": 106
     },
     {
       "label": "usePOSSessions.ts",
@@ -11633,7 +11633,7 @@
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_browserfingerprint_ts",
-      "community": 106
+      "community": 107
     },
     {
       "label": "bufferToHex()",
@@ -11641,7 +11641,7 @@
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
       "source_location": "L18",
       "id": "browserfingerprint_buffertohex",
-      "community": 106
+      "community": 107
     },
     {
       "label": "collectBrowserInfo()",
@@ -11649,7 +11649,7 @@
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
       "source_location": "L23",
       "id": "browserfingerprint_collectbrowserinfo",
-      "community": 106
+      "community": 107
     },
     {
       "label": "hashFingerprintSource()",
@@ -11657,7 +11657,7 @@
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
       "source_location": "L45",
       "id": "browserfingerprint_hashfingerprintsource",
-      "community": 106
+      "community": 107
     },
     {
       "label": "generateBrowserFingerprint()",
@@ -11665,7 +11665,7 @@
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
       "source_location": "L65",
       "id": "browserfingerprint_generatebrowserfingerprint",
-      "community": 106
+      "community": 107
     },
     {
       "label": "constants.ts",
@@ -11737,7 +11737,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_imageutils_test_ts",
-      "community": 107
+      "community": 108
     },
     {
       "label": "constructor()",
@@ -11745,7 +11745,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
       "source_location": "L74",
       "id": "imageutils_test_constructor",
-      "community": 107
+      "community": 108
     },
     {
       "label": "arrayBuffer()",
@@ -11753,7 +11753,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
       "source_location": "L78",
       "id": "imageutils_test_arraybuffer",
-      "community": 107
+      "community": 108
     },
     {
       "label": "MockImage",
@@ -11761,7 +11761,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
       "source_location": "L103",
       "id": "imageutils_test_mockimage",
-      "community": 107
+      "community": 108
     },
     {
       "label": ".src()",
@@ -11769,7 +11769,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
       "source_location": "L109",
       "id": "imageutils_test_mockimage_src",
-      "community": 107
+      "community": 108
     },
     {
       "label": "imageUtils.ts",
@@ -11777,7 +11777,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_imageutils_ts",
-      "community": 108
+      "community": 109
     },
     {
       "label": "getUploadImagesData()",
@@ -11785,7 +11785,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
       "source_location": "L4",
       "id": "imageutils_getuploadimagesdata",
-      "community": 108
+      "community": 109
     },
     {
       "label": "convertImagesToWebp()",
@@ -11793,7 +11793,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
       "source_location": "L26",
       "id": "imageutils_convertimagestowebp",
-      "community": 108
+      "community": 109
     },
     {
       "label": "convertToJpg()",
@@ -11801,7 +11801,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
       "source_location": "L38",
       "id": "imageutils_converttojpg",
-      "community": 108
+      "community": 109
     },
     {
       "label": "convertImagesToJpg()",
@@ -11809,7 +11809,7 @@
       "source_file": "packages/athena-webapp/src/lib/imageUtils.ts",
       "source_location": "L75",
       "id": "imageutils_convertimagestojpg",
-      "community": 108
+      "community": 109
     },
     {
       "label": "logger.ts",
@@ -12081,7 +12081,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_pos_transactionutils_ts",
-      "community": 109
+      "community": 110
     },
     {
       "label": "generateTransactionNumber()",
@@ -12089,7 +12089,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
       "source_location": "L14",
       "id": "transactionutils_generatetransactionnumber",
-      "community": 109
+      "community": 110
     },
     {
       "label": "formatCurrency()",
@@ -12097,7 +12097,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
       "source_location": "L29",
       "id": "transactionutils_formatcurrency",
-      "community": 109
+      "community": 110
     },
     {
       "label": "calculateChange()",
@@ -12105,7 +12105,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
       "source_location": "L42",
       "id": "transactionutils_calculatechange",
-      "community": 109
+      "community": 110
     },
     {
       "label": "formatTimestamp()",
@@ -12113,7 +12113,7 @@
       "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
       "source_location": "L49",
       "id": "transactionutils_formattimestamp",
-      "community": 109
+      "community": 110
     },
     {
       "label": "validation.ts",
@@ -12233,7 +12233,7 @@
       "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "community": 55
+      "community": 53
     },
     {
       "label": "getProductName()",
@@ -12241,7 +12241,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L18",
       "id": "productutils_getproductname",
-      "community": 55
+      "community": 53
     },
     {
       "label": "sortProduct()",
@@ -12249,7 +12249,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L66",
       "id": "productutils_sortproduct",
-      "community": 55
+      "community": 53
     },
     {
       "label": "category.ts",
@@ -12457,7 +12457,7 @@
       "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_timelineutils_ts",
-      "community": 110
+      "community": 111
     },
     {
       "label": "enrichTimelineEvent()",
@@ -12465,7 +12465,7 @@
       "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
       "source_location": "L184",
       "id": "timelineutils_enrichtimelineevent",
-      "community": 110
+      "community": 111
     },
     {
       "label": "enrichTimelineEvents()",
@@ -12473,7 +12473,7 @@
       "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
       "source_location": "L200",
       "id": "timelineutils_enrichtimelineevents",
-      "community": 110
+      "community": 111
     },
     {
       "label": "groupEventsByTimeframe()",
@@ -12481,7 +12481,7 @@
       "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
       "source_location": "L206",
       "id": "timelineutils_groupeventsbytimeframe",
-      "community": 110
+      "community": 111
     },
     {
       "label": "getTimeRangeLabel()",
@@ -12489,7 +12489,7 @@
       "source_file": "packages/athena-webapp/src/lib/timelineUtils.ts",
       "source_location": "L244",
       "id": "timelineutils_gettimerangelabel",
-      "community": 110
+      "community": 111
     },
     {
       "label": "utils.test.ts",
@@ -13345,7 +13345,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_tests_pos_simple_test_ts",
-      "community": 33
+      "community": 32
     },
     {
       "label": "generateTransactionNumber()",
@@ -13353,7 +13353,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L38",
       "id": "simple_test_generatetransactionnumber",
-      "community": 33
+      "community": 32
     },
     {
       "label": "validateInventory()",
@@ -13361,7 +13361,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L77",
       "id": "simple_test_validateinventory",
-      "community": 33
+      "community": 32
     },
     {
       "label": "validateInventoryWithAggregation()",
@@ -13369,7 +13369,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L130",
       "id": "simple_test_validateinventorywithaggregation",
-      "community": 33
+      "community": 32
     },
     {
       "label": "formatCurrency()",
@@ -13377,7 +13377,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L173",
       "id": "simple_test_formatcurrency",
-      "community": 33
+      "community": 32
     },
     {
       "label": "formatPaymentMethod()",
@@ -13385,7 +13385,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L201",
       "id": "simple_test_formatpaymentmethod",
-      "community": 33
+      "community": 32
     },
     {
       "label": "formatReceiptDate()",
@@ -13393,7 +13393,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L225",
       "id": "simple_test_formatreceiptdate",
-      "community": 33
+      "community": 32
     },
     {
       "label": "addToCart()",
@@ -13401,7 +13401,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L249",
       "id": "simple_test_addtocart",
-      "community": 33
+      "community": 32
     },
     {
       "label": "removeFromCart()",
@@ -13409,7 +13409,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L288",
       "id": "simple_test_removefromcart",
-      "community": 33
+      "community": 32
     },
     {
       "label": "updateQuantity()",
@@ -13417,7 +13417,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L311",
       "id": "simple_test_updatequantity",
-      "community": 33
+      "community": 32
     },
     {
       "label": "usePrint.test.ts",
@@ -13569,7 +13569,7 @@
       "source_file": "packages/storefront-webapp/src/api/analytics.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_analytics_ts",
-      "community": 111
+      "community": 112
     },
     {
       "label": "postAnalytics()",
@@ -13577,7 +13577,7 @@
       "source_file": "packages/storefront-webapp/src/api/analytics.ts",
       "source_location": "L3",
       "id": "analytics_postanalytics",
-      "community": 111
+      "community": 112
     },
     {
       "label": "updateAnalyticsOwner()",
@@ -13585,7 +13585,7 @@
       "source_file": "packages/storefront-webapp/src/api/analytics.ts",
       "source_location": "L32",
       "id": "analytics_updateanalyticsowner",
-      "community": 111
+      "community": 112
     },
     {
       "label": "logout()",
@@ -13593,7 +13593,7 @@
       "source_file": "packages/storefront-webapp/src/api/analytics.ts",
       "source_location": "L60",
       "id": "analytics_logout",
-      "community": 111
+      "community": 112
     },
     {
       "label": "getProductViewCount()",
@@ -13601,7 +13601,7 @@
       "source_file": "packages/storefront-webapp/src/api/analytics.ts",
       "source_location": "L78",
       "id": "analytics_getproductviewcount",
-      "community": 111
+      "community": 112
     },
     {
       "label": "auth.ts",
@@ -13713,7 +13713,7 @@
       "source_file": "packages/storefront-webapp/src/api/category.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_category_ts",
-      "community": 112
+      "community": 113
     },
     {
       "label": "getBaseUrl()",
@@ -13721,7 +13721,7 @@
       "source_file": "packages/storefront-webapp/src/api/category.ts",
       "source_location": "L9",
       "id": "category_getbaseurl",
-      "community": 112
+      "community": 113
     },
     {
       "label": "getAllCategories()",
@@ -13729,7 +13729,7 @@
       "source_file": "packages/storefront-webapp/src/api/category.ts",
       "source_location": "L11",
       "id": "category_getallcategories",
-      "community": 112
+      "community": 113
     },
     {
       "label": "getAllCategoriesWithSubcategories()",
@@ -13737,7 +13737,7 @@
       "source_file": "packages/storefront-webapp/src/api/category.ts",
       "source_location": "L25",
       "id": "category_getallcategorieswithsubcategories",
-      "community": 112
+      "community": 113
     },
     {
       "label": "getCategory()",
@@ -13745,7 +13745,7 @@
       "source_file": "packages/storefront-webapp/src/api/category.ts",
       "source_location": "L39",
       "id": "category_getcategory",
-      "community": 112
+      "community": 113
     },
     {
       "label": "checkoutSession.test.ts",
@@ -13769,7 +13769,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_checkoutsession_ts",
-      "community": 16
+      "community": 17
     },
     {
       "label": "getBaseUrl()",
@@ -13777,7 +13777,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L5",
       "id": "checkoutsession_getbaseurl",
-      "community": 16
+      "community": 17
     },
     {
       "label": "CheckoutSessionError",
@@ -13785,7 +13785,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L64",
       "id": "checkoutsession_checkoutsessionerror",
-      "community": 16
+      "community": 17
     },
     {
       "label": ".constructor()",
@@ -13793,7 +13793,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L69",
       "id": "checkoutsession_checkoutsessionerror_constructor",
-      "community": 16
+      "community": 17
     },
     {
       "label": "isRecord()",
@@ -13801,7 +13801,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L78",
       "id": "checkoutsession_isrecord",
-      "community": 16
+      "community": 17
     },
     {
       "label": "parseJson()",
@@ -13809,7 +13809,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L81",
       "id": "checkoutsession_parsejson",
-      "community": 16
+      "community": 17
     },
     {
       "label": "getCheckoutErrorMessageFromPayload()",
@@ -13817,7 +13817,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L98",
       "id": "checkoutsession_getcheckouterrormessagefrompayload",
-      "community": 16
+      "community": 17
     },
     {
       "label": "parseCheckoutResponse()",
@@ -13825,7 +13825,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L115",
       "id": "checkoutsession_parsecheckoutresponse",
-      "community": 16
+      "community": 17
     },
     {
       "label": "defaultCheckoutActionMessage()",
@@ -13833,7 +13833,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L135",
       "id": "checkoutsession_defaultcheckoutactionmessage",
-      "community": 16
+      "community": 17
     },
     {
       "label": "getCheckoutActionErrorMessage()",
@@ -13841,7 +13841,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L147",
       "id": "checkoutsession_getcheckoutactionerrormessage",
-      "community": 16
+      "community": 17
     },
     {
       "label": "createCheckoutSession()",
@@ -13849,7 +13849,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L184",
       "id": "checkoutsession_createcheckoutsession",
-      "community": 16
+      "community": 17
     },
     {
       "label": "getActiveCheckoutSession()",
@@ -13857,7 +13857,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L204",
       "id": "checkoutsession_getactivecheckoutsession",
-      "community": 16
+      "community": 17
     },
     {
       "label": "getPendingCheckoutSessions()",
@@ -13865,7 +13865,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L215",
       "id": "checkoutsession_getpendingcheckoutsessions",
-      "community": 16
+      "community": 17
     },
     {
       "label": "getCheckoutSession()",
@@ -13873,7 +13873,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L226",
       "id": "checkoutsession_getcheckoutsession",
-      "community": 16
+      "community": 17
     },
     {
       "label": "updateCheckoutSession()",
@@ -13881,7 +13881,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L239",
       "id": "checkoutsession_updatecheckoutsession",
-      "community": 16
+      "community": 17
     },
     {
       "label": "verifyCheckoutSessionPayment()",
@@ -13889,7 +13889,7 @@
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.ts",
       "source_location": "L274",
       "id": "checkoutsession_verifycheckoutsessionpayment",
-      "community": 16
+      "community": 17
     },
     {
       "label": "color.ts",
@@ -13969,7 +13969,7 @@
       "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_onlineorder_ts",
-      "community": 113
+      "community": 114
     },
     {
       "label": "getBaseUrl()",
@@ -13977,7 +13977,7 @@
       "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
       "source_location": "L4",
       "id": "onlineorder_getbaseurl",
-      "community": 113
+      "community": 114
     },
     {
       "label": "getOrders()",
@@ -13985,7 +13985,7 @@
       "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
       "source_location": "L6",
       "id": "onlineorder_getorders",
-      "community": 113
+      "community": 114
     },
     {
       "label": "getOrder()",
@@ -13993,7 +13993,7 @@
       "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
       "source_location": "L24",
       "id": "onlineorder_getorder",
-      "community": 113
+      "community": 114
     },
     {
       "label": "updateOrdersOwner()",
@@ -14001,7 +14001,7 @@
       "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
       "source_location": "L42",
       "id": "onlineorder_updateordersowner",
-      "community": 113
+      "community": 114
     },
     {
       "label": "organization.ts",
@@ -14249,7 +14249,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_rewards_ts",
-      "community": 34
+      "community": 33
     },
     {
       "label": "getBaseUrl()",
@@ -14257,7 +14257,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L3",
       "id": "rewards_getbaseurl",
-      "community": 34
+      "community": 33
     },
     {
       "label": "getUserPoints()",
@@ -14265,7 +14265,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L54",
       "id": "rewards_getuserpoints",
-      "community": 34
+      "community": 33
     },
     {
       "label": "getPointHistory()",
@@ -14273,7 +14273,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L71",
       "id": "rewards_getpointhistory",
-      "community": 34
+      "community": 33
     },
     {
       "label": "getRewardTiers()",
@@ -14281,7 +14281,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L90",
       "id": "rewards_getrewardtiers",
-      "community": 34
+      "community": 33
     },
     {
       "label": "redeemRewardPoints()",
@@ -14289,7 +14289,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L107",
       "id": "rewards_redeemrewardpoints",
-      "community": 34
+      "community": 33
     },
     {
       "label": "getEligiblePastOrders()",
@@ -14297,7 +14297,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L129",
       "id": "rewards_geteligiblepastorders",
-      "community": 34
+      "community": 33
     },
     {
       "label": "awardPointsForPastOrder()",
@@ -14305,7 +14305,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L151",
       "id": "rewards_awardpointsforpastorder",
-      "community": 34
+      "community": 33
     },
     {
       "label": "getOrderRewardPoints()",
@@ -14313,7 +14313,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L175",
       "id": "rewards_getorderrewardpoints",
-      "community": 34
+      "community": 33
     },
     {
       "label": "awardPointsForGuestOrders()",
@@ -14321,7 +14321,7 @@
       "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L198",
       "id": "rewards_awardpointsforguestorders",
-      "community": 34
+      "community": 33
     },
     {
       "label": "savedBag.ts",
@@ -14329,7 +14329,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_savedbag_ts",
-      "community": 53
+      "community": 54
     },
     {
       "label": "getBaseUrl()",
@@ -14337,7 +14337,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L8",
       "id": "savedbag_getbaseurl",
-      "community": 53
+      "community": 54
     },
     {
       "label": "getActiveSavedBag()",
@@ -14345,7 +14345,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L10",
       "id": "savedbag_getactivesavedbag",
-      "community": 53
+      "community": 54
     },
     {
       "label": "addItemToSavedBag()",
@@ -14353,7 +14353,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L25",
       "id": "savedbag_additemtosavedbag",
-      "community": 53
+      "community": 54
     },
     {
       "label": "updateSavedBagItem()",
@@ -14361,7 +14361,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L61",
       "id": "savedbag_updatesavedbagitem",
-      "community": 53
+      "community": 54
     },
     {
       "label": "removeItemFromSavedBag()",
@@ -14369,7 +14369,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L91",
       "id": "savedbag_removeitemfromsavedbag",
-      "community": 53
+      "community": 54
     },
     {
       "label": "updateSavedBagOwner()",
@@ -14377,7 +14377,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L109",
       "id": "savedbag_updatesavedbagowner",
-      "community": 53
+      "community": 54
     },
     {
       "label": "storeFrontUser.ts",
@@ -14385,7 +14385,7 @@
       "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_storefrontuser_ts",
-      "community": 114
+      "community": 115
     },
     {
       "label": "getBaseUrl()",
@@ -14393,7 +14393,7 @@
       "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
       "source_location": "L5",
       "id": "storefrontuser_getbaseurl",
-      "community": 114
+      "community": 115
     },
     {
       "label": "getGuest()",
@@ -14401,7 +14401,7 @@
       "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
       "source_location": "L7",
       "id": "storefrontuser_getguest",
-      "community": 114
+      "community": 115
     },
     {
       "label": "getActiveUser()",
@@ -14409,7 +14409,7 @@
       "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
       "source_location": "L28",
       "id": "storefrontuser_getactiveuser",
-      "community": 114
+      "community": 115
     },
     {
       "label": "updateUser()",
@@ -14417,7 +14417,7 @@
       "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
       "source_location": "L46",
       "id": "storefrontuser_updateuser",
-      "community": 114
+      "community": 115
     },
     {
       "label": "storefront.ts",
@@ -15273,7 +15273,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
-      "community": 31
+      "community": 34
     },
     {
       "label": "getPotentialPoints()",
@@ -15281,7 +15281,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
       "source_location": "L107",
       "id": "utils_getpotentialpoints",
-      "community": 31
+      "community": 34
     },
     {
       "label": "FadeIn.tsx",
@@ -15817,7 +15817,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_page_inventorylevelbadge_tsx",
-      "community": 115
+      "community": 116
     },
     {
       "label": "SoldOutBadge()",
@@ -15825,7 +15825,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
       "source_location": "L3",
       "id": "inventorylevelbadge_soldoutbadge",
-      "community": 115
+      "community": 116
     },
     {
       "label": "LowStockBadge()",
@@ -15833,7 +15833,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
       "source_location": "L14",
       "id": "inventorylevelbadge_lowstockbadge",
-      "community": 115
+      "community": 116
     },
     {
       "label": "SellingFastBadge()",
@@ -15841,7 +15841,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
       "source_location": "L22",
       "id": "inventorylevelbadge_sellingfastbadge",
-      "community": 115
+      "community": 116
     },
     {
       "label": "SellingFastSignal()",
@@ -15849,7 +15849,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
       "source_location": "L30",
       "id": "inventorylevelbadge_sellingfastsignal",
-      "community": 115
+      "community": 116
     },
     {
       "label": "OnSaleProduct.tsx",
@@ -16233,7 +16233,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_tsx",
-      "community": 54
+      "community": 55
     },
     {
       "label": "PendingItem()",
@@ -16241,7 +16241,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L62",
       "id": "shoppingbag_pendingitem",
-      "community": 54
+      "community": 55
     },
     {
       "label": "handleOnCheckoutClick()",
@@ -16249,7 +16249,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L476",
       "id": "shoppingbag_handleoncheckoutclick",
-      "community": 54
+      "community": 55
     },
     {
       "label": "handleClickOnDiscountCode()",
@@ -16257,7 +16257,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L525",
       "id": "shoppingbag_handleclickondiscountcode",
-      "community": 54
+      "community": 55
     },
     {
       "label": "isSkuUnavailable()",
@@ -16265,7 +16265,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L537",
       "id": "shoppingbag_isskuunavailable",
-      "community": 54
+      "community": 55
     },
     {
       "label": "handleMoveToSaved()",
@@ -16273,7 +16273,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L552",
       "id": "shoppingbag_handlemovetosaved",
-      "community": 54
+      "community": 55
     },
     {
       "label": "handleDeleteItem()",
@@ -16281,7 +16281,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L566",
       "id": "shoppingbag_handledeleteitem",
-      "community": 54
+      "community": 55
     },
     {
       "label": "CheckoutUnavailable.tsx",
@@ -16625,7 +16625,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "community": 69
+      "community": 81
     },
     {
       "label": "image-with-fallback.tsx",
@@ -17617,7 +17617,7 @@
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_feeutils_ts",
-      "community": 81
+      "community": 82
     },
     {
       "label": "meetsThreshold()",
@@ -17625,7 +17625,7 @@
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L17",
       "id": "feeutils_meetsthreshold",
-      "community": 81
+      "community": 82
     },
     {
       "label": "isFeeWaived()",
@@ -17633,7 +17633,7 @@
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L34",
       "id": "feeutils_isfeewaived",
-      "community": 81
+      "community": 82
     },
     {
       "label": "isAnyFeeWaived()",
@@ -17641,7 +17641,7 @@
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L74",
       "id": "feeutils_isanyfeewaived",
-      "community": 81
+      "community": 82
     },
     {
       "label": "hasWaiverConfigured()",
@@ -17649,7 +17649,7 @@
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L100",
       "id": "feeutils_haswaiverconfigured",
-      "community": 81
+      "community": 82
     },
     {
       "label": "getRemainingForFreeDelivery()",
@@ -17657,7 +17657,7 @@
       "source_file": "packages/storefront-webapp/src/lib/feeUtils.ts",
       "source_location": "L138",
       "id": "feeutils_getremainingforfreedelivery",
-      "community": 81
+      "community": 82
     },
     {
       "label": "ghana.ts",
@@ -17721,7 +17721,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "community": 55
+      "community": 53
     },
     {
       "label": "isSoldOut()",
@@ -17729,7 +17729,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L45",
       "id": "productutils_issoldout",
-      "community": 55
+      "community": 53
     },
     {
       "label": "hasLowStock()",
@@ -17737,7 +17737,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L52",
       "id": "productutils_haslowstock",
-      "community": 55
+      "community": 53
     },
     {
       "label": "sortSkusByLength()",
@@ -17745,7 +17745,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L62",
       "id": "productutils_sortskusbylength",
-      "community": 55
+      "community": 53
     },
     {
       "label": "bag.ts",
@@ -18089,7 +18089,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_ts",
-      "community": 116
+      "community": 117
     },
     {
       "label": "inferStorefrontJourneyFromRoute()",
@@ -18097,7 +18097,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
       "source_location": "L25",
       "id": "storefrontfailureobservability_inferstorefrontjourneyfromroute",
-      "community": 116
+      "community": 117
     },
     {
       "label": "normalizeStorefrontError()",
@@ -18105,7 +18105,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
       "source_location": "L47",
       "id": "storefrontfailureobservability_normalizestorefronterror",
-      "community": 116
+      "community": 117
     },
     {
       "label": "createStorefrontFailureEvent()",
@@ -18113,7 +18113,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
       "source_location": "L136",
       "id": "storefrontfailureobservability_createstorefrontfailureevent",
-      "community": 116
+      "community": 117
     },
     {
       "label": "emitStorefrontFailure()",
@@ -18121,7 +18121,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.ts",
       "source_location": "L154",
       "id": "storefrontfailureobservability_emitstorefrontfailure",
-      "community": 116
+      "community": 117
     },
     {
       "label": "storefrontJourneyEvents.test.ts",
@@ -18137,7 +18137,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_storefrontjourneyevents_ts",
-      "community": 0
+      "community": 1
     },
     {
       "label": "compactContext()",
@@ -18145,7 +18145,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L7",
       "id": "storefrontjourneyevents_compactcontext",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createJourneyEvent()",
@@ -18153,7 +18153,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L19",
       "id": "storefrontjourneyevents_createjourneyevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createLandingPageViewedEvent()",
@@ -18161,7 +18161,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L33",
       "id": "storefrontjourneyevents_createlandingpageviewedevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createCategoryBrowseViewedEvent()",
@@ -18169,7 +18169,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L41",
       "id": "storefrontjourneyevents_createcategorybrowseviewedevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createProductDetailViewedEvent()",
@@ -18177,7 +18177,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L59",
       "id": "storefrontjourneyevents_createproductdetailviewedevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createBagViewedEvent()",
@@ -18185,7 +18185,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L83",
       "id": "storefrontjourneyevents_createbagviewedevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createBagAddSucceededEvent()",
@@ -18193,7 +18193,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L101",
       "id": "storefrontjourneyevents_createbagaddsucceededevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createBagRemoveSucceededEvent()",
@@ -18201,7 +18201,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L122",
       "id": "storefrontjourneyevents_createbagremovesucceededevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createCheckoutStartEvent()",
@@ -18209,7 +18209,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L143",
       "id": "storefrontjourneyevents_createcheckoutstartevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createCheckoutDetailsViewedEvent()",
@@ -18217,7 +18217,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L164",
       "id": "storefrontjourneyevents_createcheckoutdetailsviewedevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createOrderReviewViewedEvent()",
@@ -18225,7 +18225,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L179",
       "id": "storefrontjourneyevents_createorderreviewviewedevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createPaymentSubmissionStartedEvent()",
@@ -18233,7 +18233,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L194",
       "id": "storefrontjourneyevents_createpaymentsubmissionstartedevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createPaymentVerificationStartedEvent()",
@@ -18241,7 +18241,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L215",
       "id": "storefrontjourneyevents_createpaymentverificationstartedevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createCheckoutCompletionEvent()",
@@ -18249,7 +18249,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L233",
       "id": "storefrontjourneyevents_createcheckoutcompletionevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createCheckoutCompletionSucceededEvent()",
@@ -18257,7 +18257,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L256",
       "id": "storefrontjourneyevents_createcheckoutcompletionsucceededevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createCheckoutCompletionBlockedEvent()",
@@ -18265,7 +18265,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L273",
       "id": "storefrontjourneyevents_createcheckoutcompletionblockedevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createCheckoutCompletionCanceledEvent()",
@@ -18273,7 +18273,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L290",
       "id": "storefrontjourneyevents_createcheckoutcompletioncanceledevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "getAuthEntryStep()",
@@ -18281,7 +18281,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L307",
       "id": "storefrontjourneyevents_getauthentrystep",
-      "community": 0
+      "community": 1
     },
     {
       "label": "getAuthRequestStep()",
@@ -18289,7 +18289,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L311",
       "id": "storefrontjourneyevents_getauthrequeststep",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createAuthEntryViewedEvent()",
@@ -18297,7 +18297,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L315",
       "id": "storefrontjourneyevents_createauthentryviewedevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createAuthRequestStartedEvent()",
@@ -18305,7 +18305,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L335",
       "id": "storefrontjourneyevents_createauthrequeststartedevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createAuthVerificationViewedEvent()",
@@ -18313,7 +18313,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L355",
       "id": "storefrontjourneyevents_createauthverificationviewedevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createAuthVerificationSucceededEvent()",
@@ -18321,7 +18321,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L370",
       "id": "storefrontjourneyevents_createauthverificationsucceededevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createRewardsAlertViewedEvent()",
@@ -18329,7 +18329,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L387",
       "id": "storefrontjourneyevents_createrewardsalertviewedevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createRewardsAlertDismissedEvent()",
@@ -18337,7 +18337,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L395",
       "id": "storefrontjourneyevents_createrewardsalertdismissedevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createRewardsAlertShopNowEvent()",
@@ -18345,7 +18345,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L403",
       "id": "storefrontjourneyevents_createrewardsalertshopnowevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createPromoAlertViewedEvent()",
@@ -18353,7 +18353,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L411",
       "id": "storefrontjourneyevents_createpromoalertviewedevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createPromoAlertDismissedEvent()",
@@ -18361,7 +18361,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L435",
       "id": "storefrontjourneyevents_createpromoalertdismissedevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createPromoAlertShopNowEvent()",
@@ -18369,7 +18369,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L459",
       "id": "storefrontjourneyevents_createpromoalertshopnowevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createWelcomeBackModalViewedEvent()",
@@ -18377,7 +18377,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L483",
       "id": "storefrontjourneyevents_createwelcomebackmodalviewedevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createWelcomeBackModalDismissedEvent()",
@@ -18385,7 +18385,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L501",
       "id": "storefrontjourneyevents_createwelcomebackmodaldismissedevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createWelcomeBackModalSubmittedEvent()",
@@ -18393,7 +18393,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L519",
       "id": "storefrontjourneyevents_createwelcomebackmodalsubmittedevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createLeaveReviewModalViewedEvent()",
@@ -18401,7 +18401,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L537",
       "id": "storefrontjourneyevents_createleavereviewmodalviewedevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createLeaveReviewModalDismissedEvent()",
@@ -18409,7 +18409,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L555",
       "id": "storefrontjourneyevents_createleavereviewmodaldismissedevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createUpsellModalViewedEvent()",
@@ -18417,7 +18417,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L573",
       "id": "storefrontjourneyevents_createupsellmodalviewedevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createUpsellModalDismissedEvent()",
@@ -18425,7 +18425,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L600",
       "id": "storefrontjourneyevents_createupsellmodaldismissedevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createUpsellModalSubmittedEvent()",
@@ -18433,7 +18433,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L627",
       "id": "storefrontjourneyevents_createupsellmodalsubmittedevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createUpsellModalAddToBagEvent()",
@@ -18441,7 +18441,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L654",
       "id": "storefrontjourneyevents_createupsellmodaladdtobagevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createSavedBagViewedEvent()",
@@ -18449,7 +18449,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L676",
       "id": "storefrontjourneyevents_createsavedbagviewedevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createSavedBagMoveToBagEvent()",
@@ -18457,7 +18457,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L684",
       "id": "storefrontjourneyevents_createsavedbagmovetobagevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createSavedBagRemoveEvent()",
@@ -18465,7 +18465,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L705",
       "id": "storefrontjourneyevents_createsavedbagremoveevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createBagMoveToSavedEvent()",
@@ -18473,7 +18473,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L726",
       "id": "storefrontjourneyevents_createbagmovetosavedevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createDiscountCodeTriggerEvent()",
@@ -18481,7 +18481,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L747",
       "id": "storefrontjourneyevents_creatediscountcodetriggerevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createReviewEditorViewedEvent()",
@@ -18489,7 +18489,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L762",
       "id": "storefrontjourneyevents_createrevieweditorviewedevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "createReviewSubmittedEvent()",
@@ -18497,7 +18497,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts",
       "source_location": "L786",
       "id": "storefrontjourneyevents_createreviewsubmittedevent",
-      "community": 0
+      "community": 1
     },
     {
       "label": "storefrontObservability.test.ts",
@@ -18521,7 +18521,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_storefrontobservability_ts",
-      "community": 117
+      "community": 118
     },
     {
       "label": "getOrCreateStorefrontObservabilitySessionId()",
@@ -18529,7 +18529,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L109",
       "id": "storefrontobservability_getorcreatestorefrontobservabilitysessionid",
-      "community": 117
+      "community": 118
     },
     {
       "label": "createStorefrontObservabilityContext()",
@@ -18537,7 +18537,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L134",
       "id": "storefrontobservability_createstorefrontobservabilitycontext",
-      "community": 117
+      "community": 118
     },
     {
       "label": "createStorefrontObservabilityPayload()",
@@ -18545,7 +18545,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L157",
       "id": "storefrontobservability_createstorefrontobservabilitypayload",
-      "community": 117
+      "community": 118
     },
     {
       "label": "trackStorefrontEvent()",
@@ -18553,7 +18553,7 @@
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L193",
       "id": "storefrontobservability_trackstorefrontevent",
-      "community": 117
+      "community": 118
     },
     {
       "label": "utils.test.ts",
@@ -18913,7 +18913,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_auth_verify_tsx",
-      "community": 82
+      "community": 83
     },
     {
       "label": "reportAuthFailure()",
@@ -18921,7 +18921,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L93",
       "id": "auth_verify_reportauthfailure",
-      "community": 82
+      "community": 83
     },
     {
       "label": "formatTime()",
@@ -18929,7 +18929,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L149",
       "id": "auth_verify_formattime",
-      "community": 82
+      "community": 83
     },
     {
       "label": "handleCodeChange()",
@@ -18937,7 +18937,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L156",
       "id": "auth_verify_handlecodechange",
-      "community": 82
+      "community": 83
     },
     {
       "label": "onSubmit()",
@@ -18945,7 +18945,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L201",
       "id": "auth_verify_onsubmit",
-      "community": 82
+      "community": 83
     },
     {
       "label": "resendVerificationCode()",
@@ -18953,7 +18953,7 @@
       "source_file": "packages/storefront-webapp/src/routes/auth.verify.tsx",
       "source_location": "L282",
       "id": "auth_verify_resendverificationcode",
-      "community": 82
+      "community": 83
     },
     {
       "label": "index.tsx",
@@ -19489,7 +19489,7 @@
       "source_file": "scripts/graphify-check.ts",
       "source_location": "L1",
       "id": "scripts_graphify_check_ts",
-      "community": 83
+      "community": 84
     },
     {
       "label": "fileExists()",
@@ -19497,7 +19497,7 @@
       "source_file": "scripts/graphify-check.ts",
       "source_location": "L62",
       "id": "graphify_check_fileexists",
-      "community": 83
+      "community": 84
     },
     {
       "label": "collectRepoCodeFiles()",
@@ -19505,7 +19505,7 @@
       "source_file": "scripts/graphify-check.ts",
       "source_location": "L71",
       "id": "graphify_check_collectrepocodefiles",
-      "community": 83
+      "community": 84
     },
     {
       "label": "copyGraphifyCheckInputs()",
@@ -19513,7 +19513,7 @@
       "source_file": "scripts/graphify-check.ts",
       "source_location": "L105",
       "id": "graphify_check_copygraphifycheckinputs",
-      "community": 83
+      "community": 84
     },
     {
       "label": "collectStaleGraphifyArtifacts()",
@@ -19521,7 +19521,7 @@
       "source_file": "scripts/graphify-check.ts",
       "source_location": "L123",
       "id": "graphify_check_collectstalegraphifyartifacts",
-      "community": 83
+      "community": 84
     },
     {
       "label": "runGraphifyCheck()",
@@ -19529,7 +19529,7 @@
       "source_file": "scripts/graphify-check.ts",
       "source_location": "L150",
       "id": "graphify_check_rungraphifycheck",
-      "community": 83
+      "community": 84
     },
     {
       "label": "graphify-rebuild.test.ts",
@@ -19625,7 +19625,7 @@
       "source_file": "scripts/graphify-wiki.ts",
       "source_location": "L1",
       "id": "scripts_graphify_wiki_ts",
-      "community": 12
+      "community": 13
     },
     {
       "label": "fileExists()",
@@ -19633,7 +19633,7 @@
       "source_file": "scripts/graphify-wiki.ts",
       "source_location": "L78",
       "id": "graphify_wiki_fileexists",
-      "community": 12
+      "community": 13
     },
     {
       "label": "collectRepoCodeFiles()",
@@ -19641,7 +19641,7 @@
       "source_file": "scripts/graphify-wiki.ts",
       "source_location": "L87",
       "id": "graphify_wiki_collectrepocodefiles",
-      "community": 12
+      "community": 13
     },
     {
       "label": "readDir()",
@@ -19649,7 +19649,7 @@
       "source_file": "scripts/graphify-wiki.ts",
       "source_location": "L121",
       "id": "graphify_wiki_readdir",
-      "community": 12
+      "community": 13
     },
     {
       "label": "normalizeRepoPath()",
@@ -19657,7 +19657,7 @@
       "source_file": "scripts/graphify-wiki.ts",
       "source_location": "L126",
       "id": "graphify_wiki_normalizerepopath",
-      "community": 12
+      "community": 13
     },
     {
       "label": "toMarkdownLink()",
@@ -19665,7 +19665,7 @@
       "source_file": "scripts/graphify-wiki.ts",
       "source_location": "L130",
       "id": "graphify_wiki_tomarkdownlink",
-      "community": 12
+      "community": 13
     },
     {
       "label": "toSourceLink()",
@@ -19673,7 +19673,7 @@
       "source_file": "scripts/graphify-wiki.ts",
       "source_location": "L138",
       "id": "graphify_wiki_tosourcelink",
-      "community": 12
+      "community": 13
     },
     {
       "label": "formatList()",
@@ -19681,7 +19681,7 @@
       "source_file": "scripts/graphify-wiki.ts",
       "source_location": "L143",
       "id": "graphify_wiki_formatlist",
-      "community": 12
+      "community": 13
     },
     {
       "label": "countCommunities()",
@@ -19689,7 +19689,7 @@
       "source_file": "scripts/graphify-wiki.ts",
       "source_location": "L147",
       "id": "graphify_wiki_countcommunities",
-      "community": 12
+      "community": 13
     },
     {
       "label": "buildDegreeIndex()",
@@ -19697,7 +19697,7 @@
       "source_file": "scripts/graphify-wiki.ts",
       "source_location": "L151",
       "id": "graphify_wiki_builddegreeindex",
-      "community": 12
+      "community": 13
     },
     {
       "label": "scoreNode()",
@@ -19705,7 +19705,7 @@
       "source_file": "scripts/graphify-wiki.ts",
       "source_location": "L162",
       "id": "graphify_wiki_scorenode",
-      "community": 12
+      "community": 13
     },
     {
       "label": "compareHotspots()",
@@ -19713,7 +19713,7 @@
       "source_file": "scripts/graphify-wiki.ts",
       "source_location": "L169",
       "id": "graphify_wiki_comparehotspots",
-      "community": 12
+      "community": 13
     },
     {
       "label": "buildHotspotLines()",
@@ -19721,7 +19721,7 @@
       "source_file": "scripts/graphify-wiki.ts",
       "source_location": "L189",
       "id": "graphify_wiki_buildhotspotlines",
-      "community": 12
+      "community": 13
     },
     {
       "label": "loadGraphifyGraph()",
@@ -19729,7 +19729,7 @@
       "source_file": "scripts/graphify-wiki.ts",
       "source_location": "L212",
       "id": "graphify_wiki_loadgraphifygraph",
-      "community": 12
+      "community": 13
     },
     {
       "label": "buildRootIndexPage()",
@@ -19737,7 +19737,7 @@
       "source_file": "scripts/graphify-wiki.ts",
       "source_location": "L226",
       "id": "graphify_wiki_buildrootindexpage",
-      "community": 12
+      "community": 13
     },
     {
       "label": "buildPackagePage()",
@@ -19745,7 +19745,7 @@
       "source_file": "scripts/graphify-wiki.ts",
       "source_location": "L271",
       "id": "graphify_wiki_buildpackagepage",
-      "community": 12
+      "community": 13
     },
     {
       "label": "generateGraphifyWikiPages()",
@@ -19753,7 +19753,7 @@
       "source_file": "scripts/graphify-wiki.ts",
       "source_location": "L338",
       "id": "graphify_wiki_generategraphifywikipages",
-      "community": 12
+      "community": 13
     },
     {
       "label": "writeGraphifyWikiPages()",
@@ -19761,7 +19761,7 @@
       "source_file": "scripts/graphify-wiki.ts",
       "source_location": "L370",
       "id": "graphify_wiki_writegraphifywikipages",
-      "community": 12
+      "community": 13
     },
     {
       "label": "harness-app-registry.test.ts",
@@ -20897,7 +20897,7 @@
       "source_file": "scripts/harness-inferential-review.ts",
       "source_location": "L1",
       "id": "scripts_harness_inferential_review_ts",
-      "community": 1
+      "community": 0
     },
     {
       "label": "normalizeRepoPath()",
@@ -20905,7 +20905,7 @@
       "source_file": "scripts/harness-inferential-review.ts",
       "source_location": "L108",
       "id": "harness_inferential_review_normalizerepopath",
-      "community": 1
+      "community": 0
     },
     {
       "label": "sortUnique()",
@@ -20913,7 +20913,7 @@
       "source_file": "scripts/harness-inferential-review.ts",
       "source_location": "L112",
       "id": "harness_inferential_review_sortunique",
-      "community": 1
+      "community": 0
     },
     {
       "label": "fileExists()",
@@ -20921,7 +20921,7 @@
       "source_file": "scripts/harness-inferential-review.ts",
       "source_location": "L118",
       "id": "harness_inferential_review_fileexists",
-      "community": 1
+      "community": 0
     },
     {
       "label": "readUtf8OrNull()",
@@ -20929,7 +20929,7 @@
       "source_file": "scripts/harness-inferential-review.ts",
       "source_location": "L127",
       "id": "harness_inferential_review_readutf8ornull",
-      "community": 1
+      "community": 0
     },
     {
       "label": "runCommand()",
@@ -20937,7 +20937,7 @@
       "source_file": "scripts/harness-inferential-review.ts",
       "source_location": "L141",
       "id": "harness_inferential_review_runcommand",
-      "community": 1
+      "community": 0
     },
     {
       "label": "getChangedFilesForInferentialReview()",
@@ -20945,7 +20945,7 @@
       "source_file": "scripts/harness-inferential-review.ts",
       "source_location": "L168",
       "id": "harness_inferential_review_getchangedfilesforinferentialreview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "isHarnessCriticalFile()",
@@ -20953,7 +20953,7 @@
       "source_file": "scripts/harness-inferential-review.ts",
       "source_location": "L232",
       "id": "harness_inferential_review_isharnesscriticalfile",
-      "community": 1
+      "community": 0
     },
     {
       "label": "buildFinding()",
@@ -20961,7 +20961,7 @@
       "source_file": "scripts/harness-inferential-review.ts",
       "source_location": "L257",
       "id": "harness_inferential_review_buildfinding",
-      "community": 1
+      "community": 0
     },
     {
       "label": "includesCaseInsensitive()",
@@ -20969,247 +20969,303 @@
       "source_file": "scripts/harness-inferential-review.ts",
       "source_location": "L275",
       "id": "harness_inferential_review_includescaseinsensitive",
-      "community": 1
+      "community": 0
+    },
+    {
+      "label": "escapeRegExp()",
+      "file_type": "code",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L279",
+      "id": "harness_inferential_review_escaperegexp",
+      "community": 0
+    },
+    {
+      "label": "buildShellCommandPattern()",
+      "file_type": "code",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L283",
+      "id": "harness_inferential_review_buildshellcommandpattern",
+      "community": 0
+    },
+    {
+      "label": "hasHarnessReviewCommand()",
+      "file_type": "code",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L290",
+      "id": "harness_inferential_review_hasharnessreviewcommand",
+      "community": 0
+    },
+    {
+      "label": "hasHarnessInferentialCommand()",
+      "file_type": "code",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L297",
+      "id": "harness_inferential_review_hasharnessinferentialcommand",
+      "community": 0
+    },
+    {
+      "label": "extractWorkflowJobSection()",
+      "file_type": "code",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L303",
+      "id": "harness_inferential_review_extractworkflowjobsection",
+      "community": 0
+    },
+    {
+      "label": "extractWorkflowRunCommands()",
+      "file_type": "code",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L337",
+      "id": "harness_inferential_review_extractworkflowruncommands",
+      "community": 0
+    },
+    {
+      "label": "workflowJobHasEnvSetting()",
+      "file_type": "code",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L354",
+      "id": "harness_inferential_review_workflowjobhasenvsetting",
+      "community": 0
     },
     {
       "label": "slugifyForFindingId()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L279",
+      "source_location": "L371",
       "id": "harness_inferential_review_slugifyforfindingid",
-      "community": 1
+      "community": 0
     },
     {
       "label": "isHarnessScriptSourceFile()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L286",
+      "source_location": "L378",
       "id": "harness_inferential_review_isharnessscriptsourcefile",
-      "community": 1
+      "community": 0
     },
     {
       "label": "toHarnessScriptTestPath()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L291",
+      "source_location": "L383",
       "id": "harness_inferential_review_toharnessscripttestpath",
-      "community": 1
+      "community": 0
     },
     {
       "label": "formatMissingSignals()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L295",
+      "source_location": "L387",
       "id": "harness_inferential_review_formatmissingsignals",
-      "community": 1
+      "community": 0
     },
     {
       "label": "createReducedSignalFinding()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L299",
+      "source_location": "L391",
       "id": "harness_inferential_review_createreducedsignalfinding",
-      "community": 1
+      "community": 0
     },
     {
       "label": "collectHarnessScriptTestUpdateFindings()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L316",
+      "source_location": "L408",
       "id": "harness_inferential_review_collectharnessscripttestupdatefindings",
-      "community": 1
+      "community": 0
     },
     {
       "label": "collectHarnessSafetySignalFindings()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L353",
+      "source_location": "L445",
       "id": "harness_inferential_review_collectharnesssafetysignalfindings",
-      "community": 1
+      "community": 0
     },
     {
       "label": "runDeterministicSemanticAnalysis()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L449",
+      "source_location": "L541",
       "id": "harness_inferential_review_rundeterministicsemanticanalysis",
-      "community": 1
+      "community": 0
     },
     {
       "label": "resolveSemanticMode()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L468",
+      "source_location": "L560",
       "id": "harness_inferential_review_resolvesemanticmode",
-      "community": 1
+      "community": 0
     },
     {
       "label": "buildShadowSummary()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L477",
+      "source_location": "L569",
       "id": "harness_inferential_review_buildshadowsummary",
-      "community": 1
+      "community": 0
     },
     {
       "label": "truncateForPrompt()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L483",
+      "source_location": "L575",
       "id": "harness_inferential_review_truncateforprompt",
-      "community": 1
+      "community": 0
     },
     {
       "label": "buildSemanticPrompt()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L491",
+      "source_location": "L583",
       "id": "harness_inferential_review_buildsemanticprompt",
-      "community": 1
+      "community": 0
     },
     {
       "label": "extractTextFromAnthropicResponse()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L519",
+      "source_location": "L611",
       "id": "harness_inferential_review_extracttextfromanthropicresponse",
-      "community": 1
+      "community": 0
     },
     {
       "label": "extractJsonPayload()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L545",
+      "source_location": "L637",
       "id": "harness_inferential_review_extractjsonpayload",
-      "community": 1
+      "community": 0
     },
     {
       "label": "normalizeSemanticFinding()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L565",
+      "source_location": "L657",
       "id": "harness_inferential_review_normalizesemanticfinding",
-      "community": 1
+      "community": 0
     },
     {
       "label": "parseSemanticResponse()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L614",
+      "source_location": "L706",
       "id": "harness_inferential_review_parsesemanticresponse",
-      "community": 1
+      "community": 0
     },
     {
       "label": "runAnthropicSemanticAnalysis()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L637",
+      "source_location": "L729",
       "id": "harness_inferential_review_runanthropicsemanticanalysis",
-      "community": 1
+      "community": 0
     },
     {
       "label": "runDeterministicInferentialProvider()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L676",
+      "source_location": "L768",
       "id": "harness_inferential_review_rundeterministicinferentialprovider",
-      "community": 1
+      "community": 0
     },
     {
       "label": "sortFindings()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L844",
+      "source_location": "L970",
       "id": "harness_inferential_review_sortfindings",
-      "community": 1
+      "community": 0
     },
     {
       "label": "formatStatusLabel()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L863",
+      "source_location": "L989",
       "id": "harness_inferential_review_formatstatuslabel",
-      "community": 1
+      "community": 0
     },
     {
       "label": "buildHumanReport()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L876",
+      "source_location": "L1002",
       "id": "harness_inferential_review_buildhumanreport",
-      "community": 1
+      "community": 0
     },
     {
       "label": "writeMachineOutput()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L946",
+      "source_location": "L1072",
       "id": "harness_inferential_review_writemachineoutput",
-      "community": 1
+      "community": 0
     },
     {
       "label": "toHistoryFileStamp()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L956",
+      "source_location": "L1082",
       "id": "harness_inferential_review_tohistoryfilestamp",
-      "community": 1
+      "community": 0
     },
     {
       "label": "writeHistorySnapshot()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L960",
+      "source_location": "L1086",
       "id": "harness_inferential_review_writehistorysnapshot",
-      "community": 1
+      "community": 0
     },
     {
       "label": "createOutput()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L976",
+      "source_location": "L1102",
       "id": "harness_inferential_review_createoutput",
-      "community": 1
+      "community": 0
     },
     {
       "label": "createShadowOutput()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1005",
+      "source_location": "L1131",
       "id": "harness_inferential_review_createshadowoutput",
-      "community": 1
+      "community": 0
     },
     {
       "label": "createProviderFailure()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1023",
+      "source_location": "L1149",
       "id": "harness_inferential_review_createproviderfailure",
-      "community": 1
+      "community": 0
     },
     {
       "label": "createRuntimeFailure()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1052",
+      "source_location": "L1178",
       "id": "harness_inferential_review_createruntimefailure",
-      "community": 1
+      "community": 0
     },
     {
       "label": "runHarnessInferentialReview()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1081",
+      "source_location": "L1207",
       "id": "harness_inferential_review_runharnessinferentialreview",
-      "community": 1
+      "community": 0
     },
     {
       "label": "parseHarnessInferentialReviewArgs()",
       "file_type": "code",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1329",
+      "source_location": "L1455",
       "id": "harness_inferential_review_parseharnessinferentialreviewargs",
-      "community": 1
+      "community": 0
     },
     {
       "label": "harness-janitor.test.ts",
@@ -21273,7 +21329,7 @@
       "source_file": "scripts/harness-janitor.ts",
       "source_location": "L1",
       "id": "scripts_harness_janitor_ts",
-      "community": 14
+      "community": 15
     },
     {
       "label": "formatError()",
@@ -21281,7 +21337,7 @@
       "source_file": "scripts/harness-janitor.ts",
       "source_location": "L69",
       "id": "harness_janitor_formaterror",
-      "community": 14
+      "community": 15
     },
     {
       "label": "sortUniquePaths()",
@@ -21289,7 +21345,7 @@
       "source_file": "scripts/harness-janitor.ts",
       "source_location": "L73",
       "id": "harness_janitor_sortuniquepaths",
-      "community": 14
+      "community": 15
     },
     {
       "label": "fileExists()",
@@ -21297,7 +21353,7 @@
       "source_file": "scripts/harness-janitor.ts",
       "source_location": "L79",
       "id": "harness_janitor_fileexists",
-      "community": 14
+      "community": 15
     },
     {
       "label": "readUtf8OrNull()",
@@ -21305,7 +21361,7 @@
       "source_file": "scripts/harness-janitor.ts",
       "source_location": "L88",
       "id": "harness_janitor_readutf8ornull",
-      "community": 14
+      "community": 15
     },
     {
       "label": "snapshotFiles()",
@@ -21313,7 +21369,7 @@
       "source_file": "scripts/harness-janitor.ts",
       "source_location": "L96",
       "id": "harness_janitor_snapshotfiles",
-      "community": 14
+      "community": 15
     },
     {
       "label": "compareSnapshots()",
@@ -21321,7 +21377,7 @@
       "source_file": "scripts/harness-janitor.ts",
       "source_location": "L107",
       "id": "harness_janitor_comparesnapshots",
-      "community": 14
+      "community": 15
     },
     {
       "label": "formatDetailLines()",
@@ -21329,7 +21385,7 @@
       "source_file": "scripts/harness-janitor.ts",
       "source_location": "L124",
       "id": "harness_janitor_formatdetaillines",
-      "community": 14
+      "community": 15
     },
     {
       "label": "formatArtifactList()",
@@ -21337,7 +21393,7 @@
       "source_file": "scripts/harness-janitor.ts",
       "source_location": "L131",
       "id": "harness_janitor_formatartifactlist",
-      "community": 14
+      "community": 15
     },
     {
       "label": "withCapturedConsole()",
@@ -21345,7 +21401,7 @@
       "source_file": "scripts/harness-janitor.ts",
       "source_location": "L139",
       "id": "harness_janitor_withcapturedconsole",
-      "community": 14
+      "community": 15
     },
     {
       "label": "runCheckStep()",
@@ -21353,7 +21409,7 @@
       "source_file": "scripts/harness-janitor.ts",
       "source_location": "L163",
       "id": "harness_janitor_runcheckstep",
-      "community": 14
+      "community": 15
     },
     {
       "label": "runRepairStep()",
@@ -21361,7 +21417,7 @@
       "source_file": "scripts/harness-janitor.ts",
       "source_location": "L175",
       "id": "harness_janitor_runrepairstep",
-      "community": 14
+      "community": 15
     },
     {
       "label": "buildSummary()",
@@ -21369,7 +21425,7 @@
       "source_file": "scripts/harness-janitor.ts",
       "source_location": "L215",
       "id": "harness_janitor_buildsummary",
-      "community": 14
+      "community": 15
     },
     {
       "label": "hasFailures()",
@@ -21377,7 +21433,7 @@
       "source_file": "scripts/harness-janitor.ts",
       "source_location": "L242",
       "id": "harness_janitor_hasfailures",
-      "community": 14
+      "community": 15
     },
     {
       "label": "runHarnessJanitor()",
@@ -21385,7 +21441,7 @@
       "source_file": "scripts/harness-janitor.ts",
       "source_location": "L252",
       "id": "harness_janitor_runharnessjanitor",
-      "community": 14
+      "community": 15
     },
     {
       "label": "parseHarnessJanitorCliArgs()",
@@ -21393,7 +21449,7 @@
       "source_file": "scripts/harness-janitor.ts",
       "source_location": "L342",
       "id": "harness_janitor_parseharnessjanitorcliargs",
-      "community": 14
+      "community": 15
     },
     {
       "label": "formatHarnessJanitorReport()",
@@ -21401,7 +21457,7 @@
       "source_file": "scripts/harness-janitor.ts",
       "source_location": "L372",
       "id": "harness_janitor_formatharnessjanitorreport",
-      "community": 14
+      "community": 15
     },
     {
       "label": "harness-review.test.ts",
@@ -21409,39 +21465,55 @@
       "source_file": "scripts/harness-review.test.ts",
       "source_location": "L1",
       "id": "scripts_harness_review_test_ts",
-      "community": 118
+      "community": 58
     },
     {
       "label": "write()",
       "file_type": "code",
       "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L10",
+      "source_location": "L15",
       "id": "harness_review_test_write",
-      "community": 118
+      "community": 58
     },
     {
       "label": "createFixtureRepo()",
       "file_type": "code",
       "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L16",
+      "source_location": "L21",
       "id": "harness_review_test_createfixturerepo",
-      "community": 118
+      "community": 58
+    },
+    {
+      "label": "runGit()",
+      "file_type": "code",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L241",
+      "id": "harness_review_test_rungit",
+      "community": 58
+    },
+    {
+      "label": "initializeGitHistory()",
+      "file_type": "code",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L254",
+      "id": "harness_review_test_initializegithistory",
+      "community": 58
     },
     {
       "label": "log()",
       "file_type": "code",
       "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L258",
+      "source_location": "L284",
       "id": "harness_review_test_log",
-      "community": 118
+      "community": 58
     },
     {
       "label": "error()",
       "file_type": "code",
       "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L259",
+      "source_location": "L285",
       "id": "harness_review_test_error",
-      "community": 118
+      "community": 58
     },
     {
       "label": "harness-review.ts",
@@ -21449,127 +21521,151 @@
       "source_file": "scripts/harness-review.ts",
       "source_location": "L1",
       "id": "scripts_harness_review_ts",
-      "community": 17
+      "community": 11
     },
     {
       "label": "normalizeRepoPath()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L44",
+      "source_location": "L49",
       "id": "harness_review_normalizerepopath",
-      "community": 17
+      "community": 11
     },
     {
       "label": "matchesPathPrefix()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L48",
+      "source_location": "L53",
       "id": "harness_review_matchespathprefix",
-      "community": 17
+      "community": 11
     },
     {
       "label": "normalizeValidationCommand()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L62",
+      "source_location": "L67",
       "id": "harness_review_normalizevalidationcommand",
-      "community": 17
+      "community": 11
     },
     {
       "label": "normalizeBehaviorScenarioName()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L70",
+      "source_location": "L75",
       "id": "harness_review_normalizebehaviorscenarioname",
-      "community": 17
+      "community": 11
     },
     {
       "label": "fileExists()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L74",
+      "source_location": "L79",
       "id": "harness_review_fileexists",
-      "community": 17
+      "community": 11
     },
     {
       "label": "hasAnyHarnessDocs()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L83",
+      "source_location": "L88",
       "id": "harness_review_hasanyharnessdocs",
-      "community": 17
+      "community": 11
     },
     {
       "label": "readJsonFile()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L103",
+      "source_location": "L108",
       "id": "harness_review_readjsonfile",
-      "community": 17
+      "community": 11
+    },
+    {
+      "label": "sortUniquePaths()",
+      "file_type": "code",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L112",
+      "id": "harness_review_sortuniquepaths",
+      "community": 11
     },
     {
       "label": "loadReviewTarget()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L107",
+      "source_location": "L118",
       "id": "harness_review_loadreviewtarget",
-      "community": 17
+      "community": 11
     },
     {
       "label": "loadReviewTargets()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L244",
+      "source_location": "L255",
       "id": "harness_review_loadreviewtargets",
-      "community": 17
+      "community": 11
     },
     {
       "label": "collectCommandsForChangedFiles()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L277",
+      "source_location": "L288",
       "id": "harness_review_collectcommandsforchangedfiles",
-      "community": 17
+      "community": 11
     },
     {
-      "label": "getChangedFilesFromGit()",
+      "label": "runGitCommand()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L362",
-      "id": "harness_review_getchangedfilesfromgit",
-      "community": 17
+      "source_location": "L373",
+      "id": "harness_review_rungitcommand",
+      "community": 11
+    },
+    {
+      "label": "getChangedFilesForHarnessReview()",
+      "file_type": "code",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L393",
+      "id": "harness_review_getchangedfilesforharnessreview",
+      "community": 11
     },
     {
       "label": "runPackageScript()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L400",
+      "source_location": "L487",
       "id": "harness_review_runpackagescript",
-      "community": 17
+      "community": 11
     },
     {
       "label": "runRawCommand()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L414",
+      "source_location": "L501",
       "id": "harness_review_runrawcommand",
-      "community": 17
+      "community": 11
     },
     {
       "label": "runHarnessBehaviorScenario()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L427",
+      "source_location": "L514",
       "id": "harness_review_runharnessbehaviorscenario",
-      "community": 17
+      "community": 11
     },
     {
       "label": "runHarnessReview()",
       "file_type": "code",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L441",
+      "source_location": "L528",
       "id": "harness_review_runharnessreview",
-      "community": 17
+      "community": 11
+    },
+    {
+      "label": "parseHarnessReviewArgs()",
+      "file_type": "code",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L603",
+      "id": "harness_review_parseharnessreviewargs",
+      "community": 11
     },
     {
       "label": "harness-runtime-trends.test.ts",
@@ -21593,7 +21689,7 @@
       "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L1",
       "id": "scripts_harness_runtime_trends_ts",
-      "community": 15
+      "community": 16
     },
     {
       "label": "toHistoryFileStamp()",
@@ -21601,7 +21697,7 @@
       "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L115",
       "id": "harness_runtime_trends_tohistoryfilestamp",
-      "community": 15
+      "community": 16
     },
     {
       "label": "splitInputLines()",
@@ -21609,7 +21705,7 @@
       "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L119",
       "id": "harness_runtime_trends_splitinputlines",
-      "community": 15
+      "community": 16
     },
     {
       "label": "sortUnique()",
@@ -21617,7 +21713,7 @@
       "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L125",
       "id": "harness_runtime_trends_sortunique",
-      "community": 15
+      "community": 16
     },
     {
       "label": "isHarnessBehaviorScenarioReport()",
@@ -21625,7 +21721,7 @@
       "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L131",
       "id": "harness_runtime_trends_isharnessbehaviorscenarioreport",
-      "community": 15
+      "community": 16
     },
     {
       "label": "parseHarnessBehaviorReportLines()",
@@ -21633,7 +21729,7 @@
       "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L149",
       "id": "harness_runtime_trends_parseharnessbehaviorreportlines",
-      "community": 15
+      "community": 16
     },
     {
       "label": "percentile()",
@@ -21641,7 +21737,7 @@
       "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L191",
       "id": "harness_runtime_trends_percentile",
-      "community": 15
+      "community": 16
     },
     {
       "label": "buildNumericTrendStats()",
@@ -21649,7 +21745,7 @@
       "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L202",
       "id": "harness_runtime_trends_buildnumerictrendstats",
-      "community": 15
+      "community": 16
     },
     {
       "label": "sortCountEntries()",
@@ -21657,7 +21753,7 @@
       "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L227",
       "id": "harness_runtime_trends_sortcountentries",
-      "community": 15
+      "community": 16
     },
     {
       "label": "formatPercent()",
@@ -21665,7 +21761,7 @@
       "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L233",
       "id": "harness_runtime_trends_formatpercent",
-      "community": 15
+      "community": 16
     },
     {
       "label": "formatMs()",
@@ -21673,7 +21769,7 @@
       "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L237",
       "id": "harness_runtime_trends_formatms",
-      "community": 15
+      "community": 16
     },
     {
       "label": "buildScenarioTrend()",
@@ -21681,7 +21777,7 @@
       "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L241",
       "id": "harness_runtime_trends_buildscenariotrend",
-      "community": 15
+      "community": 16
     },
     {
       "label": "buildRegressionWarnings()",
@@ -21689,7 +21785,7 @@
       "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L337",
       "id": "harness_runtime_trends_buildregressionwarnings",
-      "community": 15
+      "community": 16
     },
     {
       "label": "buildRuntimeTrendOutput()",
@@ -21697,7 +21793,7 @@
       "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L409",
       "id": "harness_runtime_trends_buildruntimetrendoutput",
-      "community": 15
+      "community": 16
     },
     {
       "label": "collectHarnessRuntimeTrends()",
@@ -21705,7 +21801,7 @@
       "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L473",
       "id": "harness_runtime_trends_collectharnessruntimetrends",
-      "community": 15
+      "community": 16
     },
     {
       "label": "runHarnessRuntimeTrends()",
@@ -21713,7 +21809,7 @@
       "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L481",
       "id": "harness_runtime_trends_runharnessruntimetrends",
-      "community": 15
+      "community": 16
     },
     {
       "label": "parseHarnessRuntimeTrendsArgs()",
@@ -21721,7 +21817,7 @@
       "source_file": "scripts/harness-runtime-trends.ts",
       "source_location": "L509",
       "id": "harness_runtime_trends_parseharnessruntimetrendsargs",
-      "community": 15
+      "community": 16
     },
     {
       "label": "harness-scorecard.test.ts",
@@ -22247,7 +22343,7 @@
       "label": "log()",
       "file_type": "code",
       "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L84",
+      "source_location": "L82",
       "id": "pre_push_review_test_log",
       "community": 164
     },
@@ -22255,7 +22351,7 @@
       "label": "warn()",
       "file_type": "code",
       "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L85",
+      "source_location": "L83",
       "id": "pre_push_review_test_warn",
       "community": 164
     },
@@ -22263,7 +22359,7 @@
       "label": "error()",
       "file_type": "code",
       "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L86",
+      "source_location": "L84",
       "id": "pre_push_review_test_error",
       "community": 164
     },
@@ -22279,7 +22375,7 @@
       "label": "getChangedFilesVsOriginMain()",
       "file_type": "code",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L25",
+      "source_location": "L28",
       "id": "pre_push_review_getchangedfilesvsoriginmain",
       "community": 119
     },
@@ -22287,7 +22383,7 @@
       "label": "runArchitectureCheck()",
       "file_type": "code",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L66",
+      "source_location": "L69",
       "id": "pre_push_review_runarchitecturecheck",
       "community": 119
     },
@@ -22295,7 +22391,7 @@
       "label": "runHarnessSelfReview()",
       "file_type": "code",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L78",
+      "source_location": "L81",
       "id": "pre_push_review_runharnessselfreview",
       "community": 119
     },
@@ -22303,7 +22399,7 @@
       "label": "runPrePushReview()",
       "file_type": "code",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L93",
+      "source_location": "L96",
       "id": "pre_push_review_runprepushreview",
       "community": 119
     }
@@ -46832,6 +46928,90 @@
       "source_location": "L279",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
+      "_tgt": "harness_inferential_review_escaperegexp",
+      "source": "scripts_harness_inferential_review_ts",
+      "target": "harness_inferential_review_escaperegexp",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L283",
+      "weight": 1.0,
+      "_src": "scripts_harness_inferential_review_ts",
+      "_tgt": "harness_inferential_review_buildshellcommandpattern",
+      "source": "scripts_harness_inferential_review_ts",
+      "target": "harness_inferential_review_buildshellcommandpattern",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L290",
+      "weight": 1.0,
+      "_src": "scripts_harness_inferential_review_ts",
+      "_tgt": "harness_inferential_review_hasharnessreviewcommand",
+      "source": "scripts_harness_inferential_review_ts",
+      "target": "harness_inferential_review_hasharnessreviewcommand",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L297",
+      "weight": 1.0,
+      "_src": "scripts_harness_inferential_review_ts",
+      "_tgt": "harness_inferential_review_hasharnessinferentialcommand",
+      "source": "scripts_harness_inferential_review_ts",
+      "target": "harness_inferential_review_hasharnessinferentialcommand",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L303",
+      "weight": 1.0,
+      "_src": "scripts_harness_inferential_review_ts",
+      "_tgt": "harness_inferential_review_extractworkflowjobsection",
+      "source": "scripts_harness_inferential_review_ts",
+      "target": "harness_inferential_review_extractworkflowjobsection",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L337",
+      "weight": 1.0,
+      "_src": "scripts_harness_inferential_review_ts",
+      "_tgt": "harness_inferential_review_extractworkflowruncommands",
+      "source": "scripts_harness_inferential_review_ts",
+      "target": "harness_inferential_review_extractworkflowruncommands",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L354",
+      "weight": 1.0,
+      "_src": "scripts_harness_inferential_review_ts",
+      "_tgt": "harness_inferential_review_workflowjobhasenvsetting",
+      "source": "scripts_harness_inferential_review_ts",
+      "target": "harness_inferential_review_workflowjobhasenvsetting",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L371",
+      "weight": 1.0,
+      "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_slugifyforfindingid",
       "source": "scripts_harness_inferential_review_ts",
       "target": "harness_inferential_review_slugifyforfindingid",
@@ -46841,7 +47021,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L286",
+      "source_location": "L378",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_isharnessscriptsourcefile",
@@ -46853,7 +47033,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L291",
+      "source_location": "L383",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_toharnessscripttestpath",
@@ -46865,7 +47045,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L295",
+      "source_location": "L387",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_formatmissingsignals",
@@ -46877,7 +47057,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L299",
+      "source_location": "L391",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_createreducedsignalfinding",
@@ -46889,7 +47069,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L316",
+      "source_location": "L408",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_collectharnessscripttestupdatefindings",
@@ -46901,7 +47081,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L353",
+      "source_location": "L445",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_collectharnesssafetysignalfindings",
@@ -46913,7 +47093,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L449",
+      "source_location": "L541",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_rundeterministicsemanticanalysis",
@@ -46925,7 +47105,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L468",
+      "source_location": "L560",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_resolvesemanticmode",
@@ -46937,7 +47117,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L477",
+      "source_location": "L569",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_buildshadowsummary",
@@ -46949,7 +47129,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L483",
+      "source_location": "L575",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_truncateforprompt",
@@ -46961,7 +47141,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L491",
+      "source_location": "L583",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_buildsemanticprompt",
@@ -46973,7 +47153,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L519",
+      "source_location": "L611",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_extracttextfromanthropicresponse",
@@ -46985,7 +47165,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L545",
+      "source_location": "L637",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_extractjsonpayload",
@@ -46997,7 +47177,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L565",
+      "source_location": "L657",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_normalizesemanticfinding",
@@ -47009,7 +47189,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L614",
+      "source_location": "L706",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_parsesemanticresponse",
@@ -47021,7 +47201,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L637",
+      "source_location": "L729",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_runanthropicsemanticanalysis",
@@ -47033,7 +47213,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L676",
+      "source_location": "L768",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_rundeterministicinferentialprovider",
@@ -47045,7 +47225,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L844",
+      "source_location": "L970",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_sortfindings",
@@ -47057,7 +47237,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L863",
+      "source_location": "L989",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_formatstatuslabel",
@@ -47069,7 +47249,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L876",
+      "source_location": "L1002",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_buildhumanreport",
@@ -47081,7 +47261,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L946",
+      "source_location": "L1072",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_writemachineoutput",
@@ -47093,7 +47273,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L956",
+      "source_location": "L1082",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_tohistoryfilestamp",
@@ -47105,7 +47285,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L960",
+      "source_location": "L1086",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_writehistorysnapshot",
@@ -47117,7 +47297,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L976",
+      "source_location": "L1102",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_createoutput",
@@ -47129,7 +47309,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1005",
+      "source_location": "L1131",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_createshadowoutput",
@@ -47141,7 +47321,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1023",
+      "source_location": "L1149",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_createproviderfailure",
@@ -47153,7 +47333,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1052",
+      "source_location": "L1178",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_createruntimefailure",
@@ -47165,7 +47345,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1081",
+      "source_location": "L1207",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_runharnessinferentialreview",
@@ -47177,7 +47357,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1329",
+      "source_location": "L1455",
       "weight": 1.0,
       "_src": "scripts_harness_inferential_review_ts",
       "_tgt": "harness_inferential_review_parseharnessinferentialreviewargs",
@@ -47201,7 +47381,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L280",
+      "source_location": "L372",
       "weight": 1.0,
       "_src": "harness_inferential_review_slugifyforfindingid",
       "_tgt": "harness_inferential_review_normalizerepopath",
@@ -47213,7 +47393,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L287",
+      "source_location": "L379",
       "weight": 1.0,
       "_src": "harness_inferential_review_isharnessscriptsourcefile",
       "_tgt": "harness_inferential_review_normalizerepopath",
@@ -47225,7 +47405,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L292",
+      "source_location": "L384",
       "weight": 1.0,
       "_src": "harness_inferential_review_toharnessscripttestpath",
       "_tgt": "harness_inferential_review_normalizerepopath",
@@ -47237,7 +47417,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L589",
+      "source_location": "L681",
       "weight": 1.0,
       "_src": "harness_inferential_review_normalizesemanticfinding",
       "_tgt": "harness_inferential_review_normalizerepopath",
@@ -47261,7 +47441,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L320",
+      "source_location": "L412",
       "weight": 1.0,
       "_src": "harness_inferential_review_collectharnessscripttestupdatefindings",
       "_tgt": "harness_inferential_review_sortunique",
@@ -47273,7 +47453,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L357",
+      "source_location": "L449",
       "weight": 1.0,
       "_src": "harness_inferential_review_collectharnesssafetysignalfindings",
       "_tgt": "harness_inferential_review_sortunique",
@@ -47285,7 +47465,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L997",
+      "source_location": "L1123",
       "weight": 1.0,
       "_src": "harness_inferential_review_createoutput",
       "_tgt": "harness_inferential_review_sortunique",
@@ -47297,7 +47477,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1106",
+      "source_location": "L1232",
       "weight": 1.0,
       "_src": "harness_inferential_review_runharnessinferentialreview",
       "_tgt": "harness_inferential_review_sortunique",
@@ -47321,7 +47501,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L333",
+      "source_location": "L425",
       "weight": 1.0,
       "_src": "harness_inferential_review_collectharnessscripttestupdatefindings",
       "_tgt": "harness_inferential_review_fileexists",
@@ -47333,7 +47513,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L422",
+      "source_location": "L514",
       "weight": 1.0,
       "_src": "harness_inferential_review_collectharnesssafetysignalfindings",
       "_tgt": "harness_inferential_review_readutf8ornull",
@@ -47345,7 +47525,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L495",
+      "source_location": "L587",
       "weight": 1.0,
       "_src": "harness_inferential_review_buildsemanticprompt",
       "_tgt": "harness_inferential_review_readutf8ornull",
@@ -47357,7 +47537,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L694",
+      "source_location": "L788",
       "weight": 1.0,
       "_src": "harness_inferential_review_rundeterministicinferentialprovider",
       "_tgt": "harness_inferential_review_readutf8ornull",
@@ -47381,7 +47561,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L306",
+      "source_location": "L398",
       "weight": 1.0,
       "_src": "harness_inferential_review_createreducedsignalfinding",
       "_tgt": "harness_inferential_review_buildfinding",
@@ -47393,7 +47573,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L335",
+      "source_location": "L427",
       "weight": 1.0,
       "_src": "harness_inferential_review_collectharnessscripttestupdatefindings",
       "_tgt": "harness_inferential_review_buildfinding",
@@ -47405,7 +47585,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L697",
+      "source_location": "L791",
       "weight": 1.0,
       "_src": "harness_inferential_review_rundeterministicinferentialprovider",
       "_tgt": "harness_inferential_review_buildfinding",
@@ -47417,7 +47597,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L729",
+      "source_location": "L942",
       "weight": 1.0,
       "_src": "harness_inferential_review_rundeterministicinferentialprovider",
       "_tgt": "harness_inferential_review_includescaseinsensitive",
@@ -47429,7 +47609,115 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L307",
+      "source_location": "L292",
+      "weight": 1.0,
+      "_src": "harness_inferential_review_hasharnessreviewcommand",
+      "_tgt": "harness_inferential_review_escaperegexp",
+      "source": "harness_inferential_review_escaperegexp",
+      "target": "harness_inferential_review_hasharnessreviewcommand",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L291",
+      "weight": 1.0,
+      "_src": "harness_inferential_review_hasharnessreviewcommand",
+      "_tgt": "harness_inferential_review_buildshellcommandpattern",
+      "source": "harness_inferential_review_buildshellcommandpattern",
+      "target": "harness_inferential_review_hasharnessreviewcommand",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L298",
+      "weight": 1.0,
+      "_src": "harness_inferential_review_hasharnessinferentialcommand",
+      "_tgt": "harness_inferential_review_buildshellcommandpattern",
+      "source": "harness_inferential_review_buildshellcommandpattern",
+      "target": "harness_inferential_review_hasharnessinferentialcommand",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L821",
+      "weight": 1.0,
+      "_src": "harness_inferential_review_rundeterministicinferentialprovider",
+      "_tgt": "harness_inferential_review_hasharnessreviewcommand",
+      "source": "harness_inferential_review_hasharnessreviewcommand",
+      "target": "harness_inferential_review_rundeterministicinferentialprovider",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L834",
+      "weight": 1.0,
+      "_src": "harness_inferential_review_rundeterministicinferentialprovider",
+      "_tgt": "harness_inferential_review_hasharnessinferentialcommand",
+      "source": "harness_inferential_review_hasharnessinferentialcommand",
+      "target": "harness_inferential_review_rundeterministicinferentialprovider",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L341",
+      "weight": 1.0,
+      "_src": "harness_inferential_review_extractworkflowruncommands",
+      "_tgt": "harness_inferential_review_extractworkflowjobsection",
+      "source": "harness_inferential_review_extractworkflowjobsection",
+      "target": "harness_inferential_review_extractworkflowruncommands",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L360",
+      "weight": 1.0,
+      "_src": "harness_inferential_review_workflowjobhasenvsetting",
+      "_tgt": "harness_inferential_review_extractworkflowjobsection",
+      "source": "harness_inferential_review_extractworkflowjobsection",
+      "target": "harness_inferential_review_workflowjobhasenvsetting",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L861",
+      "weight": 1.0,
+      "_src": "harness_inferential_review_rundeterministicinferentialprovider",
+      "_tgt": "harness_inferential_review_extractworkflowruncommands",
+      "source": "harness_inferential_review_extractworkflowruncommands",
+      "target": "harness_inferential_review_rundeterministicinferentialprovider",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L897",
+      "weight": 1.0,
+      "_src": "harness_inferential_review_rundeterministicinferentialprovider",
+      "_tgt": "harness_inferential_review_workflowjobhasenvsetting",
+      "source": "harness_inferential_review_workflowjobhasenvsetting",
+      "target": "harness_inferential_review_rundeterministicinferentialprovider",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-inferential-review.ts",
+      "source_location": "L399",
       "weight": 1.0,
       "_src": "harness_inferential_review_createreducedsignalfinding",
       "_tgt": "harness_inferential_review_slugifyforfindingid",
@@ -47441,7 +47729,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L336",
+      "source_location": "L428",
       "weight": 1.0,
       "_src": "harness_inferential_review_collectharnessscripttestupdatefindings",
       "_tgt": "harness_inferential_review_slugifyforfindingid",
@@ -47453,7 +47741,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L324",
+      "source_location": "L416",
       "weight": 1.0,
       "_src": "harness_inferential_review_collectharnessscripttestupdatefindings",
       "_tgt": "harness_inferential_review_isharnessscriptsourcefile",
@@ -47465,7 +47753,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L328",
+      "source_location": "L420",
       "weight": 1.0,
       "_src": "harness_inferential_review_collectharnessscripttestupdatefindings",
       "_tgt": "harness_inferential_review_toharnessscripttestpath",
@@ -47477,7 +47765,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L311",
+      "source_location": "L403",
       "weight": 1.0,
       "_src": "harness_inferential_review_createreducedsignalfinding",
       "_tgt": "harness_inferential_review_formatmissingsignals",
@@ -47489,7 +47777,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L436",
+      "source_location": "L528",
       "weight": 1.0,
       "_src": "harness_inferential_review_collectharnesssafetysignalfindings",
       "_tgt": "harness_inferential_review_createreducedsignalfinding",
@@ -47501,7 +47789,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L453",
+      "source_location": "L545",
       "weight": 1.0,
       "_src": "harness_inferential_review_rundeterministicsemanticanalysis",
       "_tgt": "harness_inferential_review_collectharnessscripttestupdatefindings",
@@ -47513,7 +47801,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L457",
+      "source_location": "L549",
       "weight": 1.0,
       "_src": "harness_inferential_review_rundeterministicsemanticanalysis",
       "_tgt": "harness_inferential_review_collectharnesssafetysignalfindings",
@@ -47525,7 +47813,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L464",
+      "source_location": "L556",
       "weight": 1.0,
       "_src": "harness_inferential_review_rundeterministicsemanticanalysis",
       "_tgt": "harness_inferential_review_sortfindings",
@@ -47537,7 +47825,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1176",
+      "source_location": "L1302",
       "weight": 1.0,
       "_src": "harness_inferential_review_runharnessinferentialreview",
       "_tgt": "harness_inferential_review_rundeterministicsemanticanalysis",
@@ -47549,7 +47837,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1089",
+      "source_location": "L1215",
       "weight": 1.0,
       "_src": "harness_inferential_review_runharnessinferentialreview",
       "_tgt": "harness_inferential_review_resolvesemanticmode",
@@ -47561,7 +47849,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L629",
+      "source_location": "L721",
       "weight": 1.0,
       "_src": "harness_inferential_review_parsesemanticresponse",
       "_tgt": "harness_inferential_review_buildshadowsummary",
@@ -47573,7 +47861,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1232",
+      "source_location": "L1358",
       "weight": 1.0,
       "_src": "harness_inferential_review_runharnessinferentialreview",
       "_tgt": "harness_inferential_review_buildshadowsummary",
@@ -47585,7 +47873,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L500",
+      "source_location": "L592",
       "weight": 1.0,
       "_src": "harness_inferential_review_buildsemanticprompt",
       "_tgt": "harness_inferential_review_truncateforprompt",
@@ -47597,7 +47885,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L656",
+      "source_location": "L748",
       "weight": 1.0,
       "_src": "harness_inferential_review_runanthropicsemanticanalysis",
       "_tgt": "harness_inferential_review_buildsemanticprompt",
@@ -47609,7 +47897,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L665",
+      "source_location": "L757",
       "weight": 1.0,
       "_src": "harness_inferential_review_runanthropicsemanticanalysis",
       "_tgt": "harness_inferential_review_extracttextfromanthropicresponse",
@@ -47621,7 +47909,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L615",
+      "source_location": "L707",
       "weight": 1.0,
       "_src": "harness_inferential_review_parsesemanticresponse",
       "_tgt": "harness_inferential_review_extractjsonpayload",
@@ -47633,7 +47921,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L633",
+      "source_location": "L725",
       "weight": 1.0,
       "_src": "harness_inferential_review_parsesemanticresponse",
       "_tgt": "harness_inferential_review_sortfindings",
@@ -47645,7 +47933,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L666",
+      "source_location": "L758",
       "weight": 1.0,
       "_src": "harness_inferential_review_runanthropicsemanticanalysis",
       "_tgt": "harness_inferential_review_parsesemanticresponse",
@@ -47657,7 +47945,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L840",
+      "source_location": "L966",
       "weight": 1.0,
       "_src": "harness_inferential_review_rundeterministicinferentialprovider",
       "_tgt": "harness_inferential_review_sortfindings",
@@ -47669,7 +47957,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L999",
+      "source_location": "L1125",
       "weight": 1.0,
       "_src": "harness_inferential_review_createoutput",
       "_tgt": "harness_inferential_review_sortfindings",
@@ -47681,7 +47969,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1018",
+      "source_location": "L1144",
       "weight": 1.0,
       "_src": "harness_inferential_review_createshadowoutput",
       "_tgt": "harness_inferential_review_sortfindings",
@@ -47693,7 +47981,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1182",
+      "source_location": "L1308",
       "weight": 1.0,
       "_src": "harness_inferential_review_runharnessinferentialreview",
       "_tgt": "harness_inferential_review_sortfindings",
@@ -47705,7 +47993,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L881",
+      "source_location": "L1007",
       "weight": 1.0,
       "_src": "harness_inferential_review_buildhumanreport",
       "_tgt": "harness_inferential_review_formatstatuslabel",
@@ -47717,7 +48005,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1118",
+      "source_location": "L1244",
       "weight": 1.0,
       "_src": "harness_inferential_review_runharnessinferentialreview",
       "_tgt": "harness_inferential_review_buildhumanreport",
@@ -47729,7 +48017,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1119",
+      "source_location": "L1245",
       "weight": 1.0,
       "_src": "harness_inferential_review_runharnessinferentialreview",
       "_tgt": "harness_inferential_review_writemachineoutput",
@@ -47741,7 +48029,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L969",
+      "source_location": "L1095",
       "weight": 1.0,
       "_src": "harness_inferential_review_writehistorysnapshot",
       "_tgt": "harness_inferential_review_tohistoryfilestamp",
@@ -47753,7 +48041,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1282",
+      "source_location": "L1408",
       "weight": 1.0,
       "_src": "harness_inferential_review_runharnessinferentialreview",
       "_tgt": "harness_inferential_review_writehistorysnapshot",
@@ -47765,7 +48053,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1031",
+      "source_location": "L1157",
       "weight": 1.0,
       "_src": "harness_inferential_review_createproviderfailure",
       "_tgt": "harness_inferential_review_createoutput",
@@ -47777,7 +48065,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1060",
+      "source_location": "L1186",
       "weight": 1.0,
       "_src": "harness_inferential_review_createruntimefailure",
       "_tgt": "harness_inferential_review_createoutput",
@@ -47789,7 +48077,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1129",
+      "source_location": "L1255",
       "weight": 1.0,
       "_src": "harness_inferential_review_runharnessinferentialreview",
       "_tgt": "harness_inferential_review_createoutput",
@@ -47801,7 +48089,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1226",
+      "source_location": "L1352",
       "weight": 1.0,
       "_src": "harness_inferential_review_runharnessinferentialreview",
       "_tgt": "harness_inferential_review_createshadowoutput",
@@ -47813,7 +48101,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1160",
+      "source_location": "L1286",
       "weight": 1.0,
       "_src": "harness_inferential_review_runharnessinferentialreview",
       "_tgt": "harness_inferential_review_createproviderfailure",
@@ -47825,7 +48113,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-inferential-review.ts",
-      "source_location": "L1110",
+      "source_location": "L1236",
       "weight": 1.0,
       "_src": "harness_inferential_review_runharnessinferentialreview",
       "_tgt": "harness_inferential_review_createruntimefailure",
@@ -48233,7 +48521,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L10",
+      "source_location": "L15",
       "weight": 1.0,
       "_src": "scripts_harness_review_test_ts",
       "_tgt": "harness_review_test_write",
@@ -48245,7 +48533,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L16",
+      "source_location": "L21",
       "weight": 1.0,
       "_src": "scripts_harness_review_test_ts",
       "_tgt": "harness_review_test_createfixturerepo",
@@ -48257,7 +48545,31 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L780",
+      "source_location": "L241",
+      "weight": 1.0,
+      "_src": "scripts_harness_review_test_ts",
+      "_tgt": "harness_review_test_rungit",
+      "source": "scripts_harness_review_test_ts",
+      "target": "harness_review_test_rungit",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L254",
+      "weight": 1.0,
+      "_src": "scripts_harness_review_test_ts",
+      "_tgt": "harness_review_test_initializegithistory",
+      "source": "scripts_harness_review_test_ts",
+      "target": "harness_review_test_initializegithistory",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L832",
       "weight": 1.0,
       "_src": "scripts_harness_review_test_ts",
       "_tgt": "harness_review_test_log",
@@ -48269,7 +48581,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L781",
+      "source_location": "L833",
       "weight": 1.0,
       "_src": "scripts_harness_review_test_ts",
       "_tgt": "harness_review_test_error",
@@ -48281,7 +48593,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.test.ts",
-      "source_location": "L20",
+      "source_location": "L25",
       "weight": 1.0,
       "_src": "harness_review_test_createfixturerepo",
       "_tgt": "harness_review_test_write",
@@ -48290,10 +48602,22 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-review.test.ts",
+      "source_location": "L255",
+      "weight": 1.0,
+      "_src": "harness_review_test_initializegithistory",
+      "_tgt": "harness_review_test_rungit",
+      "source": "harness_review_test_rungit",
+      "target": "harness_review_test_initializegithistory",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L44",
+      "source_location": "L49",
       "weight": 1.0,
       "_src": "scripts_harness_review_ts",
       "_tgt": "harness_review_normalizerepopath",
@@ -48305,7 +48629,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L48",
+      "source_location": "L53",
       "weight": 1.0,
       "_src": "scripts_harness_review_ts",
       "_tgt": "harness_review_matchespathprefix",
@@ -48317,7 +48641,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L62",
+      "source_location": "L67",
       "weight": 1.0,
       "_src": "scripts_harness_review_ts",
       "_tgt": "harness_review_normalizevalidationcommand",
@@ -48329,7 +48653,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L70",
+      "source_location": "L75",
       "weight": 1.0,
       "_src": "scripts_harness_review_ts",
       "_tgt": "harness_review_normalizebehaviorscenarioname",
@@ -48341,7 +48665,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L74",
+      "source_location": "L79",
       "weight": 1.0,
       "_src": "scripts_harness_review_ts",
       "_tgt": "harness_review_fileexists",
@@ -48353,7 +48677,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L83",
+      "source_location": "L88",
       "weight": 1.0,
       "_src": "scripts_harness_review_ts",
       "_tgt": "harness_review_hasanyharnessdocs",
@@ -48365,7 +48689,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L103",
+      "source_location": "L108",
       "weight": 1.0,
       "_src": "scripts_harness_review_ts",
       "_tgt": "harness_review_readjsonfile",
@@ -48377,7 +48701,19 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L107",
+      "source_location": "L112",
+      "weight": 1.0,
+      "_src": "scripts_harness_review_ts",
+      "_tgt": "harness_review_sortuniquepaths",
+      "source": "scripts_harness_review_ts",
+      "target": "harness_review_sortuniquepaths",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L118",
       "weight": 1.0,
       "_src": "scripts_harness_review_ts",
       "_tgt": "harness_review_loadreviewtarget",
@@ -48389,7 +48725,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L244",
+      "source_location": "L255",
       "weight": 1.0,
       "_src": "scripts_harness_review_ts",
       "_tgt": "harness_review_loadreviewtargets",
@@ -48401,7 +48737,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L277",
+      "source_location": "L288",
       "weight": 1.0,
       "_src": "scripts_harness_review_ts",
       "_tgt": "harness_review_collectcommandsforchangedfiles",
@@ -48413,19 +48749,31 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L362",
+      "source_location": "L373",
       "weight": 1.0,
       "_src": "scripts_harness_review_ts",
-      "_tgt": "harness_review_getchangedfilesfromgit",
+      "_tgt": "harness_review_rungitcommand",
       "source": "scripts_harness_review_ts",
-      "target": "harness_review_getchangedfilesfromgit",
+      "target": "harness_review_rungitcommand",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L400",
+      "source_location": "L393",
+      "weight": 1.0,
+      "_src": "scripts_harness_review_ts",
+      "_tgt": "harness_review_getchangedfilesforharnessreview",
+      "source": "scripts_harness_review_ts",
+      "target": "harness_review_getchangedfilesforharnessreview",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L487",
       "weight": 1.0,
       "_src": "scripts_harness_review_ts",
       "_tgt": "harness_review_runpackagescript",
@@ -48437,7 +48785,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L414",
+      "source_location": "L501",
       "weight": 1.0,
       "_src": "scripts_harness_review_ts",
       "_tgt": "harness_review_runrawcommand",
@@ -48449,7 +48797,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L427",
+      "source_location": "L514",
       "weight": 1.0,
       "_src": "scripts_harness_review_ts",
       "_tgt": "harness_review_runharnessbehaviorscenario",
@@ -48461,7 +48809,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L441",
+      "source_location": "L528",
       "weight": 1.0,
       "_src": "scripts_harness_review_ts",
       "_tgt": "harness_review_runharnessreview",
@@ -48470,10 +48818,22 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L603",
+      "weight": 1.0,
+      "_src": "scripts_harness_review_ts",
+      "_tgt": "harness_review_parseharnessreviewargs",
+      "source": "scripts_harness_review_ts",
+      "target": "harness_review_parseharnessreviewargs",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L49",
+      "source_location": "L54",
       "weight": 1.0,
       "_src": "harness_review_matchespathprefix",
       "_tgt": "harness_review_normalizerepopath",
@@ -48485,7 +48845,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L230",
+      "source_location": "L241",
       "weight": 1.0,
       "_src": "harness_review_loadreviewtarget",
       "_tgt": "harness_review_normalizerepopath",
@@ -48497,7 +48857,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L221",
+      "source_location": "L232",
       "weight": 1.0,
       "_src": "harness_review_loadreviewtarget",
       "_tgt": "harness_review_normalizebehaviorscenarioname",
@@ -48509,7 +48869,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L95",
+      "source_location": "L100",
       "weight": 1.0,
       "_src": "harness_review_hasanyharnessdocs",
       "_tgt": "harness_review_fileexists",
@@ -48521,7 +48881,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L114",
+      "source_location": "L125",
       "weight": 1.0,
       "_src": "harness_review_loadreviewtarget",
       "_tgt": "harness_review_fileexists",
@@ -48533,7 +48893,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L256",
+      "source_location": "L267",
       "weight": 1.0,
       "_src": "harness_review_loadreviewtargets",
       "_tgt": "harness_review_hasanyharnessdocs",
@@ -48545,7 +48905,19 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L264",
+      "source_location": "L430",
+      "weight": 1.0,
+      "_src": "harness_review_getchangedfilesforharnessreview",
+      "_tgt": "harness_review_sortuniquepaths",
+      "source": "harness_review_sortuniquepaths",
+      "target": "harness_review_getchangedfilesforharnessreview",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L275",
       "weight": 1.0,
       "_src": "harness_review_loadreviewtargets",
       "_tgt": "harness_review_loadreviewtarget",
@@ -48557,7 +48929,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L452",
+      "source_location": "L543",
       "weight": 1.0,
       "_src": "harness_review_runharnessreview",
       "_tgt": "harness_review_loadreviewtargets",
@@ -48569,12 +48941,24 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-review.ts",
-      "source_location": "L459",
+      "source_location": "L550",
       "weight": 1.0,
       "_src": "harness_review_runharnessreview",
       "_tgt": "harness_review_collectcommandsforchangedfiles",
       "source": "harness_review_collectcommandsforchangedfiles",
       "target": "harness_review_runharnessreview",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-review.ts",
+      "source_location": "L397",
+      "weight": 1.0,
+      "_src": "harness_review_getchangedfilesforharnessreview",
+      "_tgt": "harness_review_rungitcommand",
+      "source": "harness_review_rungitcommand",
+      "target": "harness_review_getchangedfilesforharnessreview",
       "confidence_score": 1.0
     },
     {
@@ -50237,7 +50621,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L84",
+      "source_location": "L144",
       "weight": 1.0,
       "_src": "scripts_pre_push_review_test_ts",
       "_tgt": "pre_push_review_test_log",
@@ -50249,7 +50633,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L85",
+      "source_location": "L145",
       "weight": 1.0,
       "_src": "scripts_pre_push_review_test_ts",
       "_tgt": "pre_push_review_test_warn",
@@ -50261,7 +50645,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/pre-push-review.test.ts",
-      "source_location": "L86",
+      "source_location": "L146",
       "weight": 1.0,
       "_src": "scripts_pre_push_review_test_ts",
       "_tgt": "pre_push_review_test_error",
@@ -50273,7 +50657,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L25",
+      "source_location": "L28",
       "weight": 1.0,
       "_src": "scripts_pre_push_review_ts",
       "_tgt": "pre_push_review_getchangedfilesvsoriginmain",
@@ -50285,7 +50669,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L66",
+      "source_location": "L69",
       "weight": 1.0,
       "_src": "scripts_pre_push_review_ts",
       "_tgt": "pre_push_review_runarchitecturecheck",
@@ -50297,7 +50681,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L78",
+      "source_location": "L81",
       "weight": 1.0,
       "_src": "scripts_pre_push_review_ts",
       "_tgt": "pre_push_review_runharnessselfreview",
@@ -50309,7 +50693,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L93",
+      "source_location": "L96",
       "weight": 1.0,
       "_src": "scripts_pre_push_review_ts",
       "_tgt": "pre_push_review_runprepushreview",

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,14 +8,14 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1198
-- Graph nodes: 2788
-- Graph edges: 2334
+- Graph nodes: 2800
+- Graph edges: 2358
 - Communities: 1113
 
 ## Graph Hotspots
-- `storefrontJourneyEvents.ts` (45 edges, Community 0) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `createJourneyEvent()` (40 edges, Community 0) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `harness-inferential-review.ts` (39 edges, Community 1) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
+- `harness-inferential-review.ts` (46 edges, Community 0) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
+- `storefrontJourneyEvents.ts` (45 edges, Community 1) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
+- `createJourneyEvent()` (40 edges, Community 1) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `harness-check.ts` (32 edges, Community 2) - [`scripts/harness-check.ts`](../../scripts/harness-check.ts)
 - `harness-generate.ts` (30 edges, Community 3) - [`scripts/harness-generate.ts`](../../scripts/harness-generate.ts)
 - `storeConfigV2.ts` (27 edges, Community 4) - [`packages/athena-webapp/convex/inventory/storeConfigV2.ts`](../../packages/athena-webapp/convex/inventory/storeConfigV2.ts)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -19,8 +19,8 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 ## Graph Hotspots
 - `storeConfigV2.ts` (27 edges, Community 4) - [`packages/athena-webapp/convex/inventory/storeConfigV2.ts`](../../../packages/athena-webapp/convex/inventory/storeConfigV2.ts)
 - `ProductStock.tsx` (19 edges, Community 9) - [`packages/athena-webapp/src/components/add-product/ProductStock.tsx`](../../../packages/athena-webapp/src/components/add-product/ProductStock.tsx)
-- `checkoutSession.ts` (17 edges, Community 11) - [`packages/athena-webapp/convex/storeFront/checkoutSession.ts`](../../../packages/athena-webapp/convex/storeFront/checkoutSession.ts)
-- `DataTableViewOptions()` (16 edges, Community 13) - [`packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx`](../../../packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx)
+- `checkoutSession.ts` (17 edges, Community 12) - [`packages/athena-webapp/convex/storeFront/checkoutSession.ts`](../../../packages/athena-webapp/convex/storeFront/checkoutSession.ts)
+- `DataTableViewOptions()` (16 edges, Community 14) - [`packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx`](../../../packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-view-options.tsx)
 - `storeConfig.ts` (16 edges, Community 8) - [`packages/athena-webapp/src/lib/storeConfig.ts`](../../../packages/athena-webapp/src/lib/storeConfig.ts)
 
 ## Navigation

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -17,10 +17,10 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 - [validation-map.json](../../../packages/storefront-webapp/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `storefrontJourneyEvents.ts` (45 edges, Community 0) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `createJourneyEvent()` (40 edges, Community 0) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
+- `storefrontJourneyEvents.ts` (45 edges, Community 1) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
+- `createJourneyEvent()` (40 edges, Community 1) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `getStoreConfigV2()` (17 edges, Community 8) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
-- `checkoutSession.ts` (14 edges, Community 16) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
+- `checkoutSession.ts` (14 edges, Community 17) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
 - `storeConfig.ts` (14 edges, Community 8) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 
 ## Navigation

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "harness:review": "bun scripts/harness-review.ts",
     "harness:test": "bun scripts/harness-test.ts",
     "pre-push:review": "bun scripts/pre-push-review.ts",
-    "pr:athena": "bun run --filter '@athena/webapp' audit:convex && bun run --filter '@athena/webapp' lint:convex:changed && bun run architecture:check && bun run --filter '@athena/webapp' test && bun run --filter '@athena/storefront-webapp' test && bun run harness:test && bun run harness:check && bun run harness:inferential-review && bun run harness:audit && bun run harness:scorecard && bun run graphify:check",
+    "pr:athena": "bun run --filter '@athena/webapp' audit:convex && bun run --filter '@athena/webapp' lint:convex:changed && bun run architecture:check && bun run --filter '@athena/webapp' test && bun run --filter '@athena/storefront-webapp' test && bun run harness:test && bun run harness:check && bun run harness:review --base origin/main && bun run harness:inferential-review && bun run harness:audit && bun run harness:scorecard && bun run graphify:check",
     "test": "bun run --filter '@athena/webapp' test && bun run --filter '@athena/storefront-webapp' test",
     "test:coverage": "bun run --filter '@athena/webapp' test:coverage && bun run --filter '@athena/storefront-webapp' test:coverage && bun scripts/coverage-summary.mjs"
   },

--- a/scripts/harness-inferential-review.test.ts
+++ b/scripts/harness-inferential-review.test.ts
@@ -28,7 +28,7 @@ async function createFixtureRepo() {
       {
         scripts: {
           "pr:athena":
-            "bun run harness:check && bun run harness:inferential-review && bun run harness:audit && bun run graphify:check",
+            "bun run harness:check && bun run harness:review --base origin/main && bun run harness:inferential-review && bun run harness:audit && bun run graphify:check",
         },
       },
       null,
@@ -46,6 +46,8 @@ async function createFixtureRepo() {
       "    steps:",
       "      - name: Harness check",
       "        run: bun run harness:check",
+      "      - name: Targeted harness review",
+      "        run: bun run harness:review --base origin/main",
       "      - name: Inferential harness review",
       "        env:",
       "          HARNESS_INFERENTIAL_SEMANTIC_MODE: shadow",
@@ -134,7 +136,7 @@ describe("runHarnessInferentialReview", () => {
         {
           scripts: {
             "pr:athena":
-              "bun run harness:check && bun run harness:audit && bun run graphify:check",
+              "bun run harness:check && bun run harness:review --base origin/main && bun run harness:audit && bun run graphify:check",
           },
         },
         null,
@@ -157,6 +159,138 @@ describe("runHarnessInferentialReview", () => {
       filePath: "package.json",
     });
     expect(result.humanReport).toContain("Remediation:");
+  });
+
+  it("fails when pr:athena omits harness review", async () => {
+    const rootDir = await createFixtureRepo();
+    await write(
+      "package.json",
+      JSON.stringify(
+        {
+          scripts: {
+            "pr:athena":
+              "bun run harness:check && bun run harness:inferential-review && bun run harness:audit && bun run graphify:check",
+          },
+        },
+        null,
+        2
+      ),
+      rootDir
+    );
+
+    const result = await runHarnessInferentialReview(rootDir, {
+      getChangedFiles: async () => ["package.json"],
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.machine.status).toBe("fail");
+    expect(result.machine.findings).toContainEqual(
+      expect.objectContaining({
+        id: "missing-pr-athena-review-step",
+        severity: "high",
+        filePath: "package.json",
+      })
+    );
+  });
+
+  it("fails when pr:athena is blank", async () => {
+    const rootDir = await createFixtureRepo();
+    await write(
+      "package.json",
+      JSON.stringify(
+        {
+          scripts: {
+            "pr:athena": "",
+          },
+        },
+        null,
+        2
+      ),
+      rootDir
+    );
+
+    const result = await runHarnessInferentialReview(rootDir, {
+      getChangedFiles: async () => ["package.json"],
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.machine.status).toBe("fail");
+    expect(result.machine.findings).toContainEqual(
+      expect.objectContaining({
+        id: "missing-pr-athena-review-step",
+        severity: "high",
+        filePath: "package.json",
+      })
+    );
+    expect(result.machine.findings).toContainEqual(
+      expect.objectContaining({
+        id: "missing-pr-athena-inferential-step",
+        severity: "high",
+        filePath: "package.json",
+      })
+    );
+  });
+
+  it("accepts the equals-form harness review flag in pr:athena", async () => {
+    const rootDir = await createFixtureRepo();
+    await write(
+      "package.json",
+      JSON.stringify(
+        {
+          scripts: {
+            "pr:athena":
+              "bun run harness:check && bun run harness:review --base=origin/main && bun run harness:inferential-review && bun run harness:audit && bun run graphify:check",
+          },
+        },
+        null,
+        2
+      ),
+      rootDir
+    );
+
+    const result = await runHarnessInferentialReview(rootDir, {
+      getChangedFiles: async () => ["package.json"],
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.machine.status).toBe("pass");
+    expect(result.machine.findings).toEqual([]);
+  });
+
+  it("does not treat echoed harness review text as a real pr:athena gate", async () => {
+    const rootDir = await createFixtureRepo();
+    await write(
+      "package.json",
+      JSON.stringify(
+        {
+          scripts: {
+            "pr:athena":
+              "echo bun run harness:review --base origin/main && bun run harness:inferential-review && bun run harness:audit && bun run graphify:check",
+          },
+        },
+        null,
+        2
+      ),
+      rootDir
+    );
+
+    const result = await runHarnessInferentialReview(rootDir, {
+      getChangedFiles: async () => ["package.json"],
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.machine.status).toBe("fail");
+    expect(result.machine.findings).toContainEqual(
+      expect.objectContaining({
+        id: "missing-pr-athena-review-step",
+        severity: "high",
+        filePath: "package.json",
+      })
+    );
   });
 
   it("fails when a harness-critical script changes without its test update", async () => {
@@ -189,6 +323,8 @@ describe("runHarnessInferentialReview", () => {
         "    steps:",
         "      - name: Harness check",
         "        run: bun run harness:check",
+        "      - name: Targeted harness review",
+        "        run: bun run harness:review --base origin/main",
         "      - name: Inferential harness review",
         "        run: bun run harness:inferential-review",
         "      - name: Harness audit",
@@ -209,6 +345,163 @@ describe("runHarnessInferentialReview", () => {
     expect(result.machine.findings).toContainEqual(
       expect.objectContaining({
         id: "missing-ci-shadow-semantic-mode",
+        severity: "high",
+        filePath: ".github/workflows/athena-pr-tests.yml",
+      })
+    );
+  });
+
+  it("fails when the PR workflow omits harness review", async () => {
+    const rootDir = await createFixtureRepo();
+    await write(
+      ".github/workflows/athena-pr-tests.yml",
+      [
+        "name: Athena PR Tests",
+        "jobs:",
+        "  harness-validation:",
+        "    steps:",
+        "      - name: Harness check",
+        "        run: bun run harness:check",
+        "      - name: Inferential harness review",
+        "        env:",
+        "          HARNESS_INFERENTIAL_SEMANTIC_MODE: shadow",
+        "        run: bun run harness:inferential-review",
+        "      - name: Harness audit",
+        "        run: bun run harness:audit",
+        "      - name: Graphify check",
+        "        run: bun run graphify:check",
+      ].join("\n"),
+      rootDir
+    );
+
+    const result = await runHarnessInferentialReview(rootDir, {
+      getChangedFiles: async () => [".github/workflows/athena-pr-tests.yml"],
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.machine.status).toBe("fail");
+    expect(result.machine.findings).toContainEqual(
+      expect.objectContaining({
+        id: "missing-ci-review-step",
+        severity: "high",
+        filePath: ".github/workflows/athena-pr-tests.yml",
+      })
+    );
+  });
+
+  it("accepts the equals-form harness review flag in the PR workflow", async () => {
+    const rootDir = await createFixtureRepo();
+    await write(
+      ".github/workflows/athena-pr-tests.yml",
+      [
+        "name: Athena PR Tests",
+        "jobs:",
+        "  harness-validation:",
+        "    steps:",
+        "      - name: Harness check",
+        "        run: bun run harness:check",
+        "      - name: Targeted harness review",
+        "        run: bun run harness:review --base=origin/main",
+        "      - name: Inferential harness review",
+        "        env:",
+        "          HARNESS_INFERENTIAL_SEMANTIC_MODE: shadow",
+        "        run: bun run harness:inferential-review",
+        "      - name: Harness audit",
+        "        run: bun run harness:audit",
+        "      - name: Graphify check",
+        "        run: bun run graphify:check",
+      ].join("\n"),
+      rootDir
+    );
+
+    const result = await runHarnessInferentialReview(rootDir, {
+      getChangedFiles: async () => [".github/workflows/athena-pr-tests.yml"],
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.machine.status).toBe("pass");
+    expect(result.machine.findings).toEqual([]);
+  });
+
+  it("does not treat commented harness review text as a real workflow gate", async () => {
+    const rootDir = await createFixtureRepo();
+    await write(
+      ".github/workflows/athena-pr-tests.yml",
+      [
+        "name: Athena PR Tests",
+        "jobs:",
+        "  harness-validation:",
+        "    steps:",
+        "      - name: Harness check",
+        "        run: bun run harness:check",
+        "      # run: bun run harness:review --base origin/main",
+        "      - name: Inferential harness review",
+        "        env:",
+        "          HARNESS_INFERENTIAL_SEMANTIC_MODE: shadow",
+        "        run: bun run harness:inferential-review",
+        "      - name: Harness audit",
+        "        run: bun run harness:audit",
+        "      - name: Graphify check",
+        "        run: bun run graphify:check",
+      ].join("\n"),
+      rootDir
+    );
+
+    const result = await runHarnessInferentialReview(rootDir, {
+      getChangedFiles: async () => [".github/workflows/athena-pr-tests.yml"],
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.machine.status).toBe("fail");
+    expect(result.machine.findings).toContainEqual(
+      expect.objectContaining({
+        id: "missing-ci-review-step",
+        severity: "high",
+        filePath: ".github/workflows/athena-pr-tests.yml",
+      })
+    );
+  });
+
+  it("does not treat harness review in another job as the PR validation gate", async () => {
+    const rootDir = await createFixtureRepo();
+    await write(
+      ".github/workflows/athena-pr-tests.yml",
+      [
+        "name: Athena PR Tests",
+        "jobs:",
+        "  janitor:",
+        "    steps:",
+        "      - name: Scheduled harness review",
+        "        run: bun run harness:review --base origin/main",
+        "  harness-validation:",
+        "    steps:",
+        "      - name: Harness check",
+        "        run: bun run harness:check",
+        "      - name: Inferential harness review",
+        "        env:",
+        "          HARNESS_INFERENTIAL_SEMANTIC_MODE: shadow",
+        "        run: bun run harness:inferential-review",
+        "      - name: Harness audit",
+        "        run: bun run harness:audit",
+        "      - name: Graphify check",
+        "        run: bun run graphify:check",
+      ].join("\n"),
+      rootDir
+    );
+
+    const result = await runHarnessInferentialReview(rootDir, {
+      getChangedFiles: async () => [".github/workflows/athena-pr-tests.yml"],
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.machine.status).toBe("fail");
+    expect(result.machine.findings).toContainEqual(
+      expect.objectContaining({
+        id: "missing-ci-review-step",
         severity: "high",
         filePath: ".github/workflows/athena-pr-tests.yml",
       })

--- a/scripts/harness-inferential-review.ts
+++ b/scripts/harness-inferential-review.ts
@@ -276,6 +276,98 @@ function includesCaseInsensitive(haystack: string, needle: string) {
   return haystack.toLowerCase().includes(needle.toLowerCase());
 }
 
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function buildShellCommandPattern(commandBody: string) {
+  return new RegExp(
+    `(?:^|&&|\\|\\||;)\\s*${commandBody}(?=\\s*(?:&&|\\|\\||;|$))`,
+    "i"
+  );
+}
+
+function hasHarnessReviewCommand(value: string, baseRef: string) {
+  const pattern = buildShellCommandPattern(
+    `bun\\s+run\\s+harness:review\\s+--base(?:\\s+|=)${escapeRegExp(baseRef)}`
+  );
+  return pattern.test(value);
+}
+
+function hasHarnessInferentialCommand(value: string) {
+  return buildShellCommandPattern(
+    "bun\\s+run\\s+harness:inferential-review"
+  ).test(value);
+}
+
+function extractWorkflowJobSection(
+  workflowContents: string,
+  jobName: string
+) {
+  const lines = workflowContents.split(/\r?\n/);
+  let inJobsBlock = false;
+  let insideTargetJob = false;
+  const section: string[] = [];
+
+  for (const line of lines) {
+    if (!inJobsBlock) {
+      if (line.trim() === "jobs:") {
+        inJobsBlock = true;
+      }
+      continue;
+    }
+
+    const jobMatch = line.match(/^  ([A-Za-z0-9_-]+):\s*$/);
+    if (jobMatch) {
+      if (insideTargetJob) {
+        break;
+      }
+
+      insideTargetJob = jobMatch[1] === jobName;
+    }
+
+    if (insideTargetJob) {
+      section.push(line);
+    }
+  }
+
+  return section.join("\n");
+}
+
+function extractWorkflowRunCommands(
+  workflowContents: string,
+  jobName: string
+) {
+  const jobSection = extractWorkflowJobSection(workflowContents, jobName);
+  if (!jobSection) {
+    return [];
+  }
+
+  return jobSection
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("run:"))
+    .map((line) => line.slice("run:".length).trim())
+    .filter(Boolean);
+}
+
+function workflowJobHasEnvSetting(
+  workflowContents: string,
+  jobName: string,
+  key: string,
+  value: string
+) {
+  const jobSection = extractWorkflowJobSection(workflowContents, jobName);
+  if (!jobSection) {
+    return false;
+  }
+
+  return jobSection
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .some((line) => line === `${key}: ${value}`);
+}
+
 function slugifyForFindingId(value: string) {
   return normalizeRepoPath(value)
     .toLowerCase()
@@ -677,6 +769,8 @@ export async function runDeterministicInferentialProvider(
   input: InferentialProviderInput
 ): Promise<InferentialProviderResult> {
   const findings: InferentialFinding[] = [];
+  const reviewBaseRef = "origin/main";
+  const workflowJobName = "harness-validation";
   const packageJsonPath = path.join(input.rootDir, "package.json");
   const workflowPath = path.join(
     input.rootDir,
@@ -724,10 +818,20 @@ export async function runDeterministicInferentialProvider(
       );
     }
 
-    if (
-      prAthenaScript &&
-      !includesCaseInsensitive(prAthenaScript, "bun run harness:inferential-review")
-    ) {
+    if (!hasHarnessReviewCommand(prAthenaScript, reviewBaseRef)) {
+      findings.push(
+        buildFinding(
+          "missing-pr-athena-review-step",
+          "high",
+          "pr:athena omits harness review",
+          "package.json",
+          "Athena preflight does not currently include the harness review gate.",
+          "Add `bun run harness:review --base origin/main` to the `pr:athena` script before final success output."
+        )
+      );
+    }
+
+    if (!hasHarnessInferentialCommand(prAthenaScript)) {
       findings.push(
         buildFinding(
           "missing-pr-athena-inferential-step",
@@ -754,9 +858,26 @@ export async function runDeterministicInferentialProvider(
       )
     );
   } else if (
-    !includesCaseInsensitive(
-      workflowContents,
-      "run: bun run harness:inferential-review"
+    !extractWorkflowRunCommands(workflowContents, workflowJobName).some(
+      (command) => hasHarnessReviewCommand(command, reviewBaseRef)
+    )
+  ) {
+    findings.push(
+      buildFinding(
+        "missing-ci-review-step",
+        "high",
+        "CI omits harness review",
+        ".github/workflows/athena-pr-tests.yml",
+        "Athena PR workflow does not enforce the harness review gate as a blocking CI step.",
+        "Add a workflow step with `run: bun run harness:review --base origin/main` in the harness validation job."
+      )
+    );
+  }
+
+  if (
+    workflowContents &&
+    !extractWorkflowRunCommands(workflowContents, workflowJobName).some(
+      hasHarnessInferentialCommand
     )
   ) {
     findings.push(
@@ -769,10 +890,15 @@ export async function runDeterministicInferentialProvider(
         "Add a workflow step with `run: bun run harness:inferential-review` in the harness validation job."
       )
     );
-  } else if (
-    !includesCaseInsensitive(
+  }
+
+  if (
+    workflowContents &&
+    !workflowJobHasEnvSetting(
       workflowContents,
-      "HARNESS_INFERENTIAL_SEMANTIC_MODE: shadow"
+      workflowJobName,
+      "HARNESS_INFERENTIAL_SEMANTIC_MODE",
+      "shadow"
     )
   ) {
     findings.push(

--- a/scripts/harness-review.test.ts
+++ b/scripts/harness-review.test.ts
@@ -1,9 +1,14 @@
+import { spawnSync } from "node:child_process";
 import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { runHarnessReview } from "./harness-review";
+import {
+  getChangedFilesForHarnessReview,
+  parseHarnessReviewArgs,
+  runHarnessReview,
+} from "./harness-review";
 
 const tempRoots: string[] = [];
 
@@ -231,6 +236,27 @@ async function createFixtureRepo() {
   );
 
   return rootDir;
+}
+
+function runGit(rootDir: string, args: string[]) {
+  const result = spawnSync("git", args, {
+    cwd: rootDir,
+    encoding: "utf8",
+  });
+
+  if (result.status !== 0) {
+    throw new Error(result.stderr.trim() || `git ${args.join(" ")} failed`);
+  }
+
+  return result.stdout.trim();
+}
+
+function initializeGitHistory(rootDir: string) {
+  runGit(rootDir, ["init"]);
+  runGit(rootDir, ["config", "user.name", "Athena Harness Tests"]);
+  runGit(rootDir, ["config", "user.email", "athena-harness-tests@example.com"]);
+  runGit(rootDir, ["add", "."]);
+  runGit(rootDir, ["commit", "-m", "Initial fixture"]);
 }
 
 afterEach(async () => {
@@ -783,5 +809,107 @@ describe("runHarnessReview", () => {
     });
 
     expect(steps).toEqual(["harness:check"]);
+  });
+
+  it("passes the requested base ref to the changed-file selector", async () => {
+    const rootDir = await createFixtureRepo();
+    const observedBaseRefs: Array<string | undefined> = [];
+    const steps: string[] = [];
+
+    await runHarnessReview(rootDir, {
+      baseRef: "origin/main",
+      getChangedFiles: async (_nextRootDir, baseRef) => {
+        observedBaseRefs.push(baseRef);
+        return ["packages/athena-webapp/src/app.ts"];
+      },
+      runHarnessCheck: async () => {
+        steps.push("harness:check");
+      },
+      runPackageScript: async (workspace, script) => {
+        steps.push(`${workspace}:${script}`);
+      },
+      logger: {
+        log() {},
+        error() {},
+      },
+    });
+
+    expect(observedBaseRefs).toEqual(["origin/main"]);
+    expect(steps).toEqual([
+      "harness:check",
+      "@athena/webapp:audit:convex",
+      "@athena/webapp:lint:convex:changed",
+      "@athena/webapp:test",
+    ]);
+  });
+});
+
+describe("parseHarnessReviewArgs", () => {
+  it("accepts --base <ref>", () => {
+    expect(parseHarnessReviewArgs(["--base", "origin/main"])).toEqual({
+      baseRef: "origin/main",
+    });
+  });
+
+  it("accepts --base=<ref>", () => {
+    expect(parseHarnessReviewArgs(["--base=origin/main"])).toEqual({
+      baseRef: "origin/main",
+    });
+  });
+
+  it("rejects missing --base values", () => {
+    expect(() => parseHarnessReviewArgs(["--base"])).toThrow(
+      "Missing value for --base. Usage: bun run harness:review --base origin/main"
+    );
+  });
+});
+
+describe("getChangedFilesForHarnessReview", () => {
+  it("combines base diff, tracked changes, and untracked files without duplicates", async () => {
+    const rootDir = await createFixtureRepo();
+    initializeGitHistory(rootDir);
+
+    await write(
+      "packages/athena-webapp/src/app.ts",
+      "export const app = 'committed-change';\n",
+      rootDir
+    );
+    runGit(rootDir, ["add", "packages/athena-webapp/src/app.ts"]);
+    runGit(rootDir, ["commit", "-m", "Committed athena change"]);
+
+    await write(
+      "packages/athena-webapp/src/app.ts",
+      "export const app = 'working-tree-change';\n",
+      rootDir
+    );
+    await write(
+      "packages/storefront-webapp/src/app.ts",
+      "export const storefront = 'working-tree-change';\n",
+      rootDir
+    );
+    await write(
+      "packages/valkey-proxy-server/new-surface.js",
+      "export const newSurface = true;\n",
+      rootDir
+    );
+
+    await expect(
+      getChangedFilesForHarnessReview(rootDir, "HEAD~1")
+    ).resolves.toEqual([
+      "packages/athena-webapp/src/app.ts",
+      "packages/storefront-webapp/src/app.ts",
+      "packages/valkey-proxy-server/new-surface.js",
+    ]);
+  });
+
+  it("fails clearly when the base ref is unreachable", async () => {
+    const rootDir = await createFixtureRepo();
+    initializeGitHistory(rootDir);
+
+    await expect(
+      getChangedFilesForHarnessReview(rootDir, "origin/does-not-exist")
+    ).rejects.toThrow(
+      "Base ref check failed for origin/does-not-exist"
+    );
   });
 });

--- a/scripts/harness-review.ts
+++ b/scripts/harness-review.ts
@@ -32,8 +32,13 @@ type LoadedReviewTarget = {
 
 type HarnessReviewLogger = Pick<Console, "log" | "error">;
 
+type ParsedHarnessReviewArgs = {
+  baseRef?: string;
+};
+
 type HarnessReviewOptions = {
-  getChangedFiles?: (rootDir: string) => Promise<string[]>;
+  baseRef?: string;
+  getChangedFiles?: (rootDir: string, baseRef?: string) => Promise<string[]>;
   logger?: HarnessReviewLogger;
   runHarnessCheck?: (rootDir: string) => Promise<void>;
   runPackageScript?: (workspace: string, script: string) => Promise<void>;
@@ -102,6 +107,12 @@ async function hasAnyHarnessDocs(
 
 async function readJsonFile<T>(filePath: string) {
   return JSON.parse(await readFile(filePath, "utf8")) as T;
+}
+
+function sortUniquePaths(paths: string[]) {
+  return [...new Set(paths.map((entry) => normalizeRepoPath(entry).trim()).filter(Boolean))].sort(
+    (left, right) => left.localeCompare(right)
+  );
 }
 
 async function loadReviewTarget(
@@ -359,42 +370,118 @@ function collectCommandsForChangedFiles(
   };
 }
 
-async function getChangedFilesFromGit(rootDir: string) {
-  const trackedDiff = Bun.spawn(
-    ["git", "diff", "--name-only", "--diff-filter=ACDMRTUXB", "HEAD", "--"],
-    {
-      cwd: rootDir,
-      stdout: "pipe",
-      stderr: "pipe",
-    }
-  );
-  const untrackedDiff = Bun.spawn(["git", "ls-files", "--others", "--exclude-standard"], {
+async function runGitCommand(rootDir: string, command: string[]) {
+  const process = Bun.spawn(command, {
     cwd: rootDir,
     stdout: "pipe",
     stderr: "pipe",
   });
 
-  const [trackedOutput, untrackedOutput, trackedExitCode, untrackedExitCode] =
-    await Promise.all([
-      new Response(trackedDiff.stdout).text(),
-      new Response(untrackedDiff.stdout).text(),
-      trackedDiff.exited,
-      untrackedDiff.exited,
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(process.stdout).text(),
+    new Response(process.stderr).text(),
+    process.exited,
+  ]);
+
+  return {
+    stdout,
+    stderr,
+    exitCode,
+  };
+}
+
+export async function getChangedFilesForHarnessReview(
+  rootDir: string,
+  baseRef?: string
+) {
+  const trackedDiff = runGitCommand(rootDir, [
+    "git",
+    "diff",
+    "--name-only",
+    "--diff-filter=ACDMRTUXB",
+    "HEAD",
+    "--",
+  ]);
+  const untrackedDiff = runGitCommand(rootDir, [
+    "git",
+    "ls-files",
+    "--others",
+    "--exclude-standard",
+  ]);
+
+  if (!baseRef) {
+    const [trackedResult, untrackedResult] = await Promise.all([
+      trackedDiff,
+      untrackedDiff,
     ]);
 
-  if (trackedExitCode !== 0) {
-    const stderr = await new Response(trackedDiff.stderr).text();
-    throw new Error(stderr.trim() || "Failed to read tracked git changes.");
+    if (trackedResult.exitCode !== 0) {
+      throw new Error(
+        trackedResult.stderr.trim() || "Failed to read tracked git changes."
+      );
+    }
+
+    if (untrackedResult.exitCode !== 0) {
+      throw new Error(
+        untrackedResult.stderr.trim() || "Failed to read untracked git changes."
+      );
+    }
+
+    return sortUniquePaths([
+      ...trackedResult.stdout.split("\n"),
+      ...untrackedResult.stdout.split("\n"),
+    ]);
   }
 
-  if (untrackedExitCode !== 0) {
-    const stderr = await new Response(untrackedDiff.stderr).text();
-    throw new Error(stderr.trim() || "Failed to read untracked git changes.");
+  const refCheck = await runGitCommand(rootDir, [
+    "git",
+    "rev-parse",
+    "--verify",
+    baseRef,
+  ]);
+
+  if (refCheck.exitCode !== 0) {
+    const detail = refCheck.stderr.trim() || `${baseRef} is not reachable.`;
+    throw new Error(`Base ref check failed for ${baseRef}: ${detail}`);
   }
 
-  return [...trackedOutput.split("\n"), ...untrackedOutput.split("\n")]
-    .map((filePath) => filePath.trim())
-    .filter(Boolean);
+  const [baseDiff, trackedResult, untrackedResult] = await Promise.all([
+    runGitCommand(rootDir, [
+      "git",
+      "diff",
+      "--name-only",
+      "--diff-filter=ACDMRTUXB",
+      `${baseRef}...HEAD`,
+      "--",
+    ]),
+    trackedDiff,
+    untrackedDiff,
+  ]);
+
+  if (baseDiff.exitCode !== 0) {
+    throw new Error(
+      baseDiff.stderr.trim() ||
+        `Failed to read changed files against ${baseRef}.`
+    );
+  }
+
+  if (trackedResult.exitCode !== 0) {
+    throw new Error(
+      trackedResult.stderr.trim() || "Failed to read tracked git changes."
+    );
+  }
+
+  if (untrackedResult.exitCode !== 0) {
+    throw new Error(
+      untrackedResult.stderr.trim() || "Failed to read untracked git changes."
+    );
+  }
+
+  return sortUniquePaths([
+    ...baseDiff.stdout.split("\n"),
+    ...trackedResult.stdout.split("\n"),
+    ...untrackedResult.stdout.split("\n"),
+  ]);
 }
 
 async function runPackageScript(rootDir: string, workspace: string, script: string) {
@@ -444,8 +531,12 @@ export async function runHarnessReview(
 ) {
   const logger = options.logger ?? console;
   const runCheck = options.runHarnessCheck ?? runHarnessCheck;
+  const baseRef = options.baseRef;
   const changedFiles =
-    (await (options.getChangedFiles ?? getChangedFilesFromGit)(rootDir)) ?? [];
+    (await (options.getChangedFiles ?? getChangedFilesForHarnessReview)(
+      rootDir,
+      baseRef
+    )) ?? [];
 
   await runCheck(rootDir);
 
@@ -509,6 +600,54 @@ export async function runHarnessReview(
   }
 }
 
+export function parseHarnessReviewArgs(
+  argv: string[]
+): ParsedHarnessReviewArgs {
+  let baseRef: string | undefined;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === "--base") {
+      const value = argv[index + 1]?.trim();
+      if (!value) {
+        throw new Error(
+          "Missing value for --base. Usage: bun run harness:review --base origin/main"
+        );
+      }
+      baseRef = value;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith("--base=")) {
+      const value = arg.slice("--base=".length).trim();
+      if (!value) {
+        throw new Error(
+          "Missing value for --base. Usage: bun run harness:review --base origin/main"
+        );
+      }
+      baseRef = value;
+      continue;
+    }
+
+    throw new Error(
+      `Unknown argument: ${arg}. Usage: bun run harness:review [--base <ref>]`
+    );
+  }
+
+  return {
+    baseRef,
+  };
+}
+
 if (import.meta.main) {
-  await runHarnessReview(process.cwd());
+  try {
+    const parsed = parseHarnessReviewArgs(Bun.argv.slice(2));
+    await runHarnessReview(process.cwd(), { baseRef: parsed.baseRef });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`\n[harness:review] BLOCKED: ${message}`);
+    process.exit(1);
+  }
 }

--- a/scripts/pre-push-review.test.ts
+++ b/scripts/pre-push-review.test.ts
@@ -76,9 +76,7 @@ describe("pre-push review wiring", () => {
         steps.push("architecture:check");
       },
       runHarnessReview: async (_rootDir, options) => {
-        steps.push("harness:review");
-        const files = await options.getChangedFiles(ROOT_DIR);
-        steps.push(`files:${files.join(",")}`);
+        steps.push(`harness:review:${options.baseRef}`);
       },
       logger: {
         log() {},
@@ -90,10 +88,66 @@ describe("pre-push review wiring", () => {
     expect(steps).toEqual([
       "harness:self-review:origin/main",
       "architecture:check",
-      "harness:review",
-      "changed-files",
-      "files:packages/athena-webapp/src/main.tsx",
+      "harness:review:origin/main",
     ]);
+  });
+
+  it("preserves the non-blocking origin/main fallback when handing off to harness review", async () => {
+    const steps: string[] = [];
+
+    await prePushReview.runPrePushReview(ROOT_DIR, {
+      getChangedFiles: async () => {
+        steps.push("changed-files-fallback");
+        return [];
+      },
+      runHarnessSelfReview: async () => {
+        steps.push("harness:self-review:origin/main");
+      },
+      runArchitectureCheck: async () => {
+        steps.push("architecture:check");
+      },
+      runHarnessReview: async (_rootDir, options) => {
+        steps.push(`harness:review:${options.baseRef}`);
+        const files = await options.getChangedFiles?.(ROOT_DIR, options.baseRef);
+        steps.push(`files:${files?.join(",") ?? ""}`);
+      },
+      logger: {
+        log() {},
+        warn() {},
+        error() {},
+      },
+    });
+
+    expect(steps).toEqual([
+      "harness:self-review:origin/main",
+      "architecture:check",
+      "harness:review:origin/main",
+      "changed-files-fallback",
+      "files:",
+    ]);
+  });
+
+  it("does not pass the base ref into default-style changed-file helpers", async () => {
+    const observedSpawnTypes: string[] = [];
+
+    await prePushReview.runPrePushReview(ROOT_DIR, {
+      getChangedFiles: (async (_rootDir: string, spawn = Bun.spawn) => {
+        observedSpawnTypes.push(typeof spawn);
+        return [];
+      }) as unknown as (rootDir: string) => Promise<string[]>,
+      runHarnessSelfReview: async () => {},
+      runArchitectureCheck: async () => {},
+      runHarnessReview: async (_rootDir, options) => {
+        await options.getChangedFiles?.(ROOT_DIR, options.baseRef);
+      },
+      logger: {
+        log() {},
+        warn() {},
+        error() {},
+      },
+    });
+
+    expect(observedSpawnTypes).toEqual(["function"]);
   });
 
   it("keeps the husky pre-push hook pointed at the repo review script", async () => {
@@ -119,6 +173,7 @@ describe("repo harness ergonomics", () => {
     expect(workflow).toContain("harness-implementation-tests:");
     expect(workflow).toContain("fetch-depth: 0");
     expect(workflow).toContain("run: bun run harness:self-review --base origin/main");
+    expect(workflow).toContain("run: bun run harness:review --base origin/main");
     expect(workflow).toContain("run: bun run harness:test");
     expect(workflow).toContain("run: python3 -m pip install graphifyy");
     expect(workflow).toContain("run: bun run harness:audit");
@@ -139,6 +194,9 @@ describe("repo harness ergonomics", () => {
     };
 
     expect(packageJson.scripts?.["pr:athena"]).toContain("bun run harness:test");
+    expect(packageJson.scripts?.["pr:athena"]).toContain(
+      "bun run harness:review --base origin/main"
+    );
     expect(packageJson.scripts?.["pr:athena"]).toContain("bun run harness:audit");
     expect(packageJson.scripts?.["pr:athena"]).toContain(
       "bun run harness:inferential-review"

--- a/scripts/pre-push-review.ts
+++ b/scripts/pre-push-review.ts
@@ -17,7 +17,10 @@ type PrePushReviewOptions = {
   runHarnessSelfReview?: (rootDir: string) => Promise<void>;
   runHarnessReview?: (
     rootDir: string,
-    options: { getChangedFiles: (rootDir: string) => Promise<string[]> }
+    options: {
+      baseRef: string;
+      getChangedFiles?: (rootDir: string, baseRef?: string) => Promise<string[]>;
+    }
   ) => Promise<void>;
   logger?: PrePushReviewLogger;
 };
@@ -96,6 +99,8 @@ export async function runPrePushReview(
 ) {
   const logger = options.logger ?? console;
   const getChangedFiles = options.getChangedFiles ?? getChangedFilesVsOriginMain;
+  const getChangedFilesForHarnessReview = async (nextRootDir: string) =>
+    getChangedFiles(nextRootDir);
   const runArchitecture = options.runArchitectureCheck ?? runArchitectureCheck;
   const runSelfReview = options.runHarnessSelfReview ?? runHarnessSelfReview;
   const review = options.runHarnessReview ?? runHarnessReview;
@@ -111,7 +116,8 @@ export async function runPrePushReview(
   // runHarnessReview internally runs harness:check first, then targeted per-surface scripts
   logger.log(`[pre-push] Step 3/3: harness:review (vs ${BASE_REF})`);
   await review(rootDir, {
-    getChangedFiles,
+    baseRef: BASE_REF,
+    getChangedFiles: getChangedFilesForHarnessReview,
   });
 
   logger.log("\n[pre-push] All checks passed.");


### PR DESCRIPTION
## Summary
- add `--base` support to `harness:review` so clean branches and CI can diff against `origin/main`
- enforce `bun run harness:review --base origin/main` in `pr:athena`, PR CI, and inferential policy checks
- preserve the non-blocking pre-push fallback for missing `origin/main` and add regression coverage for bypass cases

## Why
The harness audit found that targeted review coverage was not actually enforced in the PR path. This patch makes the review command usable off a clean branch, wires it into the real PR gates, and hardens the inferential checks so comments, echoes, wrong jobs, and other near-miss shapes do not spoof enforcement.

## Validation
- `bun test scripts/harness-inferential-review.test.ts`
- `bun test scripts/pre-push-review.test.ts scripts/harness-inferential-review.test.ts scripts/harness-review.test.ts`
- `bun run pr:athena`
- `bun run harness:behavior --scenario sample-runtime-smoke --record-video`

https://linear.app/v26-labs/issue/V26-228/make-harnessreview-base-aware-and-enforce-it-in-prathena-and-pr-ci
