### PR TITLE
[V26-262]: Fix POS product search pagination

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 2848 nodes · 2405 edges · 1130 communities detected
+- 2847 nodes · 2402 edges · 1130 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1288,28 +1288,28 @@ Cohesion: 0.22
 Nodes (2): isValidEmail(), validateCustomerInfo()
 
 ### Community 30 - "Community 30"
-Cohesion: 0.36
-Nodes (8): collectAllPages(), createTransactionFromSessionHandler(), listCompletedTransactionsForDay(), listProductSkusByProductId(), listSessionItems(), listStoreProducts(), listStoreSkus(), listTransactionItems()
-
-### Community 31 - "Community 31"
 Cohesion: 0.31
 Nodes (5): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getPotentialPoints()
 
-### Community 32 - "Community 32"
+### Community 31 - "Community 31"
 Cohesion: 0.29
 Nodes (6): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile()
 
-### Community 33 - "Community 33"
+### Community 32 - "Community 32"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 34 - "Community 34"
+### Community 33 - "Community 33"
 Cohesion: 0.38
 Nodes (9): awardPointsForGuestOrders(), awardPointsForPastOrder(), getBaseUrl(), getEligiblePastOrders(), getOrderRewardPoints(), getPointHistory(), getRewardTiers(), getUserPoints() (+1 more)
 
-### Community 35 - "Community 35"
+### Community 34 - "Community 34"
 Cohesion: 0.4
 Nodes (8): fileExists(), isJsonObject(), normalizeGraphJsonArtifact(), normalizeGraphJsonContents(), resolveGraphifyPython(), runGraphifyRebuild(), sortJsonArray(), sortJsonValue()
+
+### Community 35 - "Community 35"
+Cohesion: 0.36
+Nodes (6): createTransactionFromSessionHandler(), listCompletedTransactionsForDay(), listProductSkusByProductId(), listSessionItems(), listTransactionItems(), readAllQueryResults()
 
 ### Community 36 - "Community 36"
 Cohesion: 0.28
@@ -1333,11 +1333,11 @@ Nodes (1): Logger
 
 ### Community 41 - "Community 41"
 Cohesion: 0.43
-Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
+Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 42 - "Community 42"
 Cohesion: 0.43
-Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
+Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
 ### Community 43 - "Community 43"
 Cohesion: 0.25
@@ -1456,16 +1456,16 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 72 - "Community 72"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
-
-### Community 73 - "Community 73"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 74 - "Community 74"
+### Community 73 - "Community 73"
 Cohesion: 0.4
 Nodes (2): useBulkOperations(), validateOperationValue()
+
+### Community 74 - "Community 74"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 75 - "Community 75"
 Cohesion: 0.33
@@ -1480,28 +1480,28 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 78 - "Community 78"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 79 - "Community 79"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 80 - "Community 80"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 81 - "Community 81"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 81 - "Community 81"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 82 - "Community 82"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 83 - "Community 83"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 84 - "Community 84"
 Cohesion: 0.53
@@ -1680,20 +1680,20 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 128 - "Community 128"
-Cohesion: 0.67
-Nodes (2): toDisplayAmount(), toPesewas()
-
-### Community 129 - "Community 129"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 130 - "Community 130"
+### Community 129 - "Community 129"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 131 - "Community 131"
+### Community 130 - "Community 130"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
+
+### Community 131 - "Community 131"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 132 - "Community 132"
 Cohesion: 0.5
@@ -1712,12 +1712,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 136 - "Community 136"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 137 - "Community 137"
 Cohesion: 0.67
 Nodes (2): countGroupedAnalytics(), groupAnalytics()
+
+### Community 137 - "Community 137"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 138 - "Community 138"
 Cohesion: 0.5
@@ -1748,32 +1748,32 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 145 - "Community 145"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 146 - "Community 146"
 Cohesion: 0.67
 Nodes (2): getRiskStyles(), RiskIndicators()
+
+### Community 146 - "Community 146"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 147 - "Community 147"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 148 - "Community 148"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 149 - "Community 149"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 150 - "Community 150"
+### Community 149 - "Community 149"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 151 - "Community 151"
+### Community 150 - "Community 150"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+
+### Community 151 - "Community 151"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 152 - "Community 152"
 Cohesion: 0.5
@@ -1796,8 +1796,8 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 157 - "Community 157"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): toDisplayAmount(), toPesewas()
 
 ### Community 158 - "Community 158"
 Cohesion: 0.67

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -6113,25 +6113,13 @@
     },
     {
       "_src": "packages_athena_webapp_convex_inventory_pos_ts",
-      "_tgt": "pos_collectallpages",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "contains",
-      "source": "packages_athena_webapp_convex_inventory_pos_ts",
-      "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L19",
-      "target": "pos_collectallpages",
-      "weight": 1
-    },
-    {
-      "_src": "packages_athena_webapp_convex_inventory_pos_ts",
       "_tgt": "pos_createtransactionfromsessionhandler",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_pos_ts",
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L939",
+      "source_location": "L908",
       "target": "pos_createtransactionfromsessionhandler",
       "weight": 1
     },
@@ -6143,7 +6131,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_pos_ts",
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L15",
+      "source_location": "L10",
       "target": "pos_isconvexproductid",
       "weight": 1
     },
@@ -6155,8 +6143,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_pos_ts",
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L92",
+      "source_location": "L101",
       "target": "pos_listcompletedtransactionsforday",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_inventory_pos_ts",
+      "_tgt": "pos_listmatchingstoreskus",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_inventory_pos_ts",
+      "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
+      "source_location": "L35",
+      "target": "pos_listmatchingstoreskus",
       "weight": 1
     },
     {
@@ -6167,7 +6167,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_pos_ts",
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L41",
+      "source_location": "L24",
       "target": "pos_listproductskusbyproductid",
       "weight": 1
     },
@@ -6179,32 +6179,8 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_pos_ts",
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L83",
+      "source_location": "L93",
       "target": "pos_listsessionitems",
-      "weight": 1
-    },
-    {
-      "_src": "packages_athena_webapp_convex_inventory_pos_ts",
-      "_tgt": "pos_liststoreproducts",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "contains",
-      "source": "packages_athena_webapp_convex_inventory_pos_ts",
-      "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L53",
-      "target": "pos_liststoreproducts",
-      "weight": 1
-    },
-    {
-      "_src": "packages_athena_webapp_convex_inventory_pos_ts",
-      "_tgt": "pos_liststoreskus",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "contains",
-      "source": "packages_athena_webapp_convex_inventory_pos_ts",
-      "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L62",
-      "target": "pos_liststoreskus",
       "weight": 1
     },
     {
@@ -6215,8 +6191,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_inventory_pos_ts",
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L71",
+      "source_location": "L82",
       "target": "pos_listtransactionitems",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_inventory_pos_ts",
+      "_tgt": "pos_readallqueryresults",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_inventory_pos_ts",
+      "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
+      "source_location": "L14",
+      "target": "pos_readallqueryresults",
       "weight": 1
     },
     {
@@ -22163,79 +22151,55 @@
       "relation": "calls",
       "source": "pos_listsessionitems",
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L953",
+      "source_location": "L922",
       "target": "pos_createtransactionfromsessionhandler",
       "weight": 1
     },
     {
       "_src": "pos_listcompletedtransactionsforday",
-      "_tgt": "pos_collectallpages",
+      "_tgt": "pos_readallqueryresults",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "calls",
-      "source": "pos_collectallpages",
+      "source": "pos_readallqueryresults",
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L98",
+      "source_location": "L107",
       "target": "pos_listcompletedtransactionsforday",
       "weight": 1
     },
     {
       "_src": "pos_listproductskusbyproductid",
-      "_tgt": "pos_collectallpages",
+      "_tgt": "pos_readallqueryresults",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "calls",
-      "source": "pos_collectallpages",
+      "source": "pos_readallqueryresults",
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L45",
+      "source_location": "L28",
       "target": "pos_listproductskusbyproductid",
       "weight": 1
     },
     {
       "_src": "pos_listsessionitems",
-      "_tgt": "pos_collectallpages",
+      "_tgt": "pos_readallqueryresults",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "calls",
-      "source": "pos_collectallpages",
+      "source": "pos_readallqueryresults",
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L84",
+      "source_location": "L94",
       "target": "pos_listsessionitems",
       "weight": 1
     },
     {
-      "_src": "pos_liststoreproducts",
-      "_tgt": "pos_collectallpages",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "calls",
-      "source": "pos_collectallpages",
-      "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L54",
-      "target": "pos_liststoreproducts",
-      "weight": 1
-    },
-    {
-      "_src": "pos_liststoreskus",
-      "_tgt": "pos_collectallpages",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "calls",
-      "source": "pos_collectallpages",
-      "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L63",
-      "target": "pos_liststoreskus",
-      "weight": 1
-    },
-    {
       "_src": "pos_listtransactionitems",
-      "_tgt": "pos_collectallpages",
+      "_tgt": "pos_readallqueryresults",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "calls",
-      "source": "pos_collectallpages",
+      "source": "pos_readallqueryresults",
       "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L75",
+      "source_location": "L86",
       "target": "pos_listtransactionitems",
       "weight": 1
     },
