### PR TITLE
[V26-229]: treat skipped inferential runs as non-healthy

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 2788 nodes · 2334 edges · 1113 communities detected
+- 2791 nodes · 2340 edges · 1113 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1171,12 +1171,12 @@ Cohesion: 0.16
 Nodes (25): asArray(), asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), assignOrDelete(), asString() (+17 more)
 
 ### Community 5 - "Community 5"
-Cohesion: 0.13
-Nodes (22): asRegExp(), collectLatencyDiagnostics(), collectRuntimeSignalDiagnostics(), collectRuntimeSignalMatches(), consumeLines(), escapeRegExp(), formatAssertionDiagnostics(), formatError() (+14 more)
+Cohesion: 0.15
+Nodes (22): buildDocumentationStatus(), buildEmptyHistoryMetric(), buildGraphifyStatus(), buildInferentialSummaryNote(), buildSummary(), collectHarnessScorecard(), countMissingSnippets(), createFileSystem() (+14 more)
 
 ### Community 6 - "Community 6"
-Cohesion: 0.16
-Nodes (20): buildDocumentationStatus(), buildEmptyHistoryMetric(), buildGraphifyStatus(), buildSummary(), collectHarnessScorecard(), countMissingSnippets(), createFileSystem(), extractScenarioNames() (+12 more)
+Cohesion: 0.13
+Nodes (22): asRegExp(), collectLatencyDiagnostics(), collectRuntimeSignalDiagnostics(), collectRuntimeSignalMatches(), consumeLines(), escapeRegExp(), formatAssertionDiagnostics(), formatError() (+14 more)
 
 ### Community 7 - "Community 7"
 Cohesion: 0.15
@@ -1363,16 +1363,16 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 53 - "Community 53"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
+
+### Community 54 - "Community 54"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
-### Community 54 - "Community 54"
+### Community 55 - "Community 55"
 Cohesion: 0.29
 Nodes (0):
-
-### Community 55 - "Community 55"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
 
 ### Community 56 - "Community 56"
 Cohesion: 0.52
@@ -1803,15 +1803,15 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 163 - "Community 163"
+Cohesion: 0.83
+Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
+
+### Community 164 - "Community 164"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
 
-### Community 164 - "Community 164"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 165 - "Community 165"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 166 - "Community 166"
@@ -1831,16 +1831,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 170 - "Community 170"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 171 - "Community 171"
 Cohesion: 1.0
 Nodes (2): listBagItems(), loadBagWithItems()
 
-### Community 171 - "Community 171"
-Cohesion: 0.67
-Nodes (1): View()
-
 ### Community 172 - "Community 172"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 173 - "Community 173"
 Cohesion: 0.67
@@ -1855,16 +1855,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 176 - "Community 176"
-Cohesion: 1.0
-Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 177 - "Community 177"
 Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+Nodes (2): AnalyticsCombinedUsers(), processAnalyticsToUsers()
 
 ### Community 178 - "Community 178"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 179 - "Community 179"
 Cohesion: 0.67
@@ -1876,11 +1876,11 @@ Nodes (0):
 
 ### Community 181 - "Community 181"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 182 - "Community 182"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 183 - "Community 183"
 Cohesion: 0.67
@@ -1888,11 +1888,11 @@ Nodes (0):
 
 ### Community 184 - "Community 184"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 185 - "Community 185"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 186 - "Community 186"
 Cohesion: 0.67
@@ -1936,75 +1936,75 @@ Nodes (0):
 
 ### Community 196 - "Community 196"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 197 - "Community 197"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (1): SingleLineError()
 
 ### Community 198 - "Community 198"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 199 - "Community 199"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 200 - "Community 200"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 201 - "Community 201"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): TableSkeleton()
 
 ### Community 202 - "Community 202"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 203 - "Community 203"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): NotFound()
 
 ### Community 204 - "Community 204"
 Cohesion: 0.67
-Nodes (1): AppContextMenu()
+Nodes (0):
 
 ### Community 205 - "Community 205"
 Cohesion: 0.67
-Nodes (1): Badge()
+Nodes (1): AppContextMenu()
 
 ### Community 206 - "Community 206"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (1): Badge()
 
 ### Community 207 - "Community 207"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (1): LoadingButton()
 
 ### Community 208 - "Community 208"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): onChange()
 
 ### Community 209 - "Community 209"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): AlertModal()
 
 ### Community 210 - "Community 210"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): OverlayModal()
 
 ### Community 211 - "Community 211"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): Skeleton()
 
 ### Community 212 - "Community 212"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Toaster()
 
 ### Community 213 - "Community 213"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 214 - "Community 214"
 Cohesion: 0.67
@@ -2032,11 +2032,11 @@ Nodes (0):
 
 ### Community 220 - "Community 220"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 221 - "Community 221"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 222 - "Community 222"
 Cohesion: 0.67
@@ -2052,59 +2052,59 @@ Nodes (0):
 
 ### Community 225 - "Community 225"
 Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
+Nodes (0):
 
 ### Community 226 - "Community 226"
 Cohesion: 0.67
-Nodes (1): App()
+Nodes (1): isInMaintenanceMode()
 
 ### Community 227 - "Community 227"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): App()
 
 ### Community 228 - "Community 228"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 229 - "Community 229"
 Cohesion: 1.0
 Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
-### Community 229 - "Community 229"
+### Community 230 - "Community 230"
 Cohesion: 0.67
 Nodes (1): hashPassword()
 
-### Community 230 - "Community 230"
+### Community 231 - "Community 231"
 Cohesion: 0.67
 Nodes (1): useAppSession()
 
-### Community 231 - "Community 231"
+### Community 232 - "Community 232"
 Cohesion: 0.67
 Nodes (1): createVersionChecker()
 
-### Community 232 - "Community 232"
+### Community 233 - "Community 233"
 Cohesion: 0.67
 Nodes (1): manualChunks()
 
-### Community 233 - "Community 233"
+### Community 234 - "Community 234"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 234 - "Community 234"
+### Community 235 - "Community 235"
 Cohesion: 1.0
 Nodes (2): getAllColors(), getBaseUrl()
 
-### Community 235 - "Community 235"
+### Community 236 - "Community 236"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 236 - "Community 236"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 237 - "Community 237"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 238 - "Community 238"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 239 - "Community 239"
 Cohesion: 0.67
@@ -2115,24 +2115,24 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 241 - "Community 241"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 242 - "Community 242"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 242 - "Community 242"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 243 - "Community 243"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 244 - "Community 244"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 245 - "Community 245"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 245 - "Community 245"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 246 - "Community 246"
 Cohesion: 0.67
@@ -2211,16 +2211,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 265 - "Community 265"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
-
-### Community 266 - "Community 266"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 267 - "Community 267"
+### Community 266 - "Community 266"
 Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
+
+### Community 267 - "Community 267"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 268 - "Community 268"
 Cohesion: 1.0
@@ -7291,7 +7291,7 @@ _Questions this graph is uniquely positioned to answer:_
   _Cohesion score 0.09 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**
   _Cohesion score 0.12 - nodes in this community are weakly interconnected._
