### PR TITLE
[V26-261]: Pin TanStack Start server resolution

### DIFF
--- a/packages/storefront-webapp/tsconfig.json
+++ b/packages/storefront-webapp/tsconfig.json
@@ -30,10 +30,9 @@
     "paths": {
       "@/*": ["./src/*"],
       "@athena/webapp": ["../athena-webapp"],
-      "@tanstack/start": ["../../node_modules/@tanstack/start"],
-      "@tanstack/start/*": ["../../node_modules/@tanstack/start/*"],
-      "@tanstack/react-router": ["../../node_modules/@tanstack/react-router"],
-      "@tanstack/react-router/*": ["../../node_modules/@tanstack/react-router/*"]
+      "@tanstack/start": ["../../node_modules/@tanstack/start/dist/esm/client.d.ts"],
+      "@tanstack/start/server": ["../../node_modules/@tanstack/start/dist/esm/server.d.ts"],
+      "@tanstack/react-router": ["../../node_modules/@tanstack/react-router/dist/esm/index.d.ts"]
     },
     "types": ["vitest/globals", "vite/client", "@testing-library/jest-dom"]
   }

--- a/packages/storefront-webapp/vite.config.ts
+++ b/packages/storefront-webapp/vite.config.ts
@@ -42,10 +42,17 @@ export default defineConfig({
     alias: {
       "~": __dirname,
       "@": path.resolve(__dirname, "./src"),
-      "@tanstack/start": path.resolve(__dirname, "../../node_modules/@tanstack/start"),
+      "@tanstack/start": path.resolve(
+        __dirname,
+        "../../node_modules/@tanstack/start/dist/esm/client.js",
+      ),
+      "@tanstack/start/server": path.resolve(
+        __dirname,
+        "../../node_modules/@tanstack/start/dist/esm/server.js",
+      ),
       "@tanstack/react-router": path.resolve(
         __dirname,
-        "../../node_modules/@tanstack/react-router",
+        "../../node_modules/@tanstack/react-router/dist/esm/index.js",
       ),
     },
   },


### PR DESCRIPTION
## Summary
- pin the storefront TypeScript `@tanstack/start/server` import to the workspace-root TanStack Start package
- update Vite aliasing so the storefront server entrypoint resolves the same TanStack Start server module at build time
- avoid fallback to stale `packages/storefront-webapp/node_modules` server types that require the older `createStartHandler({ createRouter })(...)` contract

## Why
The earlier resolution hardening fixed the package root import path, but `src/ssr.tsx` still imported the `@tanstack/start/server` subpath. TypeScript was resolving that subpath from an untracked local `packages/storefront-webapp/node_modules/@tanstack/start@1.97.2`, which made `createStartHandler(defaultStreamHandler)` fail on `main` even though the workspace root uses `@tanstack/start@1.120.x`. This follow-up pins the server subpath explicitly so the storefront build resolves one consistent TanStack Start API.

## Validation
- `bunx tsc --noEmit -p /Users/kwamina/athena/.worktrees/codex-V26-261-web-vitals-verify/packages/storefront-webapp/tsconfig.json`
- `bun run --filter '@athena/storefront-webapp' build`
- `bun run harness:review --base origin/main`
- `bun run graphify:rebuild`

https://linear.app/v26-labs/issue/V26-261/verify-storefront-web-vitals-recovery-and-add-regression-coverage-for
