### PR TITLE
[V26-261]: Harden storefront TanStack dependency resolution

### DIFF
--- a/packages/storefront-webapp/tsconfig.json
+++ b/packages/storefront-webapp/tsconfig.json
@@ -29,7 +29,11 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
-      "@athena/webapp": ["../athena-webapp"]
+      "@athena/webapp": ["../athena-webapp"],
+      "@tanstack/start": ["../../node_modules/@tanstack/start"],
+      "@tanstack/start/*": ["../../node_modules/@tanstack/start/*"],
+      "@tanstack/react-router": ["../../node_modules/@tanstack/react-router"],
+      "@tanstack/react-router/*": ["../../node_modules/@tanstack/react-router/*"]
     },
     "types": ["vitest/globals", "vite/client", "@testing-library/jest-dom"]
   }

--- a/packages/storefront-webapp/vite.config.ts
+++ b/packages/storefront-webapp/vite.config.ts
@@ -42,6 +42,11 @@ export default defineConfig({
     alias: {
       "~": __dirname,
       "@": path.resolve(__dirname, "./src"),
+      "@tanstack/start": path.resolve(__dirname, "../../node_modules/@tanstack/start"),
+      "@tanstack/react-router": path.resolve(
+        __dirname,
+        "../../node_modules/@tanstack/react-router",
+      ),
     },
   },
 });


### PR DESCRIPTION
## Summary
- pin storefront TypeScript resolution for `@tanstack/start` and `@tanstack/react-router` to the workspace root
- add matching Vite aliases so runtime bundling uses the same TanStack packages as the workspace build
- prevent stray `packages/storefront-webapp/node_modules` installs from shadowing the workspace dependency graph during storefront builds

## Why
`@athena/storefront-webapp` was building against two different TanStack Start APIs depending on which `node_modules` tree TypeScript and Vite found first. A stray local install under `packages/storefront-webapp/node_modules` surfaced older `@tanstack/start@1.97.x` entrypoint contracts, while the workspace root resolves the current `@tanstack/start@1.120.x` API used by the app. Hardening resolution at the package boundary makes the storefront build consistent and fixes the local production-audit workflow without changing app runtime code.

## Validation
- `bunx tsc --noEmit -p /Users/kwamina/athena/.worktrees/codex-V26-261-web-vitals-verify/packages/storefront-webapp/tsconfig.json`
- `bun run --filter '@athena/storefront-webapp' build` (validated in the worktree with a simulated shadowing `packages/storefront-webapp/node_modules` present)
- `bun run graphify:rebuild`
- `bun run harness:review`

https://linear.app/v26-labs/issue/V26-261/verify-storefront-web-vitals-recovery-and-add-regression-coverage-for