-- **Should `Community 5` be split into smaller, more focused modules?**
+- **Should `Community 6` be split into smaller, more focused modules?**
   _Cohesion score 0.13 - nodes in this community are weakly interconnected._
 - **Should `Community 9` be split into smaller, more focused modules?**
   _Cohesion score 0.11 - nodes in this community are weakly interconnected._

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -217,7 +217,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_emails_discountcode_tsx",
-      "community": 165
+      "community": 166
     },
     {
       "label": "ProductCard()",
@@ -225,7 +225,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
       "source_location": "L33",
       "id": "discountcode_productcard",
-      "community": 165
+      "community": 166
     },
     {
       "label": "chunkProducts()",
@@ -233,7 +233,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountCode.tsx",
       "source_location": "L98",
       "id": "discountcode_chunkproducts",
-      "community": 165
+      "community": 166
     },
     {
       "label": "DiscountReminder.tsx",
@@ -241,7 +241,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_emails_discountreminder_tsx",
-      "community": 166
+      "community": 167
     },
     {
       "label": "ProductCard()",
@@ -249,7 +249,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
       "source_location": "L31",
       "id": "discountreminder_productcard",
-      "community": 166
+      "community": 167
     },
     {
       "label": "chunkProducts()",
@@ -257,7 +257,7 @@
       "source_file": "packages/athena-webapp/convex/emails/DiscountReminder.tsx",
       "source_location": "L85",
       "id": "discountreminder_chunkproducts",
-      "community": 166
+      "community": 167
     },
     {
       "label": "FeedbackRequest.tsx",
@@ -641,7 +641,7 @@
       "source_file": "packages/athena-webapp/convex/http/utils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_http_utils_ts",
-      "community": 167
+      "community": 168
     },
     {
       "label": "getStoreDataFromRequest()",
@@ -649,7 +649,7 @@
       "source_file": "packages/athena-webapp/convex/http/utils.ts",
       "source_location": "L5",
       "id": "utils_getstoredatafromrequest",
-      "community": 167
+      "community": 168
     },
     {
       "label": "getStorefrontUserFromRequest()",
@@ -657,7 +657,7 @@
       "source_file": "packages/athena-webapp/convex/http/utils.ts",
       "source_location": "L12",
       "id": "utils_getstorefrontuserfromrequest",
-      "community": 167
+      "community": 168
     },
     {
       "label": "http.ts",
@@ -1785,7 +1785,7 @@
       "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_llm_utils_analyticsutils_ts",
-      "community": 168
+      "community": 169
     },
     {
       "label": "calculateDeviceDistribution()",
@@ -1793,7 +1793,7 @@
       "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
       "source_location": "L11",
       "id": "analyticsutils_calculatedevicedistribution",
-      "community": 168
+      "community": 169
     },
     {
       "label": "calculateActivityTrend()",
@@ -1801,7 +1801,7 @@
       "source_file": "packages/athena-webapp/convex/llm/utils/analyticsUtils.ts",
       "source_location": "L43",
       "id": "analyticsutils_calculateactivitytrend",
-      "community": 168
+      "community": 169
     },
     {
       "label": "index.tsx",
@@ -2129,7 +2129,7 @@
       "source_file": "packages/athena-webapp/convex/paystack/index.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_paystack_index_ts",
-      "community": 169
+      "community": 170
     },
     {
       "label": "listTransactions()",
@@ -2137,7 +2137,7 @@
       "source_file": "packages/athena-webapp/convex/paystack/index.ts",
       "source_location": "L7",
       "id": "index_listtransactions",
-      "community": 169
+      "community": 170
     },
     {
       "label": "verifyTransaction()",
@@ -2145,7 +2145,7 @@
       "source_file": "packages/athena-webapp/convex/paystack/index.ts",
       "source_location": "L109",
       "id": "index_verifytransaction",
-      "community": 169
+      "community": 170
     },
     {
       "label": "schema.ts",
@@ -3033,7 +3033,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/bag.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_convex_storefront_helpers_bag_ts",
-      "community": 170
+      "community": 171
     },
     {
       "label": "listBagItems()",
@@ -3041,7 +3041,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/bag.ts",
       "source_location": "L7",
       "id": "bag_listbagitems",
-      "community": 170
+      "community": 171
     },
     {
       "label": "loadBagWithItems()",
@@ -3049,7 +3049,7 @@
       "source_file": "packages/athena-webapp/convex/storeFront/helpers/bag.ts",
       "source_location": "L14",
       "id": "bag_loadbagwithitems",
-      "community": 170
+      "community": 171
     },
     {
       "label": "onlineOrder.ts",
@@ -3785,7 +3785,7 @@
       "source_file": "packages/athena-webapp/src/components/View.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_view_tsx",
-      "community": 171
+      "community": 172
     },
     {
       "label": "View()",
@@ -3793,7 +3793,7 @@
       "source_file": "packages/storefront-webapp/src/components/View.tsx",
       "source_location": "L4",
       "id": "view_view",
-      "community": 171
+      "community": 172
     },
     {
       "label": "AttributesManager.tsx",
@@ -3961,7 +3961,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_productavailability_tsx",
-      "community": 172
+      "community": 173
     },
     {
       "label": "ProductAvailabilityView()",
@@ -3969,7 +3969,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
       "source_location": "L5",
       "id": "productavailability_productavailabilityview",
-      "community": 172
+      "community": 173
     },
     {
       "label": "ProductAvailability()",
@@ -3977,7 +3977,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailability.tsx",
       "source_location": "L18",
       "id": "productavailability_productavailability",
-      "community": 172
+      "community": 173
     },
     {
       "label": "ProductAvailabilityToggleGroup.tsx",
@@ -4321,7 +4321,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_sheetprovider_tsx",
-      "community": 173
+      "community": 174
     },
     {
       "label": "useSheet()",
@@ -4329,7 +4329,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
       "source_location": "L11",
       "id": "sheetprovider_usesheet",
-      "community": 173
+      "community": 174
     },
     {
       "label": "SheetProvider()",
@@ -4337,7 +4337,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/SheetProvider.tsx",
       "source_location": "L19",
       "id": "sheetprovider_sheetprovider",
-      "community": 173
+      "community": 174
     },
     {
       "label": "WigType.tsx",
@@ -4345,7 +4345,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_wigtype_tsx",
-      "community": 174
+      "community": 175
     },
     {
       "label": "WigTypeView()",
@@ -4353,7 +4353,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
       "source_location": "L8",
       "id": "wigtype_wigtypeview",
-      "community": 174
+      "community": 175
     },
     {
       "label": "WigType()",
@@ -4361,7 +4361,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/WigType.tsx",
       "source_location": "L21",
       "id": "wigtype_wigtype",
-      "community": 174
+      "community": 175
     },
     {
       "label": "CopyImagesProvider.tsx",
@@ -4369,7 +4369,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesprovider_tsx",
-      "community": 175
+      "community": 176
     },
     {
       "label": "useCopyImages()",
@@ -4377,7 +4377,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
       "source_location": "L13",
       "id": "copyimagesprovider_usecopyimages",
-      "community": 175
+      "community": 176
     },
     {
       "label": "CopyImagesProvider()",
@@ -4385,7 +4385,7 @@
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesProvider.tsx",
       "source_location": "L21",
       "id": "copyimagesprovider_copyimagesprovider",
-      "community": 175
+      "community": 176
     },
     {
       "label": "CopyImagesView.tsx",
@@ -4553,7 +4553,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analyticscombinedusers_tsx",
-      "community": 176
+      "community": 177
     },
     {
       "label": "processAnalyticsToUsers()",
@@ -4561,7 +4561,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
       "source_location": "L10",
       "id": "analyticscombinedusers_processanalyticstousers",
-      "community": 176
+      "community": 177
     },
     {
       "label": "AnalyticsCombinedUsers()",
@@ -4569,7 +4569,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsCombinedUsers.tsx",
       "source_location": "L100",
       "id": "analyticscombinedusers_analyticscombinedusers",
-      "community": 176
+      "community": 177
     },
     {
       "label": "AnalyticsItems.tsx",
@@ -4609,7 +4609,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsTopUsers.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_analyticstopusers_tsx",
-      "community": 177
+      "community": 178
     },
     {
       "label": "processAnalyticsToUsers()",
@@ -4617,7 +4617,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsTopUsers.tsx",
       "source_location": "L10",
       "id": "analyticstopusers_processanalyticstousers",
-      "community": 177
+      "community": 178
     },
     {
       "label": "AnalyticsTopUsers()",
@@ -4625,7 +4625,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsTopUsers.tsx",
       "source_location": "L100",
       "id": "analyticstopusers_analyticstopusers",
-      "community": 177
+      "community": 178
     },
     {
       "label": "AnalyticsUsers.tsx",
@@ -4729,7 +4729,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_analytics_storefrontobservabilitypanel_tsx",
-      "community": 178
+      "community": 179
     },
     {
       "label": "formatLabel()",
@@ -4737,7 +4737,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
       "source_location": "L15",
       "id": "storefrontobservabilitypanel_formatlabel",
-      "community": 178
+      "community": 179
     },
     {
       "label": "SummaryCard()",
@@ -4745,7 +4745,7 @@
       "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
       "source_location": "L19",
       "id": "storefrontobservabilitypanel_summarycard",
-      "community": 178
+      "community": 179
     },
     {
       "label": "VisitorChart.tsx",
@@ -5257,7 +5257,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_log_items_provider_tsx",
-      "community": 179
+      "community": 180
     },
     {
       "label": "LogItemsProvider()",
@@ -5265,7 +5265,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
       "source_location": "L15",
       "id": "log_items_provider_logitemsprovider",
-      "community": 179
+      "community": 180
     },
     {
       "label": "useLogItems()",
@@ -5273,7 +5273,7 @@
       "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/log-items-provider.tsx",
       "source_location": "L39",
       "id": "log_items_provider_uselogitems",
-      "community": 179
+      "community": 180
     },
     {
       "label": "useLoadLogItems.ts",
@@ -5425,7 +5425,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_auth_login_inputotp_tsx",
-      "community": 180
+      "community": 181
     },
     {
       "label": "handlePinChange()",
@@ -5433,7 +5433,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
       "source_location": "L48",
       "id": "inputotp_handlepinchange",
-      "community": 180
+      "community": 181
     },
     {
       "label": "onSubmit()",
@@ -5441,7 +5441,7 @@
       "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.tsx",
       "source_location": "L56",
       "id": "inputotp_onsubmit",
-      "community": 180
+      "community": 181
     },
     {
       "label": "LoginForm.tsx",
@@ -5793,7 +5793,7 @@
       "source_file": "packages/athena-webapp/src/components/common/FadeIn.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_common_fadein_tsx",
-      "community": 181
+      "community": 182
     },
     {
       "label": "FadeIn()",
@@ -5801,7 +5801,7 @@
       "source_file": "packages/storefront-webapp/src/components/common/FadeIn.tsx",
       "source_location": "L3",
       "id": "fadein_fadein",
-      "community": 181
+      "community": 182
     },
     {
       "label": "PageHeader.tsx",
@@ -6001,7 +6001,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_bestsellers_tsx",
-      "community": 182
+      "community": 183
     },
     {
       "label": "handleRemoveBestSeller()",
@@ -6009,7 +6009,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
       "source_location": "L53",
       "id": "bestsellers_handleremovebestseller",
-      "community": 182
+      "community": 183
     },
     {
       "label": "onDragEnd()",
@@ -6017,7 +6017,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/BestSellers.tsx",
       "source_location": "L65",
       "id": "bestsellers_ondragend",
-      "community": 182
+      "community": 183
     },
     {
       "label": "BestSellersDialog.tsx",
@@ -6041,7 +6041,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_featuredsection_tsx",
-      "community": 183
+      "community": 184
     },
     {
       "label": "handleHighlightedItem()",
@@ -6049,7 +6049,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
       "source_location": "L47",
       "id": "featuredsection_handlehighlighteditem",
-      "community": 183
+      "community": 184
     },
     {
       "label": "onDragEnd()",
@@ -6057,7 +6057,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
       "source_location": "L53",
       "id": "featuredsection_ondragend",
-      "community": 183
+      "community": 184
     },
     {
       "label": "FeaturedSectionDialog.tsx",
@@ -6369,7 +6369,7 @@
       "source_file": "packages/athena-webapp/src/components/homepage/VideoPlayer.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_homepage_videoplayer_tsx",
-      "community": 184
+      "community": 185
     },
     {
       "label": "VideoPlayer()",
@@ -6377,7 +6377,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
       "source_location": "L9",
       "id": "videoplayer_videoplayer",
-      "community": 184
+      "community": 185
     },
     {
       "label": "index.tsx",
@@ -6585,7 +6585,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_orderview_tsx",
-      "community": 185
+      "community": 186
     },
     {
       "label": "handleRefundOrder()",
@@ -6593,7 +6593,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderView.tsx",
       "source_location": "L67",
       "id": "orderview_handlerefundorder",
-      "community": 185
+      "community": 186
     },
     {
       "label": "handleVerifyPayment()",
@@ -6601,7 +6601,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/OrderView.tsx",
       "source_location": "L423",
       "id": "orderview_handleverifypayment",
-      "community": 185
+      "community": 186
     },
     {
       "label": "Orders.tsx",
@@ -6633,7 +6633,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/PickupDetailsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_orders_pickupdetailsview_tsx",
-      "community": 186
+      "community": 187
     },
     {
       "label": "PickupDetailsView()",
@@ -6641,7 +6641,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/PickupDetailsView.tsx",
       "source_location": "L9",
       "id": "pickupdetailsview_pickupdetailsview",
-      "community": 186
+      "community": 187
     },
     {
       "label": "DeliveryDetails()",
@@ -6649,7 +6649,7 @@
       "source_file": "packages/athena-webapp/src/components/orders/PickupDetailsView.tsx",
       "source_location": "L67",
       "id": "pickupdetailsview_deliverydetails",
-      "community": 186
+      "community": 187
     },
     {
       "label": "RefundsView.tsx",
@@ -7057,7 +7057,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-switcher.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_organization_switcher_tsx",
-      "community": 187
+      "community": 188
     },
     {
       "label": "onOrganizationSelect()",
@@ -7065,7 +7065,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-switcher.tsx",
       "source_location": "L94",
       "id": "organization_switcher_onorganizationselect",
-      "community": 187
+      "community": 188
     },
     {
       "label": "handleSignOut()",
@@ -7073,7 +7073,7 @@
       "source_file": "packages/athena-webapp/src/components/organization-switcher.tsx",
       "source_location": "L99",
       "id": "organization_switcher_handlesignout",
-      "community": 187
+      "community": 188
     },
     {
       "label": "CartItems.tsx",
@@ -7657,7 +7657,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_session_heldsessionslist_tsx",
-      "community": 188
+      "community": 189
     },
     {
       "label": "hasExpired()",
@@ -7665,7 +7665,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx",
       "source_location": "L54",
       "id": "heldsessionslist_hasexpired",
-      "community": 188
+      "community": 189
     },
     {
       "label": "getSessionCartItemsCount()",
@@ -7673,7 +7673,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx",
       "source_location": "L58",
       "id": "heldsessionslist_getsessioncartitemscount",
-      "community": 188
+      "community": 189
     },
     {
       "label": "HoldSessionDialog.tsx",
@@ -7753,7 +7753,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
-      "community": 189
+      "community": 190
     },
     {
       "label": "formatPaymentMethod()",
@@ -7761,7 +7761,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
       "source_location": "L19",
       "id": "transactionsview_formatpaymentmethod",
-      "community": 189
+      "community": 190
     },
     {
       "label": "isToday()",
@@ -7769,7 +7769,7 @@
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
       "source_location": "L25",
       "id": "transactionsview_istoday",
-      "community": 189
+      "community": 190
     },
     {
       "label": "transactionColumns.tsx",
@@ -7977,7 +7977,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsListView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_productslistview_tsx",
-      "community": 190
+      "community": 191
     },
     {
       "label": "ProductActionsToggleGroup()",
@@ -7985,7 +7985,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsListView.tsx",
       "source_location": "L20",
       "id": "productslistview_productactionstogglegroup",
-      "community": 190
+      "community": 191
     },
     {
       "label": "handleClearCache()",
@@ -7993,7 +7993,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsListView.tsx",
       "source_location": "L65",
       "id": "productslistview_handleclearcache",
-      "community": 190
+      "community": 191
     },
     {
       "label": "ProductsTableContext.tsx",
@@ -8001,7 +8001,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsTableContext.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_productstablecontext_tsx",
-      "community": 191
+      "community": 192
     },
     {
       "label": "ProductsTableProvider()",
@@ -8009,7 +8009,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsTableContext.tsx",
       "source_location": "L16",
       "id": "productstablecontext_productstableprovider",
-      "community": 191
+      "community": 192
     },
     {
       "label": "useProductsTableState()",
@@ -8017,7 +8017,7 @@
       "source_file": "packages/athena-webapp/src/components/products/ProductsTableContext.tsx",
       "source_location": "L60",
       "id": "productstablecontext_useproductstablestate",
-      "community": 191
+      "community": 192
     },
     {
       "label": "ProductsView.tsx",
@@ -8049,7 +8049,7 @@
       "source_file": "packages/athena-webapp/src/components/products/StoreProductsView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_storeproductsview_tsx",
-      "community": 192
+      "community": 193
     },
     {
       "label": "ProductActionsToggleGroup()",
@@ -8057,7 +8057,7 @@
       "source_file": "packages/athena-webapp/src/components/products/StoreProductsView.tsx",
       "source_location": "L19",
       "id": "storeproductsview_productactionstogglegroup",
-      "community": 192
+      "community": 193
     },
     {
       "label": "Navigation()",
@@ -8065,7 +8065,7 @@
       "source_file": "packages/athena-webapp/src/components/products/StoreProductsView.tsx",
       "source_location": "L45",
       "id": "storeproductsview_navigation",
-      "community": 192
+      "community": 193
     },
     {
       "label": "UnresolvedProducts.tsx",
@@ -8081,7 +8081,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/AddComplimentaryProduct.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_products_complimentary_addcomplimentaryproduct_tsx",
-      "community": 193
+      "community": 194
     },
     {
       "label": "handleAddComplimentaryProducts()",
@@ -8089,7 +8089,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/AddComplimentaryProduct.tsx",
       "source_location": "L40",
       "id": "addcomplimentaryproduct_handleaddcomplimentaryproducts",
-      "community": 193
+      "community": 194
     },
     {
       "label": "AddComplimentaryProduct()",
@@ -8097,7 +8097,7 @@
       "source_file": "packages/athena-webapp/src/components/products/complimentary/AddComplimentaryProduct.tsx",
       "source_location": "L128",
       "id": "addcomplimentaryproduct_addcomplimentaryproduct",
-      "community": 193
+      "community": 194
     },
     {
       "label": "ComplimentaryProducts.tsx",
@@ -8441,7 +8441,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_color_picker_tsx",
-      "community": 194
+      "community": 195
     },
     {
       "label": "handleInputChange()",
@@ -8449,7 +8449,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
       "source_location": "L20",
       "id": "color_picker_handleinputchange",
-      "community": 194
+      "community": 195
     },
     {
       "label": "handleBlur()",
@@ -8457,7 +8457,7 @@
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/color-picker.tsx",
       "source_location": "L24",
       "id": "color_picker_handleblur",
-      "community": 194
+      "community": 195
     },
     {
       "label": "promo-code-modal.tsx",
@@ -8713,7 +8713,7 @@
       "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_providers_currency_provider_tsx",
-      "community": 195
+      "community": 196
     },
     {
       "label": "useStoreCurrency()",
@@ -8721,7 +8721,7 @@
       "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
       "source_location": "L17",
       "id": "currency_provider_usestorecurrency",
-      "community": 195
+      "community": 196
     },
     {
       "label": "CurrencyProvider()",
@@ -8729,7 +8729,7 @@
       "source_file": "packages/athena-webapp/src/components/providers/currency-provider.tsx",
       "source_location": "L25",
       "id": "currency_provider_currencyprovider",
-      "community": 195
+      "community": 196
     },
     {
       "label": "RatingStars.tsx",
@@ -8841,7 +8841,7 @@
       "source_file": "packages/athena-webapp/src/components/states/error/SingleLineError.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_states_error_singlelineerror_tsx",
-      "community": 196
+      "community": 197
     },
     {
       "label": "SingleLineError()",
@@ -8849,7 +8849,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/error/SingleLineError.tsx",
       "source_location": "L3",
       "id": "singlelineerror_singlelineerror",
-      "community": 196
+      "community": 197
     },
     {
       "label": "index.tsx",
@@ -8857,7 +8857,7 @@
       "source_file": "packages/athena-webapp/src/components/states/error/index.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_states_error_index_tsx",
-      "community": 197
+      "community": 198
     },
     {
       "label": "ErrorPage()",
@@ -8865,7 +8865,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/error/index.tsx",
       "source_location": "L9",
       "id": "index_errorpage",
-      "community": 197
+      "community": 198
     },
     {
       "label": "app-skeleton.tsx",
@@ -8873,7 +8873,7 @@
       "source_file": "packages/athena-webapp/src/components/states/loading/app-skeleton.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_states_loading_app_skeleton_tsx",
-      "community": 198
+      "community": 199
     },
     {
       "label": "AppSkeleton()",
@@ -8881,7 +8881,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/app-skeleton.tsx",
       "source_location": "L3",
       "id": "app_skeleton_appskeleton",
-      "community": 198
+      "community": 199
     },
     {
       "label": "dashboard-skeleton.tsx",
@@ -8889,7 +8889,7 @@
       "source_file": "packages/athena-webapp/src/components/states/loading/dashboard-skeleton.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_states_loading_dashboard_skeleton_tsx",
-      "community": 199
+      "community": 200
     },
     {
       "label": "DashboardSkeleton()",
@@ -8897,7 +8897,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/dashboard-skeleton.tsx",
       "source_location": "L3",
       "id": "dashboard_skeleton_dashboardskeleton",
-      "community": 199
+      "community": 200
     },
     {
       "label": "table-skeleton.tsx",
@@ -8905,7 +8905,7 @@
       "source_file": "packages/athena-webapp/src/components/states/loading/table-skeleton.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_states_loading_table_skeleton_tsx",
-      "community": 200
+      "community": 201
     },
     {
       "label": "TableSkeleton()",
@@ -8913,7 +8913,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/table-skeleton.tsx",
       "source_location": "L3",
       "id": "table_skeleton_tableskeleton",
-      "community": 200
+      "community": 201
     },
     {
       "label": "transactions-skeleton.tsx",
@@ -8921,7 +8921,7 @@
       "source_file": "packages/athena-webapp/src/components/states/loading/transactions-skeleton.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_states_loading_transactions_skeleton_tsx",
-      "community": 201
+      "community": 202
     },
     {
       "label": "TransactionsSkeleton()",
@@ -8929,7 +8929,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/transactions-skeleton.tsx",
       "source_location": "L3",
       "id": "transactions_skeleton_transactionsskeleton",
-      "community": 201
+      "community": 202
     },
     {
       "label": "NoPermission.tsx",
@@ -8969,7 +8969,7 @@
       "source_file": "packages/athena-webapp/src/components/states/not-found/NotFound.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_states_not_found_notfound_tsx",
-      "community": 202
+      "community": 203
     },
     {
       "label": "NotFound()",
@@ -8977,7 +8977,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/not-found/NotFound.tsx",
       "source_location": "L4",
       "id": "notfound_notfound",
-      "community": 202
+      "community": 203
     },
     {
       "label": "NotFoundView.tsx",
@@ -9017,7 +9017,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FeesView.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_store_configuration_components_feesview_tsx",
-      "community": 203
+      "community": 204
     },
     {
       "label": "handleUpdateFees()",
@@ -9025,7 +9025,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FeesView.tsx",
       "source_location": "L36",
       "id": "feesview_handleupdatefees",
-      "community": 203
+      "community": 204
     },
     {
       "label": "handleToggleAllFees()",
@@ -9033,7 +9033,7 @@
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FeesView.tsx",
       "source_location": "L104",
       "id": "feesview_handletoggleallfees",
-      "community": 203
+      "community": 204
     },
     {
       "label": "FulfillmentView.tsx",
@@ -9329,7 +9329,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/app-context-menu.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_app_context_menu_tsx",
-      "community": 204
+      "community": 205
     },
     {
       "label": "AppContextMenu()",
@@ -9337,7 +9337,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/app-context-menu.tsx",
       "source_location": "L20",
       "id": "app_context_menu_appcontextmenu",
-      "community": 204
+      "community": 205
     },
     {
       "label": "badge.tsx",
@@ -9345,7 +9345,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/badge.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_badge_tsx",
-      "community": 205
+      "community": 206
     },
     {
       "label": "Badge()",
@@ -9353,7 +9353,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/badge.tsx",
       "source_location": "L30",
       "id": "badge_badge",
-      "community": 205
+      "community": 206
     },
     {
       "label": "button.test.tsx",
@@ -9601,7 +9601,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/loading-button.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_loading_button_tsx",
-      "community": 206
+      "community": 207
     },
     {
       "label": "LoadingButton()",
@@ -9609,7 +9609,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/loading-button.tsx",
       "source_location": "L9",
       "id": "loading_button_loadingbutton",
-      "community": 206
+      "community": 207
     },
     {
       "label": "modal.tsx",
@@ -9617,7 +9617,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modal.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_modal_tsx",
-      "community": 207
+      "community": 208
     },
     {
       "label": "onChange()",
@@ -9625,7 +9625,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modal.tsx",
       "source_location": "L38",
       "id": "modal_onchange",
-      "community": 207
+      "community": 208
     },
     {
       "label": "action-modal.tsx",
@@ -9641,7 +9641,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/alert-modal.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_modals_alert_modal_tsx",
-      "community": 208
+      "community": 209
     },
     {
       "label": "AlertModal()",
@@ -9649,7 +9649,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/alert-modal.tsx",
       "source_location": "L20",
       "id": "alert_modal_alertmodal",
-      "community": 208
+      "community": 209
     },
     {
       "label": "custom-modal-example.tsx",
@@ -9729,7 +9729,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/modals/overlay-modal.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_modals_overlay_modal_tsx",
-      "community": 209
+      "community": 210
     },
     {
       "label": "OverlayModal()",
@@ -9737,7 +9737,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/overlay-modal.tsx",
       "source_location": "L12",
       "id": "overlay_modal_overlaymodal",
-      "community": 209
+      "community": 210
     },
     {
       "label": "store-modal.tsx",
@@ -9905,7 +9905,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/skeleton.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_skeleton_tsx",
-      "community": 210
+      "community": 211
     },
     {
       "label": "Skeleton()",
@@ -9913,7 +9913,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/skeleton.tsx",
       "source_location": "L3",
       "id": "skeleton_skeleton",
-      "community": 210
+      "community": 211
     },
     {
       "label": "sonner.tsx",
@@ -9921,7 +9921,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/sonner.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_sonner_tsx",
-      "community": 211
+      "community": 212
     },
     {
       "label": "Toaster()",
@@ -9929,7 +9929,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/sonner.tsx",
       "source_location": "L6",
       "id": "sonner_toaster",
-      "community": 211
+      "community": 212
     },
     {
       "label": "spinner.tsx",
@@ -9937,7 +9937,7 @@
       "source_file": "packages/athena-webapp/src/components/ui/spinner.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_ui_spinner_tsx",
-      "community": 212
+      "community": 213
     },
     {
       "label": "Spinner()",
@@ -9945,7 +9945,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/spinner.tsx",
       "source_location": "L3",
       "id": "spinner_spinner",
-      "community": 212
+      "community": 213
     },
     {
       "label": "switch.tsx",
@@ -10273,7 +10273,7 @@
       "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_activitysummarycards_tsx",
-      "community": 213
+      "community": 214
     },
     {
       "label": "SummaryCard()",
@@ -10281,7 +10281,7 @@
       "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
       "source_location": "L19",
       "id": "activitysummarycards_summarycard",
-      "community": 213
+      "community": 214
     },
     {
       "label": "ActivitySummaryCards()",
@@ -10289,7 +10289,7 @@
       "source_file": "packages/athena-webapp/src/components/users/ActivitySummaryCards.tsx",
       "source_location": "L44",
       "id": "activitysummarycards_activitysummarycards",
-      "community": 213
+      "community": 214
     },
     {
       "label": "CustomerBehaviorTimeline.tsx",
@@ -10329,7 +10329,7 @@
       "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_tsx",
-      "community": 214
+      "community": 215
     },
     {
       "label": "formatObservabilityLabel()",
@@ -10337,7 +10337,7 @@
       "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
       "source_location": "L139",
       "id": "timelineeventcard_formatobservabilitylabel",
-      "community": 214
+      "community": 215
     },
     {
       "label": "loadMore()",
@@ -10345,7 +10345,7 @@
       "source_file": "packages/athena-webapp/src/components/users/TimelineEventCard.tsx",
       "source_location": "L175",
       "id": "timelineeventcard_loadmore",
-      "community": 214
+      "community": 215
     },
     {
       "label": "UserActivity.tsx",
@@ -10353,7 +10353,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_components_users_useractivity_tsx",
-      "community": 215
+      "community": 216
     },
     {
       "label": "ActivityHeader()",
@@ -10361,7 +10361,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
       "source_location": "L22",
       "id": "useractivity_activityheader",
-      "community": 215
+      "community": 216
     },
     {
       "label": "UserActivity()",
@@ -10369,7 +10369,7 @@
       "source_file": "packages/athena-webapp/src/components/users/UserActivity.tsx",
       "source_location": "L45",
       "id": "useractivity_useractivity",
-      "community": 215
+      "community": 216
     },
     {
       "label": "UserAnalyticsName.tsx",
@@ -10577,7 +10577,7 @@
       "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_contexts_onlineordercontext_tsx",
-      "community": 216
+      "community": 217
     },
     {
       "label": "OnlineOrderProvider()",
@@ -10585,7 +10585,7 @@
       "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
       "source_location": "L24",
       "id": "onlineordercontext_onlineorderprovider",
-      "community": 216
+      "community": 217
     },
     {
       "label": "useOnlineOrder()",
@@ -10593,7 +10593,7 @@
       "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.tsx",
       "source_location": "L38",
       "id": "onlineordercontext_useonlineorder",
-      "community": 216
+      "community": 217
     },
     {
       "label": "PermissionsContext.tsx",
@@ -10601,7 +10601,7 @@
       "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_contexts_permissionscontext_tsx",
-      "community": 217
+      "community": 218
     },
     {
       "label": "PermissionsProvider()",
@@ -10609,7 +10609,7 @@
       "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
       "source_location": "L23",
       "id": "permissionscontext_permissionsprovider",
-      "community": 217
+      "community": 218
     },
     {
       "label": "usePermissionsContext()",
@@ -10617,7 +10617,7 @@
       "source_file": "packages/athena-webapp/src/contexts/PermissionsContext.tsx",
       "source_location": "L51",
       "id": "permissionscontext_usepermissionscontext",
-      "community": 217
+      "community": 218
     },
     {
       "label": "ProductContext.tsx",
@@ -10625,7 +10625,7 @@
       "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_contexts_productcontext_tsx",
-      "community": 218
+      "community": 219
     },
     {
       "label": "ProductProvider()",
@@ -10633,7 +10633,7 @@
       "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
       "source_location": "L54",
       "id": "productcontext_productprovider",
-      "community": 218
+      "community": 219
     },
     {
       "label": "useProduct()",
@@ -10641,7 +10641,7 @@
       "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
       "source_location": "L282",
       "id": "productcontext_useproduct",
-      "community": 218
+      "community": 219
     },
     {
       "label": "ThemeContext.tsx",
@@ -10657,7 +10657,7 @@
       "source_file": "packages/athena-webapp/src/contexts/UserContext.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_contexts_usercontext_tsx",
-      "community": 219
+      "community": 220
     },
     {
       "label": "UserProvider()",
@@ -10665,7 +10665,7 @@
       "source_file": "packages/athena-webapp/src/contexts/UserContext.tsx",
       "source_location": "L12",
       "id": "usercontext_userprovider",
-      "community": 219
+      "community": 220
     },
     {
       "label": "useUserContext()",
@@ -10673,7 +10673,7 @@
       "source_file": "packages/athena-webapp/src/contexts/UserContext.tsx",
       "source_location": "L37",
       "id": "usercontext_useusercontext",
-      "community": 219
+      "community": 220
     },
     {
       "label": "use-image-upload.ts",
@@ -10785,7 +10785,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useAuth.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_useauth_ts",
-      "community": 220
+      "community": 221
     },
     {
       "label": "useAuth()",
@@ -10793,7 +10793,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useAuth.ts",
       "source_location": "L4",
       "id": "useauth_useauth",
-      "community": 220
+      "community": 221
     },
     {
       "label": "useBulkOperations.test.ts",
@@ -11025,7 +11025,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetActiveStore.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usegetactivestore_ts",
-      "community": 221
+      "community": 222
     },
     {
       "label": "useGetActiveStore()",
@@ -11033,7 +11033,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetActiveStore.ts",
       "source_location": "L9",
       "id": "usegetactivestore_usegetactivestore",
-      "community": 221
+      "community": 222
     },
     {
       "label": "useGetStores()",
@@ -11041,7 +11041,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetActiveStore.ts",
       "source_location": "L50",
       "id": "usegetactivestore_usegetstores",
-      "community": 221
+      "community": 222
     },
     {
       "label": "useGetAuthedUser.ts",
@@ -11113,7 +11113,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usegetorganizations_ts",
-      "community": 222
+      "community": 223
     },
     {
       "label": "useGetActiveOrganization()",
@@ -11121,7 +11121,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
       "source_location": "L6",
       "id": "usegetorganizations_usegetactiveorganization",
-      "community": 222
+      "community": 223
     },
     {
       "label": "useGetOrganizations()",
@@ -11129,7 +11129,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetOrganizations.ts",
       "source_location": "L31",
       "id": "usegetorganizations_usegetorganizations",
-      "community": 222
+      "community": 223
     },
     {
       "label": "useGetProducts.ts",
@@ -11137,7 +11137,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_usegetproducts_ts",
-      "community": 223
+      "community": 224
     },
     {
       "label": "useGetProducts()",
@@ -11145,7 +11145,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
       "source_location": "L5",
       "id": "usegetproducts_usegetproducts",
-      "community": 223
+      "community": 224
     },
     {
       "label": "useGetUnresolvedProducts()",
@@ -11153,7 +11153,7 @@
       "source_file": "packages/athena-webapp/src/hooks/useGetProducts.ts",
       "source_location": "L31",
       "id": "usegetproducts_usegetunresolvedproducts",
-      "community": 223
+      "community": 224
     },
     {
       "label": "useGetSubcategories.ts",
@@ -11265,7 +11265,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSOperations.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_hooks_useposoperations_ts",
-      "community": 224
+      "community": 225
     },
     {
       "label": "usePOSOperations()",
@@ -11273,7 +11273,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSOperations.ts",
       "source_location": "L30",
       "id": "useposoperations_useposoperations",
-      "community": 224
+      "community": 225
     },
     {
       "label": "usePOSState()",
@@ -11281,7 +11281,7 @@
       "source_file": "packages/athena-webapp/src/hooks/usePOSOperations.ts",
       "source_location": "L580",
       "id": "useposoperations_useposstate",
-      "community": 224
+      "community": 225
     },
     {
       "label": "usePOSProducts.ts",
@@ -11889,7 +11889,7 @@
       "source_file": "packages/athena-webapp/src/lib/maintenanceUtils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_maintenanceutils_ts",
-      "community": 225
+      "community": 226
     },
     {
       "label": "isInMaintenanceMode()",
@@ -11897,7 +11897,7 @@
       "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.ts",
       "source_location": "L7",
       "id": "maintenanceutils_isinmaintenancemode",
-      "community": 225
+      "community": 226
     },
     {
       "label": "navigationUtils.ts",
@@ -12233,7 +12233,7 @@
       "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "community": 55
+      "community": 53
     },
     {
       "label": "getProductName()",
@@ -12241,7 +12241,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L18",
       "id": "productutils_getproductname",
-      "community": 55
+      "community": 53
     },
     {
       "label": "sortProduct()",
@@ -12249,7 +12249,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L66",
       "id": "productutils_sortproduct",
-      "community": 55
+      "community": 53
     },
     {
       "label": "category.ts",
@@ -12577,7 +12577,7 @@
       "source_file": "packages/athena-webapp/src/main.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_main_tsx",
-      "community": 226
+      "community": 227
     },
     {
       "label": "App()",
@@ -12585,7 +12585,7 @@
       "source_file": "packages/storefront-webapp/src/main.tsx",
       "source_location": "L38",
       "id": "main_app",
-      "community": 226
+      "community": 227
     },
     {
       "label": "routeTree.gen.ts",
@@ -13017,7 +13017,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed.tsx",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_routes_authed_tsx",
-      "community": 227
+      "community": 228
     },
     {
       "label": "AuthedComponent()",
@@ -13025,7 +13025,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed.tsx",
       "source_location": "L18",
       "id": "authed_authedcomponent",
-      "community": 227
+      "community": 228
     },
     {
       "label": "Layout()",
@@ -13033,7 +13033,7 @@
       "source_file": "packages/athena-webapp/src/routes/_authed.tsx",
       "source_location": "L38",
       "id": "authed_layout",
-      "community": 227
+      "community": 228
     },
     {
       "label": "index.tsx",
@@ -13321,7 +13321,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/inventoryValidationLogic.test.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_tests_pos_inventoryvalidationlogic_test_ts",
-      "community": 228
+      "community": 229
     },
     {
       "label": "validateInventoryForTransaction()",
@@ -13329,7 +13329,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/inventoryValidationLogic.test.ts",
       "source_location": "L20",
       "id": "inventoryvalidationlogic_test_validateinventoryfortransaction",
-      "community": 228
+      "community": 229
     },
     {
       "label": "mockGetSku()",
@@ -13337,7 +13337,7 @@
       "source_file": "packages/athena-webapp/src/tests/pos/inventoryValidationLogic.test.ts",
       "source_location": "L66",
       "id": "inventoryvalidationlogic_test_mockgetsku",
-      "community": 228
+      "community": 229
     },
     {
       "label": "simple.test.ts",
@@ -13449,7 +13449,7 @@
       "source_file": "packages/athena-webapp/src/utils/index.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_utils_index_ts",
-      "community": 229
+      "community": 230
     },
     {
       "label": "hashPassword()",
@@ -13457,7 +13457,7 @@
       "source_file": "packages/storefront-webapp/src/utils/index.ts",
       "source_location": "L1",
       "id": "index_hashpassword",
-      "community": 229
+      "community": 230
     },
     {
       "label": "session.ts",
@@ -13465,7 +13465,7 @@
       "source_file": "packages/athena-webapp/src/utils/session.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_utils_session_ts",
-      "community": 230
+      "community": 231
     },
     {
       "label": "useAppSession()",
@@ -13473,7 +13473,7 @@
       "source_file": "packages/storefront-webapp/src/utils/session.ts",
       "source_location": "L8",
       "id": "session_useappsession",
-      "community": 230
+      "community": 231
     },
     {
       "label": "versionChecker.ts",
@@ -13481,7 +13481,7 @@
       "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_src_utils_versionchecker_ts",
-      "community": 231
+      "community": 232
     },
     {
       "label": "createVersionChecker()",
@@ -13489,7 +13489,7 @@
       "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
       "source_location": "L16",
       "id": "versionchecker_createversionchecker",
-      "community": 231
+      "community": 232
     },
     {
       "label": "tailwind.config.js",
@@ -13513,7 +13513,7 @@
       "source_file": "packages/athena-webapp/vite.config.ts",
       "source_location": "L1",
       "id": "packages_athena_webapp_vite_config_ts",
-      "community": 232
+      "community": 233
     },
     {
       "label": "manualChunks()",
@@ -13521,7 +13521,7 @@
       "source_file": "packages/storefront-webapp/vite.config.ts",
       "source_location": "L19",
       "id": "vite_config_manualchunks",
-      "community": 232
+      "community": 233
     },
     {
       "label": "vitest.config.ts",
@@ -13609,7 +13609,7 @@
       "source_file": "packages/storefront-webapp/src/api/auth.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_auth_ts",
-      "community": 233
+      "community": 234
     },
     {
       "label": "verifyUserAccount()",
@@ -13617,7 +13617,7 @@
       "source_file": "packages/storefront-webapp/src/api/auth.ts",
       "source_location": "L3",
       "id": "auth_verifyuseraccount",
-      "community": 233
+      "community": 234
     },
     {
       "label": "logout()",
@@ -13625,7 +13625,7 @@
       "source_file": "packages/storefront-webapp/src/api/auth.ts",
       "source_location": "L32",
       "id": "auth_logout",
-      "community": 233
+      "community": 234
     },
     {
       "label": "bag.ts",
@@ -13897,7 +13897,7 @@
       "source_file": "packages/storefront-webapp/src/api/color.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_color_ts",
-      "community": 234
+      "community": 235
     },
     {
       "label": "getBaseUrl()",
@@ -13905,7 +13905,7 @@
       "source_file": "packages/storefront-webapp/src/api/color.ts",
       "source_location": "L5",
       "id": "color_getbaseurl",
-      "community": 234
+      "community": 235
     },
     {
       "label": "getAllColors()",
@@ -13913,7 +13913,7 @@
       "source_file": "packages/storefront-webapp/src/api/color.ts",
       "source_location": "L7",
       "id": "color_getallcolors",
-      "community": 234
+      "community": 235
     },
     {
       "label": "guest.ts",
@@ -14009,7 +14009,7 @@
       "source_file": "packages/storefront-webapp/src/api/organization.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_organization_ts",
-      "community": 235
+      "community": 236
     },
     {
       "label": "getAllOrganizations()",
@@ -14017,7 +14017,7 @@
       "source_file": "packages/storefront-webapp/src/api/organization.ts",
       "source_location": "L6",
       "id": "organization_getallorganizations",
-      "community": 235
+      "community": 236
     },
     {
       "label": "getOrganization()",
@@ -14025,7 +14025,7 @@
       "source_file": "packages/storefront-webapp/src/api/organization.ts",
       "source_location": "L18",
       "id": "organization_getorganization",
-      "community": 235
+      "community": 236
     },
     {
       "label": "product.ts",
@@ -14329,7 +14329,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_savedbag_ts",
-      "community": 53
+      "community": 54
     },
     {
       "label": "getBaseUrl()",
@@ -14337,7 +14337,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L8",
       "id": "savedbag_getbaseurl",
-      "community": 53
+      "community": 54
     },
     {
       "label": "getActiveSavedBag()",
@@ -14345,7 +14345,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L10",
       "id": "savedbag_getactivesavedbag",
-      "community": 53
+      "community": 54
     },
     {
       "label": "addItemToSavedBag()",
@@ -14353,7 +14353,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L25",
       "id": "savedbag_additemtosavedbag",
-      "community": 53
+      "community": 54
     },
     {
       "label": "updateSavedBagItem()",
@@ -14361,7 +14361,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L61",
       "id": "savedbag_updatesavedbagitem",
-      "community": 53
+      "community": 54
     },
     {
       "label": "removeItemFromSavedBag()",
@@ -14369,7 +14369,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L91",
       "id": "savedbag_removeitemfromsavedbag",
-      "community": 53
+      "community": 54
     },
     {
       "label": "updateSavedBagOwner()",
@@ -14377,7 +14377,7 @@
       "source_file": "packages/storefront-webapp/src/api/savedBag.ts",
       "source_location": "L109",
       "id": "savedbag_updatesavedbagowner",
-      "community": 53
+      "community": 54
     },
     {
       "label": "storeFrontUser.ts",
@@ -14513,7 +14513,7 @@
       "source_file": "packages/storefront-webapp/src/api/upsells.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_upsells_ts",
-      "community": 236
+      "community": 237
     },
     {
       "label": "getBaseUrl()",
@@ -14521,7 +14521,7 @@
       "source_file": "packages/storefront-webapp/src/api/upsells.ts",
       "source_location": "L3",
       "id": "upsells_getbaseurl",
-      "community": 236
+      "community": 237
     },
     {
       "label": "getLastViewedProduct()",
@@ -14529,7 +14529,7 @@
       "source_file": "packages/storefront-webapp/src/api/upsells.ts",
       "source_location": "L5",
       "id": "upsells_getlastviewedproduct",
-      "community": 236
+      "community": 237
     },
     {
       "label": "userOffers.ts",
@@ -14537,7 +14537,7 @@
       "source_file": "packages/storefront-webapp/src/api/userOffers.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_api_useroffers_ts",
-      "community": 237
+      "community": 238
     },
     {
       "label": "getBaseUrl()",
@@ -14545,7 +14545,7 @@
       "source_file": "packages/storefront-webapp/src/api/userOffers.ts",
       "source_location": "L18",
       "id": "useroffers_getbaseurl",
-      "community": 237
+      "community": 238
     },
     {
       "label": "getUserOffersEligibility()",
@@ -14553,7 +14553,7 @@
       "source_file": "packages/storefront-webapp/src/api/userOffers.ts",
       "source_location": "L23",
       "id": "useroffers_getuserofferseligibility",
-      "community": 237
+      "community": 238
     },
     {
       "label": "HeartIconFilled.tsx",
@@ -14729,7 +14729,7 @@
       "source_file": "packages/storefront-webapp/src/components/View.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_view_tsx",
-      "community": 171
+      "community": 172
     },
     {
       "label": "Auth.tsx",
@@ -14889,7 +14889,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/CustomerDetails.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_customerdetails_tsx",
-      "community": 238
+      "community": 239
     },
     {
       "label": "EnteredCustomerDetails()",
@@ -14897,7 +14897,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/CustomerDetails.tsx",
       "source_location": "L22",
       "id": "customerdetails_enteredcustomerdetails",
-      "community": 238
+      "community": 239
     },
     {
       "label": "onSubmit()",
@@ -14905,7 +14905,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/CustomerDetails.tsx",
       "source_location": "L55",
       "id": "customerdetails_onsubmit",
-      "community": 238
+      "community": 239
     },
     {
       "label": "CustomerInfoSection.tsx",
@@ -14921,7 +14921,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliveryoptionsselector_tsx",
-      "community": 239
+      "community": 240
     },
     {
       "label": "StoreSelector()",
@@ -14929,7 +14929,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
       "source_location": "L11",
       "id": "deliveryoptionsselector_storeselector",
-      "community": 239
+      "community": 240
     },
     {
       "label": "handleChange()",
@@ -14937,7 +14937,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
       "source_location": "L77",
       "id": "deliveryoptionsselector_handlechange",
-      "community": 239
+      "community": 240
     },
     {
       "label": "DeliverySection.tsx",
@@ -14945,7 +14945,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliverysection_tsx",
-      "community": 240
+      "community": 241
     },
     {
       "label": "DeliveryDetails()",
@@ -14953,7 +14953,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
       "source_location": "L11",
       "id": "deliverysection_deliverydetails",
-      "community": 240
+      "community": 241
     },
     {
       "label": "DeliveryOptions()",
@@ -14961,7 +14961,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliverySection.tsx",
       "source_location": "L22",
       "id": "deliverysection_deliveryoptions",
-      "community": 240
+      "community": 241
     },
     {
       "label": "PickupOptions.tsx",
@@ -15017,7 +15017,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_mobilebagsummary_tsx",
-      "community": 241
+      "community": 242
     },
     {
       "label": "handleRedeemPromoCode()",
@@ -15025,7 +15025,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
       "source_location": "L89",
       "id": "mobilebagsummary_handleredeempromocode",
-      "community": 241
+      "community": 242
     },
     {
       "label": "handleKeyDown()",
@@ -15033,7 +15033,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/MobileBagSummary.tsx",
       "source_location": "L110",
       "id": "mobilebagsummary_handlekeydown",
-      "community": 241
+      "community": 242
     },
     {
       "label": "OrderSummary.tsx",
@@ -15113,7 +15113,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_ts",
-      "community": 242
+      "community": 243
     },
     {
       "label": "loadCheckoutState()",
@@ -15121,7 +15121,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
       "source_location": "L4",
       "id": "checkoutstorage_loadcheckoutstate",
-      "community": 242
+      "community": 243
     },
     {
       "label": "saveCheckoutState()",
@@ -15129,7 +15129,7 @@
       "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
       "source_location": "L24",
       "id": "checkoutstorage_savecheckoutstate",
-      "community": 242
+      "community": 243
     },
     {
       "label": "deliveryFees.test.ts",
@@ -15289,7 +15289,7 @@
       "source_file": "packages/storefront-webapp/src/components/common/FadeIn.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_common_fadein_tsx",
-      "community": 181
+      "community": 182
     },
     {
       "label": "CustomerDetailsForm.tsx",
@@ -15433,7 +15433,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_home_featuredproductssection_tsx",
-      "community": 243
+      "community": 244
     },
     {
       "label": "FeaturedProductsSection()",
@@ -15441,7 +15441,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
       "source_location": "L20",
       "id": "featuredproductssection_featuredproductssection",
-      "community": 243
+      "community": 244
     },
     {
       "label": "FeaturedSection()",
@@ -15449,7 +15449,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/FeaturedProductsSection.tsx",
       "source_location": "L46",
       "id": "featuredproductssection_featuredsection",
-      "community": 243
+      "community": 244
     },
     {
       "label": "HomeHero.tsx",
@@ -15473,7 +15473,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_home_promoalert_tsx",
-      "community": 244
+      "community": 245
     },
     {
       "label": "getPromoAlertCopy()",
@@ -15481,7 +15481,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
       "source_location": "L20",
       "id": "promoalert_getpromoalertcopy",
-      "community": 244
+      "community": 245
     },
     {
       "label": "PromoAlert()",
@@ -15489,7 +15489,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
       "source_location": "L59",
       "id": "promoalert_promoalert",
-      "community": 244
+      "community": 245
     },
     {
       "label": "RewardsAlert.tsx",
@@ -15497,7 +15497,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_home_rewardsalert_tsx",
-      "community": 245
+      "community": 246
     },
     {
       "label": "onRewardsAlertClose()",
@@ -15505,7 +15505,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
       "source_location": "L20",
       "id": "rewardsalert_onrewardsalertclose",
-      "community": 245
+      "community": 246
     },
     {
       "label": "handleShopNow()",
@@ -15513,7 +15513,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
       "source_location": "L25",
       "id": "rewardsalert_handleshopnow",
-      "community": 245
+      "community": 246
     },
     {
       "label": "VideoPlayer.tsx",
@@ -15521,7 +15521,7 @@
       "source_file": "packages/storefront-webapp/src/components/home/VideoPlayer.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_home_videoplayer_tsx",
-      "community": 184
+      "community": 185
     },
     {
       "label": "hooks.ts",
@@ -15889,7 +15889,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
-      "community": 246
+      "community": 247
     },
     {
       "label": "findSize()",
@@ -15897,7 +15897,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
       "source_location": "L61",
       "id": "productattribute_findsize",
-      "community": 246
+      "community": 247
     },
     {
       "label": "handleClick()",
@@ -15905,7 +15905,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttribute.tsx",
       "source_location": "L65",
       "id": "productattribute_handleclick",
-      "community": 246
+      "community": 247
     },
     {
       "label": "ProductAttributes.tsx",
@@ -16081,7 +16081,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_product_reviews_revieweditor_tsx",
-      "community": 247
+      "community": 248
     },
     {
       "label": "handleFormDataChange()",
@@ -16089,7 +16089,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
       "source_location": "L150",
       "id": "revieweditor_handleformdatachange",
-      "community": 247
+      "community": 248
     },
     {
       "label": "handleSubmit()",
@@ -16097,7 +16097,7 @@
       "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
       "source_location": "L157",
       "id": "revieweditor_handlesubmit",
-      "community": 247
+      "community": 248
     },
     {
       "label": "ReviewForm.tsx",
@@ -16233,7 +16233,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_tsx",
-      "community": 54
+      "community": 55
     },
     {
       "label": "PendingItem()",
@@ -16241,7 +16241,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L62",
       "id": "shoppingbag_pendingitem",
-      "community": 54
+      "community": 55
     },
     {
       "label": "handleOnCheckoutClick()",
@@ -16249,7 +16249,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L476",
       "id": "shoppingbag_handleoncheckoutclick",
-      "community": 54
+      "community": 55
     },
     {
       "label": "handleClickOnDiscountCode()",
@@ -16257,7 +16257,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L525",
       "id": "shoppingbag_handleclickondiscountcode",
-      "community": 54
+      "community": 55
     },
     {
       "label": "isSkuUnavailable()",
@@ -16265,7 +16265,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L537",
       "id": "shoppingbag_isskuunavailable",
-      "community": 54
+      "community": 55
     },
     {
       "label": "handleMoveToSaved()",
@@ -16273,7 +16273,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L552",
       "id": "shoppingbag_handlemovetosaved",
-      "community": 54
+      "community": 55
     },
     {
       "label": "handleDeleteItem()",
@@ -16281,7 +16281,7 @@
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.tsx",
       "source_location": "L566",
       "id": "shoppingbag_handledeleteitem",
-      "community": 54
+      "community": 55
     },
     {
       "label": "CheckoutUnavailable.tsx",
@@ -16377,7 +16377,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/error/SingleLineError.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_states_error_singlelineerror_tsx",
-      "community": 196
+      "community": 197
     },
     {
       "label": "index.tsx",
@@ -16385,7 +16385,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/error/index.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_states_error_index_tsx",
-      "community": 197
+      "community": 198
     },
     {
       "label": "app-skeleton.tsx",
@@ -16393,7 +16393,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/app-skeleton.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_states_loading_app_skeleton_tsx",
-      "community": 198
+      "community": 199
     },
     {
       "label": "dashboard-skeleton.tsx",
@@ -16401,7 +16401,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/dashboard-skeleton.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_states_loading_dashboard_skeleton_tsx",
-      "community": 199
+      "community": 200
     },
     {
       "label": "table-skeleton.tsx",
@@ -16409,7 +16409,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/table-skeleton.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_states_loading_table_skeleton_tsx",
-      "community": 200
+      "community": 201
     },
     {
       "label": "transactions-skeleton.tsx",
@@ -16417,7 +16417,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/loading/transactions-skeleton.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_states_loading_transactions_skeleton_tsx",
-      "community": 201
+      "community": 202
     },
     {
       "label": "Maintenance.tsx",
@@ -16433,7 +16433,7 @@
       "source_file": "packages/storefront-webapp/src/components/states/not-found/NotFound.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_states_not_found_notfound_tsx",
-      "community": 202
+      "community": 203
     },
     {
       "label": "AnimatedCard.tsx",
@@ -16481,7 +16481,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/app-context-menu.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_app_context_menu_tsx",
-      "community": 204
+      "community": 205
     },
     {
       "label": "badge.tsx",
@@ -16489,7 +16489,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/badge.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_badge_tsx",
-      "community": 205
+      "community": 206
     },
     {
       "label": "breadcrumb.tsx",
@@ -16673,7 +16673,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/loading-button.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_loading_button_tsx",
-      "community": 206
+      "community": 207
     },
     {
       "label": "modal.tsx",
@@ -16681,7 +16681,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modal.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modal_tsx",
-      "community": 207
+      "community": 208
     },
     {
       "label": "LeaveAReviewModal.tsx",
@@ -16745,7 +16745,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalform_tsx",
-      "community": 248
+      "community": 249
     },
     {
       "label": "handleSubmit()",
@@ -16753,7 +16753,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
       "source_location": "L48",
       "id": "upsellmodalform_handlesubmit",
-      "community": 248
+      "community": 249
     },
     {
       "label": "handleInputChange()",
@@ -16761,7 +16761,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModalForm.tsx",
       "source_location": "L63",
       "id": "upsellmodalform_handleinputchange",
-      "community": 248
+      "community": 249
     },
     {
       "label": "UpsellModalSuccess.tsx",
@@ -16785,7 +16785,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodal_tsx",
-      "community": 249
+      "community": 250
     },
     {
       "label": "handleClose()",
@@ -16793,7 +16793,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
       "source_location": "L63",
       "id": "welcomebackmodal_handleclose",
-      "community": 249
+      "community": 250
     },
     {
       "label": "handleSuccess()",
@@ -16801,7 +16801,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModal.tsx",
       "source_location": "L76",
       "id": "welcomebackmodal_handlesuccess",
-      "community": 249
+      "community": 250
     },
     {
       "label": "WelcomeBackModalForm.tsx",
@@ -16809,7 +16809,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalform_tsx",
-      "community": 250
+      "community": 251
     },
     {
       "label": "handleSubmit()",
@@ -16817,7 +16817,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
       "source_location": "L36",
       "id": "welcomebackmodalform_handlesubmit",
-      "community": 250
+      "community": 251
     },
     {
       "label": "handleInputChange()",
@@ -16825,7 +16825,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
       "source_location": "L51",
       "id": "welcomebackmodalform_handleinputchange",
-      "community": 250
+      "community": 251
     },
     {
       "label": "WelcomeBackModalSuccess.tsx",
@@ -16857,7 +16857,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/alert-modal.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_alert_modal_tsx",
-      "community": 208
+      "community": 209
     },
     {
       "label": "welcomeBackModalAnimations.ts",
@@ -16913,7 +16913,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/modals/overlay-modal.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_modals_overlay_modal_tsx",
-      "community": 209
+      "community": 210
     },
     {
       "label": "types.ts",
@@ -16985,7 +16985,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/skeleton.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_skeleton_tsx",
-      "community": 210
+      "community": 211
     },
     {
       "label": "sonner.tsx",
@@ -16993,7 +16993,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/sonner.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_sonner_tsx",
-      "community": 211
+      "community": 212
     },
     {
       "label": "spinner.tsx",
@@ -17001,7 +17001,7 @@
       "source_file": "packages/storefront-webapp/src/components/ui/spinner.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_components_ui_spinner_tsx",
-      "community": 212
+      "community": 213
     },
     {
       "label": "table.tsx",
@@ -17097,7 +17097,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_contexts_navigationbarprovider_tsx",
-      "community": 251
+      "community": 252
     },
     {
       "label": "NavigationBarProvider()",
@@ -17105,7 +17105,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
       "source_location": "L16",
       "id": "navigationbarprovider_navigationbarprovider",
-      "community": 251
+      "community": 252
     },
     {
       "label": "useNavigationBarContext()",
@@ -17113,7 +17113,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
       "source_location": "L39",
       "id": "navigationbarprovider_usenavigationbarcontext",
-      "community": 251
+      "community": 252
     },
     {
       "label": "StoreContext.tsx",
@@ -17121,7 +17121,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
-      "community": 252
+      "community": 253
     },
     {
       "label": "StoreProvider()",
@@ -17129,7 +17129,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
       "source_location": "L25",
       "id": "storecontext_storeprovider",
-      "community": 252
+      "community": 253
     },
     {
       "label": "useStoreContext()",
@@ -17137,7 +17137,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StoreContext.tsx",
       "source_location": "L82",
       "id": "storecontext_usestorecontext",
-      "community": 252
+      "community": 253
     },
     {
       "label": "StorefrontObservabilityProvider.tsx",
@@ -17145,7 +17145,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_tsx",
-      "community": 253
+      "community": 254
     },
     {
       "label": "StorefrontObservabilityProvider()",
@@ -17153,7 +17153,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
       "source_location": "L20",
       "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
-      "community": 253
+      "community": 254
     },
     {
       "label": "useStorefrontObservability()",
@@ -17161,7 +17161,7 @@
       "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
       "source_location": "L55",
       "id": "storefrontobservabilityprovider_usestorefrontobservability",
-      "community": 253
+      "community": 254
     },
     {
       "label": "use-store-modal.tsx",
@@ -17177,7 +17177,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useAuth.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_useauth_ts",
-      "community": 220
+      "community": 221
     },
     {
       "label": "useCheckout.ts",
@@ -17385,7 +17385,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_useproductdiscount_ts",
-      "community": 254
+      "community": 255
     },
     {
       "label": "useProductDiscounts()",
@@ -17393,7 +17393,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
       "source_location": "L25",
       "id": "useproductdiscount_useproductdiscounts",
-      "community": 254
+      "community": 255
     },
     {
       "label": "useProductDiscount()",
@@ -17401,7 +17401,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
       "source_location": "L107",
       "id": "useproductdiscount_useproductdiscount",
-      "community": 254
+      "community": 255
     },
     {
       "label": "useProductPageLogic.ts",
@@ -17505,7 +17505,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_hooks_useshoppingbag_ts",
-      "community": 255
+      "community": 256
     },
     {
       "label": "useShoppingBag()",
@@ -17513,7 +17513,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
       "source_location": "L52",
       "id": "useshoppingbag_useshoppingbag",
-      "community": 255
+      "community": 256
     },
     {
       "label": "isUnavailableProductList()",
@@ -17521,7 +17521,7 @@
       "source_file": "packages/storefront-webapp/src/hooks/useShoppingBag.ts",
       "source_location": "L540",
       "id": "useshoppingbag_isunavailableproductlist",
-      "community": 255
+      "community": 256
     },
     {
       "label": "useStorefrontObservability.ts",
@@ -17689,7 +17689,7 @@
       "source_file": "packages/storefront-webapp/src/lib/maintenanceUtils.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_ts",
-      "community": 225
+      "community": 226
     },
     {
       "label": "analytics.ts",
@@ -17721,7 +17721,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "community": 55
+      "community": 53
     },
     {
       "label": "isSoldOut()",
@@ -17729,7 +17729,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L45",
       "id": "productutils_issoldout",
-      "community": 55
+      "community": 53
     },
     {
       "label": "hasLowStock()",
@@ -17737,7 +17737,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L52",
       "id": "productutils_haslowstock",
-      "community": 55
+      "community": 53
     },
     {
       "label": "sortSkusByLength()",
@@ -17745,7 +17745,7 @@
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L62",
       "id": "productutils_sortskusbylength",
-      "community": 55
+      "community": 53
     },
     {
       "label": "bag.ts",
@@ -18609,7 +18609,7 @@
       "source_file": "packages/storefront-webapp/src/main.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_main_tsx",
-      "community": 226
+      "community": 227
     },
     {
       "label": "routeTree.gen.ts",
@@ -18657,7 +18657,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_index_tsx",
-      "community": 256
+      "community": 257
     },
     {
       "label": "getPaymentText()",
@@ -18665,7 +18665,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
       "source_location": "L102",
       "id": "index_getpaymenttext",
-      "community": 256
+      "community": 257
     },
     {
       "label": "getOrderMessage()",
@@ -18673,7 +18673,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/index.tsx",
       "source_location": "L429",
       "id": "index_getordermessage",
-      "community": 256
+      "community": 257
     },
     {
       "label": "review.tsx",
@@ -18681,7 +18681,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_review_tsx",
-      "community": 257
+      "community": 258
     },
     {
       "label": "OrderNavigation()",
@@ -18689,7 +18689,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
       "source_location": "L46",
       "id": "review_ordernavigation",
-      "community": 257
+      "community": 258
     },
     {
       "label": "getOrderMessage()",
@@ -18697,7 +18697,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/$orderId/review.tsx",
       "source_location": "L250",
       "id": "review_getordermessage",
-      "community": 257
+      "community": 258
     },
     {
       "label": "index.tsx",
@@ -18777,7 +18777,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_layout_account_tsx",
-      "community": 258
+      "community": 259
     },
     {
       "label": "accountBeforeLoad()",
@@ -18785,7 +18785,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
       "source_location": "L17",
       "id": "account_accountbeforeload",
-      "community": 258
+      "community": 259
     },
     {
       "label": "handleOnSubmitForm()",
@@ -18793,7 +18793,7 @@
       "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
       "source_location": "L63",
       "id": "account_handleonsubmitform",
-      "community": 258
+      "community": 259
     },
     {
       "label": "contact-us.tsx",
@@ -18969,7 +18969,7 @@
       "source_file": "packages/storefront-webapp/src/routes/login.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_login_tsx",
-      "community": 259
+      "community": 260
     },
     {
       "label": "loginBeforeLoad()",
@@ -18977,7 +18977,7 @@
       "source_file": "packages/storefront-webapp/src/routes/login.tsx",
       "source_location": "L47",
       "id": "login_loginbeforeload",
-      "community": 259
+      "community": 260
     },
     {
       "label": "onSubmit()",
@@ -18985,7 +18985,7 @@
       "source_file": "packages/storefront-webapp/src/routes/login.tsx",
       "source_location": "L141",
       "id": "login_onsubmit",
-      "community": 259
+      "community": 260
     },
     {
       "label": "bag.index.tsx",
@@ -19113,7 +19113,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_verify_index_tsx",
-      "community": 260
+      "community": 261
     },
     {
       "label": "Verify()",
@@ -19121,7 +19121,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
       "source_location": "L21",
       "id": "verify_index_verify",
-      "community": 260
+      "community": 261
     },
     {
       "label": "VerifyCheckoutSessionPayment()",
@@ -19129,7 +19129,7 @@
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
       "source_location": "L107",
       "id": "verify_index_verifycheckoutsessionpayment",
-      "community": 260
+      "community": 261
     },
     {
       "label": "signup.tsx",
@@ -19137,7 +19137,7 @@
       "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_routes_signup_tsx",
-      "community": 261
+      "community": 262
     },
     {
       "label": "signupBeforeLoad()",
@@ -19145,7 +19145,7 @@
       "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
       "source_location": "L66",
       "id": "signup_signupbeforeload",
-      "community": 261
+      "community": 262
     },
     {
       "label": "onSubmit()",
@@ -19153,7 +19153,7 @@
       "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
       "source_location": "L161",
       "id": "signup_onsubmit",
-      "community": 261
+      "community": 262
     },
     {
       "label": "ssr.tsx",
@@ -19169,7 +19169,7 @@
       "source_file": "packages/storefront-webapp/src/utils/index.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_utils_index_ts",
-      "community": 229
+      "community": 230
     },
     {
       "label": "session.ts",
@@ -19177,7 +19177,7 @@
       "source_file": "packages/storefront-webapp/src/utils/session.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_utils_session_ts",
-      "community": 230
+      "community": 231
     },
     {
       "label": "versionChecker.ts",
@@ -19185,7 +19185,7 @@
       "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
-      "community": 231
+      "community": 232
     },
     {
       "label": "tailwind.config.js",
@@ -19233,7 +19233,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_tests_e2e_helpers_env_ts",
-      "community": 262
+      "community": 263
     },
     {
       "label": "requireEnv()",
@@ -19241,7 +19241,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
       "source_location": "L1",
       "id": "env_requireenv",
-      "community": 262
+      "community": 263
     },
     {
       "label": "optionalNumberEnv()",
@@ -19249,7 +19249,7 @@
       "source_file": "packages/storefront-webapp/tests/e2e/helpers/env.ts",
       "source_location": "L11",
       "id": "env_optionalnumberenv",
-      "community": 262
+      "community": 263
     },
     {
       "label": "vite.config.ts",
@@ -19257,7 +19257,7 @@
       "source_file": "packages/storefront-webapp/vite.config.ts",
       "source_location": "L1",
       "id": "packages_storefront_webapp_vite_config_ts",
-      "community": 232
+      "community": 233
     },
     {
       "label": "vitest.config.ts",
@@ -19377,7 +19377,7 @@
       "source_file": "packages/valkey-proxy-server/app.test.js",
       "source_location": "L1",
       "id": "packages_valkey_proxy_server_app_test_js",
-      "community": 263
+      "community": 264
     },
     {
       "label": "createResponseRecorder()",
@@ -19385,7 +19385,7 @@
       "source_file": "packages/valkey-proxy-server/app.test.js",
       "source_location": "L6",
       "id": "app_test_createresponserecorder",
-      "community": 263
+      "community": 264
     },
     {
       "label": "createSilentLogger()",
@@ -19393,7 +19393,7 @@
       "source_file": "packages/valkey-proxy-server/app.test.js",
       "source_location": "L25",
       "id": "app_test_createsilentlogger",
-      "community": 263
+      "community": 264
     },
     {
       "label": "index.js",
@@ -19601,7 +19601,7 @@
       "source_file": "scripts/graphify-wiki.test.ts",
       "source_location": "L1",
       "id": "scripts_graphify_wiki_test_ts",
-      "community": 264
+      "community": 265
     },
     {
       "label": "write()",
@@ -19609,7 +19609,7 @@
       "source_file": "scripts/graphify-wiki.test.ts",
       "source_location": "L10",
       "id": "graphify_wiki_test_write",
-      "community": 264
+      "community": 265
     },
     {
       "label": "createFixtureRoot()",
@@ -19617,7 +19617,7 @@
       "source_file": "scripts/graphify-wiki.test.ts",
       "source_location": "L16",
       "id": "graphify_wiki_test_createfixtureroot",
-      "community": 264
+      "community": 265
     },
     {
       "label": "graphify-wiki.ts",
@@ -19809,7 +19809,7 @@
       "source_file": "scripts/harness-audit.test.ts",
       "source_location": "L1",
       "id": "scripts_harness_audit_test_ts",
-      "community": 265
+      "community": 266
     },
     {
       "label": "write()",
@@ -19817,7 +19817,7 @@
       "source_file": "scripts/harness-audit.test.ts",
       "source_location": "L11",
       "id": "harness_audit_test_write",
-      "community": 265
+      "community": 266
     },
     {
       "label": "createFixtureRepo()",
@@ -19825,7 +19825,7 @@
       "source_file": "scripts/harness-audit.test.ts",
       "source_location": "L17",
       "id": "harness_audit_test_createfixturerepo",
-      "community": 265
+      "community": 266
     },
     {
       "label": "harness-audit.ts",
@@ -20081,7 +20081,7 @@
       "source_file": "scripts/harness-behavior.test.ts",
       "source_location": "L1",
       "id": "scripts_harness_behavior_test_ts",
-      "community": 266
+      "community": 267
     },
     {
       "label": "write()",
@@ -20089,7 +20089,7 @@
       "source_file": "scripts/harness-behavior.test.ts",
       "source_location": "L15",
       "id": "harness_behavior_test_write",
-      "community": 266
+      "community": 267
     },
     {
       "label": "createFixtureRoot()",
@@ -20097,7 +20097,7 @@
       "source_file": "scripts/harness-behavior.test.ts",
       "source_location": "L21",
       "id": "harness_behavior_test_createfixtureroot",
-      "community": 266
+      "community": 267
     },
     {
       "label": "harness-behavior.ts",
@@ -20105,7 +20105,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L1",
       "id": "scripts_harness_behavior_ts",
-      "community": 5
+      "community": 6
     },
     {
       "label": "HarnessBehaviorPhaseError",
@@ -20113,7 +20113,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L222",
       "id": "harness_behavior_harnessbehaviorphaseerror",
-      "community": 5
+      "community": 6
     },
     {
       "label": ".constructor()",
@@ -20121,7 +20121,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L227",
       "id": "harness_behavior_harnessbehaviorphaseerror_constructor",
-      "community": 5
+      "community": 6
     },
     {
       "label": "logPhase()",
@@ -20129,7 +20129,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L281",
       "id": "harness_behavior_logphase",
-      "community": 5
+      "community": 6
     },
     {
       "label": "sleep()",
@@ -20137,7 +20137,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L289",
       "id": "harness_behavior_sleep",
-      "community": 5
+      "community": 6
     },
     {
       "label": "asRegExp()",
@@ -20145,7 +20145,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L295",
       "id": "harness_behavior_asregexp",
-      "community": 5
+      "community": 6
     },
     {
       "label": "escapeRegExp()",
@@ -20153,7 +20153,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L303",
       "id": "harness_behavior_escaperegexp",
-      "community": 5
+      "community": 6
     },
     {
       "label": "formatError()",
@@ -20161,7 +20161,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L307",
       "id": "harness_behavior_formaterror",
-      "community": 5
+      "community": 6
     },
     {
       "label": "getLinesForSource()",
@@ -20169,7 +20169,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L315",
       "id": "harness_behavior_getlinesforsource",
-      "community": 5
+      "community": 6
     },
     {
       "label": "consumeLines()",
@@ -20177,7 +20177,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L328",
       "id": "harness_behavior_consumelines",
-      "community": 5
+      "community": 6
     },
     {
       "label": "stopProcess()",
@@ -20185,7 +20185,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L394",
       "id": "harness_behavior_stopprocess",
-      "community": 5
+      "community": 6
     },
     {
       "label": "startProcess()",
@@ -20193,7 +20193,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L416",
       "id": "harness_behavior_startprocess",
-      "community": 5
+      "community": 6
     },
     {
       "label": "spawnCommand()",
@@ -20201,7 +20201,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L550",
       "id": "harness_behavior_spawncommand",
-      "community": 5
+      "community": 6
     },
     {
       "label": "resolveHarnessBehaviorShell()",
@@ -20209,7 +20209,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L604",
       "id": "harness_behavior_resolveharnessbehaviorshell",
-      "community": 5
+      "community": 6
     },
     {
       "label": "runHttpReadinessCheck()",
@@ -20217,7 +20217,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L631",
       "id": "harness_behavior_runhttpreadinesscheck",
-      "community": 5
+      "community": 6
     },
     {
       "label": "collectRuntimeSignalMatches()",
@@ -20225,7 +20225,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L663",
       "id": "harness_behavior_collectruntimesignalmatches",
-      "community": 5
+      "community": 6
     },
     {
       "label": "collectRuntimeSignalDiagnostics()",
@@ -20233,7 +20233,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L720",
       "id": "harness_behavior_collectruntimesignaldiagnostics",
-      "community": 5
+      "community": 6
     },
     {
       "label": "collectLatencyDiagnostics()",
@@ -20241,7 +20241,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L753",
       "id": "harness_behavior_collectlatencydiagnostics",
-      "community": 5
+      "community": 6
     },
     {
       "label": "formatAssertionDiagnostics()",
@@ -20249,7 +20249,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L801",
       "id": "harness_behavior_formatassertiondiagnostics",
-      "community": 5
+      "community": 6
     },
     {
       "label": "runPlaywrightFlow()",
@@ -20257,7 +20257,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L853",
       "id": "harness_behavior_runplaywrightflow",
-      "community": 5
+      "community": 6
     },
     {
       "label": "wrapPhaseError()",
@@ -20265,7 +20265,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L957",
       "id": "harness_behavior_wrapphaseerror",
-      "community": 5
+      "community": 6
     },
     {
       "label": "runPhaseWithDuration()",
@@ -20273,7 +20273,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L968",
       "id": "harness_behavior_runphasewithduration",
-      "community": 5
+      "community": 6
     },
     {
       "label": "runHarnessBehaviorScenario()",
@@ -20281,7 +20281,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L981",
       "id": "harness_behavior_runharnessbehaviorscenario",
-      "community": 5
+      "community": 6
     },
     {
       "label": "parseHarnessBehaviorArgs()",
@@ -20289,7 +20289,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L1215",
       "id": "harness_behavior_parseharnessbehaviorargs",
-      "community": 5
+      "community": 6
     },
     {
       "label": "printHarnessBehaviorUsage()",
@@ -20297,7 +20297,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L1287",
       "id": "harness_behavior_printharnessbehaviorusage",
-      "community": 5
+      "community": 6
     },
     {
       "label": "runHarnessBehaviorCli()",
@@ -20305,7 +20305,7 @@
       "source_file": "scripts/harness-behavior.ts",
       "source_location": "L1295",
       "id": "harness_behavior_runharnessbehaviorcli",
-      "community": 5
+      "community": 6
     },
     {
       "label": "harness-check.test.ts",
@@ -20313,7 +20313,7 @@
       "source_file": "scripts/harness-check.test.ts",
       "source_location": "L1",
       "id": "scripts_harness_check_test_ts",
-      "community": 267
+      "community": 268
     },
     {
       "label": "write()",
@@ -20321,7 +20321,7 @@
       "source_file": "scripts/harness-check.test.ts",
       "source_location": "L42",
       "id": "harness_check_test_write",
-      "community": 267
+      "community": 268
     },
     {
       "label": "createFixtureRepo()",
@@ -20329,7 +20329,7 @@
       "source_file": "scripts/harness-check.test.ts",
       "source_location": "L48",
       "id": "harness_check_test_createfixturerepo",
-      "community": 267
+      "community": 268
     },
     {
       "label": "harness-check.ts",
@@ -20601,7 +20601,7 @@
       "source_file": "scripts/harness-generate.test.ts",
       "source_location": "L1",
       "id": "scripts_harness_generate_test_ts",
-      "community": 268
+      "community": 269
     },
     {
       "label": "write()",
@@ -20609,7 +20609,7 @@
       "source_file": "scripts/harness-generate.test.ts",
       "source_location": "L10",
       "id": "harness_generate_test_write",
-      "community": 268
+      "community": 269
     },
     {
       "label": "createFixtureRepo()",
@@ -20617,7 +20617,7 @@
       "source_file": "scripts/harness-generate.test.ts",
       "source_location": "L16",
       "id": "harness_generate_test_createfixturerepo",
-      "community": 268
+      "community": 269
     },
     {
       "label": "harness-generate.ts",
@@ -20873,7 +20873,7 @@
       "source_file": "scripts/harness-inferential-review.test.ts",
       "source_location": "L1",
       "id": "scripts_harness_inferential_review_test_ts",
-      "community": 269
+      "community": 270
     },
     {
       "label": "write()",
@@ -20881,7 +20881,7 @@
       "source_file": "scripts/harness-inferential-review.test.ts",
       "source_location": "L13",
       "id": "harness_inferential_review_test_write",
-      "community": 269
+      "community": 270
     },
     {
       "label": "createFixtureRepo()",
@@ -20889,7 +20889,7 @@
       "source_file": "scripts/harness-inferential-review.test.ts",
       "source_location": "L19",
       "id": "harness_inferential_review_test_createfixturerepo",
-      "community": 269
+      "community": 270
     },
     {
       "label": "harness-inferential-review.ts",
@@ -21729,7 +21729,7 @@
       "source_file": "scripts/harness-scorecard.test.ts",
       "source_location": "L1",
       "id": "scripts_harness_scorecard_test_ts",
-      "community": 270
+      "community": 163
     },
     {
       "label": "write()",
@@ -21737,15 +21737,23 @@
       "source_file": "scripts/harness-scorecard.test.ts",
       "source_location": "L11",
       "id": "harness_scorecard_test_write",
-      "community": 270
+      "community": 163
+    },
+    {
+      "label": "createInferentialArtifact()",
+      "file_type": "code",
+      "source_file": "scripts/harness-scorecard.test.ts",
+      "source_location": "L17",
+      "id": "harness_scorecard_test_createinferentialartifact",
+      "community": 163
     },
     {
       "label": "createFixtureRepo()",
       "file_type": "code",
       "source_file": "scripts/harness-scorecard.test.ts",
-      "source_location": "L17",
+      "source_location": "L49",
       "id": "harness_scorecard_test_createfixturerepo",
-      "community": 270
+      "community": 163
     },
     {
       "label": "harness-scorecard.ts",
@@ -21753,7 +21761,7 @@
       "source_file": "scripts/harness-scorecard.ts",
       "source_location": "L1",
       "id": "scripts_harness_scorecard_ts",
-      "community": 6
+      "community": 5
     },
     {
       "label": "normalizeRepoPath()",
@@ -21761,7 +21769,7 @@
       "source_file": "scripts/harness-scorecard.ts",
       "source_location": "L189",
       "id": "harness_scorecard_normalizerepopath",
-      "community": 6
+      "community": 5
     },
     {
       "label": "sortUnique()",
@@ -21769,7 +21777,7 @@
       "source_file": "scripts/harness-scorecard.ts",
       "source_location": "L193",
       "id": "harness_scorecard_sortunique",
-      "community": 6
+      "community": 5
     },
     {
       "label": "isRuntimeScenarioName()",
@@ -21777,7 +21785,7 @@
       "source_file": "scripts/harness-scorecard.ts",
       "source_location": "L199",
       "id": "harness_scorecard_isruntimescenarioname",
-      "community": 6
+      "community": 5
     },
     {
       "label": "fileExists()",
@@ -21785,7 +21793,7 @@
       "source_file": "scripts/harness-scorecard.ts",
       "source_location": "L203",
       "id": "harness_scorecard_fileexists",
-      "community": 6
+      "community": 5
     },
     {
       "label": "readJsonFile()",
@@ -21793,7 +21801,7 @@
       "source_file": "scripts/harness-scorecard.ts",
       "source_location": "L212",
       "id": "harness_scorecard_readjsonfile",
-      "community": 6
+      "community": 5
     },
     {
       "label": "listDirectory()",
@@ -21801,7 +21809,7 @@
       "source_file": "scripts/harness-scorecard.ts",
       "source_location": "L216",
       "id": "harness_scorecard_listdirectory",
-      "community": 6
+      "community": 5
     },
     {
       "label": "readTextFile()",
@@ -21809,7 +21817,7 @@
       "source_file": "scripts/harness-scorecard.ts",
       "source_location": "L220",
       "id": "harness_scorecard_readtextfile",
-      "community": 6
+      "community": 5
     },
     {
       "label": "createFileSystem()",
@@ -21817,7 +21825,7 @@
       "source_file": "scripts/harness-scorecard.ts",
       "source_location": "L224",
       "id": "harness_scorecard_createfilesystem",
-      "community": 6
+      "community": 5
     },
     {
       "label": "extractScenarioSection()",
@@ -21825,7 +21833,7 @@
       "source_file": "scripts/harness-scorecard.ts",
       "source_location": "L233",
       "id": "harness_scorecard_extractscenariosection",
-      "community": 6
+      "community": 5
     },
     {
       "label": "extractScenarioNames()",
@@ -21833,7 +21841,7 @@
       "source_file": "scripts/harness-scorecard.ts",
       "source_location": "L255",
       "id": "harness_scorecard_extractscenarionames",
-      "community": 6
+      "community": 5
     },
     {
       "label": "countMissingSnippets()",
@@ -21841,7 +21849,7 @@
       "source_file": "scripts/harness-scorecard.ts",
       "source_location": "L268",
       "id": "harness_scorecard_countmissingsnippets",
-      "community": 6
+      "community": 5
     },
     {
       "label": "buildDocumentationStatus()",
@@ -21849,7 +21857,7 @@
       "source_file": "scripts/harness-scorecard.ts",
       "source_location": "L275",
       "id": "harness_scorecard_builddocumentationstatus",
-      "community": 6
+      "community": 5
     },
     {
       "label": "buildGraphifyStatus()",
@@ -21857,103 +21865,119 @@
       "source_file": "scripts/harness-scorecard.ts",
       "source_location": "L299",
       "id": "harness_scorecard_buildgraphifystatus",
-      "community": 6
+      "community": 5
+    },
+    {
+      "label": "isHealthyInferentialStatus()",
+      "file_type": "code",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L311",
+      "id": "harness_scorecard_ishealthyinferentialstatus",
+      "community": 5
+    },
+    {
+      "label": "buildInferentialSummaryNote()",
+      "file_type": "code",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L315",
+      "id": "harness_scorecard_buildinferentialsummarynote",
+      "community": 5
     },
     {
       "label": "buildSummary()",
       "file_type": "code",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L311",
+      "source_location": "L327",
       "id": "harness_scorecard_buildsummary",
-      "community": 6
+      "community": 5
     },
     {
       "label": "hasAnyHarnessDocs()",
       "file_type": "code",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L374",
+      "source_location": "L389",
       "id": "harness_scorecard_hasanyharnessdocs",
-      "community": 6
+      "community": 5
     },
     {
       "label": "inspectAppDocumentation()",
       "file_type": "code",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L391",
+      "source_location": "L406",
       "id": "harness_scorecard_inspectappdocumentation",
-      "community": 6
+      "community": 5
     },
     {
       "label": "getDocumentedScenarioExpectations()",
       "file_type": "code",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L455",
+      "source_location": "L470",
       "id": "harness_scorecard_getdocumentedscenarioexpectations",
-      "community": 6
+      "community": 5
     },
     {
       "label": "inspectInferentialArtifact()",
       "file_type": "code",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L468",
+      "source_location": "L483",
       "id": "harness_scorecard_inspectinferentialartifact",
-      "community": 6
+      "community": 5
     },
     {
       "label": "buildEmptyHistoryMetric()",
       "file_type": "code",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L554",
+      "source_location": "L569",
       "id": "harness_scorecard_buildemptyhistorymetric",
-      "community": 6
+      "community": 5
     },
     {
       "label": "inspectInferentialHistory()",
       "file_type": "code",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L564",
+      "source_location": "L579",
       "id": "harness_scorecard_inspectinferentialhistory",
-      "community": 6
+      "community": 5
     },
     {
       "label": "inspectRuntimeTrendArtifact()",
       "file_type": "code",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L616",
+      "source_location": "L631",
       "id": "harness_scorecard_inspectruntimetrendartifact",
-      "community": 6
+      "community": 5
     },
     {
       "label": "inspectRuntimeTrendHistory()",
       "file_type": "code",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L659",
+      "source_location": "L674",
       "id": "harness_scorecard_inspectruntimetrendhistory",
-      "community": 6
+      "community": 5
     },
     {
       "label": "inspectGraphifyArtifacts()",
       "file_type": "code",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L709",
+      "source_location": "L724",
       "id": "harness_scorecard_inspectgraphifyartifacts",
-      "community": 6
+      "community": 5
     },
     {
       "label": "collectHarnessScorecard()",
       "file_type": "code",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L737",
+      "source_location": "L752",
       "id": "harness_scorecard_collectharnessscorecard",
-      "community": 6
+      "community": 5
     },
     {
       "label": "runHarnessScorecard()",
       "file_type": "code",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L827",
+      "source_location": "L842",
       "id": "harness_scorecard_runharnessscorecard",
-      "community": 6
+      "community": 5
     },
     {
       "label": "harness-self-review.test.ts",
@@ -22209,7 +22233,7 @@
       "source_file": "scripts/harness-test.ts",
       "source_location": "L1",
       "id": "scripts_harness_test_ts",
-      "community": 163
+      "community": 164
     },
     {
       "label": "collectHarnessTestTargets()",
@@ -22217,7 +22241,7 @@
       "source_file": "scripts/harness-test.ts",
       "source_location": "L26",
       "id": "harness_test_collectharnesstesttargets",
-      "community": 163
+      "community": 164
     },
     {
       "label": "runHarnessTest()",
@@ -22225,7 +22249,7 @@
       "source_file": "scripts/harness-test.ts",
       "source_location": "L36",
       "id": "harness_test_runharnesstest",
-      "community": 163
+      "community": 164
     },
     {
       "label": "parseHarnessTestCliArgs()",
@@ -22233,7 +22257,7 @@
       "source_file": "scripts/harness-test.ts",
       "source_location": "L72",
       "id": "harness_test_parseharnesstestcliargs",
-      "community": 163
+      "community": 164
     },
     {
       "label": "pre-push-review.test.ts",
@@ -22241,7 +22265,7 @@
       "source_file": "scripts/pre-push-review.test.ts",
       "source_location": "L1",
       "id": "scripts_pre_push_review_test_ts",
-      "community": 164
+      "community": 165
     },
     {
       "label": "log()",
@@ -22249,7 +22273,7 @@
       "source_file": "scripts/pre-push-review.test.ts",
       "source_location": "L84",
       "id": "pre_push_review_test_log",
-      "community": 164
+      "community": 165
     },
     {
       "label": "warn()",
@@ -22257,7 +22281,7 @@
       "source_file": "scripts/pre-push-review.test.ts",
       "source_location": "L85",
       "id": "pre_push_review_test_warn",
-      "community": 164
+      "community": 165
     },
     {
       "label": "error()",
@@ -22265,7 +22289,7 @@
       "source_file": "scripts/pre-push-review.test.ts",
       "source_location": "L86",
       "id": "pre_push_review_test_error",
-      "community": 164
+      "community": 165
     },
     {
       "label": "pre-push-review.ts",
@@ -48944,6 +48968,18 @@
       "source_location": "L17",
       "weight": 1.0,
       "_src": "scripts_harness_scorecard_test_ts",
+      "_tgt": "harness_scorecard_test_createinferentialartifact",
+      "source": "scripts_harness_scorecard_test_ts",
+      "target": "harness_scorecard_test_createinferentialartifact",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-scorecard.test.ts",
+      "source_location": "L49",
+      "weight": 1.0,
+      "_src": "scripts_harness_scorecard_test_ts",
       "_tgt": "harness_scorecard_test_createfixturerepo",
       "source": "scripts_harness_scorecard_test_ts",
       "target": "harness_scorecard_test_createfixturerepo",
@@ -48953,11 +48989,23 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.test.ts",
-      "source_location": "L25",
+      "source_location": "L60",
       "weight": 1.0,
       "_src": "harness_scorecard_test_createfixturerepo",
       "_tgt": "harness_scorecard_test_write",
       "source": "harness_scorecard_test_write",
+      "target": "harness_scorecard_test_createfixturerepo",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-scorecard.test.ts",
+      "source_location": "L194",
+      "weight": 1.0,
+      "_src": "harness_scorecard_test_createfixturerepo",
+      "_tgt": "harness_scorecard_test_createinferentialartifact",
+      "source": "harness_scorecard_test_createinferentialartifact",
       "target": "harness_scorecard_test_createfixturerepo",
       "confidence_score": 1.0
     },