@@ -32622,42 +32586,6 @@
     {
       "community": 128,
       "file_type": "code",
-      "id": "currency_todisplayamount",
-      "label": "toDisplayAmount()",
-      "norm_label": "todisplayamount()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "currency_topesewas",
-      "label": "toPesewas()",
-      "norm_label": "topesewas()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_lib_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/athena-webapp/convex/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
       "id": "collections_getcachedtokenrecord",
       "label": "getCachedTokenRecord()",
       "norm_label": "getcachedtokenrecord()",
@@ -32665,7 +32593,7 @@
       "source_location": "L26"
     },
     {
-      "community": 129,
+      "community": 128,
       "file_type": "code",
       "id": "collections_resolveaccesstokenforstore",
       "label": "resolveAccessTokenForStore()",
@@ -32674,7 +32602,7 @@
       "source_location": "L79"
     },
     {
-      "community": 129,
+      "community": 128,
       "file_type": "code",
       "id": "collections_resolveconfigforstore",
       "label": "resolveConfigForStore()",
@@ -32683,12 +32611,48 @@
       "source_location": "L33"
     },
     {
-      "community": 129,
+      "community": 128,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_collections_ts",
       "label": "collections.ts",
       "norm_label": "collections.ts",
       "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "normalize_maskmtnpartyid",
+      "label": "maskMtnPartyId()",
+      "norm_label": "maskmtnpartyid()",
+      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "normalize_normalizecollectionstransaction",
+      "label": "normalizeCollectionsTransaction()",
+      "norm_label": "normalizecollectionstransaction()",
+      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "normalize_parsecollectionsnotificationrequest",
+      "label": "parseCollectionsNotificationRequest()",
+      "norm_label": "parsecollectionsnotificationrequest()",
+      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 129,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_normalize_ts",
+      "label": "normalize.ts",
+      "norm_label": "normalize.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
       "source_location": "L1"
     },
     {
@@ -32856,42 +32820,6 @@
     {
       "community": 130,
       "file_type": "code",
-      "id": "normalize_maskmtnpartyid",
-      "label": "maskMtnPartyId()",
-      "norm_label": "maskmtnpartyid()",
-      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "normalize_normalizecollectionstransaction",
-      "label": "normalizeCollectionsTransaction()",
-      "norm_label": "normalizecollectionstransaction()",
-      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "normalize_parsecollectionsnotificationrequest",
-      "label": "parseCollectionsNotificationRequest()",
-      "norm_label": "parsecollectionsnotificationrequest()",
-      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 130,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_normalize_ts",
-      "label": "normalize.ts",
-      "norm_label": "normalize.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 131,
-      "file_type": "code",
       "id": "commercequeryindexes_test_expectindex",
       "label": "expectIndex()",
       "norm_label": "expectindex()",
@@ -32899,7 +32827,7 @@
       "source_location": "L19"
     },
     {
-      "community": 131,
+      "community": 130,
       "file_type": "code",
       "id": "commercequeryindexes_test_getsource",
       "label": "getSource()",
@@ -32908,7 +32836,7 @@
       "source_location": "L26"
     },
     {
-      "community": 131,
+      "community": 130,
       "file_type": "code",
       "id": "commercequeryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -32917,7 +32845,7 @@
       "source_location": "L12"
     },
     {
-      "community": 131,
+      "community": 130,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_commercequeryindexes_test_ts",
       "label": "commerceQueryIndexes.test.ts",
@@ -32926,7 +32854,7 @@
       "source_location": "L1"
     },
     {
-      "community": 132,
+      "community": 131,
       "file_type": "code",
       "id": "attributesmanager_attributesmanager",
       "label": "AttributesManager()",
@@ -32935,7 +32863,7 @@
       "source_location": "L228"
     },
     {
-      "community": 132,
+      "community": 131,
       "file_type": "code",
       "id": "attributesmanager_colormanager",
       "label": "ColorManager()",
@@ -32944,7 +32872,7 @@
       "source_location": "L45"
     },
     {
-      "community": 132,
+      "community": 131,
       "file_type": "code",
       "id": "attributesmanager_sidebar",
       "label": "Sidebar()",
@@ -32953,7 +32881,7 @@
       "source_location": "L26"
     },
     {
-      "community": 132,
+      "community": 131,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributesmanager_tsx",
       "label": "AttributesManager.tsx",
@@ -32962,7 +32890,7 @@
       "source_location": "L1"
     },
     {
-      "community": 133,
+      "community": 132,
       "file_type": "code",
       "id": "attributestable_getproductattribute",
       "label": "getProductAttribute()",
@@ -32971,7 +32899,7 @@
       "source_location": "L55"
     },
     {
-      "community": 133,
+      "community": 132,
       "file_type": "code",
       "id": "attributestable_handlechange",
       "label": "handleChange()",
@@ -32980,7 +32908,7 @@
       "source_location": "L32"
     },
     {
-      "community": 133,
+      "community": 132,
       "file_type": "code",
       "id": "attributestable_onsubmit",
       "label": "onSubmit()",
@@ -32989,7 +32917,7 @@
       "source_location": "L210"
     },
     {
-      "community": 133,
+      "community": 132,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributestable_tsx",
       "label": "AttributesTable.tsx",
@@ -32998,7 +32926,7 @@
       "source_location": "L1"
     },
     {
-      "community": 134,
+      "community": 133,
       "file_type": "code",
       "id": "categorysubcategorymanager_categorymanager",
       "label": "CategoryManager()",
@@ -33007,7 +32935,7 @@
       "source_location": "L51"
     },
     {
-      "community": 134,
+      "community": 133,
       "file_type": "code",
       "id": "categorysubcategorymanager_sidebar",
       "label": "Sidebar()",
@@ -33016,7 +32944,7 @@
       "source_location": "L26"
     },
     {
-      "community": 134,
+      "community": 133,
       "file_type": "code",
       "id": "categorysubcategorymanager_subcategorymanager",
       "label": "SubcategoryManager()",
@@ -33025,7 +32953,7 @@
       "source_location": "L290"
     },
     {
-      "community": 134,
+      "community": 133,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_categorysubcategorymanager_tsx",
       "label": "CategorySubcategoryManager.tsx",
@@ -33034,7 +32962,7 @@
       "source_location": "L1"
     },
     {
-      "community": 135,
+      "community": 134,
       "file_type": "code",
       "id": "analyticsview_activecheckoutsessions",
       "label": "ActiveCheckoutSessions()",
@@ -33043,7 +32971,7 @@
       "source_location": "L48"
     },
     {
-      "community": 135,
+      "community": 134,
       "file_type": "code",
       "id": "analyticsview_analyticsview",
       "label": "AnalyticsView()",
@@ -33052,7 +32980,7 @@
       "source_location": "L88"
     },
     {
-      "community": 135,
+      "community": 134,
       "file_type": "code",
       "id": "analyticsview_storevisitors",
       "label": "StoreVisitors()",
@@ -33061,7 +32989,7 @@
       "source_location": "L14"
     },
     {
-      "community": 135,
+      "community": 134,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsview_tsx",
       "label": "AnalyticsView.tsx",
@@ -33070,7 +32998,7 @@
       "source_location": "L1"
     },
     {
-      "community": 136,
+      "community": 135,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storefrontobservabilitypanel_tsx",
       "label": "StorefrontObservabilityPanel.tsx",
@@ -33079,7 +33007,7 @@
       "source_location": "L1"
     },
     {
-      "community": 136,
+      "community": 135,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_formatlabel",
       "label": "formatLabel()",
@@ -33088,7 +33016,7 @@
       "source_location": "L15"
     },
     {
-      "community": 136,
+      "community": 135,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_gettrafficsourcebadge",
       "label": "getTrafficSourceBadge()",
@@ -33097,7 +33025,7 @@
       "source_location": "L28"
     },
     {
-      "community": 136,
+      "community": 135,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_summarycard",
       "label": "SummaryCard()",
@@ -33106,7 +33034,7 @@
       "source_location": "L19"
     },
     {
-      "community": 137,
+      "community": 136,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_utils_ts",
       "label": "utils.ts",
@@ -33115,7 +33043,7 @@
       "source_location": "L1"
     },
     {
-      "community": 137,
+      "community": 136,
       "file_type": "code",
       "id": "utils_countgroupedanalytics",
       "label": "countGroupedAnalytics()",
@@ -33124,7 +33052,7 @@
       "source_location": "L52"
     },
     {
-      "community": 137,
+      "community": 136,
       "file_type": "code",
       "id": "utils_groupanalytics",
       "label": "groupAnalytics()",
@@ -33133,7 +33061,7 @@
       "source_location": "L3"
     },
     {
-      "community": 137,
+      "community": 136,
       "file_type": "code",
       "id": "utils_groupproductviewsbyday",
       "label": "groupProductViewsByDay()",
@@ -33142,7 +33070,7 @@
       "source_location": "L90"
     },
     {
-      "community": 138,
+      "community": 137,
       "file_type": "code",
       "id": "maintenancemessageeditor_getcountdownstatus",
       "label": "getCountdownStatus()",
@@ -33151,7 +33079,7 @@
       "source_location": "L86"
     },
     {
-      "community": 138,
+      "community": 137,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlecountdownchange",
       "label": "handleCountdownChange()",
@@ -33160,7 +33088,7 @@
       "source_location": "L76"
     },
     {
-      "community": 138,
+      "community": 137,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlesave",
       "label": "handleSave()",
@@ -33169,7 +33097,7 @@
       "source_location": "L52"
     },
     {
-      "community": 138,
+      "community": 137,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_maintenancemessageeditor_tsx",
       "label": "MaintenanceMessageEditor.tsx",
@@ -33178,7 +33106,7 @@
       "source_location": "L1"
     },
     {
-      "community": 139,
+      "community": 138,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplook_tsx",
       "label": "ShopLook.tsx",
@@ -33187,7 +33115,7 @@
       "source_location": "L1"
     },
     {
-      "community": 139,
+      "community": 138,
       "file_type": "code",
       "id": "shoplook_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -33196,7 +33124,7 @@
       "source_location": "L67"
     },
     {
-      "community": 139,
+      "community": 138,
       "file_type": "code",
       "id": "shoplook_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -33205,13 +33133,49 @@
       "source_location": "L90"
     },
     {
-      "community": 139,
+      "community": 138,
       "file_type": "code",
       "id": "shoplook_ondragend",
       "label": "onDragEnd()",
       "norm_label": "ondragend()",
       "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
       "source_location": "L73"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "newtransactionview_handlequickstart",
+      "label": "handleQuickStart()",
+      "norm_label": "handlequickstart()",
+      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
+      "source_location": "L91"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "newtransactionview_handlestarttransaction",
+      "label": "handleStartTransaction()",
+      "norm_label": "handlestarttransaction()",
+      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
+      "source_location": "L68"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "newtransactionview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
+      "source_location": "L22"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
+      "label": "NewTransactionView.tsx",
+      "norm_label": "newtransactionview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
+      "source_location": "L1"
     },
     {
       "community": 14,
@@ -33369,42 +33333,6 @@
     {
       "community": 140,
       "file_type": "code",
-      "id": "newtransactionview_handlequickstart",
-      "label": "handleQuickStart()",
-      "norm_label": "handlequickstart()",
-      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
-      "source_location": "L91"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "newtransactionview_handlestarttransaction",
-      "label": "handleStartTransaction()",
-      "norm_label": "handlestarttransaction()",
-      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
-      "source_location": "L68"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "newtransactionview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
-      "source_location": "L22"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
-      "label": "NewTransactionView.tsx",
-      "norm_label": "newtransactionview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
       "id": "ordersummary_handlecompletetransaction",
       "label": "handleCompleteTransaction()",
       "norm_label": "handlecompletetransaction()",
@@ -33412,7 +33340,7 @@
       "source_location": "L128"
     },
     {
-      "community": 141,
+      "community": 140,
       "file_type": "code",
       "id": "ordersummary_handlenewtransaction",
       "label": "handleNewTransaction()",
@@ -33421,7 +33349,7 @@
       "source_location": "L162"
     },
     {
-      "community": 141,
+      "community": 140,
       "file_type": "code",
       "id": "ordersummary_handleselectedpaymentmethod",
       "label": "handleSelectedPaymentMethod()",
@@ -33430,7 +33358,7 @@
       "source_location": "L150"
     },
     {
-      "community": 141,
+      "community": 140,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -33439,7 +33367,7 @@
       "source_location": "L1"
     },
     {
-      "community": 142,
+      "community": 141,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_tsx",
       "label": "POSSettingsView.tsx",
@@ -33448,7 +33376,7 @@
       "source_location": "L1"
     },
     {
-      "community": 142,
+      "community": 141,
       "file_type": "code",
       "id": "possettingsview_handleregisterterminal",
       "label": "handleRegisterTerminal()",
@@ -33457,7 +33385,7 @@
       "source_location": "L247"
     },
     {
-      "community": 142,
+      "community": 141,
       "file_type": "code",
       "id": "possettingsview_handleupdateexistingterminal",
       "label": "handleUpdateExistingTerminal()",
@@ -33466,7 +33394,7 @@
       "source_location": "L284"
     },
     {
-      "community": 142,
+      "community": 141,
       "file_type": "code",
       "id": "possettingsview_loadfingerprint",
       "label": "loadFingerprint()",
@@ -33475,7 +33403,7 @@
       "source_location": "L166"
     },
     {
-      "community": 143,
+      "community": 142,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstock_tsx",
       "label": "ProductStock.tsx",
@@ -33484,7 +33412,7 @@
       "source_location": "L1"
     },
     {
-      "community": 143,
+      "community": 142,
       "file_type": "code",
       "id": "productstock_lowstockstatus",
       "label": "LowStockStatus()",
@@ -33493,7 +33421,7 @@
       "source_location": "L57"
     },
     {
-      "community": 143,
+      "community": 142,
       "file_type": "code",
       "id": "productstock_outofstockstatus",
       "label": "OutOfStockStatus()",
@@ -33502,7 +33430,7 @@
       "source_location": "L48"
     },
     {
-      "community": 143,
+      "community": 142,
       "file_type": "code",
       "id": "productstock_productstockstatus",
       "label": "ProductStockStatus()",
@@ -33511,7 +33439,7 @@
       "source_location": "L11"
     },
     {
-      "community": 144,
+      "community": 143,
       "file_type": "code",
       "id": "complimentaryproductsview_body",
       "label": "Body()",
@@ -33520,7 +33448,7 @@
       "source_location": "L16"
     },
     {
-      "community": 144,
+      "community": 143,
       "file_type": "code",
       "id": "complimentaryproductsview_complimentaryproductsview",
       "label": "ComplimentaryProductsView()",
@@ -33529,7 +33457,7 @@
       "source_location": "L35"
     },
     {
-      "community": 144,
+      "community": 143,
       "file_type": "code",
       "id": "complimentaryproductsview_navigation",
       "label": "Navigation()",
@@ -33538,7 +33466,7 @@
       "source_location": "L6"
     },
     {
-      "community": 144,
+      "community": 143,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
       "label": "ComplimentaryProductsView.tsx",
@@ -33547,7 +33475,7 @@
       "source_location": "L1"
     },
     {
-      "community": 145,
+      "community": 144,
       "file_type": "code",
       "id": "engagementmetrics_formatlastactivity",
       "label": "formatLastActivity()",
@@ -33556,7 +33484,7 @@
       "source_location": "L75"
     },
     {
-      "community": 145,
+      "community": 144,
       "file_type": "code",
       "id": "engagementmetrics_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -33565,7 +33493,7 @@
       "source_location": "L82"
     },
     {
-      "community": 145,
+      "community": 144,
       "file_type": "code",
       "id": "engagementmetrics_getdevicelabel",
       "label": "getDeviceLabel()",
@@ -33574,7 +33502,7 @@
       "source_location": "L93"
     },
     {
-      "community": 145,
+      "community": 144,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_engagementmetrics_tsx",
       "label": "EngagementMetrics.tsx",
@@ -33583,7 +33511,7 @@
       "source_location": "L1"
     },
     {
-      "community": 146,
+      "community": 145,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
       "label": "RiskIndicators.tsx",
@@ -33592,7 +33520,7 @@
       "source_location": "L1"
     },
     {
-      "community": 146,
+      "community": 145,
       "file_type": "code",
       "id": "riskindicators_getriskicon",
       "label": "getRiskIcon()",
@@ -33601,7 +33529,7 @@
       "source_location": "L15"
     },
     {
-      "community": 146,
+      "community": 145,
       "file_type": "code",
       "id": "riskindicators_getriskstyles",
       "label": "getRiskStyles()",
@@ -33610,7 +33538,7 @@
       "source_location": "L28"
     },
     {
-      "community": 146,
+      "community": 145,
       "file_type": "code",
       "id": "riskindicators_riskindicators",
       "label": "RiskIndicators()",
@@ -33619,7 +33547,7 @@
       "source_location": "L54"
     },
     {
-      "community": 147,
+      "community": 146,
       "file_type": "code",
       "id": "customerobservabilitytimeline_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -33628,7 +33556,7 @@
       "source_location": "L59"
     },
     {
-      "community": 147,
+      "community": 146,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -33637,7 +33565,7 @@
       "source_location": "L114"
     },
     {
-      "community": 147,
+      "community": 146,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
       "label": "getObservabilityStatusStyles()",
@@ -33646,7 +33574,7 @@
       "source_location": "L67"
     },
     {
-      "community": 147,
+      "community": 146,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_customerobservabilitytimeline_ts",
       "label": "customerObservabilityTimeline.ts",
@@ -33655,7 +33583,7 @@
       "source_location": "L1"
     },
     {
-      "community": 148,
+      "community": 147,
       "file_type": "code",
       "id": "barcodeutils_extractbarcodefrominput",
       "label": "extractBarcodeFromInput()",
@@ -33664,7 +33592,7 @@
       "source_location": "L51"
     },
     {
-      "community": 148,
+      "community": 147,
       "file_type": "code",
       "id": "barcodeutils_isurlorbarcode",
       "label": "isUrlOrBarcode()",
@@ -33673,7 +33601,7 @@
       "source_location": "L92"
     },
     {
-      "community": 148,
+      "community": 147,
       "file_type": "code",
       "id": "barcodeutils_isvalidconvexid",
       "label": "isValidConvexId()",
@@ -33682,7 +33610,7 @@
       "source_location": "L16"
     },
     {
-      "community": 148,
+      "community": 147,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_barcodeutils_ts",
       "label": "barcodeUtils.ts",
@@ -33691,7 +33619,7 @@
       "source_location": "L1"
     },
     {
-      "community": 149,
+      "community": 148,
       "file_type": "code",
       "id": "offers_getbaseurl",
       "label": "getBaseUrl()",
@@ -33700,7 +33628,7 @@
       "source_location": "L13"
     },
     {
-      "community": 149,
+      "community": 148,
       "file_type": "code",
       "id": "offers_getuserredeemedoffers",
       "label": "getUserRedeemedOffers()",
@@ -33709,7 +33637,7 @@
       "source_location": "L46"
     },
     {
-      "community": 149,
+      "community": 148,
       "file_type": "code",
       "id": "offers_submitoffer",
       "label": "submitOffer()",
@@ -33718,13 +33646,49 @@
       "source_location": "L21"
     },
     {
-      "community": 149,
+      "community": 148,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_offers_ts",
       "label": "offers.ts",
       "norm_label": "offers.ts",
       "source_file": "packages/storefront-webapp/src/api/offers.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_stores_ts",
+      "label": "stores.ts",
+      "norm_label": "stores.ts",
+      "source_file": "packages/storefront-webapp/src/api/stores.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "stores_getallstores",
+      "label": "getAllStores()",
+      "norm_label": "getallstores()",
+      "source_file": "packages/storefront-webapp/src/api/stores.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "stores_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/stores.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "stores_getstore",
+      "label": "getStore()",
+      "norm_label": "getstore()",
+      "source_file": "packages/storefront-webapp/src/api/stores.ts",
+      "source_location": "L20"
     },
     {
       "community": 15,
@@ -33882,42 +33846,6 @@
     {
       "community": 150,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_stores_ts",
-      "label": "stores.ts",
-      "norm_label": "stores.ts",
-      "source_file": "packages/storefront-webapp/src/api/stores.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 150,
-      "file_type": "code",
-      "id": "stores_getallstores",
-      "label": "getAllStores()",
-      "norm_label": "getallstores()",
-      "source_file": "packages/storefront-webapp/src/api/stores.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 150,
-      "file_type": "code",
-      "id": "stores_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/stores.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 150,
-      "file_type": "code",
-      "id": "stores_getstore",
-      "label": "getStore()",
-      "norm_label": "getstore()",
-      "source_file": "packages/storefront-webapp/src/api/stores.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 151,
-      "file_type": "code",
       "id": "packages_storefront_webapp_src_api_subcategory_ts",
       "label": "subcategory.ts",
       "norm_label": "subcategory.ts",
@@ -33925,7 +33853,7 @@
       "source_location": "L1"
     },
     {
-      "community": 151,
+      "community": 150,
       "file_type": "code",
       "id": "subcategory_getallsubcategories",
       "label": "getAllSubcategories()",
@@ -33934,7 +33862,7 @@
       "source_location": "L11"
     },
     {
-      "community": 151,
+      "community": 150,
       "file_type": "code",
       "id": "subcategory_getbaseurl",
       "label": "getBaseUrl()",
@@ -33943,7 +33871,7 @@
       "source_location": "L9"
     },
     {
-      "community": 151,
+      "community": 150,
       "file_type": "code",
       "id": "subcategory_getsubategory",
       "label": "getSubategory()",
@@ -33952,7 +33880,7 @@
       "source_location": "L25"
     },
     {
-      "community": 152,
+      "community": 151,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productactionbar_tsx",
       "label": "ProductActionBar.tsx",
@@ -33961,7 +33889,7 @@
       "source_location": "L1"
     },
     {
-      "community": 152,
+      "community": 151,
       "file_type": "code",
       "id": "productactionbar_checkscroll",
       "label": "checkScroll()",
@@ -33970,7 +33898,7 @@
       "source_location": "L50"
     },
     {
-      "community": 152,
+      "community": 151,
       "file_type": "code",
       "id": "productactionbar_handleaction",
       "label": "handleAction()",
@@ -33979,7 +33907,7 @@
       "source_location": "L92"
     },
     {
-      "community": 152,
+      "community": 151,
       "file_type": "code",
       "id": "productactionbar_handledismiss",
       "label": "handleDismiss()",
@@ -33988,7 +33916,7 @@
       "source_location": "L74"
     },
     {
-      "community": 153,
+      "community": 152,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productreminderbar_tsx",
       "label": "ProductReminderBar.tsx",
@@ -33997,7 +33925,7 @@
       "source_location": "L1"
     },
     {
-      "community": 153,
+      "community": 152,
       "file_type": "code",
       "id": "productreminderbar_checkscroll",
       "label": "checkScroll()",
@@ -34006,7 +33934,7 @@
       "source_location": "L62"
     },
     {
-      "community": 153,
+      "community": 152,
       "file_type": "code",
       "id": "productreminderbar_handleaddtobag",
       "label": "handleAddToBag()",
@@ -34015,7 +33943,7 @@
       "source_location": "L109"
     },
     {
-      "community": 153,
+      "community": 152,
       "file_type": "code",
       "id": "productreminderbar_handledismiss",
       "label": "handleDismiss()",
@@ -34024,7 +33952,7 @@
       "source_location": "L177"
     },
     {
-      "community": 154,
+      "community": 153,
       "file_type": "code",
       "id": "billingdetailssection_clearform",
       "label": "clearForm()",
@@ -34033,7 +33961,7 @@
       "source_location": "L18"
     },
     {
-      "community": 154,
+      "community": 153,
       "file_type": "code",
       "id": "billingdetailssection_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -34042,7 +33970,7 @@
       "source_location": "L52"
     },
     {
-      "community": 154,
+      "community": 153,
       "file_type": "code",
       "id": "billingdetailssection_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -34051,7 +33979,7 @@
       "source_location": "L68"
     },
     {
-      "community": 154,
+      "community": 153,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetailssection_tsx",
       "label": "BillingDetailsSection.tsx",
@@ -34060,7 +33988,7 @@
       "source_location": "L1"
     },
     {
-      "community": 155,
+      "community": 154,
       "file_type": "code",
       "id": "hooks_usegetshopsearchparams",
       "label": "useGetShopSearchParams()",
@@ -34069,7 +33997,7 @@
       "source_location": "L68"
     },
     {
-      "community": 155,
+      "community": 154,
       "file_type": "code",
       "id": "hooks_usegetstorecategories",
       "label": "useGetStoreCategories()",
@@ -34078,7 +34006,7 @@
       "source_location": "L26"
     },
     {
-      "community": 155,
+      "community": 154,
       "file_type": "code",
       "id": "hooks_usegetstoresubcategories",
       "label": "useGetStoreSubcategories()",
@@ -34087,7 +34015,7 @@
       "source_location": "L7"
     },
     {
-      "community": 155,
+      "community": 154,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
       "label": "hooks.ts",
@@ -34096,7 +34024,7 @@
       "source_location": "L1"
     },
     {
-      "community": 156,
+      "community": 155,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -34105,7 +34033,7 @@
       "source_location": "L1"
     },
     {
-      "community": 156,
+      "community": 155,
       "file_type": "code",
       "id": "productdetails_bagproduct",
       "label": "BagProduct()",
@@ -34114,7 +34042,7 @@
       "source_location": "L43"
     },
     {
-      "community": 156,
+      "community": 155,
       "file_type": "code",
       "id": "productdetails_pickupdetails",
       "label": "PickupDetails()",
@@ -34123,7 +34051,7 @@
       "source_location": "L13"
     },
     {
-      "community": 156,
+      "community": 155,
       "file_type": "code",
       "id": "productdetails_shippingpolicy",
       "label": "ShippingPolicy()",
@@ -34132,7 +34060,7 @@
       "source_location": "L88"
     },
     {
-      "community": 157,
+      "community": 156,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
       "label": "UpsellModal.tsx",
@@ -34141,7 +34069,7 @@
       "source_location": "L1"
     },
     {
-      "community": 157,
+      "community": 156,
       "file_type": "code",
       "id": "upsellmodal_handleclose",
       "label": "handleClose()",
@@ -34150,7 +34078,7 @@
       "source_location": "L111"
     },
     {
-      "community": 157,
+      "community": 156,
       "file_type": "code",
       "id": "upsellmodal_handlescroll",
       "label": "handleScroll()",
@@ -34159,13 +34087,49 @@
       "source_location": "L66"
     },
     {
-      "community": 157,
+      "community": 156,
       "file_type": "code",
       "id": "upsellmodal_handlesuccess",
       "label": "handleSuccess()",
       "norm_label": "handlesuccess()",
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
       "source_location": "L127"
+    },
+    {
+      "community": 157,
+      "file_type": "code",
+      "id": "currency_todisplayamount",
+      "label": "toDisplayAmount()",
+      "norm_label": "todisplayamount()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 157,
+      "file_type": "code",
+      "id": "currency_topesewas",
+      "label": "toPesewas()",
+      "norm_label": "topesewas()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 157,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_lib_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/athena-webapp/convex/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 157,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L1"
     },
     {
       "community": 158,
@@ -40074,92 +40038,92 @@
     {
       "community": 30,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_pos_ts",
-      "label": "pos.ts",
-      "norm_label": "pos.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
+      "id": "packages_athena_webapp_convex_inventory_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
       "source_location": "L1"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "pos_collectallpages",
-      "label": "collectAllPages()",
-      "norm_label": "collectallpages()",
-      "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L19"
+      "id": "packages_athena_webapp_src_components_orders_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "pos_createtransactionfromsessionhandler",
-      "label": "createTransactionFromSessionHandler()",
-      "norm_label": "createtransactionfromsessionhandler()",
-      "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L939"
+      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "pos_isconvexproductid",
-      "label": "isConvexProductId()",
-      "norm_label": "isconvexproductid()",
-      "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L15"
+      "id": "utils_formatdeliveryaddress",
+      "label": "formatDeliveryAddress()",
+      "norm_label": "formatdeliveryaddress()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L74"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "pos_listcompletedtransactionsforday",
-      "label": "listCompletedTransactionsForDay()",
-      "norm_label": "listcompletedtransactionsforday()",
-      "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L92"
+      "id": "utils_getamountpaidfororder",
+      "label": "getAmountPaidForOrder()",
+      "norm_label": "getamountpaidfororder()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L108"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "pos_listproductskusbyproductid",
-      "label": "listProductSkusByProductId()",
-      "norm_label": "listproductskusbyproductid()",
-      "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L41"
+      "id": "utils_getdiscountvalue",
+      "label": "getDiscountValue()",
+      "norm_label": "getdiscountvalue()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L17"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "pos_listsessionitems",
-      "label": "listSessionItems()",
-      "norm_label": "listsessionitems()",
-      "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L83"
+      "id": "utils_getorderamount",
+      "label": "getOrderAmount()",
+      "norm_label": "getorderamount()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L51"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "pos_liststoreproducts",
-      "label": "listStoreProducts()",
-      "norm_label": "liststoreproducts()",
-      "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L53"
+      "id": "utils_getorderstate",
+      "label": "getOrderState()",
+      "norm_label": "getorderstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "pos_liststoreskus",
-      "label": "listStoreSkus()",
-      "norm_label": "liststoreskus()",
-      "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L62"
+      "id": "utils_getpotentialpoints",
+      "label": "getPotentialPoints()",
+      "norm_label": "getpotentialpoints()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L107"
     },
     {
       "community": 30,
       "file_type": "code",
-      "id": "pos_listtransactionitems",
-      "label": "listTransactionItems()",
-      "norm_label": "listtransactionitems()",
-      "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
-      "source_location": "L71"
+      "id": "utils_getproductdiscountvalue",
+      "label": "getProductDiscountValue()",
+      "norm_label": "getproductdiscountvalue()",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "source_location": "L75"
     },
     {
       "community": 300,
@@ -40344,92 +40308,92 @@
     {
       "community": 31,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
-      "source_location": "L1"
+      "id": "heroheaderimageuploader_editmodebuttons",
+      "label": "EditModeButtons()",
+      "norm_label": "editmodebuttons()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
+      "source_location": "L179"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "utils_formatdeliveryaddress",
-      "label": "formatDeliveryAddress()",
-      "norm_label": "formatdeliveryaddress()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "utils_getamountpaidfororder",
-      "label": "getAmountPaidForOrder()",
-      "norm_label": "getamountpaidfororder()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "id": "heroheaderimageuploader_handleeditclick",
+      "label": "handleEditClick()",
+      "norm_label": "handleeditclick()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L108"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "utils_getdiscountvalue",
-      "label": "getDiscountValue()",
-      "norm_label": "getdiscountvalue()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L17"
+      "id": "heroheaderimageuploader_handlefileselect",
+      "label": "handleFileSelect()",
+      "norm_label": "handlefileselect()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
+      "source_location": "L113"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "utils_getorderamount",
-      "label": "getOrderAmount()",
-      "norm_label": "getorderamount()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L51"
+      "id": "heroheaderimageuploader_handlerevert",
+      "label": "handleRevert()",
+      "norm_label": "handlerevert()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
+      "source_location": "L163"
     },
     {
       "community": 31,
       "file_type": "code",
-      "id": "utils_getorderstate",
-      "label": "getOrderState()",
-      "norm_label": "getorderstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "id": "heroheaderimageuploader_handleupload",
+      "label": "handleUpload()",
+      "norm_label": "handleupload()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
+      "source_location": "L127"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "heroheaderimageuploader_reseteditstate",
+      "label": "resetEditState()",
+      "norm_label": "reseteditstate()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
+      "source_location": "L95"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "heroheaderimageuploader_uploadimage",
+      "label": "uploadImage()",
+      "norm_label": "uploadimage()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
+      "source_location": "L67"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "heroheaderimageuploader_validatefile",
+      "label": "validateFile()",
+      "norm_label": "validatefile()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "heroheaderimageuploader_viewmodebutton",
+      "label": "ViewModeButton()",
+      "norm_label": "viewmodebutton()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
+      "source_location": "L205"
+    },
+    {
+      "community": 31,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_heroheaderimageuploader_tsx",
+      "label": "HeroHeaderImageUploader.tsx",
+      "norm_label": "heroheaderimageuploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "utils_getpotentialpoints",
-      "label": "getPotentialPoints()",
-      "norm_label": "getpotentialpoints()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 31,
-      "file_type": "code",
-      "id": "utils_getproductdiscountvalue",
-      "label": "getProductDiscountValue()",
-      "norm_label": "getproductdiscountvalue()",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
-      "source_location": "L75"
     },
     {
       "community": 310,
@@ -40614,92 +40578,92 @@
     {
       "community": 32,
       "file_type": "code",
-      "id": "heroheaderimageuploader_editmodebuttons",
-      "label": "EditModeButtons()",
-      "norm_label": "editmodebuttons()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
-      "source_location": "L179"
-    },
-    {
-      "community": 32,
-      "file_type": "code",
-      "id": "heroheaderimageuploader_handleeditclick",
-      "label": "handleEditClick()",
-      "norm_label": "handleeditclick()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
-      "source_location": "L108"
-    },
-    {
-      "community": 32,
-      "file_type": "code",
-      "id": "heroheaderimageuploader_handlefileselect",
-      "label": "handleFileSelect()",
-      "norm_label": "handlefileselect()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
-      "source_location": "L113"
-    },
-    {
-      "community": 32,
-      "file_type": "code",
-      "id": "heroheaderimageuploader_handlerevert",
-      "label": "handleRevert()",
-      "norm_label": "handlerevert()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
-      "source_location": "L163"
-    },
-    {
-      "community": 32,
-      "file_type": "code",
-      "id": "heroheaderimageuploader_handleupload",
-      "label": "handleUpload()",
-      "norm_label": "handleupload()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
-      "source_location": "L127"
-    },
-    {
-      "community": 32,
-      "file_type": "code",
-      "id": "heroheaderimageuploader_reseteditstate",
-      "label": "resetEditState()",
-      "norm_label": "reseteditstate()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
-      "source_location": "L95"
-    },
-    {
-      "community": 32,
-      "file_type": "code",
-      "id": "heroheaderimageuploader_uploadimage",
-      "label": "uploadImage()",
-      "norm_label": "uploadimage()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
-      "source_location": "L67"
-    },
-    {
-      "community": 32,
-      "file_type": "code",
-      "id": "heroheaderimageuploader_validatefile",
-      "label": "validateFile()",
-      "norm_label": "validatefile()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 32,
-      "file_type": "code",
-      "id": "heroheaderimageuploader_viewmodebutton",
-      "label": "ViewModeButton()",
-      "norm_label": "viewmodebutton()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
-      "source_location": "L205"
-    },
-    {
-      "community": 32,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_heroheaderimageuploader_tsx",
-      "label": "HeroHeaderImageUploader.tsx",
-      "norm_label": "heroheaderimageuploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroHeaderImageUploader.tsx",
+      "id": "packages_athena_webapp_src_tests_pos_simple_test_ts",
+      "label": "simple.test.ts",
+      "norm_label": "simple.test.ts",
+      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 32,
+      "file_type": "code",
+      "id": "simple_test_addtocart",
+      "label": "addToCart()",
+      "norm_label": "addtocart()",
+      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
+      "source_location": "L249"
+    },
+    {
+      "community": 32,
+      "file_type": "code",
+      "id": "simple_test_formatcurrency",
+      "label": "formatCurrency()",
+      "norm_label": "formatcurrency()",
+      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
+      "source_location": "L173"
+    },
+    {
+      "community": 32,
+      "file_type": "code",
+      "id": "simple_test_formatpaymentmethod",
+      "label": "formatPaymentMethod()",
+      "norm_label": "formatpaymentmethod()",
+      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
+      "source_location": "L201"
+    },
+    {
+      "community": 32,
+      "file_type": "code",
+      "id": "simple_test_formatreceiptdate",
+      "label": "formatReceiptDate()",
+      "norm_label": "formatreceiptdate()",
+      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
+      "source_location": "L225"
+    },
+    {
+      "community": 32,
+      "file_type": "code",
+      "id": "simple_test_generatetransactionnumber",
+      "label": "generateTransactionNumber()",
+      "norm_label": "generatetransactionnumber()",
+      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 32,
+      "file_type": "code",
+      "id": "simple_test_removefromcart",
+      "label": "removeFromCart()",
+      "norm_label": "removefromcart()",
+      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
+      "source_location": "L288"
+    },
+    {
+      "community": 32,
+      "file_type": "code",
+      "id": "simple_test_updatequantity",
+      "label": "updateQuantity()",
+      "norm_label": "updatequantity()",
+      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
+      "source_location": "L311"
+    },
+    {
+      "community": 32,
+      "file_type": "code",
+      "id": "simple_test_validateinventory",
+      "label": "validateInventory()",
+      "norm_label": "validateinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 32,
+      "file_type": "code",
+      "id": "simple_test_validateinventorywithaggregation",
+      "label": "validateInventoryWithAggregation()",
+      "norm_label": "validateinventorywithaggregation()",
+      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
+      "source_location": "L130"
     },
     {
       "community": 320,
@@ -40884,92 +40848,92 @@
     {
       "community": 33,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_tests_pos_simple_test_ts",
-      "label": "simple.test.ts",
-      "norm_label": "simple.test.ts",
-      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
+      "id": "packages_storefront_webapp_src_api_rewards_ts",
+      "label": "rewards.ts",
+      "norm_label": "rewards.ts",
+      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
       "source_location": "L1"
     },
     {
       "community": 33,
       "file_type": "code",
-      "id": "simple_test_addtocart",
-      "label": "addToCart()",
-      "norm_label": "addtocart()",
-      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
-      "source_location": "L249"
+      "id": "rewards_awardpointsforguestorders",
+      "label": "awardPointsForGuestOrders()",
+      "norm_label": "awardpointsforguestorders()",
+      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
+      "source_location": "L198"
     },
     {
       "community": 33,
       "file_type": "code",
-      "id": "simple_test_formatcurrency",
-      "label": "formatCurrency()",
-      "norm_label": "formatcurrency()",
-      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
-      "source_location": "L173"
+      "id": "rewards_awardpointsforpastorder",
+      "label": "awardPointsForPastOrder()",
+      "norm_label": "awardpointsforpastorder()",
+      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
+      "source_location": "L151"
     },
     {
       "community": 33,
       "file_type": "code",
-      "id": "simple_test_formatpaymentmethod",
-      "label": "formatPaymentMethod()",
-      "norm_label": "formatpaymentmethod()",
-      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
-      "source_location": "L201"
+      "id": "rewards_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
+      "source_location": "L3"
     },
     {
       "community": 33,
       "file_type": "code",
-      "id": "simple_test_formatreceiptdate",
-      "label": "formatReceiptDate()",
-      "norm_label": "formatreceiptdate()",
-      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
-      "source_location": "L225"
+      "id": "rewards_geteligiblepastorders",
+      "label": "getEligiblePastOrders()",
+      "norm_label": "geteligiblepastorders()",
+      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
+      "source_location": "L129"
     },
     {
       "community": 33,
       "file_type": "code",
-      "id": "simple_test_generatetransactionnumber",
-      "label": "generateTransactionNumber()",
-      "norm_label": "generatetransactionnumber()",
-      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
-      "source_location": "L38"
+      "id": "rewards_getorderrewardpoints",
+      "label": "getOrderRewardPoints()",
+      "norm_label": "getorderrewardpoints()",
+      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
+      "source_location": "L175"
     },
     {
       "community": 33,
       "file_type": "code",
-      "id": "simple_test_removefromcart",
-      "label": "removeFromCart()",
-      "norm_label": "removefromcart()",
-      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
-      "source_location": "L288"
+      "id": "rewards_getpointhistory",
+      "label": "getPointHistory()",
+      "norm_label": "getpointhistory()",
+      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
+      "source_location": "L71"
     },
     {
       "community": 33,
       "file_type": "code",
-      "id": "simple_test_updatequantity",
-      "label": "updateQuantity()",
-      "norm_label": "updatequantity()",
-      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
-      "source_location": "L311"
+      "id": "rewards_getrewardtiers",
+      "label": "getRewardTiers()",
+      "norm_label": "getrewardtiers()",
+      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
+      "source_location": "L90"
     },
     {
       "community": 33,
       "file_type": "code",
-      "id": "simple_test_validateinventory",
-      "label": "validateInventory()",
-      "norm_label": "validateinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
-      "source_location": "L77"
+      "id": "rewards_getuserpoints",
+      "label": "getUserPoints()",
+      "norm_label": "getuserpoints()",
+      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
+      "source_location": "L54"
     },
     {
       "community": 33,
       "file_type": "code",
-      "id": "simple_test_validateinventorywithaggregation",
-      "label": "validateInventoryWithAggregation()",
-      "norm_label": "validateinventorywithaggregation()",
-      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
-      "source_location": "L130"
+      "id": "rewards_redeemrewardpoints",
+      "label": "redeemRewardPoints()",
+      "norm_label": "redeemrewardpoints()",
+      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
+      "source_location": "L107"
     },
     {
       "community": 330,
@@ -41154,92 +41118,92 @@
     {
       "community": 34,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_rewards_ts",
-      "label": "rewards.ts",
-      "norm_label": "rewards.ts",
-      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 34,
-      "file_type": "code",
-      "id": "rewards_awardpointsforguestorders",
-      "label": "awardPointsForGuestOrders()",
-      "norm_label": "awardpointsforguestorders()",
-      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
-      "source_location": "L198"
-    },
-    {
-      "community": 34,
-      "file_type": "code",
-      "id": "rewards_awardpointsforpastorder",
-      "label": "awardPointsForPastOrder()",
-      "norm_label": "awardpointsforpastorder()",
-      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
-      "source_location": "L151"
-    },
-    {
-      "community": 34,
-      "file_type": "code",
-      "id": "rewards_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 34,
-      "file_type": "code",
-      "id": "rewards_geteligiblepastorders",
-      "label": "getEligiblePastOrders()",
-      "norm_label": "geteligiblepastorders()",
-      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
+      "id": "graphify_rebuild_comparedeterministically",
+      "label": "compareDeterministically()",
+      "norm_label": "comparedeterministically()",
+      "source_file": "scripts/graphify-rebuild.ts",
       "source_location": "L129"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "rewards_getorderrewardpoints",
-      "label": "getOrderRewardPoints()",
-      "norm_label": "getorderrewardpoints()",
-      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
-      "source_location": "L175"
+      "id": "graphify_rebuild_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L89"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "rewards_getpointhistory",
-      "label": "getPointHistory()",
-      "norm_label": "getpointhistory()",
-      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
-      "source_location": "L71"
+      "id": "graphify_rebuild_isjsonobject",
+      "label": "isJsonObject()",
+      "norm_label": "isjsonobject()",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L125"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "rewards_getrewardtiers",
-      "label": "getRewardTiers()",
-      "norm_label": "getrewardtiers()",
-      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
-      "source_location": "L90"
+      "id": "graphify_rebuild_normalizegraphjsonartifact",
+      "label": "normalizeGraphJsonArtifact()",
+      "norm_label": "normalizegraphjsonartifact()",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L179"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "rewards_getuserpoints",
-      "label": "getUserPoints()",
-      "norm_label": "getuserpoints()",
-      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
-      "source_location": "L54"
+      "id": "graphify_rebuild_normalizegraphjsoncontents",
+      "label": "normalizeGraphJsonContents()",
+      "norm_label": "normalizegraphjsoncontents()",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L163"
     },
     {
       "community": 34,
       "file_type": "code",
-      "id": "rewards_redeemrewardpoints",
-      "label": "redeemRewardPoints()",
-      "norm_label": "redeemrewardpoints()",
-      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
-      "source_location": "L107"
+      "id": "graphify_rebuild_resolvegraphifypython",
+      "label": "resolveGraphifyPython()",
+      "norm_label": "resolvegraphifypython()",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L98"
+    },
+    {
+      "community": 34,
+      "file_type": "code",
+      "id": "graphify_rebuild_rungraphifyrebuild",
+      "label": "runGraphifyRebuild()",
+      "norm_label": "rungraphifyrebuild()",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L189"
+    },
+    {
+      "community": 34,
+      "file_type": "code",
+      "id": "graphify_rebuild_sortjsonarray",
+      "label": "sortJsonArray()",
+      "norm_label": "sortjsonarray()",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L157"
+    },
+    {
+      "community": 34,
+      "file_type": "code",
+      "id": "graphify_rebuild_sortjsonvalue",
+      "label": "sortJsonValue()",
+      "norm_label": "sortjsonvalue()",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L141"
+    },
+    {
+      "community": 34,
+      "file_type": "code",
+      "id": "scripts_graphify_rebuild_ts",
+      "label": "graphify-rebuild.ts",
+      "norm_label": "graphify-rebuild.ts",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L1"
     },
     {
       "community": 340,
@@ -41424,92 +41388,83 @@
     {
       "community": 35,
       "file_type": "code",
-      "id": "graphify_rebuild_comparedeterministically",
-      "label": "compareDeterministically()",
-      "norm_label": "comparedeterministically()",
-      "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L129"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "graphify_rebuild_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L89"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "graphify_rebuild_isjsonobject",
-      "label": "isJsonObject()",
-      "norm_label": "isjsonobject()",
-      "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L125"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "graphify_rebuild_normalizegraphjsonartifact",
-      "label": "normalizeGraphJsonArtifact()",
-      "norm_label": "normalizegraphjsonartifact()",
-      "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L179"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "graphify_rebuild_normalizegraphjsoncontents",
-      "label": "normalizeGraphJsonContents()",
-      "norm_label": "normalizegraphjsoncontents()",
-      "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L163"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "graphify_rebuild_resolvegraphifypython",
-      "label": "resolveGraphifyPython()",
-      "norm_label": "resolvegraphifypython()",
-      "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L98"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "graphify_rebuild_rungraphifyrebuild",
-      "label": "runGraphifyRebuild()",
-      "norm_label": "rungraphifyrebuild()",
-      "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L189"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "graphify_rebuild_sortjsonarray",
-      "label": "sortJsonArray()",
-      "norm_label": "sortjsonarray()",
-      "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L157"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "graphify_rebuild_sortjsonvalue",
-      "label": "sortJsonValue()",
-      "norm_label": "sortjsonvalue()",
-      "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L141"
-    },
-    {
-      "community": 35,
-      "file_type": "code",
-      "id": "scripts_graphify_rebuild_ts",
-      "label": "graphify-rebuild.ts",
-      "norm_label": "graphify-rebuild.ts",
-      "source_file": "scripts/graphify-rebuild.ts",
+      "id": "packages_athena_webapp_convex_inventory_pos_ts",
+      "label": "pos.ts",
+      "norm_label": "pos.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "pos_createtransactionfromsessionhandler",
+      "label": "createTransactionFromSessionHandler()",
+      "norm_label": "createtransactionfromsessionhandler()",
+      "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
+      "source_location": "L908"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "pos_isconvexproductid",
+      "label": "isConvexProductId()",
+      "norm_label": "isconvexproductid()",
+      "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "pos_listcompletedtransactionsforday",
+      "label": "listCompletedTransactionsForDay()",
+      "norm_label": "listcompletedtransactionsforday()",
+      "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "pos_listmatchingstoreskus",
+      "label": "listMatchingStoreSkus()",
+      "norm_label": "listmatchingstoreskus()",
+      "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "pos_listproductskusbyproductid",
+      "label": "listProductSkusByProductId()",
+      "norm_label": "listproductskusbyproductid()",
+      "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "pos_listsessionitems",
+      "label": "listSessionItems()",
+      "norm_label": "listsessionitems()",
+      "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
+      "source_location": "L93"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "pos_listtransactionitems",
+      "label": "listTransactionItems()",
+      "norm_label": "listtransactionitems()",
+      "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
+      "source_location": "L82"
+    },
+    {
+      "community": 35,
+      "file_type": "code",
+      "id": "pos_readallqueryresults",
+      "label": "readAllQueryResults()",
+      "norm_label": "readallqueryresults()",
+      "source_file": "packages/athena-webapp/convex/inventory/pos.ts",
+      "source_location": "L14"
     },
     {
       "community": 350,
@@ -43251,73 +43206,73 @@
     {
       "community": 41,
       "file_type": "code",
-      "id": "config_buildmtncollectionscallbackurl",
-      "label": "buildMtnCollectionsCallbackUrl()",
-      "norm_label": "buildmtncollectionscallbackurl()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L135"
+      "id": "index_senddiscountcodeemail",
+      "label": "sendDiscountCodeEmail()",
+      "norm_label": "senddiscountcodeemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L255"
     },
     {
       "community": 41,
       "file_type": "code",
-      "id": "config_buildmtncollectionslookupprefixes",
-      "label": "buildMtnCollectionsLookupPrefixes()",
-      "norm_label": "buildmtncollectionslookupprefixes()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "id": "index_senddiscountreminderemail",
+      "label": "sendDiscountReminderEmail()",
+      "norm_label": "senddiscountreminderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L334"
+    },
+    {
+      "community": 41,
+      "file_type": "code",
+      "id": "index_sendfeedbackrequestemail",
+      "label": "sendFeedbackRequestEmail()",
+      "norm_label": "sendfeedbackrequestemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 41,
+      "file_type": "code",
+      "id": "index_sendneworderemail",
+      "label": "sendNewOrderEmail()",
+      "norm_label": "sendneworderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L117"
+    },
+    {
+      "community": 41,
+      "file_type": "code",
+      "id": "index_sendorderemail",
+      "label": "sendOrderEmail()",
+      "norm_label": "sendorderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L43"
     },
     {
       "community": 41,
       "file_type": "code",
-      "id": "config_istargetenvironment",
-      "label": "isTargetEnvironment()",
-      "norm_label": "istargetenvironment()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L67"
+      "id": "index_sendverificationcode",
+      "label": "sendVerificationCode()",
+      "norm_label": "sendverificationcode()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L3"
     },
     {
       "community": 41,
       "file_type": "code",
-      "id": "config_readscopedvalue",
-      "label": "readScopedValue()",
-      "norm_label": "readscopedvalue()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L56"
+      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "source_location": "L1"
     },
     {
       "community": 41,
       "file_type": "code",
-      "id": "config_resolveconfigforprefix",
-      "label": "resolveConfigForPrefix()",
-      "norm_label": "resolveconfigforprefix()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 41,
-      "file_type": "code",
-      "id": "config_resolvemtncollectionsconfigfromenv",
-      "label": "resolveMtnCollectionsConfigFromEnv()",
-      "norm_label": "resolvemtncollectionsconfigfromenv()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L108"
-    },
-    {
-      "community": 41,
-      "file_type": "code",
-      "id": "config_toenvsegment",
-      "label": "toEnvSegment()",
-      "norm_label": "toenvsegment()",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 41,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_config_ts",
-      "label": "config.ts",
-      "norm_label": "config.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L1"
     },
     {
@@ -43503,73 +43458,73 @@
     {
       "community": 42,
       "file_type": "code",
-      "id": "index_senddiscountcodeemail",
-      "label": "sendDiscountCodeEmail()",
-      "norm_label": "senddiscountcodeemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L255"
+      "id": "config_buildmtncollectionscallbackurl",
+      "label": "buildMtnCollectionsCallbackUrl()",
+      "norm_label": "buildmtncollectionscallbackurl()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L135"
     },
     {
       "community": 42,
       "file_type": "code",
-      "id": "index_senddiscountreminderemail",
-      "label": "sendDiscountReminderEmail()",
-      "norm_label": "senddiscountreminderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L334"
-    },
-    {
-      "community": 42,
-      "file_type": "code",
-      "id": "index_sendfeedbackrequestemail",
-      "label": "sendFeedbackRequestEmail()",
-      "norm_label": "sendfeedbackrequestemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L167"
-    },
-    {
-      "community": 42,
-      "file_type": "code",
-      "id": "index_sendneworderemail",
-      "label": "sendNewOrderEmail()",
-      "norm_label": "sendneworderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L117"
-    },
-    {
-      "community": 42,
-      "file_type": "code",
-      "id": "index_sendorderemail",
-      "label": "sendOrderEmail()",
-      "norm_label": "sendorderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "id": "config_buildmtncollectionslookupprefixes",
+      "label": "buildMtnCollectionsLookupPrefixes()",
+      "norm_label": "buildmtncollectionslookupprefixes()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L43"
     },
     {
       "community": 42,
       "file_type": "code",
-      "id": "index_sendverificationcode",
-      "label": "sendVerificationCode()",
-      "norm_label": "sendverificationcode()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L3"
+      "id": "config_istargetenvironment",
+      "label": "isTargetEnvironment()",
+      "norm_label": "istargetenvironment()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L67"
     },
     {
       "community": 42,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
-      "source_location": "L1"
+      "id": "config_readscopedvalue",
+      "label": "readScopedValue()",
+      "norm_label": "readscopedvalue()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L56"
     },
     {
       "community": 42,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "id": "config_resolveconfigforprefix",
+      "label": "resolveConfigForPrefix()",
+      "norm_label": "resolveconfigforprefix()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 42,
+      "file_type": "code",
+      "id": "config_resolvemtncollectionsconfigfromenv",
+      "label": "resolveMtnCollectionsConfigFromEnv()",
+      "norm_label": "resolvemtncollectionsconfigfromenv()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L108"
+    },
+    {
+      "community": 42,
+      "file_type": "code",
+      "id": "config_toenvsegment",
+      "label": "toEnvSegment()",
+      "norm_label": "toenvsegment()",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 42,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_config_ts",
+      "label": "config.ts",
+      "norm_label": "config.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/config.ts",
       "source_location": "L1"
     },
     {
@@ -50199,56 +50154,56 @@
     {
       "community": 72,
       "file_type": "code",
-      "id": "image_uploader_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L100"
-    },
-    {
-      "community": 72,
-      "file_type": "code",
-      "id": "image_uploader_ondrop",
-      "label": "onDrop()",
-      "norm_label": "ondrop()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 72,
-      "file_type": "code",
-      "id": "image_uploader_removeimage",
-      "label": "removeImage()",
-      "norm_label": "removeimage()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 72,
-      "file_type": "code",
-      "id": "image_uploader_unmarkfordeletion",
-      "label": "unmarkForDeletion()",
-      "norm_label": "unmarkfordeletion()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 72,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
+      "label": "sidebar.tsx",
+      "norm_label": "sidebar.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
       "source_location": "L1"
     },
     {
       "community": 72,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
+      "id": "sidebar_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L147"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "sidebar_handlekeydown",
+      "label": "handleKeyDown()",
+      "norm_label": "handlekeydown()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L105"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "sidebar_handleonhover",
+      "label": "handleOnHover()",
+      "norm_label": "handleonhover()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L224"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "sidebar_handleonmouseleave",
+      "label": "handleOnMouseLeave()",
+      "norm_label": "handleonmouseleave()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L228"
+    },
+    {
+      "community": 72,
+      "file_type": "code",
+      "id": "sidebar_usesidebar",
+      "label": "useSidebar()",
+      "norm_label": "usesidebar()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L45"
     },
     {
       "community": 720,
@@ -50343,56 +50298,56 @@
     {
       "community": 73,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
-      "label": "sidebar.tsx",
-      "norm_label": "sidebar.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
+      "label": "useBulkOperations.ts",
+      "norm_label": "usebulkoperations.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
       "source_location": "L1"
     },
     {
       "community": 73,
       "file_type": "code",
-      "id": "sidebar_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L147"
+      "id": "usebulkoperations_applyoperation",
+      "label": "applyOperation()",
+      "norm_label": "applyoperation()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L56"
     },
     {
       "community": 73,
       "file_type": "code",
-      "id": "sidebar_handlekeydown",
-      "label": "handleKeyDown()",
-      "norm_label": "handlekeydown()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L105"
+      "id": "usebulkoperations_calculatepricewithfee",
+      "label": "calculatePriceWithFee()",
+      "norm_label": "calculatepricewithfee()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L87"
     },
     {
       "community": 73,
       "file_type": "code",
-      "id": "sidebar_handleonhover",
-      "label": "handleOnHover()",
-      "norm_label": "handleonhover()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L224"
+      "id": "usebulkoperations_computepreview",
+      "label": "computePreview()",
+      "norm_label": "computepreview()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L101"
     },
     {
       "community": 73,
       "file_type": "code",
-      "id": "sidebar_handleonmouseleave",
-      "label": "handleOnMouseLeave()",
-      "norm_label": "handleonmouseleave()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L228"
+      "id": "usebulkoperations_usebulkoperations",
+      "label": "useBulkOperations()",
+      "norm_label": "usebulkoperations()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L158"
     },
     {
       "community": 73,
       "file_type": "code",
-      "id": "sidebar_usesidebar",
-      "label": "useSidebar()",
-      "norm_label": "usesidebar()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L45"
+      "id": "usebulkoperations_validateoperationvalue",
+      "label": "validateOperationValue()",
+      "norm_label": "validateoperationvalue()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L139"
     },
     {
       "community": 730,
@@ -50487,56 +50442,56 @@
     {
       "community": 74,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
-      "label": "useBulkOperations.ts",
-      "norm_label": "usebulkoperations.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
+      "label": "useExpenseSessions.ts",
+      "norm_label": "useexpensesessions.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
       "source_location": "L1"
     },
     {
       "community": 74,
       "file_type": "code",
-      "id": "usebulkoperations_applyoperation",
-      "label": "applyOperation()",
-      "norm_label": "applyoperation()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L56"
+      "id": "useexpensesessions_useexpenseactivesession",
+      "label": "useExpenseActiveSession()",
+      "norm_label": "useexpenseactivesession()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L33"
     },
     {
       "community": 74,
       "file_type": "code",
-      "id": "usebulkoperations_calculatepricewithfee",
-      "label": "calculatePriceWithFee()",
-      "norm_label": "calculatepricewithfee()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L87"
+      "id": "useexpensesessions_useexpensesession",
+      "label": "useExpenseSession()",
+      "norm_label": "useexpensesession()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L23"
     },
     {
       "community": 74,
       "file_type": "code",
-      "id": "usebulkoperations_computepreview",
-      "label": "computePreview()",
-      "norm_label": "computepreview()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L101"
+      "id": "useexpensesessions_useexpensesessioncreate",
+      "label": "useExpenseSessionCreate()",
+      "norm_label": "useexpensesessioncreate()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L48"
     },
     {
       "community": 74,
       "file_type": "code",
-      "id": "usebulkoperations_usebulkoperations",
-      "label": "useBulkOperations()",
-      "norm_label": "usebulkoperations()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L158"
+      "id": "useexpensesessions_useexpensesessionupdate",
+      "label": "useExpenseSessionUpdate()",
+      "norm_label": "useexpensesessionupdate()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L85"
     },
     {
       "community": 74,
       "file_type": "code",
-      "id": "usebulkoperations_validateoperationvalue",
-      "label": "validateOperationValue()",
-      "norm_label": "validateoperationvalue()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L139"
+      "id": "useexpensesessions_useexpensestoresessions",
+      "label": "useExpenseStoreSessions()",
+      "norm_label": "useexpensestoresessions()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L7"
     },
     {
       "community": 740,
@@ -50631,56 +50586,56 @@
     {
       "community": 75,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
-      "label": "useExpenseSessions.ts",
-      "norm_label": "useexpensesessions.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "id": "packages_athena_webapp_src_hooks_useposcustomers_ts",
+      "label": "usePOSCustomers.ts",
+      "norm_label": "useposcustomers.ts",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L1"
     },
     {
       "community": 75,
       "file_type": "code",
-      "id": "useexpensesessions_useexpenseactivesession",
-      "label": "useExpenseActiveSession()",
-      "norm_label": "useexpenseactivesession()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L33"
+      "id": "useposcustomers_useposcustomer",
+      "label": "usePOSCustomer()",
+      "norm_label": "useposcustomer()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
+      "source_location": "L18"
     },
     {
       "community": 75,
       "file_type": "code",
-      "id": "useexpensesessions_useexpensesession",
-      "label": "useExpenseSession()",
-      "norm_label": "useexpensesession()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L23"
+      "id": "useposcustomers_useposcustomercreate",
+      "label": "usePOSCustomerCreate()",
+      "norm_label": "useposcustomercreate()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
+      "source_location": "L26"
     },
     {
       "community": 75,
       "file_type": "code",
-      "id": "useexpensesessions_useexpensesessioncreate",
-      "label": "useExpenseSessionCreate()",
-      "norm_label": "useexpensesessioncreate()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensesessionupdate",
-      "label": "useExpenseSessionUpdate()",
-      "norm_label": "useexpensesessionupdate()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensestoresessions",
-      "label": "useExpenseStoreSessions()",
-      "norm_label": "useexpensestoresessions()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "id": "useposcustomers_useposcustomersearch",
+      "label": "usePOSCustomerSearch()",
+      "norm_label": "useposcustomersearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
       "source_location": "L7"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "useposcustomers_useposcustomertransactions",
+      "label": "usePOSCustomerTransactions()",
+      "norm_label": "useposcustomertransactions()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
+      "source_location": "L90"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "useposcustomers_useposcustomerupdate",
+      "label": "usePOSCustomerUpdate()",
+      "norm_label": "useposcustomerupdate()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
+      "source_location": "L57"
     },
     {
       "community": 750,
@@ -50775,56 +50730,56 @@
     {
       "community": 76,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useposcustomers_ts",
-      "label": "usePOSCustomers.ts",
-      "norm_label": "useposcustomers.ts",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
+      "id": "behaviorutils_calculateengagementmetrics",
+      "label": "calculateEngagementMetrics()",
+      "norm_label": "calculateengagementmetrics()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L173"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "behaviorutils_calculateriskindicators",
+      "label": "calculateRiskIndicators()",
+      "norm_label": "calculateriskindicators()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "behaviorutils_getactivitypriority",
+      "label": "getActivityPriority()",
+      "norm_label": "getactivitypriority()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L251"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "behaviorutils_getcustomerjourneystage",
+      "label": "getCustomerJourneyStage()",
+      "norm_label": "getcustomerjourneystage()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "behaviorutils_getjourneystageinfo",
+      "label": "getJourneyStageInfo()",
+      "norm_label": "getjourneystageinfo()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L277"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
+      "label": "behaviorUtils.ts",
+      "norm_label": "behaviorutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "useposcustomers_useposcustomer",
-      "label": "usePOSCustomer()",
-      "norm_label": "useposcustomer()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "useposcustomers_useposcustomercreate",
-      "label": "usePOSCustomerCreate()",
-      "norm_label": "useposcustomercreate()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "useposcustomers_useposcustomersearch",
-      "label": "usePOSCustomerSearch()",
-      "norm_label": "useposcustomersearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "useposcustomers_useposcustomertransactions",
-      "label": "usePOSCustomerTransactions()",
-      "norm_label": "useposcustomertransactions()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
-      "source_location": "L90"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "useposcustomers_useposcustomerupdate",
-      "label": "usePOSCustomerUpdate()",
-      "norm_label": "useposcustomerupdate()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
-      "source_location": "L57"
     },
     {
       "community": 760,
@@ -50919,56 +50874,56 @@
     {
       "community": 77,
       "file_type": "code",
-      "id": "behaviorutils_calculateengagementmetrics",
-      "label": "calculateEngagementMetrics()",
-      "norm_label": "calculateengagementmetrics()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L173"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "behaviorutils_calculateriskindicators",
-      "label": "calculateRiskIndicators()",
-      "norm_label": "calculateriskindicators()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "behaviorutils_getactivitypriority",
-      "label": "getActivityPriority()",
-      "norm_label": "getactivitypriority()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L251"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "behaviorutils_getcustomerjourneystage",
-      "label": "getCustomerJourneyStage()",
-      "norm_label": "getcustomerjourneystage()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "behaviorutils_getjourneystageinfo",
-      "label": "getJourneyStageInfo()",
-      "norm_label": "getjourneystageinfo()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L277"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
-      "label": "behaviorUtils.ts",
-      "norm_label": "behaviorutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
+      "label": "toastService.ts",
+      "norm_label": "toastservice.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "toastservice_handleposoperation",
+      "label": "handlePOSOperation()",
+      "norm_label": "handleposoperation()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L171"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "toastservice_showinventoryerror",
+      "label": "showInventoryError()",
+      "norm_label": "showinventoryerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L302"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "toastservice_shownoactivesessionerror",
+      "label": "showNoActiveSessionError()",
+      "norm_label": "shownoactivesessionerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L319"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "toastservice_showsessionexpirederror",
+      "label": "showSessionExpiredError()",
+      "norm_label": "showsessionexpirederror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L312"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "toastservice_showvalidationerror",
+      "label": "showValidationError()",
+      "norm_label": "showvalidationerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L293"
     },
     {
       "community": 770,
@@ -51063,56 +51018,56 @@
     {
       "community": 78,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
-      "label": "toastService.ts",
-      "norm_label": "toastservice.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "id": "organizationsettingsview_handledeletestore",
+      "label": "handleDeleteStore()",
+      "norm_label": "handledeletestore()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L156"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "organizationsettingsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L198"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "organizationsettingsview_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L105"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "organizationsettingsview_organizationsettings",
+      "label": "OrganizationSettings()",
+      "norm_label": "organizationsettings()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L24"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "organizationsettingsview_savestorechanges",
+      "label": "saveStoreChanges()",
+      "norm_label": "savestorechanges()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L71"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
+      "label": "OrganizationSettingsView.tsx",
+      "norm_label": "organizationsettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "toastservice_handleposoperation",
-      "label": "handlePOSOperation()",
-      "norm_label": "handleposoperation()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L171"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "toastservice_showinventoryerror",
-      "label": "showInventoryError()",
-      "norm_label": "showinventoryerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L302"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "toastservice_shownoactivesessionerror",
-      "label": "showNoActiveSessionError()",
-      "norm_label": "shownoactivesessionerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L319"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "toastservice_showsessionexpirederror",
-      "label": "showSessionExpiredError()",
-      "norm_label": "showsessionexpirederror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L312"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "toastservice_showvalidationerror",
-      "label": "showValidationError()",
-      "norm_label": "showvalidationerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L293"
     },
     {
       "community": 780,
@@ -51207,56 +51162,56 @@
     {
       "community": 79,
       "file_type": "code",
-      "id": "organizationsettingsview_handledeletestore",
+      "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
+      "label": "StoreSettingsView.tsx",
+      "norm_label": "storesettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "storesettingsview_handledeleteallproductsinstore",
+      "label": "handleDeleteAllProductsInStore()",
+      "norm_label": "handledeleteallproductsinstore()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L232"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "storesettingsview_handledeletestore",
       "label": "handleDeleteStore()",
       "norm_label": "handledeletestore()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L156"
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L167"
     },
     {
       "community": 79,
       "file_type": "code",
-      "id": "organizationsettingsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L198"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "organizationsettingsview_onsubmit",
+      "id": "storesettingsview_onsubmit",
       "label": "onSubmit()",
       "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L105"
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L116"
     },
     {
       "community": 79,
       "file_type": "code",
-      "id": "organizationsettingsview_organizationsettings",
-      "label": "OrganizationSettings()",
-      "norm_label": "organizationsettings()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L24"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "organizationsettingsview_savestorechanges",
+      "id": "storesettingsview_savestorechanges",
       "label": "saveStoreChanges()",
       "norm_label": "savestorechanges()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L71"
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L82"
     },
     {
       "community": 79,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
-      "label": "OrganizationSettingsView.tsx",
-      "norm_label": "organizationsettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L1"
+      "id": "storesettingsview_storesettings",
+      "label": "StoreSettings()",
+      "norm_label": "storesettings()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L28"
     },
     {
       "community": 790,
@@ -51549,56 +51504,56 @@
     {
       "community": 80,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
-      "label": "StoreSettingsView.tsx",
-      "norm_label": "storesettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "id": "packages_storefront_webapp_src_api_promocodes_ts",
+      "label": "promoCodes.ts",
+      "norm_label": "promocodes.ts",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
       "source_location": "L1"
     },
     {
       "community": 80,
       "file_type": "code",
-      "id": "storesettingsview_handledeleteallproductsinstore",
-      "label": "handleDeleteAllProductsInStore()",
-      "norm_label": "handledeleteallproductsinstore()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L232"
+      "id": "promocodes_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L4"
     },
     {
       "community": 80,
       "file_type": "code",
-      "id": "storesettingsview_handledeletestore",
-      "label": "handleDeleteStore()",
-      "norm_label": "handledeletestore()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L167"
+      "id": "promocodes_getpromocodeitems",
+      "label": "getPromoCodeItems()",
+      "norm_label": "getpromocodeitems()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L49"
     },
     {
       "community": 80,
       "file_type": "code",
-      "id": "storesettingsview_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L116"
+      "id": "promocodes_getpromocodes",
+      "label": "getPromoCodes()",
+      "norm_label": "getpromocodes()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L34"
     },
     {
       "community": 80,
       "file_type": "code",
-      "id": "storesettingsview_savestorechanges",
-      "label": "saveStoreChanges()",
-      "norm_label": "savestorechanges()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L82"
+      "id": "promocodes_getredeemedpromocodes",
+      "label": "getRedeemedPromoCodes()",
+      "norm_label": "getredeemedpromocodes()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L74"
     },
     {
       "community": 80,
       "file_type": "code",
-      "id": "storesettingsview_storesettings",
-      "label": "StoreSettings()",
-      "norm_label": "storesettings()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L28"
+      "id": "promocodes_redeempromocode",
+      "label": "redeemPromoCode()",
+      "norm_label": "redeempromocode()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L6"
     },
     {
       "community": 800,
@@ -51693,56 +51648,56 @@
     {
       "community": 81,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_promocodes_ts",
-      "label": "promoCodes.ts",
-      "norm_label": "promocodes.ts",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "id": "billingdetails_clearform",
+      "label": "clearForm()",
+      "norm_label": "clearform()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L173"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "billingdetails_enteredbillingaddressdetails",
+      "label": "EnteredBillingAddressDetails()",
+      "norm_label": "enteredbillingaddressdetails()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L102"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "billingdetails_handleusebillingaddressonfile",
+      "label": "handleUseBillingAddressOnFile()",
+      "norm_label": "handleusebillingaddressonfile()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L201"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "billingdetails_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L150"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "billingdetails_togglesameasdelivery",
+      "label": "toggleSameAsDelivery()",
+      "norm_label": "togglesameasdelivery()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L155"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
+      "label": "BillingDetails.tsx",
+      "norm_label": "billingdetails.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "promocodes_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "promocodes_getpromocodeitems",
-      "label": "getPromoCodeItems()",
-      "norm_label": "getpromocodeitems()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "promocodes_getpromocodes",
-      "label": "getPromoCodes()",
-      "norm_label": "getpromocodes()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L34"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "promocodes_getredeemedpromocodes",
-      "label": "getRedeemedPromoCodes()",
-      "norm_label": "getredeemedpromocodes()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "promocodes_redeempromocode",
-      "label": "redeemPromoCode()",
-      "norm_label": "redeempromocode()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L6"
     },
     {
       "community": 810,
@@ -51837,55 +51792,55 @@
     {
       "community": 82,
       "file_type": "code",
-      "id": "billingdetails_clearform",
-      "label": "clearForm()",
-      "norm_label": "clearform()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L173"
+      "id": "checkoutexpired_checkoutexpired",
+      "label": "CheckoutExpired()",
+      "norm_label": "checkoutexpired()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L9"
     },
     {
       "community": 82,
       "file_type": "code",
-      "id": "billingdetails_enteredbillingaddressdetails",
-      "label": "EnteredBillingAddressDetails()",
-      "norm_label": "enteredbillingaddressdetails()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L102"
+      "id": "checkoutexpired_checkoutsessiongeneric",
+      "label": "CheckoutSessionGeneric()",
+      "norm_label": "checkoutsessiongeneric()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L73"
     },
     {
       "community": 82,
       "file_type": "code",
-      "id": "billingdetails_handleusebillingaddressonfile",
-      "label": "handleUseBillingAddressOnFile()",
-      "norm_label": "handleusebillingaddressonfile()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L201"
+      "id": "checkoutexpired_checkoutsessionnotfound",
+      "label": "CheckoutSessionNotFound()",
+      "norm_label": "checkoutsessionnotfound()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L54"
     },
     {
       "community": 82,
       "file_type": "code",
-      "id": "billingdetails_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L150"
+      "id": "checkoutexpired_handlesendemail",
+      "label": "handleSendEmail()",
+      "norm_label": "handlesendemail()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L98"
     },
     {
       "community": 82,
       "file_type": "code",
-      "id": "billingdetails_togglesameasdelivery",
-      "label": "toggleSameAsDelivery()",
-      "norm_label": "togglesameasdelivery()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L155"
+      "id": "checkoutexpired_nocheckoutsession",
+      "label": "NoCheckoutSession()",
+      "norm_label": "nocheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L33"
     },
     {
       "community": 82,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
-      "label": "BillingDetails.tsx",
-      "norm_label": "billingdetails.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
+      "label": "CheckoutExpired.tsx",
+      "norm_label": "checkoutexpired.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
       "source_location": "L1"
     },
     {
@@ -51981,55 +51936,55 @@
     {
       "community": 83,
       "file_type": "code",
-      "id": "checkoutexpired_checkoutexpired",
-      "label": "CheckoutExpired()",
-      "norm_label": "checkoutexpired()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L9"
+      "id": "image_uploader_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L100"
     },
     {
       "community": 83,
       "file_type": "code",
-      "id": "checkoutexpired_checkoutsessiongeneric",
-      "label": "CheckoutSessionGeneric()",
-      "norm_label": "checkoutsessiongeneric()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L73"
+      "id": "image_uploader_ondrop",
+      "label": "onDrop()",
+      "norm_label": "ondrop()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L20"
     },
     {
       "community": 83,
       "file_type": "code",
-      "id": "checkoutexpired_checkoutsessionnotfound",
-      "label": "CheckoutSessionNotFound()",
-      "norm_label": "checkoutsessionnotfound()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L54"
+      "id": "image_uploader_removeimage",
+      "label": "removeImage()",
+      "norm_label": "removeimage()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L31"
     },
     {
       "community": 83,
       "file_type": "code",
-      "id": "checkoutexpired_handlesendemail",
-      "label": "handleSendEmail()",
-      "norm_label": "handlesendemail()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L98"
+      "id": "image_uploader_unmarkfordeletion",
+      "label": "unmarkForDeletion()",
+      "norm_label": "unmarkfordeletion()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L46"
     },
     {
       "community": 83,
       "file_type": "code",
-      "id": "checkoutexpired_nocheckoutsession",
-      "label": "NoCheckoutSession()",
-      "norm_label": "nocheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L33"
+      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
     },
     {
       "community": 83,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
-      "label": "CheckoutExpired.tsx",
-      "norm_label": "checkoutexpired.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1"
     },
     {

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1215
-- Graph nodes: 2848
-- Graph edges: 2405
+- Graph nodes: 2847
+- Graph edges: 2402
 - Communities: 1130
 
 ## Graph Hotspots

--- a/packages/athena-webapp/convex/inventory/pos.ts
+++ b/packages/athena-webapp/convex/inventory/pos.ts
@@ -1,14 +1,9 @@
 import { query, mutation, MutationCtx, QueryCtx } from "../_generated/server";
 import { v } from "convex/values";
-import type { Id } from "../_generated/dataModel";
+import type { Doc, Id } from "../_generated/dataModel";
 import { capitalizeWords, generateTransactionNumber } from "../utils";
 
 const CONVEX_PRODUCT_ID_PATTERN = /^[a-z0-9]{32}$/;
-const POS_SEARCH_PAGE_SIZE = 200;
-const POS_PRODUCT_LOOKUP_SKU_PAGE_SIZE = 100;
-const POS_TRANSACTION_ITEM_PAGE_SIZE = 200;
-const POS_SESSION_ITEM_PAGE_SIZE = 200;
-const POS_TODAY_SUMMARY_PAGE_SIZE = 100;
 
 type PosReadCtx = QueryCtx | MutationCtx;
 
@@ -16,76 +11,90 @@ function isConvexProductId(value: string): value is Id<"product"> {
   return CONVEX_PRODUCT_ID_PATTERN.test(value);
 }
 
-async function collectAllPages<T>(
-  loadPage: (cursor: string | null) => Promise<{
-    page: T[];
-    continueCursor: string | null;
-    isDone: boolean;
-  }>
-) {
+async function readAllQueryResults<T>(query: AsyncIterable<T>) {
   const results: T[] = [];
-  let cursor: string | null = null;
 
-  while (true) {
-    const page = await loadPage(cursor);
-    results.push(...page.page);
-
-    if (page.isDone) {
-      return results;
-    }
-
-    cursor = page.continueCursor;
+  for await (const item of query) {
+    results.push(item);
   }
+
+  return results;
 }
 
 async function listProductSkusByProductId(
   ctx: QueryCtx,
   productId: Id<"product">
 ) {
-  return collectAllPages((cursor) =>
+  return readAllQueryResults(
     ctx.db
       .query("productSku")
       .withIndex("by_productId", (q) => q.eq("productId", productId))
-      .paginate({ cursor, numItems: POS_PRODUCT_LOOKUP_SKU_PAGE_SIZE })
   );
 }
 
-async function listStoreProducts(ctx: QueryCtx, storeId: Id<"store">) {
-  return collectAllPages((cursor) =>
-    ctx.db
-      .query("product")
-      .withIndex("by_storeId", (q) => q.eq("storeId", storeId))
-      .paginate({ cursor, numItems: POS_SEARCH_PAGE_SIZE })
-  );
-}
+async function listMatchingStoreSkus(
+  ctx: QueryCtx,
+  storeId: Id<"store">,
+  searchQuery: string
+) {
+  const matches: Array<{
+    product: Doc<"product">;
+    sku: Doc<"productSku">;
+  }> = [];
+  const productCache = new Map<Id<"product">, Doc<"product"> | null>();
 
-async function listStoreSkus(ctx: QueryCtx, storeId: Id<"store">) {
-  return collectAllPages((cursor) =>
-    ctx.db
-      .query("productSku")
-      .withIndex("by_storeId", (q) => q.eq("storeId", storeId))
-      .paginate({ cursor, numItems: POS_SEARCH_PAGE_SIZE })
-  );
+  for await (const sku of ctx.db
+    .query("productSku")
+    .withIndex("by_storeId", (q) => q.eq("storeId", storeId))) {
+    let product = productCache.get(sku.productId);
+
+    if (product === undefined) {
+      product = (await ctx.db.get("product", sku.productId)) ?? null;
+      productCache.set(sku.productId, product);
+    }
+
+    if (!product || product.storeId !== storeId) {
+      continue;
+    }
+
+    const barcodeMatches =
+      sku.barcode?.toLowerCase().includes(searchQuery) ?? false;
+    const skuMatches = sku.sku?.toLowerCase().includes(searchQuery) ?? false;
+    const nameMatches = product.name.toLowerCase().includes(searchQuery);
+    const productIdMatches = product._id.toLowerCase().includes(searchQuery);
+    const descriptionMatches =
+      product.description?.toLowerCase().includes(searchQuery) ?? false;
+
+    if (
+      barcodeMatches ||
+      skuMatches ||
+      nameMatches ||
+      descriptionMatches ||
+      productIdMatches
+    ) {
+      matches.push({ product, sku });
+    }
+  }
+
+  return matches;
 }
 
 async function listTransactionItems(
   ctx: PosReadCtx,
   transactionId: Id<"posTransaction">
 ) {
-  return collectAllPages((cursor) =>
+  return readAllQueryResults(
     ctx.db
       .query("posTransactionItem")
       .withIndex("by_transactionId", (q) => q.eq("transactionId", transactionId))
-      .paginate({ cursor, numItems: POS_TRANSACTION_ITEM_PAGE_SIZE })
   );
 }
 
 async function listSessionItems(ctx: MutationCtx, sessionId: Id<"posSession">) {
-  return collectAllPages((cursor) =>
+  return readAllQueryResults(
     ctx.db
       .query("posSessionItem")
       .withIndex("by_sessionId", (q) => q.eq("sessionId", sessionId))
-      .paginate({ cursor, numItems: POS_SESSION_ITEM_PAGE_SIZE })
   );
 }
 
@@ -95,7 +104,7 @@ async function listCompletedTransactionsForDay(
   startOfDay: number,
   endOfDay: number
 ) {
-  return collectAllPages((cursor) =>
+  return readAllQueryResults(
     ctx.db
       .query("posTransaction")
       .withIndex("by_storeId_status_completedAt", (q) =>
@@ -105,7 +114,6 @@ async function listCompletedTransactionsForDay(
           .gte("completedAt", startOfDay)
           .lte("completedAt", endOfDay)
       )
-      .paginate({ cursor, numItems: POS_TODAY_SUMMARY_PAGE_SIZE })
   );
 }
 
@@ -126,16 +134,16 @@ export const searchProducts = query({
 
       if (product?.storeId === args.storeId) {
         const productSkus = await listProductSkusByProductId(ctx, product._id);
+        let categoryName = "";
+
+        if (product.categoryId) {
+          const category = await ctx.db.get("category", product.categoryId);
+          categoryName = category?.name || "";
+        }
 
         const results = await Promise.all(
           productSkus.map(async (sku) => {
             if (!sku.netPrice) return null;
-
-            let categoryName = "";
-            if (product.categoryId) {
-              const category = await ctx.db.get("category", product.categoryId);
-              categoryName = (category as any)?.name || "";
-            }
 
             let colorName = "";
             if (sku.color) {
@@ -173,60 +181,21 @@ export const searchProducts = query({
     // matching across product name, description, SKU, barcode, and product id.
     // Keep that behavior intact here while exact product-id and barcode paths
     // move onto direct indexed reads in V26-173.
-    const allProducts = await listStoreProducts(ctx, args.storeId);
-
-    const allSkus = await listStoreSkus(ctx, args.storeId);
-
-    // Create a map of products by ID for easy lookup
-    const productMap = new Map();
-    allProducts.forEach((product) => {
-      productMap.set(product._id, product);
-    });
-
-    // Find matching SKUs (by SKU code, barcode, or product name)
-    const matchingSkus = allSkus.filter((sku) => {
-      const product = productMap.get(sku.productId);
-      if (!product) return false;
-
-      // Search in barcode field
-      const barcodeMatches = sku.barcode?.toLowerCase().includes(query);
-
-      // Search in SKU code
-      const skuMatches = sku.sku?.toLowerCase().includes(query);
-
-      // Search in product name
-      const nameMatches = product.name.toLowerCase().includes(query);
-
-      const productIdMatches = product._id.toLowerCase().includes(query);
-
-      // Search in product description
-      const descriptionMatches = product.description
-        ?.toLowerCase()
-        .includes(query);
-
-      return (
-        barcodeMatches ||
-        skuMatches ||
-        nameMatches ||
-        descriptionMatches ||
-        productIdMatches
-      );
-    });
+    const matchingSkus = await listMatchingStoreSkus(ctx, args.storeId, query);
 
     // Transform to POS-friendly format
     const results = await Promise.all(
       matchingSkus
         // .filter((sku) => sku.quantityAvailable > 0) // Only show available items
         // .slice(0, 20) // Limit results for performance
-        .map(async (sku) => {
-          const product = productMap.get(sku.productId);
-          if (!product || !sku.netPrice) return null;
+        .map(async ({ product, sku }) => {
+          if (!sku.netPrice) return null;
 
           // Get category name
           let categoryName = "";
           if (product.categoryId) {
             const category = await ctx.db.get("category", product.categoryId);
-            categoryName = (category as any)?.name || "";
+            categoryName = category?.name || "";
           }
 
           // Get color name if exists

--- a/packages/athena-webapp/convex/inventory/posQueryCleanup.test.ts
+++ b/packages/athena-webapp/convex/inventory/posQueryCleanup.test.ts
@@ -47,6 +47,16 @@ describe("V26-173 POS query cleanup", () => {
     );
   });
 
+  it("avoids manual pagination loops in POS query helpers", () => {
+    const source = readProjectFile("convex", "inventory", "pos.ts").replace(
+      /\s+/g,
+      " "
+    );
+
+    expect(source).not.toContain("async function collectAllPages");
+    expect(source).not.toContain('.paginate({ cursor, numItems:');
+  });
+
   it("passes Convex lint without a file-level waiver on pos.ts", async () => {
     const source = readProjectFile("convex", "inventory", "pos.ts");
 


### PR DESCRIPTION
## Summary
- replace the unsupported manual pagination loop in `packages/athena-webapp/convex/inventory/pos.ts` with single-pass async query iteration
- keep POS product search semantics intact while scanning store SKUs once and hydrating product details on demand
- add a regression guard to prevent `collectAllPages()` / repeated `.paginate()` from returning to the POS query helpers

## Why
The POS free-text search path could throw `This query or mutation function ran multiple paginated queries` once inventory search spilled past a single Convex page. The fix removes the illegal pagination pattern from the POS read surface while preserving the existing search matching behavior.

## Validation
- `bun run --filter '@athena/webapp' test convex/inventory/posQueryCleanup.test.ts`
- `bun run pr:athena`
- `bun run harness:behavior --scenario athena-convex-storefront-failure-visibility --record-video`

https://linear.app/v26-labs/issue/V26-262/pos-product-search-fails-when-inventory-spans-multiple-convex-pages