@@ -49124,6 +49172,30 @@
       "source_location": "L311",
       "weight": 1.0,
       "_src": "scripts_harness_scorecard_ts",
+      "_tgt": "harness_scorecard_ishealthyinferentialstatus",
+      "source": "scripts_harness_scorecard_ts",
+      "target": "harness_scorecard_ishealthyinferentialstatus",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L315",
+      "weight": 1.0,
+      "_src": "scripts_harness_scorecard_ts",
+      "_tgt": "harness_scorecard_buildinferentialsummarynote",
+      "source": "scripts_harness_scorecard_ts",
+      "target": "harness_scorecard_buildinferentialsummarynote",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L327",
+      "weight": 1.0,
+      "_src": "scripts_harness_scorecard_ts",
       "_tgt": "harness_scorecard_buildsummary",
       "source": "scripts_harness_scorecard_ts",
       "target": "harness_scorecard_buildsummary",
@@ -49133,7 +49205,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L374",
+      "source_location": "L389",
       "weight": 1.0,
       "_src": "scripts_harness_scorecard_ts",
       "_tgt": "harness_scorecard_hasanyharnessdocs",
@@ -49145,7 +49217,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L391",
+      "source_location": "L406",
       "weight": 1.0,
       "_src": "scripts_harness_scorecard_ts",
       "_tgt": "harness_scorecard_inspectappdocumentation",
@@ -49157,7 +49229,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L455",
+      "source_location": "L470",
       "weight": 1.0,
       "_src": "scripts_harness_scorecard_ts",
       "_tgt": "harness_scorecard_getdocumentedscenarioexpectations",
@@ -49169,7 +49241,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L468",
+      "source_location": "L483",
       "weight": 1.0,
       "_src": "scripts_harness_scorecard_ts",
       "_tgt": "harness_scorecard_inspectinferentialartifact",
@@ -49181,7 +49253,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L554",
+      "source_location": "L569",
       "weight": 1.0,
       "_src": "scripts_harness_scorecard_ts",
       "_tgt": "harness_scorecard_buildemptyhistorymetric",
@@ -49193,7 +49265,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L564",
+      "source_location": "L579",
       "weight": 1.0,
       "_src": "scripts_harness_scorecard_ts",
       "_tgt": "harness_scorecard_inspectinferentialhistory",
@@ -49205,7 +49277,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L616",
+      "source_location": "L631",
       "weight": 1.0,
       "_src": "scripts_harness_scorecard_ts",
       "_tgt": "harness_scorecard_inspectruntimetrendartifact",
@@ -49217,7 +49289,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L659",
+      "source_location": "L674",
       "weight": 1.0,
       "_src": "scripts_harness_scorecard_ts",
       "_tgt": "harness_scorecard_inspectruntimetrendhistory",
@@ -49229,7 +49301,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L709",
+      "source_location": "L724",
       "weight": 1.0,
       "_src": "scripts_harness_scorecard_ts",
       "_tgt": "harness_scorecard_inspectgraphifyartifacts",
@@ -49241,7 +49313,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L737",
+      "source_location": "L752",
       "weight": 1.0,
       "_src": "scripts_harness_scorecard_ts",
       "_tgt": "harness_scorecard_collectharnessscorecard",
@@ -49253,7 +49325,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L827",
+      "source_location": "L842",
       "weight": 1.0,
       "_src": "scripts_harness_scorecard_ts",
       "_tgt": "harness_scorecard_runharnessscorecard",
@@ -49277,7 +49349,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L459",
+      "source_location": "L474",
       "weight": 1.0,
       "_src": "harness_scorecard_getdocumentedscenarioexpectations",
       "_tgt": "harness_scorecard_sortunique",
@@ -49289,7 +49361,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L744",
+      "source_location": "L759",
       "weight": 1.0,
       "_src": "harness_scorecard_collectharnessscorecard",
       "_tgt": "harness_scorecard_sortunique",
@@ -49301,7 +49373,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L383",
+      "source_location": "L398",
       "weight": 1.0,
       "_src": "harness_scorecard_hasanyharnessdocs",
       "_tgt": "harness_scorecard_fileexists",
@@ -49313,7 +49385,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L399",
+      "source_location": "L414",
       "weight": 1.0,
       "_src": "harness_scorecard_inspectappdocumentation",
       "_tgt": "harness_scorecard_fileexists",
@@ -49325,7 +49397,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L473",
+      "source_location": "L488",
       "weight": 1.0,
       "_src": "harness_scorecard_inspectinferentialartifact",
       "_tgt": "harness_scorecard_fileexists",
@@ -49337,7 +49409,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L570",
+      "source_location": "L585",
       "weight": 1.0,
       "_src": "harness_scorecard_inspectinferentialhistory",
       "_tgt": "harness_scorecard_fileexists",
@@ -49349,7 +49421,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L624",
+      "source_location": "L639",
       "weight": 1.0,
       "_src": "harness_scorecard_inspectruntimetrendartifact",
       "_tgt": "harness_scorecard_fileexists",
@@ -49361,7 +49433,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L665",
+      "source_location": "L680",
       "weight": 1.0,
       "_src": "harness_scorecard_inspectruntimetrendhistory",
       "_tgt": "harness_scorecard_fileexists",
@@ -49373,7 +49445,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L713",
+      "source_location": "L728",
       "weight": 1.0,
       "_src": "harness_scorecard_inspectgraphifyartifacts",
       "_tgt": "harness_scorecard_fileexists",
@@ -49385,7 +49457,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L741",
+      "source_location": "L756",
       "weight": 1.0,
       "_src": "harness_scorecard_collectharnessscorecard",
       "_tgt": "harness_scorecard_createfilesystem",
@@ -49409,7 +49481,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L409",
+      "source_location": "L424",
       "weight": 1.0,
       "_src": "harness_scorecard_inspectappdocumentation",
       "_tgt": "harness_scorecard_extractscenarionames",
@@ -49421,7 +49493,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L406",
+      "source_location": "L421",
       "weight": 1.0,
       "_src": "harness_scorecard_inspectappdocumentation",
       "_tgt": "harness_scorecard_countmissingsnippets",
@@ -49433,7 +49505,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L431",
+      "source_location": "L446",
       "weight": 1.0,
       "_src": "harness_scorecard_inspectappdocumentation",
       "_tgt": "harness_scorecard_builddocumentationstatus",
@@ -49445,7 +49517,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L717",
+      "source_location": "L732",
       "weight": 1.0,
       "_src": "harness_scorecard_inspectgraphifyartifacts",
       "_tgt": "harness_scorecard_buildgraphifystatus",
@@ -49457,7 +49529,31 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L811",
+      "source_location": "L335",
+      "weight": 1.0,
+      "_src": "harness_scorecard_buildsummary",
+      "_tgt": "harness_scorecard_ishealthyinferentialstatus",
+      "source": "harness_scorecard_ishealthyinferentialstatus",
+      "target": "harness_scorecard_buildsummary",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L366",
+      "weight": 1.0,
+      "_src": "harness_scorecard_buildsummary",
+      "_tgt": "harness_scorecard_buildinferentialsummarynote",
+      "source": "harness_scorecard_buildinferentialsummarynote",
+      "target": "harness_scorecard_buildsummary",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/harness-scorecard.ts",
+      "source_location": "L826",
       "weight": 1.0,
       "_src": "harness_scorecard_collectharnessscorecard",
       "_tgt": "harness_scorecard_buildsummary",
@@ -49469,7 +49565,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L750",
+      "source_location": "L765",
       "weight": 1.0,
       "_src": "harness_scorecard_collectharnessscorecard",
       "_tgt": "harness_scorecard_hasanyharnessdocs",
@@ -49481,7 +49577,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L805",
+      "source_location": "L820",
       "weight": 1.0,
       "_src": "harness_scorecard_collectharnessscorecard",
       "_tgt": "harness_scorecard_inspectinferentialartifact",
@@ -49493,7 +49589,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L572",
+      "source_location": "L587",
       "weight": 1.0,
       "_src": "harness_scorecard_inspectinferentialhistory",
       "_tgt": "harness_scorecard_buildemptyhistorymetric",
@@ -49505,7 +49601,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L636",
+      "source_location": "L651",
       "weight": 1.0,
       "_src": "harness_scorecard_inspectruntimetrendartifact",
       "_tgt": "harness_scorecard_buildemptyhistorymetric",
@@ -49517,7 +49613,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L667",
+      "source_location": "L682",
       "weight": 1.0,
       "_src": "harness_scorecard_inspectruntimetrendhistory",
       "_tgt": "harness_scorecard_buildemptyhistorymetric",
@@ -49529,7 +49625,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L806",
+      "source_location": "L821",
       "weight": 1.0,
       "_src": "harness_scorecard_collectharnessscorecard",
       "_tgt": "harness_scorecard_inspectinferentialhistory",
@@ -49541,7 +49637,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L807",
+      "source_location": "L822",
       "weight": 1.0,
       "_src": "harness_scorecard_collectharnessscorecard",
       "_tgt": "harness_scorecard_inspectruntimetrendartifact",
@@ -49553,7 +49649,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L808",
+      "source_location": "L823",
       "weight": 1.0,
       "_src": "harness_scorecard_collectharnessscorecard",
       "_tgt": "harness_scorecard_inspectruntimetrendhistory",
@@ -49565,7 +49661,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L809",
+      "source_location": "L824",
       "weight": 1.0,
       "_src": "harness_scorecard_collectharnessscorecard",
       "_tgt": "harness_scorecard_inspectgraphifyartifacts",
@@ -49577,7 +49673,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "scripts/harness-scorecard.ts",
-      "source_location": "L831",
+      "source_location": "L846",
       "weight": 1.0,
       "_src": "harness_scorecard_runharnessscorecard",
       "_tgt": "harness_scorecard_collectharnessscorecard",

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1198
-- Graph nodes: 2788
-- Graph edges: 2334
+- Graph nodes: 2791
+- Graph edges: 2340
 - Communities: 1113
 
 ## Graph Hotspots
@@ -18,9 +18,9 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - `harness-inferential-review.ts` (39 edges, Community 1) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
 - `harness-check.ts` (32 edges, Community 2) - [`scripts/harness-check.ts`](../../scripts/harness-check.ts)
 - `harness-generate.ts` (30 edges, Community 3) - [`scripts/harness-generate.ts`](../../scripts/harness-generate.ts)
+- `harness-scorecard.ts` (27 edges, Community 5) - [`scripts/harness-scorecard.ts`](../../scripts/harness-scorecard.ts)
 - `storeConfigV2.ts` (27 edges, Community 4) - [`packages/athena-webapp/convex/inventory/storeConfigV2.ts`](../../packages/athena-webapp/convex/inventory/storeConfigV2.ts)
-- `harness-scorecard.ts` (25 edges, Community 6) - [`scripts/harness-scorecard.ts`](../../scripts/harness-scorecard.ts)
-- `harness-behavior.ts` (24 edges, Community 5) - [`scripts/harness-behavior.ts`](../../scripts/harness-behavior.ts)
+- `harness-behavior.ts` (24 edges, Community 6) - [`scripts/harness-behavior.ts`](../../scripts/harness-behavior.ts)
 
 ## Registered Packages
 - [Athena Webapp](packages/athena-webapp.md)

--- a/scripts/harness-scorecard.test.ts
+++ b/scripts/harness-scorecard.test.ts
@@ -14,7 +14,42 @@ async function write(relativePath: string, contents: string, rootDir: string) {
   await writeFile(filePath, contents);
 }
 
-async function createFixtureRepo(includeArtifacts: boolean) {
+function createInferentialArtifact(status: "skipped" | "pass") {
+  return {
+    version: "1.0",
+    generatedAt: "2026-04-12T04:55:00.000Z",
+    reviewMode: "semantic-shadow",
+    baseRef: "origin/main",
+    status,
+    summary:
+      status === "skipped"
+        ? "No harness-critical files are in scope. Inferential review skipped."
+        : "Inferential review completed with no actionable findings.",
+    providerName: "deterministic-policy-v1",
+    changedFiles:
+      status === "skipped" ? ["README.md"] : ["scripts/harness-scorecard.ts"],
+    targetFiles:
+      status === "skipped" ? [] : ["scripts/harness-scorecard.ts"],
+    findings: [],
+    errors: [],
+    shadow: {
+      generatedAt: "2026-04-12T04:55:00.000Z",
+      status,
+      summary:
+        status === "skipped"
+          ? "Shadow semantic review skipped because ANTHROPIC_API_KEY is not configured."
+          : "Shadow semantic review found no semantic issues.",
+      providerName: "semantic-shadow-stub",
+      findings: [],
+      errors: [],
+    },
+  };
+}
+
+async function createFixtureRepo(
+  includeArtifacts: boolean,
+  inferentialStatus: "skipped" | "pass" = "skipped"
+) {
   const rootDir = await mkdtemp(path.join(tmpdir(), "athena-harness-scorecard-"));
   tempRoots.push(rootDir);
 
@@ -156,32 +191,7 @@ async function createFixtureRepo(includeArtifacts: boolean) {
   if (includeArtifacts) {
     await write(
       "artifacts/harness-inferential-review/latest.json",
-      JSON.stringify(
-        {
-          version: "1.0",
-          generatedAt: "2026-04-12T04:55:00.000Z",
-          reviewMode: "semantic-shadow",
-          baseRef: "origin/main",
-          status: "skipped",
-          summary: "No harness-critical files are in scope. Inferential review skipped.",
-          providerName: "deterministic-policy-v1",
-          changedFiles: ["README.md"],
-          targetFiles: [],
-          findings: [],
-          errors: [],
-          shadow: {
-            generatedAt: "2026-04-12T04:55:00.000Z",
-            status: "skipped",
-            summary:
-              "Shadow semantic review skipped because ANTHROPIC_API_KEY is not configured.",
-            providerName: "semantic-shadow-stub",
-            findings: [],
-            errors: [],
-          },
-        },
-        null,
-        2
-      ),
+      JSON.stringify(createInferentialArtifact(inferentialStatus), null, 2),
       rootDir
     );
     await write(
@@ -349,7 +359,7 @@ describe("collectHarnessScorecard", () => {
       version: "1.0",
       generatedAt: "2026-04-12T05:00:00.000Z",
       summary: {
-        status: "healthy",
+        status: "mixed",
       },
     });
     expect(Object.keys(first.metrics)).toEqual([
@@ -405,6 +415,35 @@ describe("collectHarnessScorecard", () => {
     expect(first.metrics.graphify.status).toBe("paired");
     expect(first.metrics.graphify.reportPresent).toBe(true);
     expect(first.metrics.graphify.graphPresent).toBe(true);
+    expect(first.summary).toMatchObject({
+      status: "mixed",
+      healthySignals: 5,
+      degradedSignals: 1,
+      missingSignals: 0,
+    });
+    expect(first.summary.note).toContain(
+      "Inferential artifact skipped and treated as non-healthy."
+    );
+  });
+
+  it("counts a passing inferential artifact as healthy", async () => {
+    const rootDir = await createFixtureRepo(true, "pass");
+
+    const result = await collectHarnessScorecard(rootDir, {
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.metrics.inferential.status).toBe("pass");
+    expect(result.metrics.inferential.summary).toBe(
+      "Inferential review completed with no actionable findings."
+    );
+    expect(result.summary).toMatchObject({
+      status: "healthy",
+      healthySignals: 6,
+      degradedSignals: 0,
+      missingSignals: 0,
+    });
+    expect(result.summary.note).toContain("Inferential artifact pass.");
   });
 
   it("marks missing inferential and graphify artifacts explicitly", async () => {

--- a/scripts/harness-scorecard.ts
+++ b/scripts/harness-scorecard.ts
@@ -308,6 +308,22 @@ function buildGraphifyStatus(reportPresent: boolean, graphPresent: boolean) {
   return "missing" as const;
 }
 
+function isHealthyInferentialStatus(status: ArtifactStatus | "missing") {
+  return status === "pass" || status === "healthy";
+}
+
+function buildInferentialSummaryNote(status: ArtifactStatus | "missing") {
+  if (status === "missing") {
+    return "Inferential artifact missing.";
+  }
+
+  if (status === "skipped") {
+    return "Inferential artifact skipped and treated as non-healthy.";
+  }
+
+  return `Inferential artifact ${status}.`;
+}
+
 function buildSummary(
   documentation: HarnessScorecardOutput["metrics"]["documentation"],
   inferential: HarnessScorecardOutput["metrics"]["inferential"],
@@ -316,12 +332,15 @@ function buildSummary(
 ): HarnessScorecardOutput["summary"] {
   const healthySignals =
     documentation.healthyAppCount +
-    (inferential.status === "missing" ? 0 : 1) +
+    (isHealthyInferentialStatus(inferential.status) ? 1 : 0) +
     (runtimeTrends.status === "missing" ? 0 : 1) +
     (graphify.status === "paired" ? 1 : 0);
   const degradedSignals =
     documentation.degradedAppCount +
-    (inferential.status === "fail" || inferential.status === "error" ? 1 : 0) +
+    (!isHealthyInferentialStatus(inferential.status) &&
+    inferential.status !== "missing"
+      ? 1
+      : 0) +
     ((inferential.history.shadowErrorCount ?? 0) >= 2 ? 1 : 0) +
     (inferential.history.parseErrorCount > 0 ? 1 : 0) +
     (runtimeTrends.status === "mixed" || runtimeTrends.status === "degraded" ? 1 : 0) +
@@ -344,11 +363,7 @@ function buildSummary(
   noteParts.push(
     `${documentation.healthyAppCount} documentation apps healthy, ${documentation.degradedAppCount} degraded, and ${documentation.missingAppCount} missing.`
   );
-  noteParts.push(
-    inferential.status === "missing"
-      ? "Inferential artifact missing."
-      : `Inferential artifact ${inferential.status}.`
-  );
+  noteParts.push(buildInferentialSummaryNote(inferential.status));
   noteParts.push(
     runtimeTrends.status === "missing"
       ? "Runtime trend artifact missing."


### PR DESCRIPTION
## Summary
- treat inferential `skipped` artifacts as non-healthy in the scorecard summary
- surface a clearer note for skipped inferential coverage while preserving pass semantics
- add explicit scorecard coverage for both skipped and passing inferential artifacts

## Why
The harness audit found that `harness:scorecard` inflated top-line health whenever an inferential artifact existed, even when the run was skipped. This patch keeps the artifact details intact but stops skipped inferential runs from looking like healthy sensing coverage.

## Validation
- `bun test scripts/harness-scorecard.test.ts`
- `bun run pr:athena`

https://linear.app/v26-labs/issue/V26-229/treat-skipped-inferential-runs-as-non-healthy-in-harnessscorecard
