### PR TITLE
[V26-263]: Format POS amount displays from pesewas before rendering

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1215 files · ~0 words
+- 1218 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 2847 nodes · 2402 edges · 1130 communities detected
+- 2853 nodes · 2405 edges · 1133 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1140,6 +1140,9 @@
 - [[_COMMUNITY_Community 1127|Community 1127]]
 - [[_COMMUNITY_Community 1128|Community 1128]]
 - [[_COMMUNITY_Community 1129|Community 1129]]
+- [[_COMMUNITY_Community 1130|Community 1130]]
+- [[_COMMUNITY_Community 1131|Community 1131]]
+- [[_COMMUNITY_Community 1132|Community 1132]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -1565,19 +1568,19 @@ Nodes (0):
 
 ### Community 99 - "Community 99"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): Header()
 
 ### Community 100 - "Community 100"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 101 - "Community 101"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
-
-### Community 102 - "Community 102"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 102 - "Community 102"
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 103 - "Community 103"
 Cohesion: 0.4
@@ -1589,7 +1592,7 @@ Nodes (0):
 
 ### Community 105 - "Community 105"
 Cohesion: 0.4
-Nodes (1): Header()
+Nodes (0):
 
 ### Community 106 - "Community 106"
 Cohesion: 0.4
@@ -1612,16 +1615,16 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 111 - "Community 111"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 112 - "Community 112"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 112 - "Community 112"
-Cohesion: 0.4
-Nodes (1): MockImage
-
 ### Community 113 - "Community 113"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): MockImage
 
 ### Community 114 - "Community 114"
 Cohesion: 0.4
@@ -1636,35 +1639,35 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 117 - "Community 117"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 118 - "Community 118"
 Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 119 - "Community 119"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 120 - "Community 120"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
 ### Community 121 - "Community 121"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 122 - "Community 122"
-Cohesion: 0.7
-Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
-
-### Community 123 - "Community 123"
 Cohesion: 0.4
 Nodes (0):
 
+### Community 123 - "Community 123"
+Cohesion: 0.7
+Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
+
 ### Community 124 - "Community 124"
-Cohesion: 0.5
+Cohesion: 0.4
 Nodes (0):
 
 ### Community 125 - "Community 125"
@@ -1680,24 +1683,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 128 - "Community 128"
-Cohesion: 0.83
-Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 129 - "Community 129"
 Cohesion: 0.67
-Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
+Nodes (2): toDisplayAmount(), toPesewas()
 
 ### Community 130 - "Community 130"
-Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
+Cohesion: 0.83
+Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
 ### Community 131 - "Community 131"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
 ### Community 132 - "Community 132"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 133 - "Community 133"
 Cohesion: 0.5
@@ -1712,16 +1715,16 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 136 - "Community 136"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 137 - "Community 137"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 138 - "Community 138"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 139 - "Community 139"
 Cohesion: 0.5
@@ -1748,32 +1751,32 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 145 - "Community 145"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
-
-### Community 146 - "Community 146"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 146 - "Community 146"
+Cohesion: 0.67
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 147 - "Community 147"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 148 - "Community 148"
-Cohesion: 0.83
-Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 149 - "Community 149"
 Cohesion: 0.83
-Nodes (3): getAllStores(), getBaseUrl(), getStore()
+Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 150 - "Community 150"
 Cohesion: 0.83
-Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
 ### Community 151 - "Community 151"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
 
 ### Community 152 - "Community 152"
 Cohesion: 0.5
@@ -1796,8 +1799,8 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 157 - "Community 157"
-Cohesion: 0.67
-Nodes (2): toDisplayAmount(), toPesewas()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 158 - "Community 158"
 Cohesion: 0.67
@@ -2085,55 +2088,55 @@ Nodes (1): isInMaintenanceMode()
 
 ### Community 229 - "Community 229"
 Cohesion: 0.67
-Nodes (1): App()
+Nodes (0):
 
 ### Community 230 - "Community 230"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): App()
 
 ### Community 231 - "Community 231"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 232 - "Community 232"
 Cohesion: 1.0
 Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
-### Community 232 - "Community 232"
+### Community 233 - "Community 233"
 Cohesion: 0.67
 Nodes (1): hashPassword()
 
-### Community 233 - "Community 233"
+### Community 234 - "Community 234"
 Cohesion: 0.67
 Nodes (1): useAppSession()
 
-### Community 234 - "Community 234"
+### Community 235 - "Community 235"
 Cohesion: 0.67
 Nodes (1): createVersionChecker()
 
-### Community 235 - "Community 235"
+### Community 236 - "Community 236"
 Cohesion: 0.67
 Nodes (1): manualChunks()
 
-### Community 236 - "Community 236"
+### Community 237 - "Community 237"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 237 - "Community 237"
+### Community 238 - "Community 238"
 Cohesion: 1.0
 Nodes (2): getAllColors(), getBaseUrl()
 
-### Community 238 - "Community 238"
+### Community 239 - "Community 239"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 239 - "Community 239"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 240 - "Community 240"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 241 - "Community 241"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 242 - "Community 242"
 Cohesion: 0.67
@@ -2144,12 +2147,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 244 - "Community 244"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 245 - "Community 245"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 245 - "Community 245"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 246 - "Community 246"
 Cohesion: 0.67
@@ -2160,12 +2163,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 248 - "Community 248"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 249 - "Community 249"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 249 - "Community 249"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 250 - "Community 250"
 Cohesion: 0.67
@@ -2244,16 +2247,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 269 - "Community 269"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
-
-### Community 270 - "Community 270"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 271 - "Community 271"
+### Community 270 - "Community 270"
 Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
+
+### Community 271 - "Community 271"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 272 - "Community 272"
 Cohesion: 1.0
@@ -2268,11 +2271,11 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 275 - "Community 275"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 276 - "Community 276"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0):
 
 ### Community 277 - "Community 277"
@@ -5687,1714 +5690,1730 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1130 - "Community 1130"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1131 - "Community 1131"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1132 - "Community 1132"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
-- **Thin community `Community 276`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 277`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 277`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 278`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 278`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 279`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 279`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 280`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 280`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 281`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 281`** (2 nodes): `authenticateHandler()`, `cashier.ts`
+- **Thin community `Community 282`** (2 nodes): `authenticateHandler()`, `cashier.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 282`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 283`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 283`** (2 nodes): `sessionQueryIndexes.test.ts`, `readProjectFile()`
+- **Thin community `Community 284`** (2 nodes): `sessionQueryIndexes.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 284`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 285`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 285`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 286`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 286`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 287`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 287`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 288`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 288`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 289`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 289`** (2 nodes): `VerificationCodeEmail.tsx`, `VerificationCodeEmail()`
+- **Thin community `Community 290`** (2 nodes): `VerificationCodeEmail.tsx`, `VerificationCodeEmail()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 290`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 291`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 291`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 292`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 292`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 293`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 293`** (2 nodes): `listOrderItems()`, `onlineOrder.ts`
+- **Thin community `Community 294`** (2 nodes): `listOrderItems()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 294`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 295`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 295`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 296`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 296`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 297`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 297`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 298`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 298`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 299`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 299`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 300`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 300`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 301`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 301`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 302`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 302`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 303`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 303`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 304`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 304`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 305`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 305`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 306`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 306`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 307`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 307`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 308`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 308`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 309`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 309`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 310`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 310`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 311`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 311`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 312`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 312`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 313`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 313`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
+- **Thin community `Community 314`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 314`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 315`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 315`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 316`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 316`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 317`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 317`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 318`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 318`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 319`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 319`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 320`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 320`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 321`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 321`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 322`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 322`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 323`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 323`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 324`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 324`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 325`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 325`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 326`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 326`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 327`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 327`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 328`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 328`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 329`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 329`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 330`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 330`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 331`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 331`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 332`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 332`** (2 nodes): `Login()`, `index.tsx`
+- **Thin community `Community 333`** (2 nodes): `Login()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 333`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 334`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 334`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 335`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 335`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 336`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 336`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 337`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 337`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 338`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 338`** (2 nodes): `PageHeader.tsx`, `PageHeader()`
+- **Thin community `Community 339`** (2 nodes): `PageHeader.tsx`, `PageHeader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 339`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 340`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 340`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 341`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 341`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 342`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 342`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 343`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 343`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 344`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 344`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 345`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 345`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 346`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 346`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 347`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 347`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 348`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 348`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 349`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 349`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 350`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 350`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 351`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 351`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 352`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 352`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 353`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 353`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 354`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 354`** (2 nodes): `handleSignOut()`, `CashierView.tsx`
+- **Thin community `Community 355`** (2 nodes): `handleSignOut()`, `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 355`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 356`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 356`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 357`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 357`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 358`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 358`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
+- **Thin community `Community 359`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 359`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 360`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 360`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
+- **Thin community `Community 361`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 361`** (2 nodes): `ProductEntry.tsx`, `handleClearSearch()`
+- **Thin community `Community 362`** (2 nodes): `ProductEntry.tsx`, `handleClearSearch()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 362`** (2 nodes): `QuickActionsBar.tsx`, `QuickActionsBar()`
+- **Thin community `Community 363`** (2 nodes): `QuickActionsBar.tsx`, `QuickActionsBar()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 363`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 364`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 364`** (2 nodes): `TotalsDisplay.tsx`, `TotalsDisplay()`
+- **Thin community `Community 365`** (2 nodes): `TotalsDisplay.tsx`, `TotalsDisplay()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 365`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
+- **Thin community `Community 366`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 366`** (2 nodes): `usePOSCashier()`, `hooks.ts`
+- **Thin community `Community 367`** (2 nodes): `usePOSCashier()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 367`** (2 nodes): `HoldSessionDialog()`, `HoldSessionDialog.tsx`
+- **Thin community `Community 368`** (2 nodes): `HoldSessionDialog()`, `HoldSessionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 368`** (2 nodes): `VoidSessionDialog.tsx`, `VoidSessionDialog()`
+- **Thin community `Community 369`** (2 nodes): `VoidSessionDialog.tsx`, `VoidSessionDialog()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 369`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 370`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 370`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 371`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 371`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 372`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 372`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 373`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 373`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 374`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 374`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
+- **Thin community `Community 375`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 375`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 376`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 376`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 377`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 377`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 378`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 378`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 379`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 379`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 380`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 380`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 381`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 381`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 382`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 382`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 383`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 383`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 384`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 384`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 385`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 385`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 386`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 386`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 387`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 387`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 388`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 388`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 389`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 389`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 390`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 390`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 391`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 391`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 392`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 392`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 393`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 393`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 394`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 394`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 395`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 395`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 396`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 396`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 397`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 397`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 398`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 398`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 399`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 399`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 400`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 400`** (2 nodes): `DateTimePicker()`, `date-time-picker.tsx`
+- **Thin community `Community 401`** (2 nodes): `DateTimePicker()`, `date-time-picker.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 401`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 402`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 402`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 403`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 403`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 404`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 404`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 405`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 405`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 406`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 406`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 407`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 407`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 408`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 408`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 409`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 409`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 410`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 410`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 411`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 411`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 412`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 412`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 413`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 413`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 414`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 414`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 415`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 415`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 416`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 416`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 417`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 417`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 418`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 418`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 419`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 419`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 420`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 420`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 421`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 421`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 422`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 422`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 423`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 423`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 424`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 424`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 425`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 425`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 426`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 426`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 427`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 427`** (2 nodes): `useCartOperations.ts`, `useCartOperations()`
+- **Thin community `Community 428`** (2 nodes): `useCartOperations.ts`, `useCartOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 428`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 429`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 429`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 430`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 430`** (2 nodes): `useCustomerOperations.ts`, `useCustomerOperations()`
+- **Thin community `Community 431`** (2 nodes): `useCustomerOperations.ts`, `useCustomerOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 431`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 432`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 432`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
+- **Thin community `Community 433`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 433`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 434`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 434`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 435`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 435`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 436`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 436`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 437`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 437`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 438`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 438`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 439`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 439`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 440`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 440`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 441`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 441`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 442`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 442`** (2 nodes): `usePrint.ts`, `usePrint()`
+- **Thin community `Community 443`** (2 nodes): `usePrint.ts`, `usePrint()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 443`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 444`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 444`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 445`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 445`** (2 nodes): `useSessionManagement.ts`, `useSessionManagement()`
+- **Thin community `Community 446`** (2 nodes): `useSessionManagement.ts`, `useSessionManagement()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 446`** (2 nodes): `useSessionManagementExpense.ts`, `useSessionManagementExpense()`
+- **Thin community `Community 447`** (2 nodes): `useSessionManagementExpense.ts`, `useSessionManagementExpense()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 447`** (2 nodes): `useSessionManagerOperations.ts`, `useSessionManagerOperations()`
+- **Thin community `Community 448`** (2 nodes): `useSessionManagerOperations.ts`, `useSessionManagerOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 448`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 449`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 449`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 450`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 450`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 451`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 451`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 452`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 452`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 453`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 453`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 454`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 454`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 455`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 455`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 456`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 456`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 457`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 457`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 458`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 458`** (2 nodes): `LoginLayout()`, `_layout.tsx`
+- **Thin community `Community 459`** (2 nodes): `LoginLayout()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 459`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 460`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 460`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 461`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 461`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 462`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 462`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 463`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 463`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 464`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 464`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 465`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 465`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 466`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 466`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 467`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 467`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 468`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 468`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 469`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 469`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 470`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 470`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 471`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 471`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
+- **Thin community `Community 472`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 472`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 473`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 473`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 474`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 474`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 475`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 475`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 476`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 476`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 477`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 477`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 478`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 478`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 479`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 479`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 480`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 480`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 481`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 481`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 482`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 482`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 483`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 483`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 484`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 484`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 485`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 485`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 486`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 486`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 487`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 487`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 488`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 488`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 489`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 489`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 490`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 490`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 491`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 491`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 492`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 492`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 493`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 493`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 494`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 494`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 495`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 495`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 496`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 496`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 497`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 497`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 498`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 498`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 499`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 499`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 500`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 500`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 501`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 501`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 502`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 502`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 503`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 503`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 504`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 504`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 505`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 505`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 506`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 506`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 507`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 507`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 508`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 508`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 509`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 509`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 510`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 510`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 511`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 511`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 512`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 512`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 513`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 513`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 514`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 514`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 515`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 515`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 516`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 516`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 517`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 517`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 518`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 518`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 519`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 519`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 520`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 520`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 521`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 521`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 522`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 522`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 523`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 523`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 524`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 524`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 525`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 525`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 526`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 526`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 527`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 527`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 528`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 528`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 529`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 529`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 530`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 530`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 531`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 531`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 532`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 532`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 533`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 533`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 534`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 534`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 535`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 535`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 536`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 536`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 537`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 537`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 538`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 538`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 539`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 539`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 540`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 540`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 541`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 541`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 542`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 542`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 543`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 543`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 544`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 544`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 545`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 545`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 546`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 546`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 547`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 547`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 548`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 548`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 549`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 550`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 551`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 552`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 553`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 554`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 555`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 556`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 557`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 558`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 559`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 560`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 561`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 562`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 563`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 564`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 565`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 566`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 567`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 568`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 569`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 570`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 571`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 572`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 573`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 574`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 575`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 576`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 577`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 578`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (1 nodes): `api.d.ts`
+- **Thin community `Community 579`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (1 nodes): `api.js`
+- **Thin community `Community 580`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 581`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (1 nodes): `server.d.ts`
+- **Thin community `Community 582`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (1 nodes): `server.js`
+- **Thin community `Community 583`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (1 nodes): `app.ts`
+- **Thin community `Community 584`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (1 nodes): `auth.config.js`
+- **Thin community `Community 585`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (1 nodes): `auth.ts`
+- **Thin community `Community 586`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (1 nodes): `countries.ts`
+- **Thin community `Community 587`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (1 nodes): `email.ts`
+- **Thin community `Community 588`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (1 nodes): `ghana.ts`
+- **Thin community `Community 589`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (1 nodes): `payment.ts`
+- **Thin community `Community 590`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (1 nodes): `crons.ts`
+- **Thin community `Community 591`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 592`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 593`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 594`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 595`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (1 nodes): `env.ts`
+- **Thin community `Community 596`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (1 nodes): `analytics.ts`
+- **Thin community `Community 597`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (1 nodes): `auth.ts`
+- **Thin community `Community 598`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 599`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (1 nodes): `categories.ts`
+- **Thin community `Community 600`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (1 nodes): `colors.ts`
+- **Thin community `Community 601`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (1 nodes): `index.ts`
+- **Thin community `Community 602`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (1 nodes): `organizations.ts`
+- **Thin community `Community 603`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (1 nodes): `products.ts`
+- **Thin community `Community 604`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (1 nodes): `stores.ts`
+- **Thin community `Community 605`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 606`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (1 nodes): `index.ts`
+- **Thin community `Community 607`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (1 nodes): `bag.ts`
+- **Thin community `Community 608`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (1 nodes): `guest.ts`
+- **Thin community `Community 609`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (1 nodes): `index.ts`
+- **Thin community `Community 610`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (1 nodes): `me.ts`
+- **Thin community `Community 611`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (1 nodes): `offers.ts`
+- **Thin community `Community 612`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 613`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (1 nodes): `paystack.ts`
+- **Thin community `Community 614`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (1 nodes): `reviews.ts`
+- **Thin community `Community 615`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (1 nodes): `rewards.ts`
+- **Thin community `Community 616`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 617`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (1 nodes): `security.test.ts`
+- **Thin community `Community 618`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (1 nodes): `storefront.ts`
+- **Thin community `Community 619`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (1 nodes): `upsells.ts`
+- **Thin community `Community 620`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (1 nodes): `user.ts`
+- **Thin community `Community 621`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 622`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (1 nodes): `health.test.ts`
+- **Thin community `Community 623`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (1 nodes): `http.ts`
+- **Thin community `Community 624`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 625`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (1 nodes): `auth.ts`
+- **Thin community `Community 626`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 627`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 628`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (1 nodes): `categories.ts`
+- **Thin community `Community 629`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (1 nodes): `colors.ts`
+- **Thin community `Community 630`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 631`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (1 nodes): `expenseSessionItems.ts`
+- **Thin community `Community 632`** (1 nodes): `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (1 nodes): `expenseTransactions.ts`
+- **Thin community `Community 633`** (1 nodes): `expenseTransactions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 634`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 635`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 636`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (1 nodes): `organizations.ts`
+- **Thin community `Community 637`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 638`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (1 nodes): `posSessionItems.ts`
+- **Thin community `Community 639`** (1 nodes): `posSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 640`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (1 nodes): `productSku.ts`
+- **Thin community `Community 641`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (1 nodes): `productUtil.ts`
+- **Thin community `Community 642`** (1 nodes): `productUtil.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 643`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 644`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 645`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 646`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 647`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 648`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 649`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 650`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (1 nodes): `client.test.ts`
+- **Thin community `Community 651`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (1 nodes): `config.test.ts`
+- **Thin community `Community 652`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 653`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (1 nodes): `types.ts`
+- **Thin community `Community 654`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (1 nodes): `ResendOTP.ts`
+- **Thin community `Community 655`** (1 nodes): `ResendOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (1 nodes): `schema.ts`
+- **Thin community `Community 656`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 657`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 658`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 659`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 660`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (1 nodes): `cashier.ts`
+- **Thin community `Community 661`** (1 nodes): `cashier.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (1 nodes): `category.ts`
+- **Thin community `Community 662`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (1 nodes): `color.ts`
+- **Thin community `Community 663`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 664`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 665`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (1 nodes): `index.ts`
+- **Thin community `Community 666`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 667`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (1 nodes): `organization.ts`
+- **Thin community `Community 668`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 669`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (1 nodes): `product.ts`
+- **Thin community `Community 670`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 671`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 672`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (1 nodes): `store.ts`
+- **Thin community `Community 673`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 674`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 675`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (1 nodes): `customer.ts`
+- **Thin community `Community 676`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 677`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 678`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 679`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 680`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (1 nodes): `index.ts`
+- **Thin community `Community 681`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (1 nodes): `posSession.ts`
+- **Thin community `Community 682`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 683`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 684`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 685`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 686`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (1 nodes): `analytics.ts`
+- **Thin community `Community 687`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (1 nodes): `bag.ts`
+- **Thin community `Community 688`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 689`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 690`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 691`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (1 nodes): `customer.ts`
+- **Thin community `Community 692`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (1 nodes): `guest.ts`
+- **Thin community `Community 693`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (1 nodes): `index.ts`
+- **Thin community `Community 694`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (1 nodes): `offer.ts`
+- **Thin community `Community 695`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 696`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 697`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (1 nodes): `review.ts`
+- **Thin community `Community 698`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (1 nodes): `rewards.ts`
+- **Thin community `Community 699`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 700`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 701`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 702`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 703`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 704`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 705`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (1 nodes): `bag.ts`
+- **Thin community `Community 706`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 707`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (1 nodes): `customer.ts`
+- **Thin community `Community 708`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (1 nodes): `guest.ts`
+- **Thin community `Community 709`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 710`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (1 nodes): `payment.ts`
+- **Thin community `Community 711`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 712`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (1 nodes): `rewards.ts`
+- **Thin community `Community 713`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 714`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 715`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (1 nodes): `users.ts`
+- **Thin community `Community 716`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (1 nodes): `payment.ts`
+- **Thin community `Community 717`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 718`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (1 nodes): `index.ts`
+- **Thin community `Community 719`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 720`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 721`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 722`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 723`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 724`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 725`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 726`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (1 nodes): `constants.ts`
+- **Thin community `Community 727`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 728`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 729`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 730`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (1 nodes): `types.ts`
+- **Thin community `Community 731`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 732`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 733`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 734`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 735`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 736`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 737`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 738`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 739`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (1 nodes): `columns.tsx`
+- **Thin community `Community 740`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 741`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 742`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 743`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 744`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (1 nodes): `columns.tsx`
+- **Thin community `Community 745`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 746`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 747`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (1 nodes): `chart.tsx`
+- **Thin community `Community 748`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (1 nodes): `columns.tsx`
+- **Thin community `Community 749`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 750`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 751`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (1 nodes): `columns.tsx`
+- **Thin community `Community 752`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (1 nodes): `constants.ts`
+- **Thin community `Community 753`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 754`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 755`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 756`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (1 nodes): `data.ts`
+- **Thin community `Community 757`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (1 nodes): `columns.tsx`
+- **Thin community `Community 758`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 759`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 760`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (1 nodes): `columns.tsx`
+- **Thin community `Community 761`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 762`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 763`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 764`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 765`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 766`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (1 nodes): `app-sidebar.tsx`
+- **Thin community `Community 767`** (1 nodes): `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 768`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (1 nodes): `constants.ts`
+- **Thin community `Community 769`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 770`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 771`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 772`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (1 nodes): `data.ts`
+- **Thin community `Community 773`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 774`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 775`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (1 nodes): `columns.tsx`
+- **Thin community `Community 776`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 777`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 778`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 779`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 780`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 781`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (1 nodes): `columns.tsx`
+- **Thin community `Community 782`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (1 nodes): `constants.ts`
+- **Thin community `Community 783`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 784`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 785`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 786`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 787`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (1 nodes): `index.tsx`
+- **Thin community `Community 788`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (1 nodes): `columns.tsx`
+- **Thin community `Community 789`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 790`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 791`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 792`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (1 nodes): `ExpenseCompletion.tsx`
+- **Thin community `Community 793`** (1 nodes): `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 794`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 795`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 796`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (1 nodes): `constants.ts`
+- **Thin community `Community 797`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 798`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 799`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 800`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (1 nodes): `data.ts`
+- **Thin community `Community 801`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (1 nodes): `constants.ts`
+- **Thin community `Community 802`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 803`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 804`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 805`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 806`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (1 nodes): `data.ts`
+- **Thin community `Community 807`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 808`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (1 nodes): `constants.ts`
+- **Thin community `Community 809`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 810`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 811`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 812`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 813`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (1 nodes): `data.ts`
+- **Thin community `Community 814`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 815`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (1 nodes): `CartItems.tsx`
+- **Thin community `Community 816`** (1 nodes): `CartItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (1 nodes): `CashierAuthDialog.tsx`
+- **Thin community `Community 817`** (1 nodes): `CashierAuthDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 818`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 819`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (1 nodes): `SearchResultsSection.tsx`
+- **Thin community `Community 820`** (1 nodes): `SearchResultsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (1 nodes): `ExpenseReportView.tsx`
+- **Thin community `Community 821`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 822`** (1 nodes): `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (1 nodes): `TransactionView.tsx`
+- **Thin community `Community 823`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (1 nodes): `types.ts`
+- **Thin community `Community 824`** (1 nodes): `TransactionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 825`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 826`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 827`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (1 nodes): `ProductDetailView.tsx`
+- **Thin community `Community 828`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (1 nodes): `ProductStatus.tsx`
+- **Thin community `Community 829`** (1 nodes): `ProductDetailView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (1 nodes): `CategoryListView.tsx`
+- **Thin community `Community 830`** (1 nodes): `ProductStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 831`** (1 nodes): `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (1 nodes): `Products.tsx`
+- **Thin community `Community 832`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 833`** (1 nodes): `Products.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 834`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 835`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 836`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 837`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 838`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 839`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 840`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 841`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (1 nodes): `data.ts`
+- **Thin community `Community 842`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 843`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (1 nodes): `PromoCodePreview.tsx`
+- **Thin community `Community 844`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 845`** (1 nodes): `PromoCodePreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 846`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 847`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (1 nodes): `columns.tsx`
+- **Thin community `Community 848`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 849`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 850`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 851`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 852`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 853`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (1 nodes): `columns.tsx`
+- **Thin community `Community 854`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (1 nodes): `constants.ts`
+- **Thin community `Community 855`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 856`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 857`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 858`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (1 nodes): `data.ts`
+- **Thin community `Community 859`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (1 nodes): `types.ts`
+- **Thin community `Community 860`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 861`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 862`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 863`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 864`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 865`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (1 nodes): `index.tsx`
+- **Thin community `Community 866`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 867`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 868`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (1 nodes): `button.tsx`
+- **Thin community `Community 869`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 870`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (1 nodes): `calendar.tsx`
+- **Thin community `Community 871`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (1 nodes): `card.tsx`
+- **Thin community `Community 872`** (1 nodes): `calendar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 873`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 874`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (1 nodes): `command.tsx`
+- **Thin community `Community 875`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 876`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 877`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 878`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (1 nodes): `form.tsx`
+- **Thin community `Community 879`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (1 nodes): `icons.tsx`
+- **Thin community `Community 880`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 881`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (1 nodes): `input.tsx`
+- **Thin community `Community 882`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 883`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (1 nodes): `popover.tsx`
+- **Thin community `Community 884`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 885`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 886`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (1 nodes): `select.tsx`
+- **Thin community `Community 887`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (1 nodes): `separator.tsx`
+- **Thin community `Community 888`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 889`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (1 nodes): `switch.tsx`
+- **Thin community `Community 890`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (1 nodes): `table.tsx`
+- **Thin community `Community 891`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 892`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 893`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 894`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 895`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 896`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 897`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 898`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (1 nodes): `columns.tsx`
+- **Thin community `Community 899`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (1 nodes): `constants.ts`
+- **Thin community `Community 900`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 901`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 902`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 903`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (1 nodes): `data.ts`
+- **Thin community `Community 904`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 905`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 906`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (1 nodes): `columns.tsx`
+- **Thin community `Community 907`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 908`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 909`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 910`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 911`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 912`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 913`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 914`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 915`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 916`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (1 nodes): `UserBehaviorInsights.tsx`
+- **Thin community `Community 917`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (1 nodes): `index.ts`
+- **Thin community `Community 918`** (1 nodes): `UserBehaviorInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (1 nodes): `config.ts`
+- **Thin community `Community 919`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 920`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 921`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 922`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (1 nodes): `aws.ts`
+- **Thin community `Community 923`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (1 nodes): `constants.ts`
+- **Thin community `Community 924`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (1 nodes): `countries.ts`
+- **Thin community `Community 925`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (1 nodes): `ghana.ts`
+- **Thin community `Community 926`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 927`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (1 nodes): `constants.ts`
+- **Thin community `Community 928`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 929`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (1 nodes): `category.ts`
+- **Thin community `Community 930`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (1 nodes): `product.ts`
+- **Thin community `Community 931`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (1 nodes): `store.ts`
+- **Thin community `Community 932`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 933`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (1 nodes): `user.ts`
+- **Thin community `Community 934`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 935`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 936`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 937`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `__root.tsx`
+- **Thin community `Community 938`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `index.tsx`
+- **Thin community `Community 939`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `index.tsx`
+- **Thin community `Community 940`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `index.tsx`
+- **Thin community `Community 941`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 942`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 943`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 944`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 945`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 946`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `index.tsx`
+- **Thin community `Community 947`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 948`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 949`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 950`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `home.tsx`
+- **Thin community `Community 951`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 952`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 953`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 954`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `index.tsx`
+- **Thin community `Community 955`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 956`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 957`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 958`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `index.tsx`
+- **Thin community `Community 959`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 960`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 961`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 962`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 963`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 964`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 965`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `expense.index.tsx`
+- **Thin community `Community 966`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `index.tsx`
+- **Thin community `Community 967`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 968`** (1 nodes): `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 969`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 970`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 971`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `edit.tsx`
+- **Thin community `Community 972`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `index.tsx`
+- **Thin community `Community 973`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `index.tsx`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `new.tsx`
+- **Thin community `Community 974`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 975`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `new.tsx`
+- **Thin community `Community 976`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 977`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 978`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `index.tsx`
+- **Thin community `Community 979`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `new.tsx`
+- **Thin community `Community 980`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `index.tsx`
+- **Thin community `Community 981`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 982`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 983`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 984`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 985`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 986`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 987`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 988`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (1 nodes): `posStore.ts`
+- **Thin community `Community 989`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (1 nodes): `setup.ts`
+- **Thin community `Community 990`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `usePrint.test.ts`
+- **Thin community `Community 991`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 992`** (1 nodes): `posStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `types.ts`
+- **Thin community `Community 993`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 994`** (1 nodes): `usePrint.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 995`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 996`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `global.d.ts`
+- **Thin community `Community 997`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 998`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 999`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `types.ts`
+- **Thin community `Community 1000`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1001`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `client.tsx`
+- **Thin community `Community 1002`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1003`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1004`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1005`** (1 nodes): `client.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1006`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1007`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1008`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1009`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1010`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `schema.ts`
+- **Thin community `Community 1011`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1012`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1013`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1014`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1015`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1016`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1017`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1018`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1019`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1020`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `types.ts`
+- **Thin community `Community 1021`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1022`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1023`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1024`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1025`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1026`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1027`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1028`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `constants.ts`
+- **Thin community `Community 1029`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1030`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `About.tsx`
+- **Thin community `Community 1031`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1032`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1033`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1034`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1035`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1036`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1037`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1038`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1039`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1040`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `types.ts`
+- **Thin community `Community 1041`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1042`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1043`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1044`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1045`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1046`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1047`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1048`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1049`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1050`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1051`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `button.tsx`
+- **Thin community `Community 1052`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `card.tsx`
+- **Thin community `Community 1053`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1054`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `command.tsx`
+- **Thin community `Community 1055`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1056`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1057`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1058`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `form.tsx`
+- **Thin community `Community 1059`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1060`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1061`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1062`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1063`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `input.tsx`
+- **Thin community `Community 1064`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `label.tsx`
+- **Thin community `Community 1065`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1066`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1067`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1068`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `index.ts`
+- **Thin community `Community 1069`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `types.ts`
+- **Thin community `Community 1070`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1071`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1072`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1073`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1074`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `select.tsx`
+- **Thin community `Community 1075`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1076`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1077`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `table.tsx`
+- **Thin community `Community 1078`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1079`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1080`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1081`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1082`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1083`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `config.ts`
+- **Thin community `Community 1084`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1085`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1086`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1087`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `constants.ts`
+- **Thin community `Community 1088`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `countries.ts`
+- **Thin community `Community 1089`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1090`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1091`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1092`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1093`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `index.ts`
+- **Thin community `Community 1094`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `store.ts`
+- **Thin community `Community 1095`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `bag.ts`
+- **Thin community `Community 1096`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1097`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `category.ts`
+- **Thin community `Community 1098`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `organization.ts`
+- **Thin community `Community 1099`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `product.ts`
+- **Thin community `Community 1100`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `store.ts`
+- **Thin community `Community 1101`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1102`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `user.ts`
+- **Thin community `Community 1103`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `states.ts`
+- **Thin community `Community 1104`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1105`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1106`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1107`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1108`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1109`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1110`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1111`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `index.tsx`
+- **Thin community `Community 1112`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1113`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `index.tsx`
+- **Thin community `Community 1114`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1115`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1116`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1117`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1118`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1119`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `index.tsx`
+- **Thin community `Community 1120`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1121`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `ssr.tsx`
+- **Thin community `Community 1122`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1123`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1124`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1125`** (1 nodes): `ssr.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `index.js`
+- **Thin community `Community 1126`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1127`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1128`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1129`** (1 nodes): `index.js`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1130`** (1 nodes): `harness-app-registry.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1131`** (1 nodes): `valkey-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1132`** (1 nodes): `harness-behavior-scenarios.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -11255,7 +11255,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_customerinfopanel_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L155",
+      "source_location": "L156",
       "target": "customerinfopanel_clearcustomer",
       "weight": 1
     },
@@ -11267,7 +11267,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_customerinfopanel_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L146",
+      "source_location": "L147",
       "target": "customerinfopanel_handlecanceledit",
       "weight": 1
     },
@@ -11279,7 +11279,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_customerinfopanel_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L77",
+      "source_location": "L78",
       "target": "customerinfopanel_handlecreatecustomer",
       "weight": 1
     },
@@ -11291,7 +11291,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_customerinfopanel_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L115",
+      "source_location": "L116",
       "target": "customerinfopanel_handlesaveedit",
       "weight": 1
     },
@@ -11303,7 +11303,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_customerinfopanel_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L59",
+      "source_location": "L60",
       "target": "customerinfopanel_handleselectcustomer",
       "weight": 1
     },
@@ -11315,7 +11315,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_customerinfopanel_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L105",
+      "source_location": "L106",
       "target": "customerinfopanel_handlestartedit",
       "weight": 1
     },
@@ -11339,7 +11339,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
-      "source_location": "L17",
+      "source_location": "L18",
       "target": "expensereportsview_istoday",
       "weight": 1
     },
@@ -11405,13 +11405,25 @@
     },
     {
       "_src": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
+      "_tgt": "ordersummary_formatstoredamount",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L322",
+      "target": "ordersummary_formatstoredamount",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
       "_tgt": "ordersummary_handlecompletetransaction",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L128",
+      "source_location": "L129",
       "target": "ordersummary_handlecompletetransaction",
       "weight": 1
     },
@@ -11423,7 +11435,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L162",
+      "source_location": "L163",
       "target": "ordersummary_handlenewtransaction",
       "weight": 1
     },
@@ -11435,7 +11447,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L150",
+      "source_location": "L151",
       "target": "ordersummary_handleselectedpaymentmethod",
       "weight": 1
     },
@@ -11447,7 +11459,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_paymentsaddedlist_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L18",
+      "source_location": "L120",
       "target": "paymentsaddedlist_getpaymentmethodlabel",
       "weight": 1
     },
@@ -11459,7 +11471,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_paymentsaddedlist_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L93",
+      "source_location": "L95",
       "target": "paymentsaddedlist_handlecanceledit",
       "weight": 1
     },
@@ -11471,7 +11483,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_paymentsaddedlist_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L98",
+      "source_location": "L100",
       "target": "paymentsaddedlist_handleremovepayment",
       "weight": 1
     },
@@ -11483,7 +11495,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_paymentsaddedlist_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L62",
+      "source_location": "L64",
       "target": "paymentsaddedlist_handlesaveedit",
       "weight": 1
     },
@@ -11495,7 +11507,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_paymentsaddedlist_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L57",
+      "source_location": "L59",
       "target": "paymentsaddedlist_handlestartedit",
       "weight": 1
     },
@@ -11507,7 +11519,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_paymentview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L178",
+      "source_location": "L182",
       "target": "paymentview_handleaddpayment",
       "weight": 1
     },
@@ -11519,7 +11531,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_paymentview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L253",
+      "source_location": "L246",
       "target": "paymentview_handleamountblur",
       "weight": 1
     },
@@ -11531,7 +11543,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_paymentview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L224",
+      "source_location": "L228",
       "target": "paymentview_handleamountchange",
       "weight": 1
     },
@@ -11543,7 +11555,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_paymentview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L219",
+      "source_location": "L223",
       "target": "paymentview_handleclearall",
       "weight": 1
     },
@@ -11711,7 +11723,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_session_heldsessionslist_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx",
-      "source_location": "L58",
+      "source_location": "L59",
       "target": "heldsessionslist_getsessioncartitemscount",
       "weight": 1
     },
@@ -11723,7 +11735,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_session_heldsessionslist_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx",
-      "source_location": "L54",
+      "source_location": "L55",
       "target": "heldsessionslist_hasexpired",
       "weight": 1
     },
@@ -11855,7 +11867,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_totalsdisplay_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.tsx",
-      "source_location": "L12",
+      "source_location": "L14",
       "target": "totalsdisplay_totalsdisplay",
       "weight": 1
     },
@@ -11879,7 +11891,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L19",
+      "source_location": "L20",
       "target": "transactionsview_formatpaymentmethod",
       "weight": 1
     },
@@ -11891,7 +11903,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L25",
+      "source_location": "L26",
       "target": "transactionsview_istoday",
       "weight": 1
     },
@@ -15232,6 +15244,30 @@
       "weight": 1
     },
     {
+      "_src": "packages_athena_webapp_src_lib_pos_displayamounts_ts",
+      "_tgt": "displayamounts_formatstoredamount",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_lib_pos_displayamounts_ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/displayAmounts.ts",
+      "source_location": "L3",
+      "target": "displayamounts_formatstoredamount",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_lib_pos_displayamounts_ts",
+      "_tgt": "displayamounts_parsedisplayamountinput",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_lib_pos_displayamounts_ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/displayAmounts.ts",
+      "source_location": "L10",
+      "target": "displayamounts_parsedisplayamountinput",
+      "weight": 1
+    },
+    {
       "_src": "packages_athena_webapp_src_lib_pos_services_calculationservice_ts",
       "_tgt": "calculationservice_calculatecarttotals",
       "confidence": "EXTRACTED",
@@ -15419,7 +15455,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_validation_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L404",
+      "source_location": "L405",
       "target": "validation_cancompletetransaction",
       "weight": 1
     },
@@ -15431,7 +15467,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_validation_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L244",
+      "source_location": "L245",
       "target": "validation_isvalidemail",
       "weight": 1
     },
@@ -15443,7 +15479,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_validation_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L304",
+      "source_location": "L305",
       "target": "validation_isvalidphone",
       "weight": 1
     },
@@ -15455,7 +15491,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_validation_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L185",
+      "source_location": "L186",
       "target": "validation_validatebarcode",
       "weight": 1
     },
@@ -15467,7 +15503,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_validation_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L21",
+      "source_location": "L22",
       "target": "validation_validatecart",
       "weight": 1
     },
@@ -15479,7 +15515,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_validation_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L108",
+      "source_location": "L109",
       "target": "validation_validatecustomer",
       "weight": 1
     },
@@ -15491,7 +15527,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_validation_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L146",
+      "source_location": "L147",
       "target": "validation_validatepayment",
       "weight": 1
     },
@@ -15503,7 +15539,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_validation_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L317",
+      "source_location": "L318",
       "target": "validation_validatepaymentamount",
       "weight": 1
     },
@@ -15515,7 +15551,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_validation_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L359",
+      "source_location": "L360",
       "target": "validation_validatepayments",
       "weight": 1
     },
@@ -15527,7 +15563,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_validation_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L68",
+      "source_location": "L69",
       "target": "validation_validateproduct",
       "weight": 1
     },
@@ -15539,7 +15575,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_validation_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L213",
+      "source_location": "L214",
       "target": "validation_validatequantity",
       "weight": 1
     },
@@ -15551,7 +15587,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_lib_pos_validation_ts",
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L252",
+      "source_location": "L253",
       "target": "validation_validatesession",
       "weight": 1
     },
@@ -28799,7 +28835,7 @@
       "relation": "calls",
       "source": "validation_validatecustomer",
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L119",
+      "source_location": "L120",
       "target": "validation_isvalidemail",
       "weight": 1
     },
@@ -28811,7 +28847,7 @@
       "relation": "calls",
       "source": "validation_validatecustomer",
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L124",
+      "source_location": "L125",
       "target": "validation_isvalidphone",
       "weight": 1
     },
@@ -29850,50 +29886,77 @@
     {
       "community": 100,
       "file_type": "code",
-      "id": "herosectiontabs_handledisplaytypechange",
-      "label": "handleDisplayTypeChange()",
-      "norm_label": "handledisplaytypechange()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L61"
+      "id": "dashboard_getperiodrange",
+      "label": "getPeriodRange()",
+      "norm_label": "getperiodrange()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L20"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "herosectiontabs_handleimageupdate",
-      "label": "handleImageUpdate()",
-      "norm_label": "handleimageupdate()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L57"
+      "id": "dashboard_loadingsection",
+      "label": "LoadingSection()",
+      "norm_label": "loadingsection()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L50"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "herosectiontabs_handleoverlaytoggle",
-      "label": "handleOverlayToggle()",
-      "norm_label": "handleoverlaytoggle()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L98"
+      "id": "dashboard_renderproductssection",
+      "label": "renderProductsSection()",
+      "norm_label": "renderproductssection()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L342"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "herosectiontabs_handletexttoggle",
-      "label": "handleTextToggle()",
-      "norm_label": "handletexttoggle()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L134"
+      "id": "dashboard_rendersalessection",
+      "label": "renderSalesSection()",
+      "norm_label": "rendersalessection()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L322"
     },
     {
       "community": 100,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
-      "label": "HeroSectionTabs.tsx",
-      "norm_label": "herosectiontabs.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
+      "label": "Dashboard.tsx",
+      "norm_label": "dashboard.tsx",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
       "source_location": "L1"
     },
     {
       "community": 1000,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_global_d_ts",
+      "label": "global.d.ts",
+      "norm_label": "global.d.ts",
+      "source_file": "packages/storefront-webapp/global.d.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1001,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_playwright_config_ts",
+      "label": "playwright.config.ts",
+      "norm_label": "playwright.config.ts",
+      "source_file": "packages/storefront-webapp/playwright.config.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1002,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_analytics_test_ts",
+      "label": "analytics.test.ts",
+      "norm_label": "analytics.test.ts",
+      "source_file": "packages/storefront-webapp/src/api/analytics.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1003,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_types_ts",
       "label": "types.ts",
@@ -29902,7 +29965,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1001,
+      "community": 1004,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_assets_icons_hearticonfilled_tsx",
       "label": "HeartIconFilled.tsx",
@@ -29911,7 +29974,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1002,
+      "community": 1005,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_client_tsx",
       "label": "client.tsx",
@@ -29920,7 +29983,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1003,
+      "community": 1006,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
@@ -29929,7 +29992,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1004,
+      "community": 1007,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_test_tsx",
       "label": "HomePage.test.tsx",
@@ -29938,7 +30001,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1005,
+      "community": 1008,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productcard_test_tsx",
       "label": "ProductCard.test.tsx",
@@ -29947,7 +30010,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1006,
+      "community": 1009,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productcard_tsx",
       "label": "ProductCard.tsx",
@@ -29956,7 +30019,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1007,
+      "community": 101,
+      "file_type": "code",
+      "id": "herosectiontabs_handledisplaytypechange",
+      "label": "handleDisplayTypeChange()",
+      "norm_label": "handledisplaytypechange()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L61"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "herosectiontabs_handleimageupdate",
+      "label": "handleImageUpdate()",
+      "norm_label": "handleimageupdate()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L57"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "herosectiontabs_handleoverlaytoggle",
+      "label": "handleOverlayToggle()",
+      "norm_label": "handleoverlaytoggle()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L98"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "herosectiontabs_handletexttoggle",
+      "label": "handleTextToggle()",
+      "norm_label": "handletexttoggle()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L134"
+    },
+    {
+      "community": 101,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
+      "label": "HeroSectionTabs.tsx",
+      "norm_label": "herosectiontabs.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1010,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_upsell_tsx",
       "label": "Upsell.tsx",
@@ -29965,7 +30073,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1008,
+      "community": 1011,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_test_tsx",
       "label": "Checkout.test.tsx",
@@ -29974,7 +30082,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1009,
+      "community": 1012,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_tsx",
       "label": "Checkout.tsx",
@@ -29983,52 +30091,7 @@
       "source_location": "L1"
     },
     {
-      "community": 101,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
-      "label": "ReelUploader.tsx",
-      "norm_label": "reeluploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "reeluploader_formatfilesize",
-      "label": "formatFileSize()",
-      "norm_label": "formatfilesize()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L38"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "reeluploader_handlefileselect",
-      "label": "handleFileSelect()",
-      "norm_label": "handlefileselect()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L64"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "reeluploader_handleupload",
-      "label": "handleUpload()",
-      "norm_label": "handleupload()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L135"
-    },
-    {
-      "community": 101,
-      "file_type": "code",
-      "id": "reeluploader_validatefile",
-      "label": "validateFile()",
-      "norm_label": "validatefile()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 1010,
+      "community": 1013,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerinfosection_tsx",
       "label": "CustomerInfoSection.tsx",
@@ -30037,7 +30100,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1011,
+      "community": 1014,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_schema_ts",
       "label": "schema.ts",
@@ -30046,7 +30109,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1012,
+      "community": 1015,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetailssection_tsx",
       "label": "DeliveryDetailsSection.tsx",
@@ -30055,7 +30118,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1013,
+      "community": 1016,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_test_ts",
       "label": "checkoutStorage.test.ts",
@@ -30064,7 +30127,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1014,
+      "community": 1017,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_test_ts",
       "label": "deliveryFees.test.ts",
@@ -30073,7 +30136,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1015,
+      "community": 1018,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_test_ts",
       "label": "deriveCheckoutState.test.ts",
@@ -30082,7 +30145,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1016,
+      "community": 1019,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_billingdetailsschema_ts",
       "label": "billingDetailsSchema.ts",
@@ -30091,7 +30154,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1017,
+      "community": 102,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
+      "label": "ReelUploader.tsx",
+      "norm_label": "reeluploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 102,
+      "file_type": "code",
+      "id": "reeluploader_formatfilesize",
+      "label": "formatFileSize()",
+      "norm_label": "formatfilesize()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L38"
+    },
+    {
+      "community": 102,
+      "file_type": "code",
+      "id": "reeluploader_handlefileselect",
+      "label": "handleFileSelect()",
+      "norm_label": "handlefileselect()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L64"
+    },
+    {
+      "community": 102,
+      "file_type": "code",
+      "id": "reeluploader_handleupload",
+      "label": "handleUpload()",
+      "norm_label": "handleupload()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L135"
+    },
+    {
+      "community": 102,
+      "file_type": "code",
+      "id": "reeluploader_validatefile",
+      "label": "validateFile()",
+      "norm_label": "validatefile()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ReelUploader.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 1020,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutformschema_ts",
       "label": "checkoutFormSchema.ts",
@@ -30100,7 +30208,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1018,
+      "community": 1021,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_customerdetailsschema_ts",
       "label": "customerDetailsSchema.ts",
@@ -30109,7 +30217,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1019,
+      "community": 1022,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_deliverydetailsschema_ts",
       "label": "deliveryDetailsSchema.ts",
@@ -30118,52 +30226,7 @@
       "source_location": "L1"
     },
     {
-      "community": 102,
-      "file_type": "code",
-      "id": "activityview_iscreatedaction",
-      "label": "isCreatedAction()",
-      "norm_label": "iscreatedaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L58"
-    },
-    {
-      "community": 102,
-      "file_type": "code",
-      "id": "activityview_isfeedbackrequestaction",
-      "label": "isFeedbackRequestAction()",
-      "norm_label": "isfeedbackrequestaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L63"
-    },
-    {
-      "community": 102,
-      "file_type": "code",
-      "id": "activityview_isrefundaction",
-      "label": "isRefundAction()",
-      "norm_label": "isrefundaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 102,
-      "file_type": "code",
-      "id": "activityview_istransitionaction",
-      "label": "isTransitionAction()",
-      "norm_label": "istransitionaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L53"
-    },
-    {
-      "community": 102,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
-      "label": "ActivityView.tsx",
-      "norm_label": "activityview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1020,
+      "community": 1023,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_ts",
       "label": "webOrderSchema.ts",
@@ -30172,7 +30235,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1021,
+      "community": 1024,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_types_ts",
       "label": "types.ts",
@@ -30181,7 +30244,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1022,
+      "community": 1025,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_utils_test_ts",
       "label": "utils.test.ts",
@@ -30190,7 +30253,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1023,
+      "community": 1026,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilterbar_tsx",
       "label": "ProductFilterBar.tsx",
@@ -30199,7 +30262,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1024,
+      "community": 1027,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_test_tsx",
       "label": "BestSellersSection.test.tsx",
@@ -30208,7 +30271,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1025,
+      "community": 1028,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homehero_tsx",
       "label": "HomeHero.tsx",
@@ -30217,7 +30280,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1026,
+      "community": 1029,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homeherosection_tsx",
       "label": "HomeHeroSection.tsx",
@@ -30226,7 +30289,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1027,
+      "community": 103,
+      "file_type": "code",
+      "id": "activityview_iscreatedaction",
+      "label": "isCreatedAction()",
+      "norm_label": "iscreatedaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L58"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "activityview_isfeedbackrequestaction",
+      "label": "isFeedbackRequestAction()",
+      "norm_label": "isfeedbackrequestaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "activityview_isrefundaction",
+      "label": "isRefundAction()",
+      "norm_label": "isrefundaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L50"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "activityview_istransitionaction",
+      "label": "isTransitionAction()",
+      "norm_label": "istransitionaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L53"
+    },
+    {
+      "community": 103,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
+      "label": "ActivityView.tsx",
+      "norm_label": "activityview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/ActivityView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1030,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_test_ts",
       "label": "homePageContent.test.ts",
@@ -30235,7 +30343,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1028,
+      "community": 1031,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilemenu_tsx",
       "label": "MobileMenu.tsx",
@@ -30244,7 +30352,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1029,
+      "community": 1032,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_constants_ts",
       "label": "constants.ts",
@@ -30253,52 +30361,7 @@
       "source_location": "L1"
     },
     {
-      "community": 103,
-      "file_type": "code",
-      "id": "orderdetailsview_fetchtransactions",
-      "label": "fetchTransactions()",
-      "norm_label": "fetchtransactions()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L138"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "orderdetailsview_handlemarkasverified",
-      "label": "handleMarkAsVerified()",
-      "norm_label": "handlemarkasverified()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L175"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "orderdetailsview_handlemarkpaymentcollected",
-      "label": "handleMarkPaymentCollected()",
-      "norm_label": "handlemarkpaymentcollected()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L189"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "orderdetailsview_verifiedbadge",
-      "label": "VerifiedBadge()",
-      "norm_label": "verifiedbadge()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
-      "label": "OrderDetailsView.tsx",
-      "norm_label": "orderdetailsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1030,
+      "community": 1033,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navbarconstants_ts",
       "label": "navBarConstants.ts",
@@ -30307,7 +30370,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1031,
+      "community": 1034,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_about_tsx",
       "label": "About.tsx",
@@ -30316,7 +30379,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1032,
+      "community": 1035,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_aboutproduct_tsx",
       "label": "AboutProduct.tsx",
@@ -30325,7 +30388,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1033,
+      "community": 1036,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_test_tsx",
       "label": "ProductActions.test.tsx",
@@ -30334,7 +30397,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1034,
+      "community": 1037,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productinfo_tsx",
       "label": "ProductInfo.tsx",
@@ -30343,7 +30406,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1035,
+      "community": 1038,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreviews_tsx",
       "label": "ProductReviews.tsx",
@@ -30352,7 +30415,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1036,
+      "community": 1039,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productsnavigationbar_tsx",
       "label": "ProductsNavigationBar.tsx",
@@ -30361,7 +30424,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1037,
+      "community": 104,
+      "file_type": "code",
+      "id": "orderdetailsview_fetchtransactions",
+      "label": "fetchTransactions()",
+      "norm_label": "fetchtransactions()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L138"
+    },
+    {
+      "community": 104,
+      "file_type": "code",
+      "id": "orderdetailsview_handlemarkasverified",
+      "label": "handleMarkAsVerified()",
+      "norm_label": "handlemarkasverified()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L175"
+    },
+    {
+      "community": 104,
+      "file_type": "code",
+      "id": "orderdetailsview_handlemarkpaymentcollected",
+      "label": "handleMarkPaymentCollected()",
+      "norm_label": "handlemarkpaymentcollected()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L189"
+    },
+    {
+      "community": 104,
+      "file_type": "code",
+      "id": "orderdetailsview_verifiedbadge",
+      "label": "VerifiedBadge()",
+      "norm_label": "verifiedbadge()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 104,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
+      "label": "OrderDetailsView.tsx",
+      "norm_label": "orderdetailsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderDetailsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1040,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_errormessage_tsx",
       "label": "ErrorMessage.tsx",
@@ -30370,7 +30478,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1038,
+      "community": 1041,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_existingreviewmessage_tsx",
       "label": "ExistingReviewMessage.tsx",
@@ -30379,7 +30487,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1039,
+      "community": 1042,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_reviewform_tsx",
       "label": "ReviewForm.tsx",
@@ -30388,52 +30496,7 @@
       "source_location": "L1"
     },
     {
-      "community": 104,
-      "file_type": "code",
-      "id": "orderitemsview_handlerequestfeedback",
-      "label": "handleRequestFeedback()",
-      "norm_label": "handlerequestfeedback()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L77"
-    },
-    {
-      "community": 104,
-      "file_type": "code",
-      "id": "orderitemsview_handlerestockall",
-      "label": "handleRestockAll()",
-      "norm_label": "handlerestockall()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L295"
-    },
-    {
-      "community": 104,
-      "file_type": "code",
-      "id": "orderitemsview_handlereturnitemtostock",
-      "label": "handleReturnItemToStock()",
-      "norm_label": "handlereturnitemtostock()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L61"
-    },
-    {
-      "community": 104,
-      "file_type": "code",
-      "id": "orderitemsview_handleupdateorderitem",
-      "label": "handleUpdateOrderItem()",
-      "norm_label": "handleupdateorderitem()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L47"
-    },
-    {
-      "community": 104,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
-      "label": "OrderItemsView.tsx",
-      "norm_label": "orderitemsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1040,
+      "community": 1043,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_successmessage_tsx",
       "label": "SuccessMessage.tsx",
@@ -30442,7 +30505,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1041,
+      "community": 1044,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_types_ts",
       "label": "types.ts",
@@ -30451,7 +30514,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1042,
+      "community": 1045,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedbag_tsx",
       "label": "SavedBag.tsx",
@@ -30460,7 +30523,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1043,
+      "community": 1046,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedicon_tsx",
       "label": "SavedIcon.tsx",
@@ -30469,7 +30532,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1044,
+      "community": 1047,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_carticon_tsx",
       "label": "CartIcon.tsx",
@@ -30478,7 +30541,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1045,
+      "community": 1048,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_test_tsx",
       "label": "ShoppingBag.test.tsx",
@@ -30487,7 +30550,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1046,
+      "community": 1049,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
@@ -30496,7 +30559,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1047,
+      "community": 105,
+      "file_type": "code",
+      "id": "orderitemsview_handlerequestfeedback",
+      "label": "handleRequestFeedback()",
+      "norm_label": "handlerequestfeedback()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L77"
+    },
+    {
+      "community": 105,
+      "file_type": "code",
+      "id": "orderitemsview_handlerestockall",
+      "label": "handleRestockAll()",
+      "norm_label": "handlerestockall()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L295"
+    },
+    {
+      "community": 105,
+      "file_type": "code",
+      "id": "orderitemsview_handlereturnitemtostock",
+      "label": "handleReturnItemToStock()",
+      "norm_label": "handlereturnitemtostock()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L61"
+    },
+    {
+      "community": 105,
+      "file_type": "code",
+      "id": "orderitemsview_handleupdateorderitem",
+      "label": "handleUpdateOrderItem()",
+      "norm_label": "handleupdateorderitem()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L47"
+    },
+    {
+      "community": 105,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
+      "label": "OrderItemsView.tsx",
+      "norm_label": "orderitemsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderItemsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1050,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_tsx",
       "label": "Maintenance.tsx",
@@ -30505,7 +30613,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1048,
+      "community": 1051,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_animatedcard_tsx",
       "label": "AnimatedCard.tsx",
@@ -30514,7 +30622,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1049,
+      "community": 1052,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
@@ -30523,52 +30631,7 @@
       "source_location": "L1"
     },
     {
-      "community": 105,
-      "file_type": "code",
-      "id": "index_feesview",
-      "label": "FeesView()",
-      "norm_label": "feesview()",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
-      "source_location": "L29"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "index_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L42"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "index_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 105,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1050,
+      "community": 1053,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_alert_tsx",
       "label": "alert.tsx",
@@ -30577,7 +30640,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1051,
+      "community": 1054,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_breadcrumb_tsx",
       "label": "breadcrumb.tsx",
@@ -30586,7 +30649,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1052,
+      "community": 1055,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
@@ -30595,7 +30658,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1053,
+      "community": 1056,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
@@ -30604,7 +30667,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1054,
+      "community": 1057,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
@@ -30613,7 +30676,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1055,
+      "community": 1058,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
@@ -30622,7 +30685,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1056,
+      "community": 1059,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
@@ -30631,7 +30694,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1057,
+      "community": 106,
+      "file_type": "code",
+      "id": "ordersummary_formatstoredamount",
+      "label": "formatStoredAmount()",
+      "norm_label": "formatstoredamount()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L322"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "ordersummary_handlecompletetransaction",
+      "label": "handleCompleteTransaction()",
+      "norm_label": "handlecompletetransaction()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L129"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "ordersummary_handlenewtransaction",
+      "label": "handleNewTransaction()",
+      "norm_label": "handlenewtransaction()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L163"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "ordersummary_handleselectedpaymentmethod",
+      "label": "handleSelectedPaymentMethod()",
+      "norm_label": "handleselectedpaymentmethod()",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L151"
+    },
+    {
+      "community": 106,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
+      "label": "OrderSummary.tsx",
+      "norm_label": "ordersummary.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1060,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
@@ -30640,7 +30748,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1058,
+      "community": 1061,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
@@ -30649,7 +30757,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1059,
+      "community": 1062,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
@@ -30658,52 +30766,7 @@
       "source_location": "L1"
     },
     {
-      "community": 106,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_paymentview_tsx",
-      "label": "PaymentView.tsx",
-      "norm_label": "paymentview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 106,
-      "file_type": "code",
-      "id": "paymentview_handleaddpayment",
-      "label": "handleAddPayment()",
-      "norm_label": "handleaddpayment()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L178"
-    },
-    {
-      "community": 106,
-      "file_type": "code",
-      "id": "paymentview_handleamountblur",
-      "label": "handleAmountBlur()",
-      "norm_label": "handleamountblur()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L253"
-    },
-    {
-      "community": 106,
-      "file_type": "code",
-      "id": "paymentview_handleamountchange",
-      "label": "handleAmountChange()",
-      "norm_label": "handleamountchange()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L224"
-    },
-    {
-      "community": 106,
-      "file_type": "code",
-      "id": "paymentview_handleclearall",
-      "label": "handleClearAll()",
-      "norm_label": "handleclearall()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
-      "source_location": "L219"
-    },
-    {
-      "community": 1060,
+      "community": 1063,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
@@ -30712,7 +30775,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1061,
+      "community": 1064,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_image_with_fallback_tsx",
       "label": "image-with-fallback.tsx",
@@ -30721,7 +30784,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1062,
+      "community": 1065,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
@@ -30730,7 +30793,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1063,
+      "community": 1066,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_with_end_button_tsx",
       "label": "input-with-end-button.tsx",
@@ -30739,7 +30802,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1064,
+      "community": 1067,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
@@ -30748,7 +30811,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1065,
+      "community": 1068,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
@@ -30757,7 +30820,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1066,
+      "community": 1069,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodalform_tsx",
       "label": "LeaveAReviewModalForm.tsx",
@@ -30766,7 +30829,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1067,
+      "community": 107,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_paymentview_tsx",
+      "label": "PaymentView.tsx",
+      "norm_label": "paymentview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "paymentview_handleaddpayment",
+      "label": "handleAddPayment()",
+      "norm_label": "handleaddpayment()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L182"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "paymentview_handleamountblur",
+      "label": "handleAmountBlur()",
+      "norm_label": "handleamountblur()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L246"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "paymentview_handleamountchange",
+      "label": "handleAmountChange()",
+      "norm_label": "handleamountchange()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L228"
+    },
+    {
+      "community": 107,
+      "file_type": "code",
+      "id": "paymentview_handleclearall",
+      "label": "handleClearAll()",
+      "norm_label": "handleclearall()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentView.tsx",
+      "source_location": "L223"
+    },
+    {
+      "community": 1070,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
@@ -30775,7 +30883,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1068,
+      "community": 1071,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_animations_welcomebackmodalanimations_ts",
       "label": "welcomeBackModalAnimations.ts",
@@ -30784,7 +30892,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1069,
+      "community": 1072,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_index_ts",
       "label": "index.ts",
@@ -30793,52 +30901,7 @@
       "source_location": "L1"
     },
     {
-      "community": 107,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_sessionmanager_tsx",
-      "label": "SessionManager.tsx",
-      "norm_label": "sessionmanager.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "sessionmanager_onholdconfirm",
-      "label": "onHoldConfirm()",
-      "norm_label": "onholdconfirm()",
-      "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
-      "source_location": "L72"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "sessionmanager_onnewsessionclick",
-      "label": "onNewSessionClick()",
-      "norm_label": "onnewsessionclick()",
-      "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
-      "source_location": "L96"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "sessionmanager_onresumesession",
-      "label": "onResumeSession()",
-      "norm_label": "onresumesession()",
-      "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
-      "source_location": "L77"
-    },
-    {
-      "community": 107,
-      "file_type": "code",
-      "id": "sessionmanager_onvoidconfirm",
-      "label": "onVoidConfirm()",
-      "norm_label": "onvoidconfirm()",
-      "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
-      "source_location": "L90"
-    },
-    {
-      "community": 1070,
+      "community": 1073,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_types_ts",
       "label": "types.ts",
@@ -30847,7 +30910,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1071,
+      "community": 1074,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_navigation_menu_tsx",
       "label": "navigation-menu.tsx",
@@ -30856,7 +30919,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1072,
+      "community": 1075,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -30865,7 +30928,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1073,
+      "community": 1076,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
@@ -30874,7 +30937,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1074,
+      "community": 1077,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
@@ -30883,7 +30946,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1075,
+      "community": 1078,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
@@ -30892,7 +30955,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1076,
+      "community": 1079,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
@@ -30901,7 +30964,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1077,
+      "community": 108,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_sessionmanager_tsx",
+      "label": "SessionManager.tsx",
+      "norm_label": "sessionmanager.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "sessionmanager_onholdconfirm",
+      "label": "onHoldConfirm()",
+      "norm_label": "onholdconfirm()",
+      "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
+      "source_location": "L72"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "sessionmanager_onnewsessionclick",
+      "label": "onNewSessionClick()",
+      "norm_label": "onnewsessionclick()",
+      "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
+      "source_location": "L96"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "sessionmanager_onresumesession",
+      "label": "onResumeSession()",
+      "norm_label": "onresumesession()",
+      "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
+      "source_location": "L77"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "sessionmanager_onvoidconfirm",
+      "label": "onVoidConfirm()",
+      "norm_label": "onvoidconfirm()",
+      "source_file": "packages/athena-webapp/src/components/pos/SessionManager.tsx",
+      "source_location": "L90"
+    },
+    {
+      "community": 1080,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
@@ -30910,7 +31018,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1078,
+      "community": 1081,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
@@ -30919,7 +31027,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1079,
+      "community": 1082,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
@@ -30928,52 +31036,7 @@
       "source_location": "L1"
     },
     {
-      "community": 108,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_promocodeview_tsx",
-      "label": "PromoCodeView.tsx",
-      "norm_label": "promocodeview.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 108,
-      "file_type": "code",
-      "id": "promocodeview_handleaddpromocode",
-      "label": "handleAddPromoCode()",
-      "norm_label": "handleaddpromocode()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
-      "source_location": "L146"
-    },
-    {
-      "community": 108,
-      "file_type": "code",
-      "id": "promocodeview_handleupdatepromocode",
-      "label": "handleUpdatePromoCode()",
-      "norm_label": "handleupdatepromocode()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
-      "source_location": "L213"
-    },
-    {
-      "community": 108,
-      "file_type": "code",
-      "id": "promocodeview_updatehomepagediscountcode",
-      "label": "updateHomepageDiscountCode()",
-      "norm_label": "updatehomepagediscountcode()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
-      "source_location": "L299"
-    },
-    {
-      "community": 108,
-      "file_type": "code",
-      "id": "promocodeview_updateleaveareviewdiscountcode",
-      "label": "updateLeaveAReviewDiscountCode()",
-      "norm_label": "updateleaveareviewdiscountcode()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
-      "source_location": "L351"
-    },
-    {
-      "community": 1080,
+      "community": 1083,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
@@ -30982,7 +31045,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1081,
+      "community": 1084,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
@@ -30991,7 +31054,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1082,
+      "community": 1085,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
@@ -31000,7 +31063,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1083,
+      "community": 1086,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
@@ -31009,7 +31072,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1084,
+      "community": 1087,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_config_ts",
       "label": "config.ts",
@@ -31018,7 +31081,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1085,
+      "community": 1088,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
@@ -31027,7 +31090,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1086,
+      "community": 1089,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useorganizationmodal_tsx",
       "label": "useOrganizationModal.tsx",
@@ -31036,7 +31099,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1087,
+      "community": 109,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_promocodeview_tsx",
+      "label": "PromoCodeView.tsx",
+      "norm_label": "promocodeview.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "promocodeview_handleaddpromocode",
+      "label": "handleAddPromoCode()",
+      "norm_label": "handleaddpromocode()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
+      "source_location": "L146"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "promocodeview_handleupdatepromocode",
+      "label": "handleUpdatePromoCode()",
+      "norm_label": "handleupdatepromocode()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
+      "source_location": "L213"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "promocodeview_updatehomepagediscountcode",
+      "label": "updateHomepageDiscountCode()",
+      "norm_label": "updatehomepagediscountcode()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
+      "source_location": "L299"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "promocodeview_updateleaveareviewdiscountcode",
+      "label": "updateLeaveAReviewDiscountCode()",
+      "norm_label": "updateleaveareviewdiscountcode()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
+      "source_location": "L351"
+    },
+    {
+      "community": 1090,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usestorefrontobservability_ts",
       "label": "useStorefrontObservability.ts",
@@ -31045,7 +31153,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1088,
+      "community": 1091,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_constants_ts",
       "label": "constants.ts",
@@ -31054,7 +31162,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1089,
+      "community": 1092,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_countries_ts",
       "label": "countries.ts",
@@ -31063,52 +31171,7 @@
       "source_location": "L1"
     },
     {
-      "community": 109,
-      "file_type": "code",
-      "id": "custom_modal_example_basicmodalexample",
-      "label": "BasicModalExample()",
-      "norm_label": "basicmodalexample()",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
-      "source_location": "L7"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "custom_modal_example_customclosebuttonexample",
-      "label": "CustomCloseButtonExample()",
-      "norm_label": "customclosebuttonexample()",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
-      "source_location": "L69"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "custom_modal_example_custompositionmodalexample",
-      "label": "CustomPositionModalExample()",
-      "norm_label": "custompositionmodalexample()",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
-      "source_location": "L44"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "custom_modal_example_fullscreenmodalexample",
-      "label": "FullScreenModalExample()",
-      "norm_label": "fullscreenmodalexample()",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
-      "source_location": "L103"
-    },
-    {
-      "community": 109,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_example_tsx",
-      "label": "custom-modal-example.tsx",
-      "norm_label": "custom-modal-example.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1090,
+      "community": 1093,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_feeutils_test_ts",
       "label": "feeUtils.test.ts",
@@ -31117,7 +31180,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1091,
+      "community": 1094,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -31126,7 +31189,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1092,
+      "community": 1095,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
@@ -31135,7 +31198,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1093,
+      "community": 1096,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_test_ts",
       "label": "maintenanceUtils.test.ts",
@@ -31144,7 +31207,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1094,
+      "community": 1097,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_index_ts",
       "label": "index.ts",
@@ -31153,7 +31216,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1095,
+      "community": 1098,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_store_ts",
       "label": "store.ts",
@@ -31162,39 +31225,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1096,
+      "community": 1099,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bag_ts",
       "label": "bag.ts",
       "norm_label": "bag.ts",
       "source_file": "packages/storefront-webapp/src/lib/schemas/bag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1097,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_bagitem_ts",
-      "label": "bagItem.ts",
-      "norm_label": "bagitem.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/bagItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1098,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_category_ts",
-      "label": "category.ts",
-      "norm_label": "category.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/category.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1099,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_organization_ts",
-      "label": "organization.ts",
-      "norm_label": "organization.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/organization.ts",
       "source_location": "L1"
     },
     {
@@ -31380,50 +31416,77 @@
     {
       "community": 110,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
-      "label": "usePOSProducts.ts",
-      "norm_label": "useposproducts.ts",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "id": "custom_modal_example_basicmodalexample",
+      "label": "BasicModalExample()",
+      "norm_label": "basicmodalexample()",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
+      "source_location": "L7"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "custom_modal_example_customclosebuttonexample",
+      "label": "CustomCloseButtonExample()",
+      "norm_label": "customclosebuttonexample()",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
+      "source_location": "L69"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "custom_modal_example_custompositionmodalexample",
+      "label": "CustomPositionModalExample()",
+      "norm_label": "custompositionmodalexample()",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
+      "source_location": "L44"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "custom_modal_example_fullscreenmodalexample",
+      "label": "FullScreenModalExample()",
+      "norm_label": "fullscreenmodalexample()",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
+      "source_location": "L103"
+    },
+    {
+      "community": 110,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_example_tsx",
+      "label": "custom-modal-example.tsx",
+      "norm_label": "custom-modal-example.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal-example.tsx",
       "source_location": "L1"
     },
     {
-      "community": 110,
-      "file_type": "code",
-      "id": "useposproducts_useposbarcodesearch",
-      "label": "usePOSBarcodeSearch()",
-      "norm_label": "useposbarcodesearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "useposproducts_useposproductidsearch",
-      "label": "usePOSProductIdSearch()",
-      "norm_label": "useposproductidsearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L41"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "useposproducts_useposproductsearch",
-      "label": "usePOSProductSearch()",
-      "norm_label": "useposproductsearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 110,
-      "file_type": "code",
-      "id": "useposproducts_usepostransactioncomplete",
-      "label": "usePOSTransactionComplete()",
-      "norm_label": "usepostransactioncomplete()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L100"
-    },
-    {
       "community": 1100,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_bagitem_ts",
+      "label": "bagItem.ts",
+      "norm_label": "bagitem.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/bagItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1101,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_category_ts",
+      "label": "category.ts",
+      "norm_label": "category.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/category.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1102,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_organization_ts",
+      "label": "organization.ts",
+      "norm_label": "organization.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/organization.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1103,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
@@ -31432,7 +31495,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1101,
+      "community": 1104,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -31441,7 +31504,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1102,
+      "community": 1105,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
@@ -31450,7 +31513,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1103,
+      "community": 1106,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
@@ -31459,7 +31522,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1104,
+      "community": 1107,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_states_ts",
       "label": "states.ts",
@@ -31468,7 +31531,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1105,
+      "community": 1108,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_test_ts",
       "label": "storefrontFailureObservability.test.ts",
@@ -31477,7 +31540,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1106,
+      "community": 1109,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontjourneyevents_test_ts",
       "label": "storefrontJourneyEvents.test.ts",
@@ -31486,7 +31549,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1107,
+      "community": 111,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
+      "label": "usePOSProducts.ts",
+      "norm_label": "useposproducts.ts",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 111,
+      "file_type": "code",
+      "id": "useposproducts_useposbarcodesearch",
+      "label": "usePOSBarcodeSearch()",
+      "norm_label": "useposbarcodesearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 111,
+      "file_type": "code",
+      "id": "useposproducts_useposproductidsearch",
+      "label": "usePOSProductIdSearch()",
+      "norm_label": "useposproductidsearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L41"
+    },
+    {
+      "community": 111,
+      "file_type": "code",
+      "id": "useposproducts_useposproductsearch",
+      "label": "usePOSProductSearch()",
+      "norm_label": "useposproductsearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 111,
+      "file_type": "code",
+      "id": "useposproducts_usepostransactioncomplete",
+      "label": "usePOSTransactionComplete()",
+      "norm_label": "usepostransactioncomplete()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L100"
+    },
+    {
+      "community": 1110,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
@@ -31495,7 +31603,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1108,
+      "community": 1111,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
@@ -31504,7 +31612,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1109,
+      "community": 1112,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_test_ts",
       "label": "-homePageLoader.test.ts",
@@ -31513,52 +31621,7 @@
       "source_location": "L1"
     },
     {
-      "community": 111,
-      "file_type": "code",
-      "id": "browserfingerprint_buffertohex",
-      "label": "bufferToHex()",
-      "norm_label": "buffertohex()",
-      "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 111,
-      "file_type": "code",
-      "id": "browserfingerprint_collectbrowserinfo",
-      "label": "collectBrowserInfo()",
-      "norm_label": "collectbrowserinfo()",
-      "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 111,
-      "file_type": "code",
-      "id": "browserfingerprint_generatebrowserfingerprint",
-      "label": "generateBrowserFingerprint()",
-      "norm_label": "generatebrowserfingerprint()",
-      "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 111,
-      "file_type": "code",
-      "id": "browserfingerprint_hashfingerprintsource",
-      "label": "hashFingerprintSource()",
-      "norm_label": "hashfingerprintsource()",
-      "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 111,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_browserfingerprint_ts",
-      "label": "browserFingerprint.ts",
-      "norm_label": "browserfingerprint.ts",
-      "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1110,
+      "community": 1113,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -31567,7 +31630,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1111,
+      "community": 1114,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_orderitemid_review_tsx",
       "label": "$orderItemId.review.tsx",
@@ -31576,7 +31639,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1112,
+      "community": 1115,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_index_tsx",
       "label": "index.tsx",
@@ -31585,7 +31648,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1113,
+      "community": 1116,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_subcategoryslug_tsx",
       "label": "$subcategorySlug.tsx",
@@ -31594,7 +31657,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1114,
+      "community": 1117,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_index_tsx",
       "label": "index.tsx",
@@ -31603,7 +31666,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1115,
+      "community": 1118,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_rewards_index_tsx",
       "label": "rewards.index.tsx",
@@ -31612,7 +31675,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1116,
+      "community": 1119,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_saved_index_tsx",
       "label": "shop.saved.index.tsx",
@@ -31621,7 +31684,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1117,
+      "community": 112,
+      "file_type": "code",
+      "id": "browserfingerprint_buffertohex",
+      "label": "bufferToHex()",
+      "norm_label": "buffertohex()",
+      "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "browserfingerprint_collectbrowserinfo",
+      "label": "collectBrowserInfo()",
+      "norm_label": "collectbrowserinfo()",
+      "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "browserfingerprint_generatebrowserfingerprint",
+      "label": "generateBrowserFingerprint()",
+      "norm_label": "generatebrowserfingerprint()",
+      "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "browserfingerprint_hashfingerprintsource",
+      "label": "hashFingerprintSource()",
+      "norm_label": "hashfingerprintsource()",
+      "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 112,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_browserfingerprint_ts",
+      "label": "browserFingerprint.ts",
+      "norm_label": "browserfingerprint.ts",
+      "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1120,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_bag_index_tsx",
       "label": "bag.index.tsx",
@@ -31630,7 +31738,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1118,
+      "community": 1121,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_complete_tsx",
       "label": "complete.tsx",
@@ -31639,7 +31747,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1119,
+      "community": 1122,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_incomplete_tsx",
       "label": "incomplete.tsx",
@@ -31648,52 +31756,7 @@
       "source_location": "L1"
     },
     {
-      "community": 112,
-      "file_type": "code",
-      "id": "imageutils_test_arraybuffer",
-      "label": "arrayBuffer()",
-      "norm_label": "arraybuffer()",
-      "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "imageutils_test_constructor",
-      "label": "constructor()",
-      "norm_label": "constructor()",
-      "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "imageutils_test_mockimage",
-      "label": "MockImage",
-      "norm_label": "mockimage",
-      "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
-      "source_location": "L103"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "imageutils_test_mockimage_src",
-      "label": ".src()",
-      "norm_label": ".src()",
-      "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
-      "source_location": "L109"
-    },
-    {
-      "community": 112,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_imageutils_test_ts",
-      "label": "imageUtils.test.ts",
-      "norm_label": "imageutils.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1120,
+      "community": 1123,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_index_tsx",
       "label": "index.tsx",
@@ -31702,7 +31765,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1121,
+      "community": 1124,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pending_tsx",
       "label": "pending.tsx",
@@ -31711,7 +31774,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1122,
+      "community": 1125,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_ssr_tsx",
       "label": "ssr.tsx",
@@ -31720,7 +31783,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1123,
+      "community": 1126,
       "file_type": "code",
       "id": "packages_storefront_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
@@ -31729,7 +31792,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1124,
+      "community": 1127,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
@@ -31738,7 +31801,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1125,
+      "community": 1128,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_setup_ts",
       "label": "vitest.setup.ts",
@@ -31747,7 +31810,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1126,
+      "community": 1129,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_index_js",
       "label": "index.js",
@@ -31756,7 +31819,52 @@
       "source_location": "L1"
     },
     {
-      "community": 1127,
+      "community": 113,
+      "file_type": "code",
+      "id": "imageutils_test_arraybuffer",
+      "label": "arrayBuffer()",
+      "norm_label": "arraybuffer()",
+      "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
+      "source_location": "L78"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "imageutils_test_constructor",
+      "label": "constructor()",
+      "norm_label": "constructor()",
+      "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "imageutils_test_mockimage",
+      "label": "MockImage",
+      "norm_label": "mockimage",
+      "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
+      "source_location": "L103"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "imageutils_test_mockimage_src",
+      "label": ".src()",
+      "norm_label": ".src()",
+      "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
+      "source_location": "L109"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_imageutils_test_ts",
+      "label": "imageUtils.test.ts",
+      "norm_label": "imageutils.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/imageUtils.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1130,
       "file_type": "code",
       "id": "scripts_harness_app_registry_test_ts",
       "label": "harness-app-registry.test.ts",
@@ -31765,7 +31873,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1128,
+      "community": 1131,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_test_ts",
       "label": "valkey-runtime-app.test.ts",
@@ -31774,7 +31882,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1129,
+      "community": 1132,
       "file_type": "code",
       "id": "scripts_harness_behavior_scenarios_test_ts",
       "label": "harness-behavior-scenarios.test.ts",
@@ -31783,7 +31891,7 @@
       "source_location": "L1"
     },
     {
-      "community": 113,
+      "community": 114,
       "file_type": "code",
       "id": "imageutils_convertimagestojpg",
       "label": "convertImagesToJpg()",
@@ -31792,7 +31900,7 @@
       "source_location": "L75"
     },
     {
-      "community": 113,
+      "community": 114,
       "file_type": "code",
       "id": "imageutils_convertimagestowebp",
       "label": "convertImagesToWebp()",
@@ -31801,7 +31909,7 @@
       "source_location": "L26"
     },
     {
-      "community": 113,
+      "community": 114,
       "file_type": "code",
       "id": "imageutils_converttojpg",
       "label": "convertToJpg()",
@@ -31810,7 +31918,7 @@
       "source_location": "L38"
     },
     {
-      "community": 113,
+      "community": 114,
       "file_type": "code",
       "id": "imageutils_getuploadimagesdata",
       "label": "getUploadImagesData()",
@@ -31819,7 +31927,7 @@
       "source_location": "L4"
     },
     {
-      "community": 113,
+      "community": 114,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_ts",
       "label": "imageUtils.ts",
@@ -31828,7 +31936,7 @@
       "source_location": "L1"
     },
     {
-      "community": 114,
+      "community": 115,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_transactionutils_ts",
       "label": "transactionUtils.ts",
@@ -31837,7 +31945,7 @@
       "source_location": "L1"
     },
     {
-      "community": 114,
+      "community": 115,
       "file_type": "code",
       "id": "transactionutils_calculatechange",
       "label": "calculateChange()",
@@ -31846,7 +31954,7 @@
       "source_location": "L42"
     },
     {
-      "community": 114,
+      "community": 115,
       "file_type": "code",
       "id": "transactionutils_formatcurrency",
       "label": "formatCurrency()",
@@ -31855,7 +31963,7 @@
       "source_location": "L29"
     },
     {
-      "community": 114,
+      "community": 115,
       "file_type": "code",
       "id": "transactionutils_formattimestamp",
       "label": "formatTimestamp()",
@@ -31864,7 +31972,7 @@
       "source_location": "L49"
     },
     {
-      "community": 114,
+      "community": 115,
       "file_type": "code",
       "id": "transactionutils_generatetransactionnumber",
       "label": "generateTransactionNumber()",
@@ -31873,7 +31981,7 @@
       "source_location": "L14"
     },
     {
-      "community": 115,
+      "community": 116,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_timelineutils_ts",
       "label": "timelineUtils.ts",
@@ -31882,7 +31990,7 @@
       "source_location": "L1"
     },
     {
-      "community": 115,
+      "community": 116,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevent",
       "label": "enrichTimelineEvent()",
@@ -31891,7 +31999,7 @@
       "source_location": "L184"
     },
     {
-      "community": 115,
+      "community": 116,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevents",
       "label": "enrichTimelineEvents()",
@@ -31900,7 +32008,7 @@
       "source_location": "L200"
     },
     {
-      "community": 115,
+      "community": 116,
       "file_type": "code",
       "id": "timelineutils_gettimerangelabel",
       "label": "getTimeRangeLabel()",
@@ -31909,7 +32017,7 @@
       "source_location": "L244"
     },
     {
-      "community": 115,
+      "community": 116,
       "file_type": "code",
       "id": "timelineutils_groupeventsbytimeframe",
       "label": "groupEventsByTimeframe()",
@@ -31918,7 +32026,7 @@
       "source_location": "L206"
     },
     {
-      "community": 116,
+      "community": 117,
       "file_type": "code",
       "id": "analytics_getproductviewcount",
       "label": "getProductViewCount()",
@@ -31927,7 +32035,7 @@
       "source_location": "L93"
     },
     {
-      "community": 116,
+      "community": 117,
       "file_type": "code",
       "id": "analytics_logout",
       "label": "logout()",
@@ -31936,7 +32044,7 @@
       "source_location": "L75"
     },
     {
-      "community": 116,
+      "community": 117,
       "file_type": "code",
       "id": "analytics_postanalytics",
       "label": "postAnalytics()",
@@ -31945,7 +32053,7 @@
       "source_location": "L4"
     },
     {
-      "community": 116,
+      "community": 117,
       "file_type": "code",
       "id": "analytics_updateanalyticsowner",
       "label": "updateAnalyticsOwner()",
@@ -31954,7 +32062,7 @@
       "source_location": "L47"
     },
     {
-      "community": 116,
+      "community": 117,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_ts",
       "label": "analytics.ts",
@@ -31963,7 +32071,7 @@
       "source_location": "L1"
     },
     {
-      "community": 117,
+      "community": 118,
       "file_type": "code",
       "id": "category_getallcategories",
       "label": "getAllCategories()",
@@ -31972,7 +32080,7 @@
       "source_location": "L11"
     },
     {
-      "community": 117,
+      "community": 118,
       "file_type": "code",
       "id": "category_getallcategorieswithsubcategories",
       "label": "getAllCategoriesWithSubcategories()",
@@ -31981,7 +32089,7 @@
       "source_location": "L25"
     },
     {
-      "community": 117,
+      "community": 118,
       "file_type": "code",
       "id": "category_getbaseurl",
       "label": "getBaseUrl()",
@@ -31990,7 +32098,7 @@
       "source_location": "L9"
     },
     {
-      "community": 117,
+      "community": 118,
       "file_type": "code",
       "id": "category_getcategory",
       "label": "getCategory()",
@@ -31999,7 +32107,7 @@
       "source_location": "L39"
     },
     {
-      "community": 117,
+      "community": 118,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_category_ts",
       "label": "category.ts",
@@ -32008,7 +32116,7 @@
       "source_location": "L1"
     },
     {
-      "community": 118,
+      "community": 119,
       "file_type": "code",
       "id": "onlineorder_getbaseurl",
       "label": "getBaseUrl()",
@@ -32017,7 +32125,7 @@
       "source_location": "L4"
     },
     {
-      "community": 118,
+      "community": 119,
       "file_type": "code",
       "id": "onlineorder_getorder",
       "label": "getOrder()",
@@ -32026,7 +32134,7 @@
       "source_location": "L24"
     },
     {
-      "community": 118,
+      "community": 119,
       "file_type": "code",
       "id": "onlineorder_getorders",
       "label": "getOrders()",
@@ -32035,7 +32143,7 @@
       "source_location": "L6"
     },
     {
-      "community": 118,
+      "community": 119,
       "file_type": "code",
       "id": "onlineorder_updateordersowner",
       "label": "updateOrdersOwner()",
@@ -32044,58 +32152,13 @@
       "source_location": "L42"
     },
     {
-      "community": 118,
+      "community": 119,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_onlineorder_ts",
       "label": "onlineOrder.ts",
       "norm_label": "onlineorder.ts",
       "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_storefrontuser_ts",
-      "label": "storeFrontUser.ts",
-      "norm_label": "storefrontuser.ts",
-      "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "storefrontuser_getactiveuser",
-      "label": "getActiveUser()",
-      "norm_label": "getactiveuser()",
-      "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
-      "source_location": "L28"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "storefrontuser_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "storefrontuser_getguest",
-      "label": "getGuest()",
-      "norm_label": "getguest()",
-      "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 119,
-      "file_type": "code",
-      "id": "storefrontuser_updateuser",
-      "label": "updateUser()",
-      "norm_label": "updateuser()",
-      "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
-      "source_location": "L46"
     },
     {
       "community": 12,
@@ -32262,6 +32325,51 @@
     {
       "community": 120,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_storefrontuser_ts",
+      "label": "storeFrontUser.ts",
+      "norm_label": "storefrontuser.ts",
+      "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "storefrontuser_getactiveuser",
+      "label": "getActiveUser()",
+      "norm_label": "getactiveuser()",
+      "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
+      "source_location": "L28"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "storefrontuser_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "storefrontuser_getguest",
+      "label": "getGuest()",
+      "norm_label": "getguest()",
+      "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "storefrontuser_updateuser",
+      "label": "updateUser()",
+      "norm_label": "updateuser()",
+      "source_file": "packages/storefront-webapp/src/api/storeFrontUser.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
       "id": "homepage_enableprompts",
       "label": "enablePrompts()",
       "norm_label": "enableprompts()",
@@ -32269,7 +32377,7 @@
       "source_location": "L147"
     },
     {
-      "community": 120,
+      "community": 121,
       "file_type": "code",
       "id": "homepage_handleclickonleavereviewbutton",
       "label": "handleClickOnLeaveReviewButton()",
@@ -32278,7 +32386,7 @@
       "source_location": "L185"
     },
     {
-      "community": 120,
+      "community": 121,
       "file_type": "code",
       "id": "homepage_handlescroll",
       "label": "handleScroll()",
@@ -32287,7 +32395,7 @@
       "source_location": "L115"
     },
     {
-      "community": 120,
+      "community": 121,
       "file_type": "code",
       "id": "homepage_homepagereadyshell",
       "label": "HomePageReadyShell()",
@@ -32296,7 +32404,7 @@
       "source_location": "L31"
     },
     {
-      "community": 120,
+      "community": 121,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_tsx",
       "label": "HomePage.tsx",
@@ -32305,7 +32413,7 @@
       "source_location": "L1"
     },
     {
-      "community": 121,
+      "community": 122,
       "file_type": "code",
       "id": "inventorylevelbadge_lowstockbadge",
       "label": "LowStockBadge()",
@@ -32314,7 +32422,7 @@
       "source_location": "L14"
     },
     {
-      "community": 121,
+      "community": 122,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastbadge",
       "label": "SellingFastBadge()",
@@ -32323,7 +32431,7 @@
       "source_location": "L22"
     },
     {
-      "community": 121,
+      "community": 122,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastsignal",
       "label": "SellingFastSignal()",
@@ -32332,7 +32440,7 @@
       "source_location": "L30"
     },
     {
-      "community": 121,
+      "community": 122,
       "file_type": "code",
       "id": "inventorylevelbadge_soldoutbadge",
       "label": "SoldOutBadge()",
@@ -32341,7 +32449,7 @@
       "source_location": "L3"
     },
     {
-      "community": 121,
+      "community": 122,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_inventorylevelbadge_tsx",
       "label": "InventoryLevelBadge.tsx",
@@ -32350,7 +32458,7 @@
       "source_location": "L1"
     },
     {
-      "community": 122,
+      "community": 123,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_ts",
       "label": "storefrontFailureObservability.ts",
@@ -32359,7 +32467,7 @@
       "source_location": "L1"
     },
     {
-      "community": 122,
+      "community": 123,
       "file_type": "code",
       "id": "storefrontfailureobservability_createstorefrontfailureevent",
       "label": "createStorefrontFailureEvent()",
@@ -32368,7 +32476,7 @@
       "source_location": "L136"
     },
     {
-      "community": 122,
+      "community": 123,
       "file_type": "code",
       "id": "storefrontfailureobservability_emitstorefrontfailure",
       "label": "emitStorefrontFailure()",
@@ -32377,7 +32485,7 @@
       "source_location": "L154"
     },
     {
-      "community": 122,
+      "community": 123,
       "file_type": "code",
       "id": "storefrontfailureobservability_inferstorefrontjourneyfromroute",
       "label": "inferStorefrontJourneyFromRoute()",
@@ -32386,7 +32494,7 @@
       "source_location": "L25"
     },
     {
-      "community": 122,
+      "community": 123,
       "file_type": "code",
       "id": "storefrontfailureobservability_normalizestorefronterror",
       "label": "normalizeStorefrontError()",
@@ -32395,7 +32503,7 @@
       "source_location": "L47"
     },
     {
-      "community": 123,
+      "community": 124,
       "file_type": "code",
       "id": "pre_push_review_getchangedfilesvsoriginmain",
       "label": "getChangedFilesVsOriginMain()",
@@ -32404,7 +32512,7 @@
       "source_location": "L28"
     },
     {
-      "community": 123,
+      "community": 124,
       "file_type": "code",
       "id": "pre_push_review_runarchitecturecheck",
       "label": "runArchitectureCheck()",
@@ -32413,7 +32521,7 @@
       "source_location": "L69"
     },
     {
-      "community": 123,
+      "community": 124,
       "file_type": "code",
       "id": "pre_push_review_runharnessselfreview",
       "label": "runHarnessSelfReview()",
@@ -32422,7 +32530,7 @@
       "source_location": "L81"
     },
     {
-      "community": 123,
+      "community": 124,
       "file_type": "code",
       "id": "pre_push_review_runprepushreview",
       "label": "runPrePushReview()",
@@ -32431,7 +32539,7 @@
       "source_location": "L96"
     },
     {
-      "community": 123,
+      "community": 124,
       "file_type": "code",
       "id": "scripts_pre_push_review_ts",
       "label": "pre-push-review.ts",
@@ -32440,7 +32548,7 @@
       "source_location": "L1"
     },
     {
-      "community": 124,
+      "community": 125,
       "file_type": "code",
       "id": "checkout_hasallvisibilesessionitems",
       "label": "hasAllVisibileSessionItems()",
@@ -32449,7 +32557,7 @@
       "source_location": "L109"
     },
     {
-      "community": 124,
+      "community": 125,
       "file_type": "code",
       "id": "checkout_hasvalidcanonicalbagitem",
       "label": "hasValidCanonicalBagItem()",
@@ -32458,7 +32566,7 @@
       "source_location": "L84"
     },
     {
-      "community": 124,
+      "community": 125,
       "file_type": "code",
       "id": "checkout_hasvalidsessionitems",
       "label": "hasValidSessionItems()",
@@ -32467,7 +32575,7 @@
       "source_location": "L95"
     },
     {
-      "community": 124,
+      "community": 125,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_checkout_ts",
       "label": "checkout.ts",
@@ -32476,7 +32584,7 @@
       "source_location": "L1"
     },
     {
-      "community": 125,
+      "community": 126,
       "file_type": "code",
       "id": "expensesessions_buildnextexpensesessionnumber",
       "label": "buildNextExpenseSessionNumber()",
@@ -32485,7 +32593,7 @@
       "source_location": "L33"
     },
     {
-      "community": 125,
+      "community": 126,
       "file_type": "code",
       "id": "expensesessions_listexpensesessionsbystatusbefore",
       "label": "listExpenseSessionsByStatusBefore()",
@@ -32494,7 +32602,7 @@
       "source_location": "L66"
     },
     {
-      "community": 125,
+      "community": 126,
       "file_type": "code",
       "id": "expensesessions_loadexpensesessionitems",
       "label": "loadExpenseSessionItems()",
@@ -32503,7 +32611,7 @@
       "source_location": "L41"
     },
     {
-      "community": 125,
+      "community": 126,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessions_ts",
       "label": "expenseSessions.ts",
@@ -32512,7 +32620,7 @@
       "source_location": "L1"
     },
     {
-      "community": 126,
+      "community": 127,
       "file_type": "code",
       "id": "expensesessionexpiration_calculateexpensesessionexpiration",
       "label": "calculateExpenseSessionExpiration()",
@@ -32521,7 +32629,7 @@
       "source_location": "L21"
     },
     {
-      "community": 126,
+      "community": 127,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpiryduration",
       "label": "getExpenseSessionExpiryDuration()",
@@ -32530,7 +32638,7 @@
       "source_location": "L35"
     },
     {
-      "community": 126,
+      "community": 127,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpirydurationminutes",
       "label": "getExpenseSessionExpiryDurationMinutes()",
@@ -32539,7 +32647,7 @@
       "source_location": "L45"
     },
     {
-      "community": 126,
+      "community": 127,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionexpiration_ts",
       "label": "expenseSessionExpiration.ts",
@@ -32548,7 +32656,7 @@
       "source_location": "L1"
     },
     {
-      "community": 127,
+      "community": 128,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_sessionexpiration_ts",
       "label": "sessionExpiration.ts",
@@ -32557,7 +32665,7 @@
       "source_location": "L1"
     },
     {
-      "community": 127,
+      "community": 128,
       "file_type": "code",
       "id": "sessionexpiration_calculatesessionexpiration",
       "label": "calculateSessionExpiration()",
@@ -32566,7 +32674,7 @@
       "source_location": "L21"
     },
     {
-      "community": 127,
+      "community": 128,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpiryduration",
       "label": "getSessionExpiryDuration()",
@@ -32575,7 +32683,7 @@
       "source_location": "L35"
     },
     {
-      "community": 127,
+      "community": 128,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpirydurationminutes",
       "label": "getSessionExpiryDurationMinutes()",
@@ -32584,75 +32692,39 @@
       "source_location": "L45"
     },
     {
-      "community": 128,
+      "community": 129,
       "file_type": "code",
-      "id": "collections_getcachedtokenrecord",
-      "label": "getCachedTokenRecord()",
-      "norm_label": "getcachedtokenrecord()",
-      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
-      "source_location": "L26"
+      "id": "currency_todisplayamount",
+      "label": "toDisplayAmount()",
+      "norm_label": "todisplayamount()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L5"
     },
     {
-      "community": 128,
+      "community": 129,
       "file_type": "code",
-      "id": "collections_resolveaccesstokenforstore",
-      "label": "resolveAccessTokenForStore()",
-      "norm_label": "resolveaccesstokenforstore()",
-      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
-      "source_location": "L79"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "collections_resolveconfigforstore",
-      "label": "resolveConfigForStore()",
-      "norm_label": "resolveconfigforstore()",
-      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 128,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_collections_ts",
-      "label": "collections.ts",
-      "norm_label": "collections.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
+      "id": "currency_topesewas",
+      "label": "toPesewas()",
+      "norm_label": "topesewas()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
       "source_location": "L1"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "normalize_maskmtnpartyid",
-      "label": "maskMtnPartyId()",
-      "norm_label": "maskmtnpartyid()",
-      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
-      "source_location": "L10"
+      "id": "packages_athena_webapp_convex_lib_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/athena-webapp/convex/lib/currency.ts",
+      "source_location": "L1"
     },
     {
       "community": 129,
       "file_type": "code",
-      "id": "normalize_normalizecollectionstransaction",
-      "label": "normalizeCollectionsTransaction()",
-      "norm_label": "normalizecollectionstransaction()",
-      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "normalize_parsecollectionsnotificationrequest",
-      "label": "parseCollectionsNotificationRequest()",
-      "norm_label": "parsecollectionsnotificationrequest()",
-      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 129,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_normalize_ts",
-      "label": "normalize.ts",
-      "norm_label": "normalize.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
+      "id": "packages_storefront_webapp_src_lib_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
       "source_location": "L1"
     },
     {
@@ -32820,6 +32892,78 @@
     {
       "community": 130,
       "file_type": "code",
+      "id": "collections_getcachedtokenrecord",
+      "label": "getCachedTokenRecord()",
+      "norm_label": "getcachedtokenrecord()",
+      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "collections_resolveaccesstokenforstore",
+      "label": "resolveAccessTokenForStore()",
+      "norm_label": "resolveaccesstokenforstore()",
+      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
+      "source_location": "L79"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "collections_resolveconfigforstore",
+      "label": "resolveConfigForStore()",
+      "norm_label": "resolveconfigforstore()",
+      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 130,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_collections_ts",
+      "label": "collections.ts",
+      "norm_label": "collections.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/collections.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "normalize_maskmtnpartyid",
+      "label": "maskMtnPartyId()",
+      "norm_label": "maskmtnpartyid()",
+      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "normalize_normalizecollectionstransaction",
+      "label": "normalizeCollectionsTransaction()",
+      "norm_label": "normalizecollectionstransaction()",
+      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "normalize_parsecollectionsnotificationrequest",
+      "label": "parseCollectionsNotificationRequest()",
+      "norm_label": "parsecollectionsnotificationrequest()",
+      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_normalize_ts",
+      "label": "normalize.ts",
+      "norm_label": "normalize.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/normalize.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
       "id": "commercequeryindexes_test_expectindex",
       "label": "expectIndex()",
       "norm_label": "expectindex()",
@@ -32827,7 +32971,7 @@
       "source_location": "L19"
     },
     {
-      "community": 130,
+      "community": 132,
       "file_type": "code",
       "id": "commercequeryindexes_test_getsource",
       "label": "getSource()",
@@ -32836,7 +32980,7 @@
       "source_location": "L26"
     },
     {
-      "community": 130,
+      "community": 132,
       "file_type": "code",
       "id": "commercequeryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -32845,7 +32989,7 @@
       "source_location": "L12"
     },
     {
-      "community": 130,
+      "community": 132,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_commercequeryindexes_test_ts",
       "label": "commerceQueryIndexes.test.ts",
@@ -32854,7 +32998,7 @@
       "source_location": "L1"
     },
     {
-      "community": 131,
+      "community": 133,
       "file_type": "code",
       "id": "attributesmanager_attributesmanager",
       "label": "AttributesManager()",
@@ -32863,7 +33007,7 @@
       "source_location": "L228"
     },
     {
-      "community": 131,
+      "community": 133,
       "file_type": "code",
       "id": "attributesmanager_colormanager",
       "label": "ColorManager()",
@@ -32872,7 +33016,7 @@
       "source_location": "L45"
     },
     {
-      "community": 131,
+      "community": 133,
       "file_type": "code",
       "id": "attributesmanager_sidebar",
       "label": "Sidebar()",
@@ -32881,7 +33025,7 @@
       "source_location": "L26"
     },
     {
-      "community": 131,
+      "community": 133,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributesmanager_tsx",
       "label": "AttributesManager.tsx",
@@ -32890,7 +33034,7 @@
       "source_location": "L1"
     },
     {
-      "community": 132,
+      "community": 134,
       "file_type": "code",
       "id": "attributestable_getproductattribute",
       "label": "getProductAttribute()",
@@ -32899,7 +33043,7 @@
       "source_location": "L55"
     },
     {
-      "community": 132,
+      "community": 134,
       "file_type": "code",
       "id": "attributestable_handlechange",
       "label": "handleChange()",
@@ -32908,7 +33052,7 @@
       "source_location": "L32"
     },
     {
-      "community": 132,
+      "community": 134,
       "file_type": "code",
       "id": "attributestable_onsubmit",
       "label": "onSubmit()",
@@ -32917,7 +33061,7 @@
       "source_location": "L210"
     },
     {
-      "community": 132,
+      "community": 134,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributestable_tsx",
       "label": "AttributesTable.tsx",
@@ -32926,7 +33070,7 @@
       "source_location": "L1"
     },
     {
-      "community": 133,
+      "community": 135,
       "file_type": "code",
       "id": "categorysubcategorymanager_categorymanager",
       "label": "CategoryManager()",
@@ -32935,7 +33079,7 @@
       "source_location": "L51"
     },
     {
-      "community": 133,
+      "community": 135,
       "file_type": "code",
       "id": "categorysubcategorymanager_sidebar",
       "label": "Sidebar()",
@@ -32944,7 +33088,7 @@
       "source_location": "L26"
     },
     {
-      "community": 133,
+      "community": 135,
       "file_type": "code",
       "id": "categorysubcategorymanager_subcategorymanager",
       "label": "SubcategoryManager()",
@@ -32953,7 +33097,7 @@
       "source_location": "L290"
     },
     {
-      "community": 133,
+      "community": 135,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_categorysubcategorymanager_tsx",
       "label": "CategorySubcategoryManager.tsx",
@@ -32962,7 +33106,7 @@
       "source_location": "L1"
     },
     {
-      "community": 134,
+      "community": 136,
       "file_type": "code",
       "id": "analyticsview_activecheckoutsessions",
       "label": "ActiveCheckoutSessions()",
@@ -32971,7 +33115,7 @@
       "source_location": "L48"
     },
     {
-      "community": 134,
+      "community": 136,
       "file_type": "code",
       "id": "analyticsview_analyticsview",
       "label": "AnalyticsView()",
@@ -32980,7 +33124,7 @@
       "source_location": "L88"
     },
     {
-      "community": 134,
+      "community": 136,
       "file_type": "code",
       "id": "analyticsview_storevisitors",
       "label": "StoreVisitors()",
@@ -32989,7 +33133,7 @@
       "source_location": "L14"
     },
     {
-      "community": 134,
+      "community": 136,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsview_tsx",
       "label": "AnalyticsView.tsx",
@@ -32998,7 +33142,7 @@
       "source_location": "L1"
     },
     {
-      "community": 135,
+      "community": 137,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storefrontobservabilitypanel_tsx",
       "label": "StorefrontObservabilityPanel.tsx",
@@ -33007,7 +33151,7 @@
       "source_location": "L1"
     },
     {
-      "community": 135,
+      "community": 137,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_formatlabel",
       "label": "formatLabel()",
@@ -33016,7 +33160,7 @@
       "source_location": "L15"
     },
     {
-      "community": 135,
+      "community": 137,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_gettrafficsourcebadge",
       "label": "getTrafficSourceBadge()",
@@ -33025,7 +33169,7 @@
       "source_location": "L28"
     },
     {
-      "community": 135,
+      "community": 137,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_summarycard",
       "label": "SummaryCard()",
@@ -33034,7 +33178,7 @@
       "source_location": "L19"
     },
     {
-      "community": 136,
+      "community": 138,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_utils_ts",
       "label": "utils.ts",
@@ -33043,7 +33187,7 @@
       "source_location": "L1"
     },
     {
-      "community": 136,
+      "community": 138,
       "file_type": "code",
       "id": "utils_countgroupedanalytics",
       "label": "countGroupedAnalytics()",
@@ -33052,7 +33196,7 @@
       "source_location": "L52"
     },
     {
-      "community": 136,
+      "community": 138,
       "file_type": "code",
       "id": "utils_groupanalytics",
       "label": "groupAnalytics()",
@@ -33061,7 +33205,7 @@
       "source_location": "L3"
     },
     {
-      "community": 136,
+      "community": 138,
       "file_type": "code",
       "id": "utils_groupproductviewsbyday",
       "label": "groupProductViewsByDay()",
@@ -33070,7 +33214,7 @@
       "source_location": "L90"
     },
     {
-      "community": 137,
+      "community": 139,
       "file_type": "code",
       "id": "maintenancemessageeditor_getcountdownstatus",
       "label": "getCountdownStatus()",
@@ -33079,7 +33223,7 @@
       "source_location": "L86"
     },
     {
-      "community": 137,
+      "community": 139,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlecountdownchange",
       "label": "handleCountdownChange()",
@@ -33088,7 +33232,7 @@
       "source_location": "L76"
     },
     {
-      "community": 137,
+      "community": 139,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlesave",
       "label": "handleSave()",
@@ -33097,84 +33241,12 @@
       "source_location": "L52"
     },
     {
-      "community": 137,
+      "community": 139,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_maintenancemessageeditor_tsx",
       "label": "MaintenanceMessageEditor.tsx",
       "norm_label": "maintenancemessageeditor.tsx",
       "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_shoplook_tsx",
-      "label": "ShopLook.tsx",
-      "norm_label": "shoplook.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "shoplook_handlehighlighteditem",
-      "label": "handleHighlightedItem()",
-      "norm_label": "handlehighlighteditem()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
-      "source_location": "L67"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "shoplook_handleimageupdate",
-      "label": "handleImageUpdate()",
-      "norm_label": "handleimageupdate()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
-      "source_location": "L90"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "shoplook_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
-      "source_location": "L73"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "newtransactionview_handlequickstart",
-      "label": "handleQuickStart()",
-      "norm_label": "handlequickstart()",
-      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
-      "source_location": "L91"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "newtransactionview_handlestarttransaction",
-      "label": "handleStartTransaction()",
-      "norm_label": "handlestarttransaction()",
-      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
-      "source_location": "L68"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "newtransactionview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
-      "source_location": "L22"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
-      "label": "NewTransactionView.tsx",
-      "norm_label": "newtransactionview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
       "source_location": "L1"
     },
     {
@@ -33333,41 +33405,77 @@
     {
       "community": 140,
       "file_type": "code",
-      "id": "ordersummary_handlecompletetransaction",
-      "label": "handleCompleteTransaction()",
-      "norm_label": "handlecompletetransaction()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L128"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "ordersummary_handlenewtransaction",
-      "label": "handleNewTransaction()",
-      "norm_label": "handlenewtransaction()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L162"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "ordersummary_handleselectedpaymentmethod",
-      "label": "handleSelectedPaymentMethod()",
-      "norm_label": "handleselectedpaymentmethod()",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
-      "source_location": "L150"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_ordersummary_tsx",
-      "label": "OrderSummary.tsx",
-      "norm_label": "ordersummary.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/OrderSummary.tsx",
+      "id": "packages_athena_webapp_src_components_homepage_shoplook_tsx",
+      "label": "ShopLook.tsx",
+      "norm_label": "shoplook.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
       "source_location": "L1"
     },
     {
+      "community": 140,
+      "file_type": "code",
+      "id": "shoplook_handlehighlighteditem",
+      "label": "handleHighlightedItem()",
+      "norm_label": "handlehighlighteditem()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
+      "source_location": "L67"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "shoplook_handleimageupdate",
+      "label": "handleImageUpdate()",
+      "norm_label": "handleimageupdate()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
+      "source_location": "L90"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "shoplook_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLook.tsx",
+      "source_location": "L73"
+    },
+    {
       "community": 141,
+      "file_type": "code",
+      "id": "newtransactionview_handlequickstart",
+      "label": "handleQuickStart()",
+      "norm_label": "handlequickstart()",
+      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
+      "source_location": "L91"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "newtransactionview_handlestarttransaction",
+      "label": "handleStartTransaction()",
+      "norm_label": "handlestarttransaction()",
+      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
+      "source_location": "L68"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "newtransactionview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
+      "source_location": "L22"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
+      "label": "NewTransactionView.tsx",
+      "norm_label": "newtransactionview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/NewTransactionView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 142,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_tsx",
       "label": "POSSettingsView.tsx",
@@ -33376,7 +33484,7 @@
       "source_location": "L1"
     },
     {
-      "community": 141,
+      "community": 142,
       "file_type": "code",
       "id": "possettingsview_handleregisterterminal",
       "label": "handleRegisterTerminal()",
@@ -33385,7 +33493,7 @@
       "source_location": "L247"
     },
     {
-      "community": 141,
+      "community": 142,
       "file_type": "code",
       "id": "possettingsview_handleupdateexistingterminal",
       "label": "handleUpdateExistingTerminal()",
@@ -33394,7 +33502,7 @@
       "source_location": "L284"
     },
     {
-      "community": 141,
+      "community": 142,
       "file_type": "code",
       "id": "possettingsview_loadfingerprint",
       "label": "loadFingerprint()",
@@ -33403,7 +33511,7 @@
       "source_location": "L166"
     },
     {
-      "community": 142,
+      "community": 143,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstock_tsx",
       "label": "ProductStock.tsx",
@@ -33412,7 +33520,7 @@
       "source_location": "L1"
     },
     {
-      "community": 142,
+      "community": 143,
       "file_type": "code",
       "id": "productstock_lowstockstatus",
       "label": "LowStockStatus()",
@@ -33421,7 +33529,7 @@
       "source_location": "L63"
     },
     {
-      "community": 142,
+      "community": 143,
       "file_type": "code",
       "id": "productstock_outofstockstatus",
       "label": "OutOfStockStatus()",
@@ -33430,7 +33538,7 @@
       "source_location": "L54"
     },
     {
-      "community": 142,
+      "community": 143,
       "file_type": "code",
       "id": "productstock_productstockstatus",
       "label": "ProductStockStatus()",
@@ -33439,7 +33547,7 @@
       "source_location": "L11"
     },
     {
-      "community": 143,
+      "community": 144,
       "file_type": "code",
       "id": "complimentaryproductsview_body",
       "label": "Body()",
@@ -33448,7 +33556,7 @@
       "source_location": "L16"
     },
     {
-      "community": 143,
+      "community": 144,
       "file_type": "code",
       "id": "complimentaryproductsview_complimentaryproductsview",
       "label": "ComplimentaryProductsView()",
@@ -33457,7 +33565,7 @@
       "source_location": "L35"
     },
     {
-      "community": 143,
+      "community": 144,
       "file_type": "code",
       "id": "complimentaryproductsview_navigation",
       "label": "Navigation()",
@@ -33466,7 +33574,7 @@
       "source_location": "L6"
     },
     {
-      "community": 143,
+      "community": 144,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
       "label": "ComplimentaryProductsView.tsx",
@@ -33475,7 +33583,7 @@
       "source_location": "L1"
     },
     {
-      "community": 144,
+      "community": 145,
       "file_type": "code",
       "id": "engagementmetrics_formatlastactivity",
       "label": "formatLastActivity()",
@@ -33484,7 +33592,7 @@
       "source_location": "L75"
     },
     {
-      "community": 144,
+      "community": 145,
       "file_type": "code",
       "id": "engagementmetrics_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -33493,7 +33601,7 @@
       "source_location": "L82"
     },
     {
-      "community": 144,
+      "community": 145,
       "file_type": "code",
       "id": "engagementmetrics_getdevicelabel",
       "label": "getDeviceLabel()",
@@ -33502,7 +33610,7 @@
       "source_location": "L93"
     },
     {
-      "community": 144,
+      "community": 145,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_engagementmetrics_tsx",
       "label": "EngagementMetrics.tsx",
@@ -33511,7 +33619,7 @@
       "source_location": "L1"
     },
     {
-      "community": 145,
+      "community": 146,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
       "label": "RiskIndicators.tsx",
@@ -33520,7 +33628,7 @@
       "source_location": "L1"
     },
     {
-      "community": 145,
+      "community": 146,
       "file_type": "code",
       "id": "riskindicators_getriskicon",
       "label": "getRiskIcon()",
@@ -33529,7 +33637,7 @@
       "source_location": "L15"
     },
     {
-      "community": 145,
+      "community": 146,
       "file_type": "code",
       "id": "riskindicators_getriskstyles",
       "label": "getRiskStyles()",
@@ -33538,7 +33646,7 @@
       "source_location": "L28"
     },
     {
-      "community": 145,
+      "community": 146,
       "file_type": "code",
       "id": "riskindicators_riskindicators",
       "label": "RiskIndicators()",
@@ -33547,7 +33655,7 @@
       "source_location": "L54"
     },
     {
-      "community": 146,
+      "community": 147,
       "file_type": "code",
       "id": "customerobservabilitytimeline_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -33556,7 +33664,7 @@
       "source_location": "L59"
     },
     {
-      "community": 146,
+      "community": 147,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -33565,7 +33673,7 @@
       "source_location": "L114"
     },
     {
-      "community": 146,
+      "community": 147,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
       "label": "getObservabilityStatusStyles()",
@@ -33574,7 +33682,7 @@
       "source_location": "L67"
     },
     {
-      "community": 146,
+      "community": 147,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_customerobservabilitytimeline_ts",
       "label": "customerObservabilityTimeline.ts",
@@ -33583,7 +33691,7 @@
       "source_location": "L1"
     },
     {
-      "community": 147,
+      "community": 148,
       "file_type": "code",
       "id": "barcodeutils_extractbarcodefrominput",
       "label": "extractBarcodeFromInput()",
@@ -33592,7 +33700,7 @@
       "source_location": "L51"
     },
     {
-      "community": 147,
+      "community": 148,
       "file_type": "code",
       "id": "barcodeutils_isurlorbarcode",
       "label": "isUrlOrBarcode()",
@@ -33601,7 +33709,7 @@
       "source_location": "L92"
     },
     {
-      "community": 147,
+      "community": 148,
       "file_type": "code",
       "id": "barcodeutils_isvalidconvexid",
       "label": "isValidConvexId()",
@@ -33610,7 +33718,7 @@
       "source_location": "L16"
     },
     {
-      "community": 147,
+      "community": 148,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_barcodeutils_ts",
       "label": "barcodeUtils.ts",
@@ -33619,7 +33727,7 @@
       "source_location": "L1"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "offers_getbaseurl",
       "label": "getBaseUrl()",
@@ -33628,7 +33736,7 @@
       "source_location": "L13"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "offers_getuserredeemedoffers",
       "label": "getUserRedeemedOffers()",
@@ -33637,7 +33745,7 @@
       "source_location": "L46"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "offers_submitoffer",
       "label": "submitOffer()",
@@ -33646,49 +33754,13 @@
       "source_location": "L21"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_offers_ts",
       "label": "offers.ts",
       "norm_label": "offers.ts",
       "source_file": "packages/storefront-webapp/src/api/offers.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_stores_ts",
-      "label": "stores.ts",
-      "norm_label": "stores.ts",
-      "source_file": "packages/storefront-webapp/src/api/stores.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "stores_getallstores",
-      "label": "getAllStores()",
-      "norm_label": "getallstores()",
-      "source_file": "packages/storefront-webapp/src/api/stores.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "stores_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/stores.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "stores_getstore",
-      "label": "getStore()",
-      "norm_label": "getstore()",
-      "source_file": "packages/storefront-webapp/src/api/stores.ts",
-      "source_location": "L20"
     },
     {
       "community": 15,
@@ -33846,6 +33918,42 @@
     {
       "community": 150,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_stores_ts",
+      "label": "stores.ts",
+      "norm_label": "stores.ts",
+      "source_file": "packages/storefront-webapp/src/api/stores.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "stores_getallstores",
+      "label": "getAllStores()",
+      "norm_label": "getallstores()",
+      "source_file": "packages/storefront-webapp/src/api/stores.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "stores_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/stores.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "stores_getstore",
+      "label": "getStore()",
+      "norm_label": "getstore()",
+      "source_file": "packages/storefront-webapp/src/api/stores.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_api_subcategory_ts",
       "label": "subcategory.ts",
       "norm_label": "subcategory.ts",
@@ -33853,7 +33961,7 @@
       "source_location": "L1"
     },
     {
-      "community": 150,
+      "community": 151,
       "file_type": "code",
       "id": "subcategory_getallsubcategories",
       "label": "getAllSubcategories()",
@@ -33862,7 +33970,7 @@
       "source_location": "L11"
     },
     {
-      "community": 150,
+      "community": 151,
       "file_type": "code",
       "id": "subcategory_getbaseurl",
       "label": "getBaseUrl()",
@@ -33871,7 +33979,7 @@
       "source_location": "L9"
     },
     {
-      "community": 150,
+      "community": 151,
       "file_type": "code",
       "id": "subcategory_getsubategory",
       "label": "getSubategory()",
@@ -33880,7 +33988,7 @@
       "source_location": "L25"
     },
     {
-      "community": 151,
+      "community": 152,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productactionbar_tsx",
       "label": "ProductActionBar.tsx",
@@ -33889,7 +33997,7 @@
       "source_location": "L1"
     },
     {
-      "community": 151,
+      "community": 152,
       "file_type": "code",
       "id": "productactionbar_checkscroll",
       "label": "checkScroll()",
@@ -33898,7 +34006,7 @@
       "source_location": "L50"
     },
     {
-      "community": 151,
+      "community": 152,
       "file_type": "code",
       "id": "productactionbar_handleaction",
       "label": "handleAction()",
@@ -33907,7 +34015,7 @@
       "source_location": "L92"
     },
     {
-      "community": 151,
+      "community": 152,
       "file_type": "code",
       "id": "productactionbar_handledismiss",
       "label": "handleDismiss()",
@@ -33916,7 +34024,7 @@
       "source_location": "L74"
     },
     {
-      "community": 152,
+      "community": 153,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productreminderbar_tsx",
       "label": "ProductReminderBar.tsx",
@@ -33925,7 +34033,7 @@
       "source_location": "L1"
     },
     {
-      "community": 152,
+      "community": 153,
       "file_type": "code",
       "id": "productreminderbar_checkscroll",
       "label": "checkScroll()",
@@ -33934,7 +34042,7 @@
       "source_location": "L62"
     },
     {
-      "community": 152,
+      "community": 153,
       "file_type": "code",
       "id": "productreminderbar_handleaddtobag",
       "label": "handleAddToBag()",
@@ -33943,7 +34051,7 @@
       "source_location": "L109"
     },
     {
-      "community": 152,
+      "community": 153,
       "file_type": "code",
       "id": "productreminderbar_handledismiss",
       "label": "handleDismiss()",
@@ -33952,7 +34060,7 @@
       "source_location": "L177"
     },
     {
-      "community": 153,
+      "community": 154,
       "file_type": "code",
       "id": "billingdetailssection_clearform",
       "label": "clearForm()",
@@ -33961,7 +34069,7 @@
       "source_location": "L18"
     },
     {
-      "community": 153,
+      "community": 154,
       "file_type": "code",
       "id": "billingdetailssection_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -33970,7 +34078,7 @@
       "source_location": "L52"
     },
     {
-      "community": 153,
+      "community": 154,
       "file_type": "code",
       "id": "billingdetailssection_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -33979,7 +34087,7 @@
       "source_location": "L68"
     },
     {
-      "community": 153,
+      "community": 154,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetailssection_tsx",
       "label": "BillingDetailsSection.tsx",
@@ -33988,7 +34096,7 @@
       "source_location": "L1"
     },
     {
-      "community": 154,
+      "community": 155,
       "file_type": "code",
       "id": "hooks_usegetshopsearchparams",
       "label": "useGetShopSearchParams()",
@@ -33997,7 +34105,7 @@
       "source_location": "L68"
     },
     {
-      "community": 154,
+      "community": 155,
       "file_type": "code",
       "id": "hooks_usegetstorecategories",
       "label": "useGetStoreCategories()",
@@ -34006,7 +34114,7 @@
       "source_location": "L26"
     },
     {
-      "community": 154,
+      "community": 155,
       "file_type": "code",
       "id": "hooks_usegetstoresubcategories",
       "label": "useGetStoreSubcategories()",
@@ -34015,7 +34123,7 @@
       "source_location": "L7"
     },
     {
-      "community": 154,
+      "community": 155,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
       "label": "hooks.ts",
@@ -34024,7 +34132,7 @@
       "source_location": "L1"
     },
     {
-      "community": 155,
+      "community": 156,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -34033,7 +34141,7 @@
       "source_location": "L1"
     },
     {
-      "community": 155,
+      "community": 156,
       "file_type": "code",
       "id": "productdetails_bagproduct",
       "label": "BagProduct()",
@@ -34042,7 +34150,7 @@
       "source_location": "L43"
     },
     {
-      "community": 155,
+      "community": 156,
       "file_type": "code",
       "id": "productdetails_pickupdetails",
       "label": "PickupDetails()",
@@ -34051,7 +34159,7 @@
       "source_location": "L13"
     },
     {
-      "community": 155,
+      "community": 156,
       "file_type": "code",
       "id": "productdetails_shippingpolicy",
       "label": "ShippingPolicy()",
@@ -34060,7 +34168,7 @@
       "source_location": "L88"
     },
     {
-      "community": 156,
+      "community": 157,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
       "label": "UpsellModal.tsx",
@@ -34069,7 +34177,7 @@
       "source_location": "L1"
     },
     {
-      "community": 156,
+      "community": 157,
       "file_type": "code",
       "id": "upsellmodal_handleclose",
       "label": "handleClose()",
@@ -34078,7 +34186,7 @@
       "source_location": "L111"
     },
     {
-      "community": 156,
+      "community": 157,
       "file_type": "code",
       "id": "upsellmodal_handlescroll",
       "label": "handleScroll()",
@@ -34087,49 +34195,13 @@
       "source_location": "L66"
     },
     {
-      "community": 156,
+      "community": 157,
       "file_type": "code",
       "id": "upsellmodal_handlesuccess",
       "label": "handleSuccess()",
       "norm_label": "handlesuccess()",
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
       "source_location": "L127"
-    },
-    {
-      "community": 157,
-      "file_type": "code",
-      "id": "currency_todisplayamount",
-      "label": "toDisplayAmount()",
-      "norm_label": "todisplayamount()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 157,
-      "file_type": "code",
-      "id": "currency_topesewas",
-      "label": "toPesewas()",
-      "norm_label": "topesewas()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 157,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_lib_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/athena-webapp/convex/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 157,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L1"
     },
     {
       "community": 158,
@@ -35695,7 +35767,7 @@
       "label": "getSessionCartItemsCount()",
       "norm_label": "getsessioncartitemscount()",
       "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx",
-      "source_location": "L58"
+      "source_location": "L59"
     },
     {
       "community": 191,
@@ -35704,7 +35776,7 @@
       "label": "hasExpired()",
       "norm_label": "hasexpired()",
       "source_file": "packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx",
-      "source_location": "L54"
+      "source_location": "L55"
     },
     {
       "community": 191,
@@ -35731,7 +35803,7 @@
       "label": "formatPaymentMethod()",
       "norm_label": "formatpaymentmethod()",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L19"
+      "source_location": "L20"
     },
     {
       "community": 192,
@@ -35740,7 +35812,7 @@
       "label": "isToday()",
       "norm_label": "istoday()",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L25"
+      "source_location": "L26"
     },
     {
       "community": 193,
@@ -36640,7 +36712,7 @@
       "label": "canCompleteTransaction()",
       "norm_label": "cancompletetransaction()",
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L404"
+      "source_location": "L405"
     },
     {
       "community": 21,
@@ -36649,7 +36721,7 @@
       "label": "isValidEmail()",
       "norm_label": "isvalidemail()",
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L244"
+      "source_location": "L245"
     },
     {
       "community": 21,
@@ -36658,7 +36730,7 @@
       "label": "isValidPhone()",
       "norm_label": "isvalidphone()",
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L304"
+      "source_location": "L305"
     },
     {
       "community": 21,
@@ -36667,7 +36739,7 @@
       "label": "validateBarcode()",
       "norm_label": "validatebarcode()",
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L185"
+      "source_location": "L186"
     },
     {
       "community": 21,
@@ -36676,7 +36748,7 @@
       "label": "validateCart()",
       "norm_label": "validatecart()",
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L21"
+      "source_location": "L22"
     },
     {
       "community": 21,
@@ -36685,7 +36757,7 @@
       "label": "validateCustomer()",
       "norm_label": "validatecustomer()",
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L108"
+      "source_location": "L109"
     },
     {
       "community": 21,
@@ -36694,7 +36766,7 @@
       "label": "validatePayment()",
       "norm_label": "validatepayment()",
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L146"
+      "source_location": "L147"
     },
     {
       "community": 21,
@@ -36703,7 +36775,7 @@
       "label": "validatePaymentAmount()",
       "norm_label": "validatepaymentamount()",
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L317"
+      "source_location": "L318"
     },
     {
       "community": 21,
@@ -36712,7 +36784,7 @@
       "label": "validatePayments()",
       "norm_label": "validatepayments()",
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L359"
+      "source_location": "L360"
     },
     {
       "community": 21,
@@ -36721,7 +36793,7 @@
       "label": "validateProduct()",
       "norm_label": "validateproduct()",
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L68"
+      "source_location": "L69"
     },
     {
       "community": 21,
@@ -36730,7 +36802,7 @@
       "label": "validateQuantity()",
       "norm_label": "validatequantity()",
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L213"
+      "source_location": "L214"
     },
     {
       "community": 21,
@@ -36739,7 +36811,7 @@
       "label": "validateSession()",
       "norm_label": "validatesession()",
       "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L252"
+      "source_location": "L253"
     },
     {
       "community": 210,
@@ -37374,28 +37446,28 @@
     {
       "community": 229,
       "file_type": "code",
-      "id": "main_app",
-      "label": "App()",
-      "norm_label": "app()",
-      "source_file": "packages/storefront-webapp/src/main.tsx",
-      "source_location": "L38"
+      "id": "displayamounts_formatstoredamount",
+      "label": "formatStoredAmount()",
+      "norm_label": "formatstoredamount()",
+      "source_file": "packages/athena-webapp/src/lib/pos/displayAmounts.ts",
+      "source_location": "L3"
     },
     {
       "community": 229,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_main_tsx",
-      "label": "main.tsx",
-      "norm_label": "main.tsx",
-      "source_file": "packages/athena-webapp/src/main.tsx",
-      "source_location": "L1"
+      "id": "displayamounts_parsedisplayamountinput",
+      "label": "parseDisplayAmountInput()",
+      "norm_label": "parsedisplayamountinput()",
+      "source_file": "packages/athena-webapp/src/lib/pos/displayAmounts.ts",
+      "source_location": "L10"
     },
     {
       "community": 229,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_main_tsx",
-      "label": "main.tsx",
-      "norm_label": "main.tsx",
-      "source_file": "packages/storefront-webapp/src/main.tsx",
+      "id": "packages_athena_webapp_src_lib_pos_displayamounts_ts",
+      "label": "displayAmounts.ts",
+      "norm_label": "displayamounts.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/displayAmounts.ts",
       "source_location": "L1"
     },
     {
@@ -37509,6 +37581,33 @@
     {
       "community": 230,
       "file_type": "code",
+      "id": "main_app",
+      "label": "App()",
+      "norm_label": "app()",
+      "source_file": "packages/storefront-webapp/src/main.tsx",
+      "source_location": "L38"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_main_tsx",
+      "label": "main.tsx",
+      "norm_label": "main.tsx",
+      "source_file": "packages/athena-webapp/src/main.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 230,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_main_tsx",
+      "label": "main.tsx",
+      "norm_label": "main.tsx",
+      "source_file": "packages/storefront-webapp/src/main.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 231,
+      "file_type": "code",
       "id": "authed_authedcomponent",
       "label": "AuthedComponent()",
       "norm_label": "authedcomponent()",
@@ -37516,7 +37615,7 @@
       "source_location": "L18"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "authed_layout",
       "label": "Layout()",
@@ -37525,7 +37624,7 @@
       "source_location": "L38"
     },
     {
-      "community": 230,
+      "community": 231,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_tsx",
       "label": "_authed.tsx",
@@ -37534,7 +37633,7 @@
       "source_location": "L1"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_mockgetsku",
       "label": "mockGetSku()",
@@ -37543,7 +37642,7 @@
       "source_location": "L66"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_validateinventoryfortransaction",
       "label": "validateInventoryForTransaction()",
@@ -37552,7 +37651,7 @@
       "source_location": "L20"
     },
     {
-      "community": 231,
+      "community": 232,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_inventoryvalidationlogic_test_ts",
       "label": "inventoryValidationLogic.test.ts",
@@ -37561,7 +37660,7 @@
       "source_location": "L1"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "index_hashpassword",
       "label": "hashPassword()",
@@ -37570,7 +37669,7 @@
       "source_location": "L1"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -37579,7 +37678,7 @@
       "source_location": "L1"
     },
     {
-      "community": 232,
+      "community": 233,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -37588,7 +37687,7 @@
       "source_location": "L1"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_session_ts",
       "label": "session.ts",
@@ -37597,7 +37696,7 @@
       "source_location": "L1"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_session_ts",
       "label": "session.ts",
@@ -37606,7 +37705,7 @@
       "source_location": "L1"
     },
     {
-      "community": 233,
+      "community": 234,
       "file_type": "code",
       "id": "session_useappsession",
       "label": "useAppSession()",
@@ -37615,7 +37714,7 @@
       "source_location": "L8"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -37624,7 +37723,7 @@
       "source_location": "L1"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -37633,7 +37732,7 @@
       "source_location": "L1"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "versionchecker_createversionchecker",
       "label": "createVersionChecker()",
@@ -37642,7 +37741,7 @@
       "source_location": "L16"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "packages_athena_webapp_vite_config_ts",
       "label": "vite.config.ts",
@@ -37651,7 +37750,7 @@
       "source_location": "L1"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "packages_storefront_webapp_vite_config_ts",
       "label": "vite.config.ts",
@@ -37660,7 +37759,7 @@
       "source_location": "L1"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "vite_config_manualchunks",
       "label": "manualChunks()",
@@ -37669,7 +37768,7 @@
       "source_location": "L19"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "auth_logout",
       "label": "logout()",
@@ -37678,7 +37777,7 @@
       "source_location": "L32"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "auth_verifyuseraccount",
       "label": "verifyUserAccount()",
@@ -37687,7 +37786,7 @@
       "source_location": "L3"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_auth_ts",
       "label": "auth.ts",
@@ -37696,7 +37795,7 @@
       "source_location": "L1"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "color_getallcolors",
       "label": "getAllColors()",
@@ -37705,7 +37804,7 @@
       "source_location": "L7"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "color_getbaseurl",
       "label": "getBaseUrl()",
@@ -37714,7 +37813,7 @@
       "source_location": "L5"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_color_ts",
       "label": "color.ts",
@@ -37723,7 +37822,7 @@
       "source_location": "L1"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "organization_getallorganizations",
       "label": "getAllOrganizations()",
@@ -37732,7 +37831,7 @@
       "source_location": "L6"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "organization_getorganization",
       "label": "getOrganization()",
@@ -37741,40 +37840,13 @@
       "source_location": "L18"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_organization_ts",
       "label": "organization.ts",
       "norm_label": "organization.ts",
       "source_file": "packages/storefront-webapp/src/api/organization.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_upsells_ts",
-      "label": "upsells.ts",
-      "norm_label": "upsells.ts",
-      "source_file": "packages/storefront-webapp/src/api/upsells.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "upsells_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/upsells.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "upsells_getlastviewedproduct",
-      "label": "getLastViewedProduct()",
-      "norm_label": "getlastviewedproduct()",
-      "source_file": "packages/storefront-webapp/src/api/upsells.ts",
-      "source_location": "L5"
     },
     {
       "community": 24,
@@ -37878,6 +37950,33 @@
     {
       "community": 240,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_upsells_ts",
+      "label": "upsells.ts",
+      "norm_label": "upsells.ts",
+      "source_file": "packages/storefront-webapp/src/api/upsells.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "upsells_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/upsells.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "upsells_getlastviewedproduct",
+      "label": "getLastViewedProduct()",
+      "norm_label": "getlastviewedproduct()",
+      "source_file": "packages/storefront-webapp/src/api/upsells.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_api_useroffers_ts",
       "label": "userOffers.ts",
       "norm_label": "useroffers.ts",
@@ -37885,7 +37984,7 @@
       "source_location": "L1"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "useroffers_getbaseurl",
       "label": "getBaseUrl()",
@@ -37894,7 +37993,7 @@
       "source_location": "L18"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "useroffers_getuserofferseligibility",
       "label": "getUserOffersEligibility()",
@@ -37903,7 +38002,7 @@
       "source_location": "L23"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "customerdetails_enteredcustomerdetails",
       "label": "EnteredCustomerDetails()",
@@ -37912,7 +38011,7 @@
       "source_location": "L22"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "customerdetails_onsubmit",
       "label": "onSubmit()",
@@ -37921,7 +38020,7 @@
       "source_location": "L55"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerdetails_tsx",
       "label": "CustomerDetails.tsx",
@@ -37930,7 +38029,7 @@
       "source_location": "L1"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "deliveryoptionsselector_handlechange",
       "label": "handleChange()",
@@ -37939,7 +38038,7 @@
       "source_location": "L77"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "deliveryoptionsselector_storeselector",
       "label": "StoreSelector()",
@@ -37948,7 +38047,7 @@
       "source_location": "L11"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliveryoptionsselector_tsx",
       "label": "DeliveryOptionsSelector.tsx",
@@ -37957,7 +38056,7 @@
       "source_location": "L1"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "deliverysection_deliverydetails",
       "label": "DeliveryDetails()",
@@ -37966,7 +38065,7 @@
       "source_location": "L11"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "deliverysection_deliveryoptions",
       "label": "DeliveryOptions()",
@@ -37975,7 +38074,7 @@
       "source_location": "L22"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliverysection_tsx",
       "label": "DeliverySection.tsx",
@@ -37984,7 +38083,7 @@
       "source_location": "L1"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "mobilebagsummary_handlekeydown",
       "label": "handleKeyDown()",
@@ -37993,7 +38092,7 @@
       "source_location": "L110"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "mobilebagsummary_handleredeempromocode",
       "label": "handleRedeemPromoCode()",
@@ -38002,7 +38101,7 @@
       "source_location": "L89"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_mobilebagsummary_tsx",
       "label": "MobileBagSummary.tsx",
@@ -38011,7 +38110,7 @@
       "source_location": "L1"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "checkoutstorage_loadcheckoutstate",
       "label": "loadCheckoutState()",
@@ -38020,7 +38119,7 @@
       "source_location": "L4"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "checkoutstorage_savecheckoutstate",
       "label": "saveCheckoutState()",
@@ -38029,7 +38128,7 @@
       "source_location": "L24"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_ts",
       "label": "checkoutStorage.ts",
@@ -38038,7 +38137,7 @@
       "source_location": "L1"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "footer_enablecategories",
       "label": "enableCategories()",
@@ -38047,7 +38146,7 @@
       "source_location": "L131"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "footer_linkgroup",
       "label": "LinkGroup()",
@@ -38056,7 +38155,7 @@
       "source_location": "L12"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_footer_footer_tsx",
       "label": "Footer.tsx",
@@ -38065,7 +38164,7 @@
       "source_location": "L1"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "featuredproductssection_featuredproductssection",
       "label": "FeaturedProductsSection()",
@@ -38074,7 +38173,7 @@
       "source_location": "L20"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "featuredproductssection_featuredsection",
       "label": "FeaturedSection()",
@@ -38083,7 +38182,7 @@
       "source_location": "L46"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_featuredproductssection_tsx",
       "label": "FeaturedProductsSection.tsx",
@@ -38092,7 +38191,7 @@
       "source_location": "L1"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_promoalert_tsx",
       "label": "PromoAlert.tsx",
@@ -38101,7 +38200,7 @@
       "source_location": "L1"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "promoalert_getpromoalertcopy",
       "label": "getPromoAlertCopy()",
@@ -38110,40 +38209,13 @@
       "source_location": "L20"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "promoalert_promoalert",
       "label": "PromoAlert()",
       "norm_label": "promoalert()",
       "source_file": "packages/storefront-webapp/src/components/home/PromoAlert.tsx",
       "source_location": "L59"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_rewardsalert_tsx",
-      "label": "RewardsAlert.tsx",
-      "norm_label": "rewardsalert.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "rewardsalert_handleshopnow",
-      "label": "handleShopNow()",
-      "norm_label": "handleshopnow()",
-      "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
-      "source_location": "L25"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "rewardsalert_onrewardsalertclose",
-      "label": "onRewardsAlertClose()",
-      "norm_label": "onrewardsalertclose()",
-      "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
-      "source_location": "L20"
     },
     {
       "community": 25,
@@ -38247,6 +38319,33 @@
     {
       "community": 250,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_rewardsalert_tsx",
+      "label": "RewardsAlert.tsx",
+      "norm_label": "rewardsalert.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "rewardsalert_handleshopnow",
+      "label": "handleShopNow()",
+      "norm_label": "handleshopnow()",
+      "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "rewardsalert_onrewardsalertclose",
+      "label": "onRewardsAlertClose()",
+      "norm_label": "onrewardsalertclose()",
+      "source_file": "packages/storefront-webapp/src/components/home/RewardsAlert.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
       "id": "navigationbar_navigationbar",
       "label": "NavigationBar()",
       "norm_label": "navigationbar()",
@@ -38254,7 +38353,7 @@
       "source_location": "L30"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "navigationbar_storecategoriessubmenu",
       "label": "StoreCategoriesSubmenu()",
@@ -38263,7 +38362,7 @@
       "source_location": "L95"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navigationbar_tsx",
       "label": "NavigationBar.tsx",
@@ -38272,7 +38371,7 @@
       "source_location": "L1"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
       "label": "ProductAttribute.tsx",
@@ -38281,7 +38380,7 @@
       "source_location": "L1"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "productattribute_findsize",
       "label": "findSize()",
@@ -38290,7 +38389,7 @@
       "source_location": "L61"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "productattribute_handleclick",
       "label": "handleClick()",
@@ -38299,7 +38398,7 @@
       "source_location": "L65"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_revieweditor_tsx",
       "label": "ReviewEditor.tsx",
@@ -38308,7 +38407,7 @@
       "source_location": "L1"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "revieweditor_handleformdatachange",
       "label": "handleFormDataChange()",
@@ -38317,7 +38416,7 @@
       "source_location": "L150"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "revieweditor_handlesubmit",
       "label": "handleSubmit()",
@@ -38326,7 +38425,7 @@
       "source_location": "L157"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalform_tsx",
       "label": "UpsellModalForm.tsx",
@@ -38335,7 +38434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "upsellmodalform_handleinputchange",
       "label": "handleInputChange()",
@@ -38344,7 +38443,7 @@
       "source_location": "L63"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "upsellmodalform_handlesubmit",
       "label": "handleSubmit()",
@@ -38353,7 +38452,7 @@
       "source_location": "L48"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodal_tsx",
       "label": "WelcomeBackModal.tsx",
@@ -38362,7 +38461,7 @@
       "source_location": "L1"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "welcomebackmodal_handleclose",
       "label": "handleClose()",
@@ -38371,7 +38470,7 @@
       "source_location": "L63"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "welcomebackmodal_handlesuccess",
       "label": "handleSuccess()",
@@ -38380,7 +38479,7 @@
       "source_location": "L76"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalform_tsx",
       "label": "WelcomeBackModalForm.tsx",
@@ -38389,7 +38488,7 @@
       "source_location": "L1"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "welcomebackmodalform_handleinputchange",
       "label": "handleInputChange()",
@@ -38398,7 +38497,7 @@
       "source_location": "L51"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "welcomebackmodalform_handlesubmit",
       "label": "handleSubmit()",
@@ -38407,7 +38506,7 @@
       "source_location": "L36"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "navigationbarprovider_navigationbarprovider",
       "label": "NavigationBarProvider()",
@@ -38416,7 +38515,7 @@
       "source_location": "L16"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "navigationbarprovider_usenavigationbarcontext",
       "label": "useNavigationBarContext()",
@@ -38425,7 +38524,7 @@
       "source_location": "L39"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_navigationbarprovider_tsx",
       "label": "NavigationBarProvider.tsx",
@@ -38434,7 +38533,7 @@
       "source_location": "L1"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
       "label": "StoreContext.tsx",
@@ -38443,7 +38542,7 @@
       "source_location": "L1"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "storecontext_storeprovider",
       "label": "StoreProvider()",
@@ -38452,7 +38551,7 @@
       "source_location": "L25"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "storecontext_usestorecontext",
       "label": "useStoreContext()",
@@ -38461,7 +38560,7 @@
       "source_location": "L82"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_tsx",
       "label": "StorefrontObservabilityProvider.tsx",
@@ -38470,7 +38569,7 @@
       "source_location": "L1"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
       "label": "StorefrontObservabilityProvider()",
@@ -38479,40 +38578,13 @@
       "source_location": "L20"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "storefrontobservabilityprovider_usestorefrontobservability",
       "label": "useStorefrontObservability()",
       "norm_label": "usestorefrontobservability()",
       "source_file": "packages/storefront-webapp/src/contexts/StorefrontObservabilityProvider.tsx",
       "source_location": "L55"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useproductdiscount_ts",
-      "label": "useProductDiscount.ts",
-      "norm_label": "useproductdiscount.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "useproductdiscount_useproductdiscount",
-      "label": "useProductDiscount()",
-      "norm_label": "useproductdiscount()",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "useproductdiscount_useproductdiscounts",
-      "label": "useProductDiscounts()",
-      "norm_label": "useproductdiscounts()",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
-      "source_location": "L25"
     },
     {
       "community": 26,
@@ -38616,6 +38688,33 @@
     {
       "community": 260,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useproductdiscount_ts",
+      "label": "useProductDiscount.ts",
+      "norm_label": "useproductdiscount.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "useproductdiscount_useproductdiscount",
+      "label": "useProductDiscount()",
+      "norm_label": "useproductdiscount()",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "useproductdiscount_useproductdiscounts",
+      "label": "useProductDiscounts()",
+      "norm_label": "useproductdiscounts()",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductDiscount.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useshoppingbag_ts",
       "label": "useShoppingBag.ts",
       "norm_label": "useshoppingbag.ts",
@@ -38623,7 +38722,7 @@
       "source_location": "L1"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "useshoppingbag_isunavailableproductlist",
       "label": "isUnavailableProductList()",
@@ -38632,7 +38731,7 @@
       "source_location": "L556"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "useshoppingbag_useshoppingbag",
       "label": "useShoppingBag()",
@@ -38641,7 +38740,7 @@
       "source_location": "L52"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "index_getordermessage",
       "label": "getOrderMessage()",
@@ -38650,7 +38749,7 @@
       "source_location": "L429"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "index_getpaymenttext",
       "label": "getPaymentText()",
@@ -38659,7 +38758,7 @@
       "source_location": "L102"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_index_tsx",
       "label": "index.tsx",
@@ -38668,7 +38767,7 @@
       "source_location": "L1"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_review_tsx",
       "label": "review.tsx",
@@ -38677,7 +38776,7 @@
       "source_location": "L1"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "review_getordermessage",
       "label": "getOrderMessage()",
@@ -38686,7 +38785,7 @@
       "source_location": "L250"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "review_ordernavigation",
       "label": "OrderNavigation()",
@@ -38695,7 +38794,7 @@
       "source_location": "L46"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "account_accountbeforeload",
       "label": "accountBeforeLoad()",
@@ -38704,7 +38803,7 @@
       "source_location": "L17"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "account_handleonsubmitform",
       "label": "handleOnSubmitForm()",
@@ -38713,7 +38812,7 @@
       "source_location": "L63"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_account_tsx",
       "label": "account.tsx",
@@ -38722,7 +38821,7 @@
       "source_location": "L1"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "login_loginbeforeload",
       "label": "loginBeforeLoad()",
@@ -38731,7 +38830,7 @@
       "source_location": "L47"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "login_onsubmit",
       "label": "onSubmit()",
@@ -38740,7 +38839,7 @@
       "source_location": "L141"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_login_tsx",
       "label": "login.tsx",
@@ -38749,7 +38848,7 @@
       "source_location": "L1"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_verify_index_tsx",
       "label": "verify.index.tsx",
@@ -38758,7 +38857,7 @@
       "source_location": "L1"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "verify_index_verify",
       "label": "Verify()",
@@ -38767,7 +38866,7 @@
       "source_location": "L21"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "verify_index_verifycheckoutsessionpayment",
       "label": "VerifyCheckoutSessionPayment()",
@@ -38776,7 +38875,7 @@
       "source_location": "L107"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_signup_tsx",
       "label": "signup.tsx",
@@ -38785,7 +38884,7 @@
       "source_location": "L1"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "signup_onsubmit",
       "label": "onSubmit()",
@@ -38794,7 +38893,7 @@
       "source_location": "L161"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "signup_signupbeforeload",
       "label": "signupBeforeLoad()",
@@ -38803,7 +38902,7 @@
       "source_location": "L66"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "env_optionalnumberenv",
       "label": "optionalNumberEnv()",
@@ -38812,7 +38911,7 @@
       "source_location": "L11"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "env_requireenv",
       "label": "requireEnv()",
@@ -38821,7 +38920,7 @@
       "source_location": "L1"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_env_ts",
       "label": "env.ts",
@@ -38830,7 +38929,7 @@
       "source_location": "L1"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "graphify_wiki_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -38839,7 +38938,7 @@
       "source_location": "L16"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "graphify_wiki_test_write",
       "label": "write()",
@@ -38848,39 +38947,12 @@
       "source_location": "L10"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "scripts_graphify_wiki_test_ts",
       "label": "graphify-wiki.test.ts",
       "norm_label": "graphify-wiki.test.ts",
       "source_file": "scripts/graphify-wiki.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "harness_audit_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/harness-audit.test.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "harness_audit_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-audit.test.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "scripts_harness_audit_test_ts",
-      "label": "harness-audit.test.ts",
-      "norm_label": "harness-audit.test.ts",
-      "source_file": "scripts/harness-audit.test.ts",
       "source_location": "L1"
     },
     {
@@ -38985,6 +39057,33 @@
     {
       "community": 270,
       "file_type": "code",
+      "id": "harness_audit_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/harness-audit.test.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "harness_audit_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-audit.test.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "scripts_harness_audit_test_ts",
+      "label": "harness-audit.test.ts",
+      "norm_label": "harness-audit.test.ts",
+      "source_file": "scripts/harness-audit.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 271,
+      "file_type": "code",
       "id": "harness_behavior_test_createfixtureroot",
       "label": "createFixtureRoot()",
       "norm_label": "createfixtureroot()",
@@ -38992,7 +39091,7 @@
       "source_location": "L21"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "harness_behavior_test_write",
       "label": "write()",
@@ -39001,7 +39100,7 @@
       "source_location": "L15"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "scripts_harness_behavior_test_ts",
       "label": "harness-behavior.test.ts",
@@ -39010,7 +39109,7 @@
       "source_location": "L1"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "harness_check_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -39019,7 +39118,7 @@
       "source_location": "L48"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "harness_check_test_write",
       "label": "write()",
@@ -39028,7 +39127,7 @@
       "source_location": "L42"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "scripts_harness_check_test_ts",
       "label": "harness-check.test.ts",
@@ -39037,7 +39136,7 @@
       "source_location": "L1"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "harness_generate_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -39046,7 +39145,7 @@
       "source_location": "L16"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "harness_generate_test_write",
       "label": "write()",
@@ -39055,7 +39154,7 @@
       "source_location": "L10"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "scripts_harness_generate_test_ts",
       "label": "harness-generate.test.ts",
@@ -39064,7 +39163,7 @@
       "source_location": "L1"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "harness_inferential_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -39073,7 +39172,7 @@
       "source_location": "L19"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "harness_inferential_review_test_write",
       "label": "write()",
@@ -39082,7 +39181,7 @@
       "source_location": "L13"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "scripts_harness_inferential_review_test_ts",
       "label": "harness-inferential-review.test.ts",
@@ -39091,7 +39190,7 @@
       "source_location": "L1"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "harness_self_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -39100,7 +39199,7 @@
       "source_location": "L16"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "harness_self_review_test_write",
       "label": "write()",
@@ -39109,7 +39208,7 @@
       "source_location": "L10"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "scripts_harness_self_review_test_ts",
       "label": "harness-self-review.test.ts",
@@ -39118,7 +39217,7 @@
       "source_location": "L1"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "harness_test_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -39127,7 +39226,7 @@
       "source_location": "L20"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "harness_test_test_write",
       "label": "write()",
@@ -39136,7 +39235,7 @@
       "source_location": "L14"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "scripts_harness_test_test_ts",
       "label": "harness-test.test.ts",
@@ -39145,7 +39244,7 @@
       "source_location": "L1"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cloudflare_stream_ts",
       "label": "stream.ts",
@@ -39154,7 +39253,7 @@
       "source_location": "L1"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "stream_getcloudflareconfig",
       "label": "getCloudflareConfig()",
@@ -39163,7 +39262,7 @@
       "source_location": "L8"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "convexauditscript_test_createcommandshimbin",
       "label": "createCommandShimBin()",
@@ -39172,7 +39271,7 @@
       "source_location": "L10"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_convexauditscript_test_ts",
       "label": "convexAuditScript.test.ts",
@@ -39181,7 +39280,7 @@
       "source_location": "L1"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_verificationcode_tsx",
       "label": "VerificationCode.tsx",
@@ -39190,31 +39289,13 @@
       "source_location": "L1"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "verificationcode_verificationcode",
       "label": "VerificationCode()",
       "norm_label": "verificationcode()",
       "source_file": "packages/athena-webapp/convex/emails/VerificationCode.tsx",
       "source_location": "L18"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "mtnmomo_handlecollectionnotification",
-      "label": "handleCollectionNotification()",
-      "norm_label": "handlecollectionnotification()",
-      "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/mtnMomo.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_payments_routes_mtnmomo_ts",
-      "label": "mtnMomo.ts",
-      "norm_label": "mtnmomo.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/mtnMomo.ts",
-      "source_location": "L1"
     },
     {
       "community": 28,
@@ -39309,6 +39390,24 @@
     {
       "community": 280,
       "file_type": "code",
+      "id": "mtnmomo_handlecollectionnotification",
+      "label": "handleCollectionNotification()",
+      "norm_label": "handlecollectionnotification()",
+      "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/mtnMomo.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_payments_routes_mtnmomo_ts",
+      "label": "mtnMomo.ts",
+      "norm_label": "mtnmomo.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/payments/routes/mtnMomo.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_routercomposition_test_ts",
       "label": "routerComposition.test.ts",
       "norm_label": "routercomposition.test.ts",
@@ -39316,7 +39415,7 @@
       "source_location": "L1"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "routercomposition_test_readprojectfile",
       "label": "readProjectFile()",
@@ -39325,7 +39424,7 @@
       "source_location": "L6"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "cashier_authenticatehandler",
       "label": "authenticateHandler()",
@@ -39334,7 +39433,7 @@
       "source_location": "L239"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_cashier_ts",
       "label": "cashier.ts",
@@ -39343,7 +39442,7 @@
       "source_location": "L1"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posquerycleanup_test_ts",
       "label": "posQueryCleanup.test.ts",
@@ -39352,7 +39451,7 @@
       "source_location": "L1"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "posquerycleanup_test_readprojectfile",
       "label": "readProjectFile()",
@@ -39361,7 +39460,7 @@
       "source_location": "L8"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_sessionqueryindexes_test_ts",
       "label": "sessionQueryIndexes.test.ts",
@@ -39370,7 +39469,7 @@
       "source_location": "L1"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readprojectfile",
       "label": "readProjectFile()",
@@ -39379,7 +39478,7 @@
       "source_location": "L6"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stores_ts",
       "label": "stores.ts",
@@ -39388,7 +39487,7 @@
       "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "stores_tov2onlyconfig",
       "label": "toV2OnlyConfig()",
@@ -39397,7 +39496,7 @@
       "source_location": "L27"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "callllmprovider_callllmprovider",
       "label": "callLlmProvider()",
@@ -39406,7 +39505,7 @@
       "source_location": "L4"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_callllmprovider_ts",
       "label": "callLlmProvider.ts",
@@ -39415,7 +39514,7 @@
       "source_location": "L1"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "anthropic_callanthropic",
       "label": "callAnthropic()",
@@ -39424,7 +39523,7 @@
       "source_location": "L3"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_anthropic_ts",
       "label": "anthropic.ts",
@@ -39433,7 +39532,7 @@
       "source_location": "L1"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "openai_callopenai",
       "label": "callOpenAi()",
@@ -39442,7 +39541,7 @@
       "source_location": "L3"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_openai_ts",
       "label": "openai.ts",
@@ -39451,7 +39550,7 @@
       "source_location": "L1"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "foundation_test_readprojectfile",
       "label": "readProjectFile()",
@@ -39460,31 +39559,13 @@
       "source_location": "L6"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_foundation_test_ts",
       "label": "foundation.test.ts",
       "norm_label": "foundation.test.ts",
       "source_file": "packages/athena-webapp/convex/mtn/foundation.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_otp_verificationcodeemail_tsx",
-      "label": "VerificationCodeEmail.tsx",
-      "norm_label": "verificationcodeemail.tsx",
-      "source_file": "packages/athena-webapp/convex/otp/VerificationCodeEmail.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "verificationcodeemail_verificationcodeemail",
-      "label": "VerificationCodeEmail()",
-      "norm_label": "verificationcodeemail()",
-      "source_file": "packages/athena-webapp/convex/otp/VerificationCodeEmail.tsx",
-      "source_location": "L11"
     },
     {
       "community": 29,
@@ -39579,6 +39660,24 @@
     {
       "community": 290,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_otp_verificationcodeemail_tsx",
+      "label": "VerificationCodeEmail.tsx",
+      "norm_label": "verificationcodeemail.tsx",
+      "source_file": "packages/athena-webapp/convex/otp/VerificationCodeEmail.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "verificationcodeemail_verificationcodeemail",
+      "label": "VerificationCodeEmail()",
+      "norm_label": "verificationcodeemail()",
+      "source_file": "packages/athena-webapp/convex/otp/VerificationCodeEmail.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 291,
+      "file_type": "code",
       "id": "auth_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
       "norm_label": "getstorefrontactorbyid()",
@@ -39586,7 +39685,7 @@
       "source_location": "L15"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_auth_ts",
       "label": "auth.ts",
@@ -39595,7 +39694,7 @@
       "source_location": "L1"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "customerobservabilitytimeline_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -39604,7 +39703,7 @@
       "source_location": "L17"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerobservabilitytimeline_test_ts",
       "label": "customerObservabilityTimeline.test.ts",
@@ -39613,7 +39712,7 @@
       "source_location": "L1"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "helperorchestration_test_readprojectfile",
       "label": "readProjectFile()",
@@ -39622,7 +39721,7 @@
       "source_location": "L6"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helperorchestration_test_ts",
       "label": "helperOrchestration.test.ts",
@@ -39631,7 +39730,7 @@
       "source_location": "L1"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "onlineorder_listorderitems",
       "label": "listOrderItems()",
@@ -39640,7 +39739,7 @@
       "source_location": "L27"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -39649,7 +39748,7 @@
       "source_location": "L1"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "onlineorderitem_updateonlineorderitem",
       "label": "updateOnlineOrderItem()",
@@ -39658,7 +39757,7 @@
       "source_location": "L21"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
@@ -39667,7 +39766,7 @@
       "source_location": "L1"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_reviews_ts",
       "label": "reviews.ts",
@@ -39676,7 +39775,7 @@
       "source_location": "L1"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "reviews_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -39685,7 +39784,7 @@
       "source_location": "L17"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbag_ts",
       "label": "savedBag.ts",
@@ -39694,7 +39793,7 @@
       "source_location": "L1"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "savedbag_listsavedbagitems",
       "label": "listSavedBagItems()",
@@ -39703,7 +39802,7 @@
       "source_location": "L14"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_test_ts",
       "label": "storefrontObservabilityReport.test.ts",
@@ -39712,7 +39811,7 @@
       "source_location": "L1"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "storefrontobservabilityreport_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -39721,7 +39820,7 @@
       "source_location": "L8"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_syntheticmonitor_ts",
       "label": "syntheticMonitor.ts",
@@ -39730,31 +39829,13 @@
       "source_location": "L1"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "syntheticmonitor_issyntheticmonitororigin",
       "label": "isSyntheticMonitorOrigin()",
       "norm_label": "issyntheticmonitororigin()",
       "source_file": "packages/athena-webapp/convex/storeFront/syntheticMonitor.ts",
       "source_location": "L3"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_timequeryrefactors_test_ts",
-      "label": "timeQueryRefactors.test.ts",
-      "norm_label": "timequeryrefactors.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/timeQueryRefactors.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "timequeryrefactors_test_readsource",
-      "label": "readSource()",
-      "norm_label": "readsource()",
-      "source_file": "packages/athena-webapp/convex/storeFront/timeQueryRefactors.test.ts",
-      "source_location": "L5"
     },
     {
       "community": 3,
@@ -40128,6 +40209,24 @@
     {
       "community": 300,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_timequeryrefactors_test_ts",
+      "label": "timeQueryRefactors.test.ts",
+      "norm_label": "timequeryrefactors.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/timeQueryRefactors.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "timequeryrefactors_test_readsource",
+      "label": "readSource()",
+      "norm_label": "readsource()",
+      "source_file": "packages/athena-webapp/convex/storeFront/timeQueryRefactors.test.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_user_ts",
       "label": "user.ts",
       "norm_label": "user.ts",
@@ -40135,7 +40234,7 @@
       "source_location": "L1"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "user_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -40144,7 +40243,7 @@
       "source_location": "L16"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_useroffers_ts",
       "label": "userOffers.ts",
@@ -40153,7 +40252,7 @@
       "source_location": "L1"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "useroffers_determineoffereligibility",
       "label": "determineOfferEligibility()",
@@ -40162,7 +40261,7 @@
       "source_location": "L30"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "organizationview_navigation",
       "label": "Navigation()",
@@ -40171,7 +40270,7 @@
       "source_location": "L7"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationview_tsx",
       "label": "OrganizationView.tsx",
@@ -40180,7 +40279,7 @@
       "source_location": "L1"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "organizationsview_navigation",
       "label": "Navigation()",
@@ -40189,7 +40288,7 @@
       "source_location": "L12"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationsview_tsx",
       "label": "OrganizationsView.tsx",
@@ -40198,7 +40297,7 @@
       "source_location": "L1"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_permissiongate_tsx",
       "label": "PermissionGate.tsx",
@@ -40207,7 +40306,7 @@
       "source_location": "L1"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "permissiongate_permissiongate",
       "label": "PermissionGate()",
@@ -40216,7 +40315,7 @@
       "source_location": "L11"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_protectedroute_tsx",
       "label": "ProtectedRoute.tsx",
@@ -40225,7 +40324,7 @@
       "source_location": "L1"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "protectedroute_protectedroute",
       "label": "ProtectedRoute()",
@@ -40234,7 +40333,7 @@
       "source_location": "L11"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_settingsview_tsx",
       "label": "SettingsView.tsx",
@@ -40243,7 +40342,7 @@
       "source_location": "L1"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "settingsview_settingsview",
       "label": "SettingsView()",
@@ -40252,7 +40351,7 @@
       "source_location": "L3"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeactions_tsx",
       "label": "StoreActions.tsx",
@@ -40261,7 +40360,7 @@
       "source_location": "L1"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "storeactions_storeactions",
       "label": "StoreActions()",
@@ -40270,7 +40369,7 @@
       "source_location": "L12"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storedropdown_tsx",
       "label": "StoreDropdown.tsx",
@@ -40279,31 +40378,13 @@
       "source_location": "L1"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "storedropdown_storedropdown",
       "label": "StoreDropdown()",
       "norm_label": "storedropdown()",
       "source_file": "packages/athena-webapp/src/components/StoreDropdown.tsx",
       "source_location": "L42"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_storeview_tsx",
-      "label": "StoreView.tsx",
-      "norm_label": "storeview.tsx",
-      "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "storeview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
-      "source_location": "L13"
     },
     {
       "community": 31,
@@ -40398,6 +40479,24 @@
     {
       "community": 310,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_storeview_tsx",
+      "label": "StoreView.tsx",
+      "norm_label": "storeview.tsx",
+      "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "storeview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/StoreView.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesdropdown_tsx",
       "label": "StoresDropdown.tsx",
       "norm_label": "storesdropdown.tsx",
@@ -40405,7 +40504,7 @@
       "source_location": "L1"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "storesdropdown_storesdropdown",
       "label": "StoresDropdown()",
@@ -40414,7 +40513,7 @@
       "source_location": "L42"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "barcodeqrviewer_handleprint",
       "label": "handlePrint()",
@@ -40423,7 +40522,7 @@
       "source_location": "L31"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_barcodeqrviewer_tsx",
       "label": "BarcodeQRViewer.tsx",
@@ -40432,7 +40531,7 @@
       "source_location": "L1"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_processingfees_tsx",
       "label": "ProcessingFees.tsx",
@@ -40441,7 +40540,7 @@
       "source_location": "L1"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "processingfees_processingfeesview",
       "label": "ProcessingFeesView()",
@@ -40450,7 +40549,7 @@
       "source_location": "L10"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributes_tsx",
       "label": "ProductAttributes.tsx",
@@ -40459,7 +40558,7 @@
       "source_location": "L1"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "productattributes_isallowedattribute",
       "label": "isAllowedAttribute()",
@@ -40468,7 +40567,7 @@
       "source_location": "L14"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailabilitytogglegroup_tsx",
       "label": "ProductAvailabilityToggleGroup.tsx",
@@ -40477,7 +40576,7 @@
       "source_location": "L1"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "productavailabilitytogglegroup_productavailabilitytogglegroup",
       "label": "ProductAvailabilityToggleGroup()",
@@ -40486,7 +40585,7 @@
       "source_location": "L5"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -40495,7 +40594,7 @@
       "source_location": "L1"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "productdetails_handlenamechange",
       "label": "handleNameChange()",
@@ -40504,7 +40603,7 @@
       "source_location": "L10"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productimages_tsx",
       "label": "ProductImages.tsx",
@@ -40513,7 +40612,7 @@
       "source_location": "L1"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "productimages_header",
       "label": "Header()",
@@ -40522,7 +40621,7 @@
       "source_location": "L15"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productpage_tsx",
       "label": "ProductPage.tsx",
@@ -40531,7 +40630,7 @@
       "source_location": "L1"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "productpage_productpage",
       "label": "ProductPage()",
@@ -40540,7 +40639,7 @@
       "source_location": "L13"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "copyimagesview_setisupdatingsku",
       "label": "setIsUpdatingSku()",
@@ -40549,31 +40648,13 @@
       "source_location": "L116"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesview_tsx",
       "label": "CopyImagesView.tsx",
       "norm_label": "copyimagesview.tsx",
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/CopyImagesView.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_product_variant_columns_tsx",
-      "label": "product-variant-columns.tsx",
-      "norm_label": "product-variant-columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "product_variant_columns_setsourcevariant",
-      "label": "setSourceVariant()",
-      "norm_label": "setsourcevariant()",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
-      "source_location": "L47"
     },
     {
       "community": 32,
@@ -40668,6 +40749,24 @@
     {
       "community": 320,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_product_variant_columns_tsx",
+      "label": "product-variant-columns.tsx",
+      "norm_label": "product-variant-columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "product_variant_columns_setsourcevariant",
+      "label": "setSourceVariant()",
+      "norm_label": "setsourcevariant()",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/product-variant-columns.tsx",
+      "source_location": "L47"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
       "id": "activitytimeline_capitalizefirstletter",
       "label": "capitalizeFirstLetter()",
       "norm_label": "capitalizefirstletter()",
@@ -40675,7 +40774,7 @@
       "source_location": "L151"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_activitytimeline_tsx",
       "label": "ActivityTimeline.tsx",
@@ -40684,7 +40783,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "analyticsitems_analyticsitems",
       "label": "AnalyticsItems()",
@@ -40693,7 +40792,7 @@
       "source_location": "L6"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsitems_tsx",
       "label": "AnalyticsItems.tsx",
@@ -40702,7 +40801,7 @@
       "source_location": "L1"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "analyticsproducts_analyticsproducts",
       "label": "AnalyticsProducts()",
@@ -40711,7 +40810,7 @@
       "source_location": "L19"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsproducts_tsx",
       "label": "AnalyticsProducts.tsx",
@@ -40720,7 +40819,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "analyticsusers_analyticsusers",
       "label": "AnalyticsUsers()",
@@ -40729,7 +40828,7 @@
       "source_location": "L7"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsusers_tsx",
       "label": "AnalyticsUsers.tsx",
@@ -40738,7 +40837,7 @@
       "source_location": "L1"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "enhancedanalyticsview_getdaterangemilliseconds",
       "label": "getDateRangeMilliseconds()",
@@ -40747,7 +40846,7 @@
       "source_location": "L42"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_enhancedanalyticsview_tsx",
       "label": "EnhancedAnalyticsView.tsx",
@@ -40756,7 +40855,7 @@
       "source_location": "L1"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storeinsights_tsx",
       "label": "StoreInsights.tsx",
@@ -40765,7 +40864,7 @@
       "source_location": "L1"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "storeinsights_gettrendicon",
       "label": "getTrendIcon()",
@@ -40774,7 +40873,7 @@
       "source_location": "L66"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_visitorchart_tsx",
       "label": "VisitorChart.tsx",
@@ -40783,7 +40882,7 @@
       "source_location": "L1"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "visitorchart_formathour",
       "label": "formatHour()",
@@ -40792,7 +40891,7 @@
       "source_location": "L18"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "logitems_logitems",
       "label": "LogItems()",
@@ -40801,7 +40900,7 @@
       "source_location": "L6"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logitems_tsx",
       "label": "LogItems.tsx",
@@ -40810,7 +40909,7 @@
       "source_location": "L1"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "logview_header",
       "label": "Header()",
@@ -40819,30 +40918,12 @@
       "source_location": "L10"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logview_tsx",
       "label": "LogView.tsx",
       "norm_label": "logview.tsx",
       "source_file": "packages/athena-webapp/src/components/app-logs/LogView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "logsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
-      "source_location": "L27"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_logsview_tsx",
-      "label": "LogsView.tsx",
-      "norm_label": "logsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
       "source_location": "L1"
     },
     {
@@ -40938,6 +41019,24 @@
     {
       "community": 330,
       "file_type": "code",
+      "id": "logsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_logsview_tsx",
+      "label": "LogsView.tsx",
+      "norm_label": "logsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/LogsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_hooks_useloadlogitems_ts",
       "label": "useLoadLogItems.ts",
       "norm_label": "useloadlogitems.ts",
@@ -40945,7 +41044,7 @@
       "source_location": "L1"
     },
     {
-      "community": 330,
+      "community": 331,
       "file_type": "code",
       "id": "useloadlogitems_useloadlogitems",
       "label": "useLoadLogItems()",
@@ -40954,7 +41053,7 @@
       "source_location": "L12"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "auth_auth",
       "label": "Auth()",
@@ -40963,7 +41062,7 @@
       "source_location": "L3"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -40972,7 +41071,7 @@
       "source_location": "L1"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "index_login",
       "label": "Login()",
@@ -40981,7 +41080,7 @@
       "source_location": "L5"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_index_tsx",
       "label": "index.tsx",
@@ -40990,7 +41089,7 @@
       "source_location": "L1"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "bulkoperationsfilters_handleloadproducts",
       "label": "handleLoadProducts()",
@@ -40999,7 +41098,7 @@
       "source_location": "L49"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationsfilters_tsx",
       "label": "BulkOperationsFilters.tsx",
@@ -41008,7 +41107,7 @@
       "source_location": "L1"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "bulkoperationspreview_test_makerow",
       "label": "makeRow()",
@@ -41017,7 +41116,7 @@
       "source_location": "L23"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_test_tsx",
       "label": "BulkOperationsPreview.test.tsx",
@@ -41026,7 +41125,7 @@
       "source_location": "L1"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "bulkoperationspreview_formatprice",
       "label": "formatPrice()",
@@ -41035,7 +41134,7 @@
       "source_location": "L50"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_tsx",
       "label": "BulkOperationsPreview.tsx",
@@ -41044,7 +41143,7 @@
       "source_location": "L1"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "checkoutsessionstable_checkoutsessionstable",
       "label": "CheckoutSessionsTable()",
@@ -41053,7 +41152,7 @@
       "source_location": "L13"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsessionstable_tsx",
       "label": "CheckoutSessionsTable.tsx",
@@ -41062,7 +41161,7 @@
       "source_location": "L1"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "checkoutsesssionsview_navigation",
       "label": "Navigation()",
@@ -41071,7 +41170,7 @@
       "source_location": "L11"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsesssionsview_tsx",
       "label": "CheckoutSesssionsView.tsx",
@@ -41080,7 +41179,7 @@
       "source_location": "L1"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
       "label": "PageHeader.tsx",
@@ -41089,31 +41188,13 @@
       "source_location": "L1"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "pageheader_pageheader",
       "label": "PageHeader()",
       "norm_label": "pageheader()",
       "source_file": "packages/athena-webapp/src/components/common/PageHeader.tsx",
       "source_location": "L7"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "bestsellersdialog_handleaddbestseller",
-      "label": "handleAddBestSeller()",
-      "norm_label": "handleaddbestseller()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BestSellersDialog.tsx",
-      "source_location": "L29"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_bestsellersdialog_tsx",
-      "label": "BestSellersDialog.tsx",
-      "norm_label": "bestsellersdialog.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/BestSellersDialog.tsx",
-      "source_location": "L1"
     },
     {
       "community": 34,
@@ -41208,6 +41289,24 @@
     {
       "community": 340,
       "file_type": "code",
+      "id": "bestsellersdialog_handleaddbestseller",
+      "label": "handleAddBestSeller()",
+      "norm_label": "handleaddbestseller()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BestSellersDialog.tsx",
+      "source_location": "L29"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_bestsellersdialog_tsx",
+      "label": "BestSellersDialog.tsx",
+      "norm_label": "bestsellersdialog.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/BestSellersDialog.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
       "id": "featuredsectiondialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
       "norm_label": "handleaddfeatureditem()",
@@ -41215,7 +41314,7 @@
       "source_location": "L37"
     },
     {
-      "community": 340,
+      "community": 341,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsectiondialog_tsx",
       "label": "FeaturedSectionDialog.tsx",
@@ -41224,7 +41323,7 @@
       "source_location": "L1"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "home_navigation",
       "label": "Navigation()",
@@ -41233,7 +41332,7 @@
       "source_location": "L25"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_home_tsx",
       "label": "Home.tsx",
@@ -41242,7 +41341,7 @@
       "source_location": "L1"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "landingpagereelversion_handleupdateconfig",
       "label": "handleUpdateConfig()",
@@ -41251,7 +41350,7 @@
       "source_location": "L83"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_landingpagereelversion_tsx",
       "label": "LandingPageReelVersion.tsx",
@@ -41260,7 +41359,7 @@
       "source_location": "L1"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookdialog_tsx",
       "label": "ShopLookDialog.tsx",
@@ -41269,7 +41368,7 @@
       "source_location": "L1"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "shoplookdialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
@@ -41278,7 +41377,7 @@
       "source_location": "L35"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookimageuploader_tsx",
       "label": "ShopLookImageUploader.tsx",
@@ -41287,7 +41386,7 @@
       "source_location": "L1"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "shoplookimageuploader_shoplookimageuploader",
       "label": "ShopLookImageUploader()",
@@ -41296,7 +41395,7 @@
       "source_location": "L28"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "index_jointeam",
       "label": "JoinTeam()",
@@ -41305,7 +41404,7 @@
       "source_location": "L11"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_join_team_index_tsx",
       "label": "index.tsx",
@@ -41314,7 +41413,7 @@
       "source_location": "L1"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "customerdetailsview_customerdetailsview",
       "label": "CustomerDetailsView()",
@@ -41323,7 +41422,7 @@
       "source_location": "L13"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_customerdetailsview_tsx",
       "label": "CustomerDetailsView.tsx",
@@ -41332,7 +41431,7 @@
       "source_location": "L1"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "emailstatusview_handlesendorderemail",
       "label": "handleSendOrderEmail()",
@@ -41341,7 +41440,7 @@
       "source_location": "L41"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_emailstatusview_tsx",
       "label": "EmailStatusView.tsx",
@@ -41350,7 +41449,7 @@
       "source_location": "L1"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "ordermetricspanel_handletimerangechange",
       "label": "handleTimeRangeChange()",
@@ -41359,30 +41458,12 @@
       "source_location": "L33"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordermetricspanel_tsx",
       "label": "OrderMetricsPanel.tsx",
       "norm_label": "ordermetricspanel.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/OrderMetricsPanel.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "ordersview_gettimefilter",
-      "label": "getTimeFilter()",
-      "norm_label": "gettimefilter()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
-      "source_location": "L35"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_ordersview_tsx",
-      "label": "OrdersView.tsx",
-      "norm_label": "ordersview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
       "source_location": "L1"
     },
     {
@@ -41469,6 +41550,24 @@
     {
       "community": 350,
       "file_type": "code",
+      "id": "ordersview_gettimefilter",
+      "label": "getTimeFilter()",
+      "norm_label": "gettimefilter()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
+      "source_location": "L35"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_ordersview_tsx",
+      "label": "OrdersView.tsx",
+      "norm_label": "ordersview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_refundsview_tsx",
       "label": "RefundsView.tsx",
       "norm_label": "refundsview.tsx",
@@ -41476,7 +41575,7 @@
       "source_location": "L1"
     },
     {
-      "community": 350,
+      "community": 351,
       "file_type": "code",
       "id": "refundsview_handlerefundorder",
       "label": "handleRefundOrder()",
@@ -41485,7 +41584,7 @@
       "source_location": "L79"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_hooks_usegetactiveonlineorder_ts",
       "label": "useGetActiveOnlineOrder.ts",
@@ -41494,7 +41593,7 @@
       "source_location": "L1"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "usegetactiveonlineorder_usegetactiveonlineorder",
       "label": "useGetActiveOnlineOrder()",
@@ -41503,7 +41602,7 @@
       "source_location": "L6"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "data_table_toolbar_handleclearfilters",
       "label": "handleClearFilters()",
@@ -41512,7 +41611,7 @@
       "source_location": "L34"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -41521,7 +41620,7 @@
       "source_location": "L1"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "ordercolumns_if",
       "label": "if()",
@@ -41530,7 +41629,7 @@
       "source_location": "L89"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_ordercolumns_tsx",
       "label": "orderColumns.tsx",
@@ -41539,7 +41638,7 @@
       "source_location": "L1"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "cashierview_handlesignout",
       "label": "handleSignOut()",
@@ -41548,7 +41647,7 @@
       "source_location": "L63"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierview_tsx",
       "label": "CashierView.tsx",
@@ -41557,7 +41656,7 @@
       "source_location": "L1"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "debugproducts_debugproducts",
       "label": "DebugProducts()",
@@ -41566,7 +41665,7 @@
       "source_location": "L5"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_debugproducts_tsx",
       "label": "DebugProducts.tsx",
@@ -41575,7 +41674,7 @@
       "source_location": "L1"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "noresultsmessage_noresultsmessage",
       "label": "NoResultsMessage()",
@@ -41584,7 +41683,7 @@
       "source_location": "L7"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_noresultsmessage_tsx",
       "label": "NoResultsMessage.tsx",
@@ -41593,7 +41692,7 @@
       "source_location": "L1"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pininput_tsx",
       "label": "PinInput.tsx",
@@ -41602,7 +41701,7 @@
       "source_location": "L1"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "pininput_pininput",
       "label": "PinInput()",
@@ -41611,7 +41710,7 @@
       "source_location": "L13"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
       "label": "PointOfSaleView.tsx",
@@ -41620,31 +41719,13 @@
       "source_location": "L1"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "pointofsaleview_navigation",
       "label": "Navigation()",
       "norm_label": "navigation()",
       "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
       "source_location": "L34"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_printinstructions_tsx",
-      "label": "PrintInstructions.tsx",
-      "norm_label": "printinstructions.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "printinstructions_printinstructions",
-      "label": "PrintInstructions()",
-      "norm_label": "printinstructions()",
-      "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
-      "source_location": "L3"
     },
     {
       "community": 36,
@@ -41730,6 +41811,24 @@
     {
       "community": 360,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_printinstructions_tsx",
+      "label": "PrintInstructions.tsx",
+      "norm_label": "printinstructions.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "printinstructions_printinstructions",
+      "label": "PrintInstructions()",
+      "norm_label": "printinstructions()",
+      "source_file": "packages/athena-webapp/src/components/pos/PrintInstructions.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productcard_tsx",
       "label": "ProductCard.tsx",
       "norm_label": "productcard.tsx",
@@ -41737,7 +41836,7 @@
       "source_location": "L1"
     },
     {
-      "community": 360,
+      "community": 361,
       "file_type": "code",
       "id": "productcard_productcard",
       "label": "ProductCard()",
@@ -41746,7 +41845,7 @@
       "source_location": "L14"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productentry_tsx",
       "label": "ProductEntry.tsx",
@@ -41755,7 +41854,7 @@
       "source_location": "L1"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "productentry_handleclearsearch",
       "label": "handleClearSearch()",
@@ -41764,7 +41863,7 @@
       "source_location": "L86"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_quickactionsbar_tsx",
       "label": "QuickActionsBar.tsx",
@@ -41773,7 +41872,7 @@
       "source_location": "L1"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "quickactionsbar_quickactionsbar",
       "label": "QuickActionsBar()",
@@ -41782,7 +41881,7 @@
       "source_location": "L11"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessiondemo_tsx",
       "label": "SessionDemo.tsx",
@@ -41791,7 +41890,7 @@
       "source_location": "L1"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "sessiondemo_sessiondemo",
       "label": "SessionDemo()",
@@ -41800,7 +41899,7 @@
       "source_location": "L15"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_tsx",
       "label": "TotalsDisplay.tsx",
@@ -41809,25 +41908,25 @@
       "source_location": "L1"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "totalsdisplay_totalsdisplay",
       "label": "TotalsDisplay()",
       "norm_label": "totalsdisplay()",
       "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.tsx",
-      "source_location": "L12"
+      "source_location": "L14"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "expensereportsview_istoday",
       "label": "isToday()",
       "norm_label": "istoday()",
       "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
-      "source_location": "L17"
+      "source_location": "L18"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_tsx",
       "label": "ExpenseReportsView.tsx",
@@ -41836,7 +41935,7 @@
       "source_location": "L1"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "hooks_useposcashier",
       "label": "usePOSCashier()",
@@ -41845,7 +41944,7 @@
       "source_location": "L5"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_hooks_ts",
       "label": "hooks.ts",
@@ -41854,7 +41953,7 @@
       "source_location": "L1"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "holdsessiondialog_holdsessiondialog",
       "label": "HoldSessionDialog()",
@@ -41863,7 +41962,7 @@
       "source_location": "L19"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_holdsessiondialog_tsx",
       "label": "HoldSessionDialog.tsx",
@@ -41872,7 +41971,7 @@
       "source_location": "L1"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_voidsessiondialog_tsx",
       "label": "VoidSessionDialog.tsx",
@@ -41881,31 +41980,13 @@
       "source_location": "L1"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "voidsessiondialog_voidsessiondialog",
       "label": "VoidSessionDialog()",
       "norm_label": "voidsessiondialog()",
       "source_file": "packages/athena-webapp/src/components/pos/session/VoidSessionDialog.tsx",
       "source_location": "L19"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_tsx",
-      "label": "transactionColumns.tsx",
-      "norm_label": "transactioncolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "transactioncolumns_getpaymentmethodicon",
-      "label": "getPaymentMethodIcon()",
-      "norm_label": "getpaymentmethodicon()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
-      "source_location": "L22"
     },
     {
       "community": 37,
@@ -41991,6 +42072,24 @@
     {
       "community": 370,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_tsx",
+      "label": "transactionColumns.tsx",
+      "norm_label": "transactioncolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "transactioncolumns_getpaymentmethodicon",
+      "label": "getPaymentMethodIcon()",
+      "norm_label": "getpaymentmethodicon()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
+      "source_location": "L22"
+    },
+    {
+      "community": 371,
+      "file_type": "code",
       "id": "barcodeview_barcodeview",
       "label": "BarcodeView()",
       "norm_label": "barcodeview()",
@@ -41998,7 +42097,7 @@
       "source_location": "L14"
     },
     {
-      "community": 370,
+      "community": 371,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_barcodeview_tsx",
       "label": "BarcodeView.tsx",
@@ -42007,7 +42106,7 @@
       "source_location": "L1"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "categorizationview_categorizationview",
       "label": "CategorizationView()",
@@ -42016,7 +42115,7 @@
       "source_location": "L6"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_categorizationview_tsx",
       "label": "CategorizationView.tsx",
@@ -42025,7 +42124,7 @@
       "source_location": "L1"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "imagesview_handlekeydown",
       "label": "handleKeyDown()",
@@ -42034,7 +42133,7 @@
       "source_location": "L38"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_imagesview_tsx",
       "label": "ImagesView.tsx",
@@ -42043,7 +42142,7 @@
       "source_location": "L1"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_skuselector_tsx",
       "label": "SKUSelector.tsx",
@@ -42052,7 +42151,7 @@
       "source_location": "L1"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "skuselector_skuselector",
       "label": "SKUSelector()",
@@ -42061,7 +42160,7 @@
       "source_location": "L10"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_actions_tsx",
       "label": "product-actions.tsx",
@@ -42070,7 +42169,7 @@
       "source_location": "L1"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "product_actions_usedeleteproduct",
       "label": "useDeleteProduct()",
@@ -42079,7 +42178,7 @@
       "source_location": "L6"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsview_tsx",
       "label": "ProductsView.tsx",
@@ -42088,7 +42187,7 @@
       "source_location": "L1"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "productsview_productsview",
       "label": "ProductsView()",
@@ -42097,7 +42196,7 @@
       "source_location": "L5"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "add_product_command_addproductcommand",
       "label": "AddProductCommand()",
@@ -42106,7 +42205,7 @@
       "source_location": "L17"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_add_product_command_tsx",
       "label": "add-product-command.tsx",
@@ -42115,7 +42214,7 @@
       "source_location": "L1"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_products_tsx",
       "label": "Products.tsx",
@@ -42124,7 +42223,7 @@
       "source_location": "L1"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "products_products",
       "label": "Products()",
@@ -42133,7 +42232,7 @@
       "source_location": "L4"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeform_tsx",
       "label": "PromoCodeForm.tsx",
@@ -42142,31 +42241,13 @@
       "source_location": "L1"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "promocodeform_togglediscounttype",
       "label": "toggleDiscountType()",
       "norm_label": "togglediscounttype()",
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeForm.tsx",
       "source_location": "L84"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_tsx",
-      "label": "PromoCodeHeader.tsx",
-      "norm_label": "promocodeheader.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "promocodeheader_handledeletepromocode",
-      "label": "handleDeletePromoCode()",
-      "norm_label": "handledeletepromocode()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
-      "source_location": "L22"
     },
     {
       "community": 38,
@@ -42252,6 +42333,24 @@
     {
       "community": 380,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_tsx",
+      "label": "PromoCodeHeader.tsx",
+      "norm_label": "promocodeheader.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "promocodeheader_handledeletepromocode",
+      "label": "handleDeletePromoCode()",
+      "norm_label": "handledeletepromocode()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
+      "source_location": "L22"
+    },
+    {
+      "community": 381,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodesview_tsx",
       "label": "PromoCodesView.tsx",
       "norm_label": "promocodesview.tsx",
@@ -42259,7 +42358,7 @@
       "source_location": "L1"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "promocodesview_promocodesview",
       "label": "PromoCodesView()",
@@ -42268,7 +42367,7 @@
       "source_location": "L9"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectablecategories_tsx",
       "label": "SelectableCategories.tsx",
@@ -42277,7 +42376,7 @@
       "source_location": "L1"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "selectablecategories_toggle",
       "label": "toggle()",
@@ -42286,7 +42385,7 @@
       "source_location": "L23"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "discounttypetogglegroup_discounttypetogglegroup",
       "label": "DiscountTypeToggleGroup()",
@@ -42295,7 +42394,7 @@
       "source_location": "L5"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_discounttypetogglegroup_tsx",
       "label": "DiscountTypeToggleGroup.tsx",
@@ -42304,7 +42403,7 @@
       "source_location": "L1"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_promocodespantogglegroup_tsx",
       "label": "PromoCodeSpanToggleGroup.tsx",
@@ -42313,7 +42412,7 @@
       "source_location": "L1"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "promocodespantogglegroup_promocodespantogglegroup",
       "label": "PromoCodeSpanToggleGroup()",
@@ -42322,7 +42421,7 @@
       "source_location": "L4"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "capturedemails_capturedemails",
       "label": "CapturedEmails()",
@@ -42331,7 +42430,7 @@
       "source_location": "L13"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_capturedemails_tsx",
       "label": "CapturedEmails.tsx",
@@ -42340,7 +42439,7 @@
       "source_location": "L1"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_promo_code_modal_tsx",
       "label": "promo-code-modal.tsx",
@@ -42349,7 +42448,7 @@
       "source_location": "L1"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "promo_code_modal_promocodemodal",
       "label": "PromoCodeModal()",
@@ -42358,7 +42457,7 @@
       "source_location": "L29"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewactions_tsx",
       "label": "ReviewActions.tsx",
@@ -42367,7 +42466,7 @@
       "source_location": "L1"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "reviewactions_reviewactions",
       "label": "ReviewActions()",
@@ -42376,7 +42475,7 @@
       "source_location": "L20"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "empty_state_onclick",
       "label": "onClick()",
@@ -42385,7 +42484,7 @@
       "source_location": "L29"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
@@ -42394,7 +42493,7 @@
       "source_location": "L1"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "nopermission_nopermission",
       "label": "NoPermission()",
@@ -42403,30 +42502,12 @@
       "source_location": "L3"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermission_tsx",
       "label": "NoPermission.tsx",
       "norm_label": "nopermission.tsx",
       "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermission.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "nopermissionview_nopermissionview",
-      "label": "NoPermissionView()",
-      "norm_label": "nopermissionview()",
-      "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermissionView.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_states_no_permission_nopermissionview_tsx",
-      "label": "NoPermissionView.tsx",
-      "norm_label": "nopermissionview.tsx",
-      "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermissionView.tsx",
       "source_location": "L1"
     },
     {
@@ -42513,6 +42594,24 @@
     {
       "community": 390,
       "file_type": "code",
+      "id": "nopermissionview_nopermissionview",
+      "label": "NoPermissionView()",
+      "norm_label": "nopermissionview()",
+      "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermissionView.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_states_no_permission_nopermissionview_tsx",
+      "label": "NoPermissionView.tsx",
+      "norm_label": "nopermissionview.tsx",
+      "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermissionView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 391,
+      "file_type": "code",
       "id": "notfoundview_notfoundview",
       "label": "NotFoundView()",
       "norm_label": "notfoundview()",
@@ -42520,7 +42619,7 @@
       "source_location": "L4"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfoundview_tsx",
       "label": "NotFoundView.tsx",
@@ -42529,7 +42628,7 @@
       "source_location": "L1"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "contactview_contactview",
       "label": "ContactView()",
@@ -42538,7 +42637,7 @@
       "source_location": "L9"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_contactview_tsx",
       "label": "ContactView.tsx",
@@ -42547,7 +42646,7 @@
       "source_location": "L1"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "header_header",
       "label": "Header()",
@@ -42556,7 +42655,7 @@
       "source_location": "L1"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_header_tsx",
       "label": "Header.tsx",
@@ -42565,7 +42664,7 @@
       "source_location": "L1"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "maintenanceview_maintenanceview",
       "label": "MaintenanceView()",
@@ -42574,7 +42673,7 @@
       "source_location": "L13"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_tsx",
       "label": "MaintenanceView.tsx",
@@ -42583,7 +42682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_taxview_tsx",
       "label": "TaxView.tsx",
@@ -42592,7 +42691,7 @@
       "source_location": "L1"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "taxview_handleupdatetaxsettings",
       "label": "handleUpdateTaxSettings()",
@@ -42601,7 +42700,7 @@
       "source_location": "L25"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_ts",
       "label": "useStoreConfigUpdate.ts",
@@ -42610,7 +42709,7 @@
       "source_location": "L1"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "usestoreconfigupdate_usestoreconfigupdate",
       "label": "useStoreConfigUpdate()",
@@ -42619,7 +42718,7 @@
       "source_location": "L19"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_switcher_tsx",
       "label": "store-switcher.tsx",
@@ -42628,7 +42727,7 @@
       "source_location": "L1"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "store_switcher_onstoreselect",
       "label": "onStoreSelect()",
@@ -42637,7 +42736,7 @@
       "source_location": "L63"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "chart_usechart",
       "label": "useChart()",
@@ -42646,7 +42745,7 @@
       "source_location": "L25"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_chart_tsx",
       "label": "chart.tsx",
@@ -42655,7 +42754,7 @@
       "source_location": "L1"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "copy_button_handlecopy",
       "label": "handleCopy()",
@@ -42664,30 +42763,12 @@
       "source_location": "L15"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_copy_button_tsx",
       "label": "copy-button.tsx",
       "norm_label": "copy-button.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/copy-button.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "copy_wrapper_handlecopy",
-      "label": "handleCopy()",
-      "norm_label": "handlecopy()",
-      "source_file": "packages/athena-webapp/src/components/ui/copy-wrapper.tsx",
-      "source_location": "L21"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_copy_wrapper_tsx",
-      "label": "copy-wrapper.tsx",
-      "norm_label": "copy-wrapper.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/copy-wrapper.tsx",
       "source_location": "L1"
     },
     {
@@ -43026,6 +43107,24 @@
     {
       "community": 400,
       "file_type": "code",
+      "id": "copy_wrapper_handlecopy",
+      "label": "handleCopy()",
+      "norm_label": "handlecopy()",
+      "source_file": "packages/athena-webapp/src/components/ui/copy-wrapper.tsx",
+      "source_location": "L21"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_copy_wrapper_tsx",
+      "label": "copy-wrapper.tsx",
+      "norm_label": "copy-wrapper.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/copy-wrapper.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 401,
+      "file_type": "code",
       "id": "date_time_picker_datetimepicker",
       "label": "DateTimePicker()",
       "norm_label": "datetimepicker()",
@@ -43033,7 +43132,7 @@
       "source_location": "L21"
     },
     {
-      "community": 400,
+      "community": 401,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
       "label": "date-time-picker.tsx",
@@ -43042,7 +43141,7 @@
       "source_location": "L1"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "label_label",
       "label": "Label()",
@@ -43051,7 +43150,7 @@
       "source_location": "L6"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
@@ -43060,7 +43159,7 @@
       "source_location": "L1"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "custom_modal_custommodal",
       "label": "CustomModal()",
@@ -43069,7 +43168,7 @@
       "source_location": "L25"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_tsx",
       "label": "custom-modal.tsx",
@@ -43078,7 +43177,7 @@
       "source_location": "L1"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "organization_modal_onsubmit",
       "label": "onSubmit()",
@@ -43087,7 +43186,7 @@
       "source_location": "L49"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_organization_modal_tsx",
       "label": "organization-modal.tsx",
@@ -43096,7 +43195,7 @@
       "source_location": "L1"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_store_modal_tsx",
       "label": "store-modal.tsx",
@@ -43105,7 +43204,7 @@
       "source_location": "L1"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "store_modal_onsubmit",
       "label": "onSubmit()",
@@ -43114,7 +43213,7 @@
       "source_location": "L63"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_example_tsx",
       "label": "welcome-back-modal-example.tsx",
@@ -43123,7 +43222,7 @@
       "source_location": "L1"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "welcome_back_modal_example_welcomebackmodalexample",
       "label": "WelcomeBackModalExample()",
@@ -43132,7 +43231,7 @@
       "source_location": "L5"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_tsx",
       "label": "welcome-back-modal.tsx",
@@ -43141,7 +43240,7 @@
       "source_location": "L1"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "welcome_back_modal_welcomebackmodal",
       "label": "WelcomeBackModal()",
@@ -43150,7 +43249,7 @@
       "source_location": "L12"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_native_tsx",
       "label": "select-native.tsx",
@@ -43159,7 +43258,7 @@
       "source_location": "L1"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "select_native_cn",
       "label": "cn()",
@@ -43168,7 +43267,7 @@
       "source_location": "L15"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_timeline_item_tsx",
       "label": "timeline-item.tsx",
@@ -43177,31 +43276,13 @@
       "source_location": "L1"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "timeline_item_timelineitem",
       "label": "TimelineItem()",
       "norm_label": "timelineitem()",
       "source_file": "packages/athena-webapp/src/components/ui/timeline-item.tsx",
       "source_location": "L3"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_webp_image_tsx",
-      "label": "webp-image.tsx",
-      "norm_label": "webp-image.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/webp-image.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "webp_image_webpimage",
-      "label": "WebpImage()",
-      "norm_label": "webpimage()",
-      "source_file": "packages/athena-webapp/src/components/ui/webp-image.tsx",
-      "source_location": "L1"
     },
     {
       "community": 41,
@@ -43278,6 +43359,24 @@
     {
       "community": 410,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_webp_image_tsx",
+      "label": "webp-image.tsx",
+      "norm_label": "webp-image.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/webp-image.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "webp_image_webpimage",
+      "label": "WebpImage()",
+      "norm_label": "webpimage()",
+      "source_file": "packages/athena-webapp/src/components/ui/webp-image.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 411,
+      "file_type": "code",
       "id": "bagitems_bagitems",
       "label": "BagItems()",
       "norm_label": "bagitems()",
@@ -43285,7 +43384,7 @@
       "source_location": "L5"
     },
     {
-      "community": 410,
+      "community": 411,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagitems_tsx",
       "label": "BagItems.tsx",
@@ -43294,7 +43393,7 @@
       "source_location": "L1"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "bagitemsview_bagitemsview",
       "label": "BagItemsView()",
@@ -43303,7 +43402,7 @@
       "source_location": "L11"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagitemsview_tsx",
       "label": "BagItemsView.tsx",
@@ -43312,7 +43411,7 @@
       "source_location": "L1"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "bags_bags",
       "label": "Bags()",
@@ -43321,7 +43420,7 @@
       "source_location": "L4"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bags_tsx",
       "label": "Bags.tsx",
@@ -43330,7 +43429,7 @@
       "source_location": "L1"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "customerbehaviortimeline_string",
       "label": "String()",
@@ -43339,7 +43438,7 @@
       "source_location": "L110"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_customerbehaviortimeline_tsx",
       "label": "CustomerBehaviorTimeline.tsx",
@@ -43348,7 +43447,7 @@
       "source_location": "L1"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useranalyticsname_tsx",
       "label": "UserAnalyticsName.tsx",
@@ -43357,7 +43456,7 @@
       "source_location": "L1"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "useranalyticsname_useranalyticsname",
       "label": "UserAnalyticsName()",
@@ -43366,7 +43465,7 @@
       "source_location": "L13"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userbag_tsx",
       "label": "UserBag.tsx",
@@ -43375,7 +43474,7 @@
       "source_location": "L1"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "userbag_userbag",
       "label": "UserBag()",
@@ -43384,7 +43483,7 @@
       "source_location": "L7"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useronlineorders_tsx",
       "label": "UserOnlineOrders.tsx",
@@ -43393,7 +43492,7 @@
       "source_location": "L1"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "useronlineorders_useronlineorders",
       "label": "UserOnlineOrders()",
@@ -43402,7 +43501,7 @@
       "source_location": "L11"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userstatus_tsx",
       "label": "UserStatus.tsx",
@@ -43411,7 +43510,7 @@
       "source_location": "L1"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "userstatus_userstatus",
       "label": "UserStatus()",
@@ -43420,7 +43519,7 @@
       "source_location": "L7"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userview_tsx",
       "label": "UserView.tsx",
@@ -43429,31 +43528,13 @@
       "source_location": "L1"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "userview_useractions",
       "label": "UserActions()",
       "norm_label": "useractions()",
       "source_file": "packages/athena-webapp/src/components/users/UserView.tsx",
       "source_location": "L45"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "customerjourneystage_customerjourneystagecard",
-      "label": "CustomerJourneyStageCard()",
-      "norm_label": "customerjourneystagecard()",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/CustomerJourneyStage.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_behavioral_insights_customerjourneystage_tsx",
-      "label": "CustomerJourneyStage.tsx",
-      "norm_label": "customerjourneystage.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/CustomerJourneyStage.tsx",
-      "source_location": "L1"
     },
     {
       "community": 42,
@@ -43530,6 +43611,24 @@
     {
       "community": 420,
       "file_type": "code",
+      "id": "customerjourneystage_customerjourneystagecard",
+      "label": "CustomerJourneyStageCard()",
+      "norm_label": "customerjourneystagecard()",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/CustomerJourneyStage.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_behavioral_insights_customerjourneystage_tsx",
+      "label": "CustomerJourneyStage.tsx",
+      "norm_label": "customerjourneystage.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/CustomerJourneyStage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 421,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_image_upload_ts",
       "label": "use-image-upload.ts",
       "norm_label": "use-image-upload.ts",
@@ -43537,7 +43636,7 @@
       "source_location": "L1"
     },
     {
-      "community": 420,
+      "community": 421,
       "file_type": "code",
       "id": "use_image_upload_useimageupload",
       "label": "useImageUpload()",
@@ -43546,7 +43645,7 @@
       "source_location": "L7"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_mobile_tsx",
       "label": "use-mobile.tsx",
@@ -43555,7 +43654,7 @@
       "source_location": "L1"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "use_mobile_useismobile",
       "label": "useIsMobile()",
@@ -43564,7 +43663,7 @@
       "source_location": "L5"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_navigate_back_ts",
       "label": "use-navigate-back.ts",
@@ -43573,7 +43672,7 @@
       "source_location": "L1"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "use_navigate_back_usenavigateback",
       "label": "useNavigateBack()",
@@ -43582,7 +43681,7 @@
       "source_location": "L5"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_navigation_keyboard_shortcuts_ts",
       "label": "use-navigation-keyboard-shortcuts.ts",
@@ -43591,7 +43690,7 @@
       "source_location": "L1"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "use_navigation_keyboard_shortcuts_usenavigationkeyboardshortcuts",
       "label": "useNavigationKeyboardShortcuts()",
@@ -43600,7 +43699,7 @@
       "source_location": "L7"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_pagination_persistence_ts",
       "label": "use-pagination-persistence.ts",
@@ -43609,7 +43708,7 @@
       "source_location": "L1"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "use_pagination_persistence_usepaginationpersistence",
       "label": "usePaginationPersistence()",
@@ -43618,7 +43717,7 @@
       "source_location": "L9"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_table_keyboard_pagination_ts",
       "label": "use-table-keyboard-pagination.ts",
@@ -43627,7 +43726,7 @@
       "source_location": "L1"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "use_table_keyboard_pagination_usetablekeyboardpagination",
       "label": "useTableKeyboardPagination()",
@@ -43636,7 +43735,7 @@
       "source_location": "L6"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usebulkoperations_test_ts",
       "label": "useBulkOperations.test.ts",
@@ -43645,7 +43744,7 @@
       "source_location": "L1"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "usebulkoperations_test_makesku",
       "label": "makeSku()",
@@ -43654,7 +43753,7 @@
       "source_location": "L168"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecartoperations_ts",
       "label": "useCartOperations.ts",
@@ -43663,7 +43762,7 @@
       "source_location": "L1"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "usecartoperations_usecartoperations",
       "label": "useCartOperations()",
@@ -43672,7 +43771,7 @@
       "source_location": "L23"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecopytext_ts",
       "label": "useCopyText.ts",
@@ -43681,31 +43780,13 @@
       "source_location": "L1"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "usecopytext_usecopytext",
       "label": "useCopyText()",
       "norm_label": "usecopytext()",
       "source_file": "packages/athena-webapp/src/hooks/useCopyText.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usecreatecomplimentaryproduct_ts",
-      "label": "useCreateComplimentaryProduct.ts",
-      "norm_label": "usecreatecomplimentaryproduct.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useCreateComplimentaryProduct.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "usecreatecomplimentaryproduct_usecreatecomplimentaryproduct",
-      "label": "useCreateComplimentaryProduct()",
-      "norm_label": "usecreatecomplimentaryproduct()",
-      "source_file": "packages/athena-webapp/src/hooks/useCreateComplimentaryProduct.ts",
-      "source_location": "L6"
     },
     {
       "community": 43,
@@ -43782,6 +43863,24 @@
     {
       "community": 430,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usecreatecomplimentaryproduct_ts",
+      "label": "useCreateComplimentaryProduct.ts",
+      "norm_label": "usecreatecomplimentaryproduct.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useCreateComplimentaryProduct.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "usecreatecomplimentaryproduct_usecreatecomplimentaryproduct",
+      "label": "useCreateComplimentaryProduct()",
+      "norm_label": "usecreatecomplimentaryproduct()",
+      "source_file": "packages/athena-webapp/src/hooks/useCreateComplimentaryProduct.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 431,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecustomeroperations_ts",
       "label": "useCustomerOperations.ts",
       "norm_label": "usecustomeroperations.ts",
@@ -43789,7 +43888,7 @@
       "source_location": "L1"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "usecustomeroperations_usecustomeroperations",
       "label": "useCustomerOperations()",
@@ -43798,7 +43897,7 @@
       "source_location": "L21"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usedebounce_ts",
       "label": "useDebounce.ts",
@@ -43807,7 +43906,7 @@
       "source_location": "L1"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "usedebounce_usedebounce",
       "label": "useDebounce()",
@@ -43816,7 +43915,7 @@
       "source_location": "L12"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
       "label": "useExpenseOperations.ts",
@@ -43825,7 +43924,7 @@
       "source_location": "L1"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "useexpenseoperations_useexpenseoperations",
       "label": "useExpenseOperations()",
@@ -43834,7 +43933,7 @@
       "source_location": "L23"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetactiveproduct_ts",
       "label": "useGetActiveProduct.ts",
@@ -43843,7 +43942,7 @@
       "source_location": "L1"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "usegetactiveproduct_usegetactiveproduct",
       "label": "useGetActiveProduct()",
@@ -43852,7 +43951,7 @@
       "source_location": "L6"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetautheduser_ts",
       "label": "useGetAuthedUser.ts",
@@ -43861,7 +43960,7 @@
       "source_location": "L1"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "usegetautheduser_usegetautheduser",
       "label": "useGetAuthedUser()",
@@ -43870,7 +43969,7 @@
       "source_location": "L4"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcategories_ts",
       "label": "useGetCategories.ts",
@@ -43879,7 +43978,7 @@
       "source_location": "L1"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "usegetcategories_usegetcategories",
       "label": "useGetCategories()",
@@ -43888,7 +43987,7 @@
       "source_location": "L5"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcomplimentaryproducts_ts",
       "label": "useGetComplimentaryProducts.ts",
@@ -43897,7 +43996,7 @@
       "source_location": "L1"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "usegetcomplimentaryproducts_usegetcomplimentaryproducts",
       "label": "useGetComplimentaryProducts()",
@@ -43906,7 +44005,7 @@
       "source_location": "L5"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcurrencyformatter_ts",
       "label": "useGetCurrencyFormatter.ts",
@@ -43915,7 +44014,7 @@
       "source_location": "L1"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "usegetcurrencyformatter_usegetcurrencyformatter",
       "label": "useGetCurrencyFormatter()",
@@ -43924,7 +44023,7 @@
       "source_location": "L4"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetsubcategories_ts",
       "label": "useGetSubcategories.ts",
@@ -43933,31 +44032,13 @@
       "source_location": "L1"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "usegetsubcategories_usegetsubcategories",
       "label": "useGetSubcategories()",
       "norm_label": "usegetsubcategories()",
       "source_file": "packages/athena-webapp/src/hooks/useGetSubcategories.ts",
       "source_location": "L5"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usegetterminal_ts",
-      "label": "useGetTerminal.ts",
-      "norm_label": "usegetterminal.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useGetTerminal.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "usegetterminal_usegetterminal",
-      "label": "useGetTerminal()",
-      "norm_label": "usegetterminal()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetTerminal.ts",
-      "source_location": "L6"
     },
     {
       "community": 44,
@@ -44034,6 +44115,24 @@
     {
       "community": 440,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usegetterminal_ts",
+      "label": "useGetTerminal.ts",
+      "norm_label": "usegetterminal.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useGetTerminal.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "usegetterminal_usegetterminal",
+      "label": "useGetTerminal()",
+      "norm_label": "usegetterminal()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetTerminal.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 441,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usenewordernotification_ts",
       "label": "useNewOrderNotification.ts",
       "norm_label": "usenewordernotification.ts",
@@ -44041,7 +44140,7 @@
       "source_location": "L1"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "usenewordernotification_usenewordernotification",
       "label": "useNewOrderNotification()",
@@ -44050,7 +44149,7 @@
       "source_location": "L8"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usepermissions_ts",
       "label": "usePermissions.ts",
@@ -44059,7 +44158,7 @@
       "source_location": "L1"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "usepermissions_usepermissions",
       "label": "usePermissions()",
@@ -44068,7 +44167,7 @@
       "source_location": "L12"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useprint_ts",
       "label": "usePrint.ts",
@@ -44077,7 +44176,7 @@
       "source_location": "L1"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "useprint_useprint",
       "label": "usePrint()",
@@ -44086,7 +44185,7 @@
       "source_location": "L3"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useproductsearchresults_ts",
       "label": "useProductSearchResults.ts",
@@ -44095,7 +44194,7 @@
       "source_location": "L1"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "useproductsearchresults_useproductsearchresults",
       "label": "useProductSearchResults()",
@@ -44104,7 +44203,7 @@
       "source_location": "L26"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useproductwithnoimagesnotification_tsx",
       "label": "useProductWithNoImagesNotification.tsx",
@@ -44113,7 +44212,7 @@
       "source_location": "L1"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "useproductwithnoimagesnotification_useproductwithnoimagesnotification",
       "label": "useProductWithNoImagesNotification()",
@@ -44122,7 +44221,7 @@
       "source_location": "L7"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usesessionmanagement_ts",
       "label": "useSessionManagement.ts",
@@ -44131,7 +44230,7 @@
       "source_location": "L1"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "usesessionmanagement_usesessionmanagement",
       "label": "useSessionManagement()",
@@ -44140,7 +44239,7 @@
       "source_location": "L17"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usesessionmanagementexpense_ts",
       "label": "useSessionManagementExpense.ts",
@@ -44149,7 +44248,7 @@
       "source_location": "L1"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "usesessionmanagementexpense_usesessionmanagementexpense",
       "label": "useSessionManagementExpense()",
@@ -44158,7 +44257,7 @@
       "source_location": "L17"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usesessionmanageroperations_ts",
       "label": "useSessionManagerOperations.ts",
@@ -44167,7 +44266,7 @@
       "source_location": "L1"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "usesessionmanageroperations_usesessionmanageroperations",
       "label": "useSessionManagerOperations()",
@@ -44176,7 +44275,7 @@
       "source_location": "L16"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedincheckout_ts",
       "label": "useSkusReservedInCheckout.ts",
@@ -44185,30 +44284,12 @@
       "source_location": "L1"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "useskusreservedincheckout_useskusreservedincheckout",
       "label": "useSkusReservedInCheckout()",
       "norm_label": "useskusreservedincheckout()",
       "source_file": "packages/athena-webapp/src/hooks/useSkusReservedInCheckout.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useskusreservedinpossession_ts",
-      "label": "useSkusReservedInPosSession.ts",
-      "norm_label": "useskusreservedinpossession.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useSkusReservedInPosSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "useskusreservedinpossession_useskusreservedinpossession",
-      "label": "useSkusReservedInPosSession()",
-      "norm_label": "useskusreservedinpossession()",
-      "source_file": "packages/athena-webapp/src/hooks/useSkusReservedInPosSession.ts",
       "source_location": "L12"
     },
     {
@@ -44286,6 +44367,24 @@
     {
       "community": 450,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useskusreservedinpossession_ts",
+      "label": "useSkusReservedInPosSession.ts",
+      "norm_label": "useskusreservedinpossession.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useSkusReservedInPosSession.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "useskusreservedinpossession_useskusreservedinpossession",
+      "label": "useSkusReservedInPosSession()",
+      "norm_label": "useskusreservedinpossession()",
+      "source_file": "packages/athena-webapp/src/hooks/useSkusReservedInPosSession.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 451,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usetogglecomplimentaryproductactive_ts",
       "label": "useToggleComplimentaryProductActive.ts",
       "norm_label": "usetogglecomplimentaryproductactive.ts",
@@ -44293,7 +44392,7 @@
       "source_location": "L1"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "usetogglecomplimentaryproductactive_usetogglecomplimentaryproductactive",
       "label": "useToggleComplimentaryProductActive()",
@@ -44302,7 +44401,7 @@
       "source_location": "L5"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "navigationutils_getorigin",
       "label": "getOrigin()",
@@ -44311,7 +44410,7 @@
       "source_location": "L1"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_navigationutils_ts",
       "label": "navigationUtils.ts",
@@ -44320,7 +44419,7 @@
       "source_location": "L1"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "calculations_calculatecarttotals",
       "label": "calculateCartTotals()",
@@ -44329,7 +44428,7 @@
       "source_location": "L10"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_calculations_ts",
       "label": "calculations.ts",
@@ -44338,7 +44437,7 @@
       "source_location": "L1"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_security_pinhash_ts",
       "label": "pinHash.ts",
@@ -44347,7 +44446,7 @@
       "source_location": "L1"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "pinhash_hashpin",
       "label": "hashPin()",
@@ -44356,7 +44455,7 @@
       "source_location": "L12"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "index_storerootredirect",
       "label": "StoreRootRedirect()",
@@ -44365,7 +44464,7 @@
       "source_location": "L13"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_index_tsx",
       "label": "index.tsx",
@@ -44374,7 +44473,7 @@
       "source_location": "L1"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_published_index_tsx",
       "label": "published.index.tsx",
@@ -44383,7 +44482,7 @@
       "source_location": "L1"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "published_index_routecomponent",
       "label": "RouteComponent()",
@@ -44392,7 +44491,7 @@
       "source_location": "L9"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "index_index",
       "label": "Index()",
@@ -44401,7 +44500,7 @@
       "source_location": "L13"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -44410,7 +44509,7 @@
       "source_location": "L1"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "layout_index_athenaloginreadyview",
       "label": "AthenaLoginReadyView()",
@@ -44419,7 +44518,7 @@
       "source_location": "L4"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_tsx",
       "label": "_layout.index.tsx",
@@ -44428,7 +44527,7 @@
       "source_location": "L1"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "layout_loginlayout",
       "label": "LoginLayout()",
@@ -44437,30 +44536,12 @@
       "source_location": "L36"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_tsx",
       "label": "_layout.tsx",
       "norm_label": "_layout.tsx",
       "source_file": "packages/athena-webapp/src/routes/login/_layout.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "organizationssettingsaccordion_organizationsettingsaccordion",
-      "label": "OrganizationSettingsAccordion()",
-      "norm_label": "organizationsettingsaccordion()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationsSettingsAccordion.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_organization_components_organizationssettingsaccordion_tsx",
-      "label": "OrganizationsSettingsAccordion.tsx",
-      "norm_label": "organizationssettingsaccordion.tsx",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationsSettingsAccordion.tsx",
       "source_location": "L1"
     },
     {
@@ -44538,6 +44619,24 @@
     {
       "community": 460,
       "file_type": "code",
+      "id": "organizationssettingsaccordion_organizationsettingsaccordion",
+      "label": "OrganizationSettingsAccordion()",
+      "norm_label": "organizationsettingsaccordion()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationsSettingsAccordion.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_settings_organization_components_organizationssettingsaccordion_tsx",
+      "label": "OrganizationsSettingsAccordion.tsx",
+      "norm_label": "organizationssettingsaccordion.tsx",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationsSettingsAccordion.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
       "id": "formatnumber_formatnumber",
       "label": "formatNumber()",
       "norm_label": "formatnumber()",
@@ -44545,7 +44644,7 @@
       "source_location": "L1"
     },
     {
-      "community": 460,
+      "community": 461,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_formatnumber_ts",
       "label": "formatNumber.ts",
@@ -44554,7 +44653,7 @@
       "source_location": "L1"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "bannermessage_getbannermessage",
       "label": "getBannerMessage()",
@@ -44563,7 +44662,7 @@
       "source_location": "L4"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -44572,7 +44671,7 @@
       "source_location": "L1"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "checkoutsession_test_jsonresponse",
       "label": "jsonResponse()",
@@ -44581,7 +44680,7 @@
       "source_location": "L27"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_checkoutsession_test_ts",
       "label": "checkoutSession.test.ts",
@@ -44590,7 +44689,7 @@
       "source_location": "L1"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "guest_updateguest",
       "label": "updateGuest()",
@@ -44599,7 +44698,7 @@
       "source_location": "L4"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_guest_ts",
       "label": "guest.ts",
@@ -44608,7 +44707,7 @@
       "source_location": "L1"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefront_ts",
       "label": "storefront.ts",
@@ -44617,7 +44716,7 @@
       "source_location": "L1"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "storefront_getstore",
       "label": "getStore()",
@@ -44626,7 +44725,7 @@
       "source_location": "L5"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "entitypage_entitypage",
       "label": "EntityPage()",
@@ -44635,7 +44734,7 @@
       "source_location": "L10"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_entitypage_tsx",
       "label": "EntityPage.tsx",
@@ -44644,7 +44743,7 @@
       "source_location": "L1"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productspage_tsx",
       "label": "ProductsPage.tsx",
@@ -44653,7 +44752,7 @@
       "source_location": "L1"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "productspage_productcardloadingskeleton",
       "label": "ProductCardLoadingSkeleton()",
@@ -44662,7 +44761,7 @@
       "source_location": "L10"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "auth_authcomponent",
       "label": "AuthComponent()",
@@ -44671,7 +44770,7 @@
       "source_location": "L4"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -44680,7 +44779,7 @@
       "source_location": "L1"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "bagsummary_tobagsummaryitems",
       "label": "toBagSummaryItems()",
@@ -44689,30 +44788,12 @@
       "source_location": "L39"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_bagsummary_tsx",
       "label": "BagSummary.tsx",
       "norm_label": "bagsummary.tsx",
       "source_file": "packages/storefront-webapp/src/components/checkout/BagSummary.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "checkoutform_checkoutform",
-      "label": "CheckoutForm()",
-      "norm_label": "checkoutform()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/CheckoutForm.tsx",
-      "source_location": "L18"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_checkoutform_tsx",
-      "label": "CheckoutForm.tsx",
-      "norm_label": "checkoutform.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/CheckoutForm.tsx",
       "source_location": "L1"
     },
     {
@@ -44790,6 +44871,24 @@
     {
       "community": 470,
       "file_type": "code",
+      "id": "checkoutform_checkoutform",
+      "label": "CheckoutForm()",
+      "norm_label": "checkoutform()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/CheckoutForm.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_checkoutform_tsx",
+      "label": "CheckoutForm.tsx",
+      "norm_label": "checkoutform.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/CheckoutForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
       "id": "checkoutprovider_checkoutprovider",
       "label": "CheckoutProvider()",
       "norm_label": "checkoutprovider()",
@@ -44797,7 +44896,7 @@
       "source_location": "L71"
     },
     {
-      "community": 470,
+      "community": 471,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutprovider_tsx",
       "label": "CheckoutProvider.tsx",
@@ -44806,7 +44905,7 @@
       "source_location": "L1"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_pickupoptions_tsx",
       "label": "PickupOptions.tsx",
@@ -44815,7 +44914,7 @@
       "source_location": "L1"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "pickupoptions_iswithinrestrictiontime",
       "label": "isWithinRestrictionTime()",
@@ -44824,7 +44923,7 @@
       "source_location": "L12"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "enteredbillingaddressdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -44833,7 +44932,7 @@
       "source_location": "L6"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_enteredbillingaddressdetails_tsx",
       "label": "EnteredBillingAddressDetails.tsx",
@@ -44842,7 +44941,7 @@
       "source_location": "L1"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "ordersummary_ordersummary",
       "label": "OrderSummary()",
@@ -44851,7 +44950,7 @@
       "source_location": "L18"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -44860,7 +44959,7 @@
       "source_location": "L1"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "index_pickupdetails",
       "label": "PickupDetails()",
@@ -44869,7 +44968,7 @@
       "source_location": "L10"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_index_tsx",
       "label": "index.tsx",
@@ -44878,7 +44977,7 @@
       "source_location": "L1"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_paymentmethodsection_tsx",
       "label": "PaymentMethodSection.tsx",
@@ -44887,7 +44986,7 @@
       "source_location": "L1"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "paymentmethodsection_paymentmethodsection",
       "label": "PaymentMethodSection()",
@@ -44896,7 +44995,7 @@
       "source_location": "L8"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_paymentsection_tsx",
       "label": "PaymentSection.tsx",
@@ -44905,7 +45004,7 @@
       "source_location": "L1"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "paymentsection_paymentsection",
       "label": "PaymentSection()",
@@ -44914,7 +45013,7 @@
       "source_location": "L27"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "deliveryfees_calculatedeliveryfee",
       "label": "calculateDeliveryFee()",
@@ -44923,7 +45022,7 @@
       "source_location": "L40"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_ts",
       "label": "deliveryFees.ts",
@@ -44932,7 +45031,7 @@
       "source_location": "L1"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "derivecheckoutstate_derivecheckoutstate",
       "label": "deriveCheckoutState()",
@@ -44941,30 +45040,12 @@
       "source_location": "L3"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_ts",
       "label": "deriveCheckoutState.ts",
       "norm_label": "derivecheckoutstate.ts",
       "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "checkoutschemas_test_getissuemap",
-      "label": "getIssueMap()",
-      "norm_label": "getissuemap()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutSchemas.test.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutschemas_test_ts",
-      "label": "checkoutSchemas.test.ts",
-      "norm_label": "checkoutschemas.test.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutSchemas.test.ts",
       "source_location": "L1"
     },
     {
@@ -45042,6 +45123,24 @@
     {
       "community": 480,
       "file_type": "code",
+      "id": "checkoutschemas_test_getissuemap",
+      "label": "getIssueMap()",
+      "norm_label": "getissuemap()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutSchemas.test.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutschemas_test_ts",
+      "label": "checkoutSchemas.test.ts",
+      "norm_label": "checkoutschemas.test.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutSchemas.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_test_ts",
       "label": "webOrderSchema.test.ts",
       "norm_label": "weborderschema.test.ts",
@@ -45049,7 +45148,7 @@
       "source_location": "L1"
     },
     {
-      "community": 480,
+      "community": 481,
       "file_type": "code",
       "id": "weborderschema_test_getissuemap",
       "label": "getIssueMap()",
@@ -45058,7 +45157,7 @@
       "source_location": "L12"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "customerdetailsform_onsubmit",
       "label": "onSubmit()",
@@ -45067,7 +45166,7 @@
       "source_location": "L77"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_forms_customerdetailsform_tsx",
       "label": "CustomerDetailsForm.tsx",
@@ -45076,7 +45175,7 @@
       "source_location": "L1"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "deliverydetailsform_onsubmit",
       "label": "onSubmit()",
@@ -45085,7 +45184,7 @@
       "source_location": "L161"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_forms_deliverydetailsform_tsx",
       "label": "DeliveryDetailsForm.tsx",
@@ -45094,7 +45193,7 @@
       "source_location": "L1"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "hooks_usecountdown",
       "label": "useCountdown()",
@@ -45103,7 +45202,7 @@
       "source_location": "L3"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_hooks_ts",
       "label": "hooks.ts",
@@ -45112,7 +45211,7 @@
       "source_location": "L1"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_communication_trustsignals_tsx",
       "label": "TrustSignals.tsx",
@@ -45121,7 +45220,7 @@
       "source_location": "L1"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "trustsignals_trustsignals",
       "label": "TrustSignals()",
@@ -45130,7 +45229,7 @@
       "source_location": "L4"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilter_tsx",
       "label": "ProductFilter.tsx",
@@ -45139,7 +45238,7 @@
       "source_location": "L1"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "productfilter_productfilter",
       "label": "ProductFilter()",
@@ -45148,7 +45247,7 @@
       "source_location": "L14"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "filter_handlecheckboxchange",
       "label": "handleCheckboxChange()",
@@ -45157,7 +45256,7 @@
       "source_location": "L27"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_footer_filter_tsx",
       "label": "Filter.tsx",
@@ -45166,7 +45265,7 @@
       "source_location": "L1"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "bestsellerssection_bestsellerssection",
       "label": "BestSellersSection()",
@@ -45175,7 +45274,7 @@
       "source_location": "L17"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_tsx",
       "label": "BestSellersSection.tsx",
@@ -45184,7 +45283,7 @@
       "source_location": "L1"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "homepagecontent_resolvehomepagecontent",
       "label": "resolveHomepageContent()",
@@ -45193,30 +45292,12 @@
       "source_location": "L13"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_ts",
       "label": "homePageContent.ts",
       "norm_label": "homepagecontent.ts",
       "source_file": "packages/storefront-webapp/src/components/home/homePageContent.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "bagmenu_handleonlinkclick",
-      "label": "handleOnLinkClick()",
-      "norm_label": "handleonlinkclick()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/BagMenu.tsx",
-      "source_location": "L47"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_bagmenu_tsx",
-      "label": "BagMenu.tsx",
-      "norm_label": "bagmenu.tsx",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/BagMenu.tsx",
       "source_location": "L1"
     },
     {
@@ -45294,6 +45375,24 @@
     {
       "community": 490,
       "file_type": "code",
+      "id": "bagmenu_handleonlinkclick",
+      "label": "handleOnLinkClick()",
+      "norm_label": "handleonlinkclick()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/BagMenu.tsx",
+      "source_location": "L47"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_navigation_bar_bagmenu_tsx",
+      "label": "BagMenu.tsx",
+      "norm_label": "bagmenu.tsx",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/BagMenu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
       "id": "mobilebagmenu_mobilebagmenu",
       "label": "MobileBagMenu()",
       "norm_label": "mobilebagmenu()",
@@ -45301,7 +45400,7 @@
       "source_location": "L7"
     },
     {
-      "community": 490,
+      "community": 491,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilebagmenu_tsx",
       "label": "MobileBagMenu.tsx",
@@ -45310,7 +45409,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_sitebanner_tsx",
       "label": "SiteBanner.tsx",
@@ -45319,7 +45418,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "sitebanner_sitebanner",
       "label": "SiteBanner()",
@@ -45328,7 +45427,7 @@
       "source_location": "L17"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "notificationpill_notificationpill",
       "label": "NotificationPill()",
@@ -45337,7 +45436,7 @@
       "source_location": "L1"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_notification_notificationpill_tsx",
       "label": "NotificationPill.tsx",
@@ -45346,7 +45445,7 @@
       "source_location": "L1"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "dimensionbar_mapvaluetolabelindex",
       "label": "mapValueToLabelIndex()",
@@ -45355,7 +45454,7 @@
       "source_location": "L12"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_dimensionbar_tsx",
       "label": "DimensionBar.tsx",
@@ -45364,7 +45463,7 @@
       "source_location": "L1"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "discountbadge_discountbadge",
       "label": "DiscountBadge()",
@@ -45373,7 +45472,7 @@
       "source_location": "L7"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_discountbadge_tsx",
       "label": "DiscountBadge.tsx",
@@ -45382,7 +45481,7 @@
       "source_location": "L1"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "galleryviewer_handleclickonpreview",
       "label": "handleClickOnPreview()",
@@ -45391,7 +45490,7 @@
       "source_location": "L45"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_galleryviewer_tsx",
       "label": "GalleryViewer.tsx",
@@ -45400,7 +45499,7 @@
       "source_location": "L1"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "onsaleproduct_onsaleproduct",
       "label": "OnsaleProduct()",
@@ -45409,7 +45508,7 @@
       "source_location": "L5"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_onsaleproduct_tsx",
       "label": "OnSaleProduct.tsx",
@@ -45418,7 +45517,7 @@
       "source_location": "L1"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_tsx",
       "label": "ProductActions.tsx",
@@ -45427,7 +45526,7 @@
       "source_location": "L1"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "productactions_productactions",
       "label": "ProductActions()",
@@ -45436,7 +45535,7 @@
       "source_location": "L17"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattributes_tsx",
       "label": "ProductAttributes.tsx",
@@ -45445,31 +45544,13 @@
       "source_location": "L1"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "productattributes_productattributes",
       "label": "ProductAttributes()",
       "norm_label": "productattributes()",
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttributes.tsx",
       "source_location": "L3"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productpage_tsx",
-      "label": "ProductPage.tsx",
-      "norm_label": "productpage.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductPage.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "productpage_showshippingpolicy",
-      "label": "showShippingPolicy()",
-      "norm_label": "showshippingpolicy()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductPage.tsx",
-      "source_location": "L78"
     },
     {
       "community": 5,
@@ -45789,6 +45870,24 @@
     {
       "community": 500,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productpage_tsx",
+      "label": "ProductPage.tsx",
+      "norm_label": "productpage.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductPage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "productpage_showshippingpolicy",
+      "label": "showShippingPolicy()",
+      "norm_label": "showshippingpolicy()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductPage.tsx",
+      "source_location": "L78"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreview_tsx",
       "label": "ProductReview.tsx",
       "norm_label": "productreview.tsx",
@@ -45796,7 +45895,7 @@
       "source_location": "L1"
     },
     {
-      "community": 500,
+      "community": 501,
       "file_type": "code",
       "id": "productreview_handlehelpful",
       "label": "handleHelpful()",
@@ -45805,7 +45904,7 @@
       "source_location": "L87"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_reviewsummary_tsx",
       "label": "ReviewSummary.tsx",
@@ -45814,7 +45913,7 @@
       "source_location": "L1"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "reviewsummary_reviewsummary",
       "label": "ReviewSummary()",
@@ -45823,7 +45922,7 @@
       "source_location": "L8"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "orderitem_orderitem",
       "label": "OrderItem()",
@@ -45832,7 +45931,7 @@
       "source_location": "L12"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_tsx",
       "label": "OrderItem.tsx",
@@ -45841,7 +45940,7 @@
       "source_location": "L1"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_ratingselector_tsx",
       "label": "RatingSelector.tsx",
@@ -45850,7 +45949,7 @@
       "source_location": "L1"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "ratingselector_ratingselector",
       "label": "RatingSelector()",
@@ -45859,7 +45958,7 @@
       "source_location": "L18"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "guestrewardsprompt_guestrewardsprompt",
       "label": "GuestRewardsPrompt()",
@@ -45868,7 +45967,7 @@
       "source_location": "L10"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_guestrewardsprompt_tsx",
       "label": "GuestRewardsPrompt.tsx",
@@ -45877,7 +45976,7 @@
       "source_location": "L1"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "orderpointsdisplay_orderpointsdisplay",
       "label": "OrderPointsDisplay()",
@@ -45886,7 +45985,7 @@
       "source_location": "L11"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_orderpointsdisplay_tsx",
       "label": "OrderPointsDisplay.tsx",
@@ -45895,7 +45994,7 @@
       "source_location": "L1"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_pastordersrewards_tsx",
       "label": "PastOrdersRewards.tsx",
@@ -45904,7 +46003,7 @@
       "source_location": "L1"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "pastordersrewards_handleclaimpoints",
       "label": "handleClaimPoints()",
@@ -45913,7 +46012,7 @@
       "source_location": "L59"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_rewardspanel_tsx",
       "label": "RewardsPanel.tsx",
@@ -45922,7 +46021,7 @@
       "source_location": "L1"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "rewardspanel_handleredeemreward",
       "label": "handleRedeemReward()",
@@ -45931,7 +46030,7 @@
       "source_location": "L33"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "bagitem_bagitem",
       "label": "BagItem()",
@@ -45940,30 +46039,12 @@
       "source_location": "L19"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_bagitem_tsx",
       "label": "BagItem.tsx",
       "norm_label": "bagitem.tsx",
       "source_file": "packages/storefront-webapp/src/components/shopping-bag/BagItem.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "checkoutunavailable_checkoutunavailable",
-      "label": "CheckoutUnavailable()",
-      "norm_label": "checkoutunavailable()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout unavailable/CheckoutUnavailable.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_checkout_unavailable_checkoutunavailable_tsx",
-      "label": "CheckoutUnavailable.tsx",
-      "norm_label": "checkoutunavailable.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout unavailable/CheckoutUnavailable.tsx",
       "source_location": "L1"
     },
     {
@@ -46032,6 +46113,24 @@
     {
       "community": 510,
       "file_type": "code",
+      "id": "checkoutunavailable_checkoutunavailable",
+      "label": "CheckoutUnavailable()",
+      "norm_label": "checkoutunavailable()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout unavailable/CheckoutUnavailable.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_checkout_unavailable_checkoutunavailable_tsx",
+      "label": "CheckoutUnavailable.tsx",
+      "norm_label": "checkoutunavailable.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout unavailable/CheckoutUnavailable.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
       "id": "errorboundary_errorboundary",
       "label": "ErrorBoundary()",
       "norm_label": "errorboundary()",
@@ -46039,7 +46138,7 @@
       "source_location": "L22"
     },
     {
-      "community": 510,
+      "community": 511,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_errorboundary_tsx",
       "label": "ErrorBoundary.tsx",
@@ -46048,7 +46147,7 @@
       "source_location": "L1"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scrolldownbutton_tsx",
       "label": "ScrollDownButton.tsx",
@@ -46057,7 +46156,7 @@
       "source_location": "L1"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "scrolldownbutton_scrolldownbutton",
       "label": "ScrollDownButton()",
@@ -46066,7 +46165,7 @@
       "source_location": "L11"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "country_select_countryselect",
       "label": "CountrySelect()",
@@ -46075,7 +46174,7 @@
       "source_location": "L3"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_country_select_tsx",
       "label": "country-select.tsx",
@@ -46084,7 +46183,7 @@
       "source_location": "L1"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "ghana_region_select_ghanaregionselect",
       "label": "GhanaRegionSelect()",
@@ -46093,7 +46192,7 @@
       "source_location": "L3"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghana_region_select_tsx",
       "label": "ghana-region-select.tsx",
@@ -46102,7 +46201,7 @@
       "source_location": "L1"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "ghost_button_ghostbutton",
       "label": "GhostButton()",
@@ -46111,7 +46210,7 @@
       "source_location": "L9"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghost_button_tsx",
       "label": "ghost-button.tsx",
@@ -46120,7 +46219,7 @@
       "source_location": "L1"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "leaveareviewmodal_handleclose",
       "label": "handleClose()",
@@ -46129,7 +46228,7 @@
       "source_location": "L66"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodal_tsx",
       "label": "LeaveAReviewModal.tsx",
@@ -46138,7 +46237,7 @@
       "source_location": "L1"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalsuccess_tsx",
       "label": "UpsellModalSuccess.tsx",
@@ -46147,7 +46246,7 @@
       "source_location": "L1"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "upsellmodalsuccess_upsellmodalsuccess",
       "label": "UpsellModalSuccess()",
@@ -46156,7 +46255,7 @@
       "source_location": "L19"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalsuccess_tsx",
       "label": "WelcomeBackModalSuccess.tsx",
@@ -46165,7 +46264,7 @@
       "source_location": "L1"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "welcomebackmodalsuccess_welcomebackmodalsuccess",
       "label": "WelcomeBackModalSuccess()",
@@ -46174,7 +46273,7 @@
       "source_location": "L13"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "leavereviewmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -46183,31 +46282,13 @@
       "source_location": "L46"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_leavereviewmodalconfig_tsx",
       "label": "leaveReviewModalConfig.tsx",
       "norm_label": "leavereviewmodalconfig.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/modals/config/leaveReviewModalConfig.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_config_welcomebackmodalconfig_tsx",
-      "label": "welcomeBackModalConfig.tsx",
-      "norm_label": "welcomebackmodalconfig.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/config/welcomeBackModalConfig.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "welcomebackmodalconfig_getmodalconfig",
-      "label": "getModalConfig()",
-      "norm_label": "getmodalconfig()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/config/welcomeBackModalConfig.tsx",
-      "source_location": "L46"
     },
     {
       "community": 52,
@@ -46275,6 +46356,24 @@
     {
       "community": 520,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_config_welcomebackmodalconfig_tsx",
+      "label": "welcomeBackModalConfig.tsx",
+      "norm_label": "welcomebackmodalconfig.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/config/welcomeBackModalConfig.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "welcomebackmodalconfig_getmodalconfig",
+      "label": "getModalConfig()",
+      "norm_label": "getmodalconfig()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/config/welcomeBackModalConfig.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_webp_jpg_tsx",
       "label": "webp-jpg.tsx",
       "norm_label": "webp-jpg.tsx",
@@ -46282,7 +46381,7 @@
       "source_location": "L1"
     },
     {
-      "community": 520,
+      "community": 521,
       "file_type": "code",
       "id": "webp_jpg_webpimage",
       "label": "WebpImage()",
@@ -46291,7 +46390,7 @@
       "source_location": "L1"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "formsubmissionprovider_useformsubmission",
       "label": "useFormSubmission()",
@@ -46300,7 +46399,7 @@
       "source_location": "L15"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_formsubmissionprovider_tsx",
       "label": "FormSubmissionProvider.tsx",
@@ -46309,7 +46408,7 @@
       "source_location": "L1"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usecheckout_ts",
       "label": "useCheckout.ts",
@@ -46318,7 +46417,7 @@
       "source_location": "L1"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "usecheckout_usecheckout",
       "label": "useCheckout()",
@@ -46327,7 +46426,7 @@
       "source_location": "L5"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usediscountcodealert_tsx",
       "label": "useDiscountCodeAlert.tsx",
@@ -46336,7 +46435,7 @@
       "source_location": "L1"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "usediscountcodealert_usediscountcodealert",
       "label": "useDiscountCodeAlert()",
@@ -46345,7 +46444,7 @@
       "source_location": "L14"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useenhancedtracking_ts",
       "label": "useEnhancedTracking.ts",
@@ -46354,7 +46453,7 @@
       "source_location": "L1"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "useenhancedtracking_useenhancedtracking",
       "label": "useEnhancedTracking()",
@@ -46363,7 +46462,7 @@
       "source_location": "L29"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetactivecheckoutsession_tsx",
       "label": "useGetActiveCheckoutSession.tsx",
@@ -46372,7 +46471,7 @@
       "source_location": "L1"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "usegetactivecheckoutsession_usegetactivecheckoutsession",
       "label": "useGetActiveCheckoutSession()",
@@ -46381,7 +46480,7 @@
       "source_location": "L5"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproduct_tsx",
       "label": "useGetProduct.tsx",
@@ -46390,7 +46489,7 @@
       "source_location": "L1"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "usegetproduct_usegetproductquery",
       "label": "useGetProductQuery()",
@@ -46399,7 +46498,7 @@
       "source_location": "L5"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductfilters_ts",
       "label": "useGetProductFilters.ts",
@@ -46408,7 +46507,7 @@
       "source_location": "L1"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "usegetproductfilters_usegetproductfilters",
       "label": "useGetProductFilters()",
@@ -46417,7 +46516,7 @@
       "source_location": "L3"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductreviews_ts",
       "label": "useGetProductReviews.ts",
@@ -46426,30 +46525,12 @@
       "source_location": "L1"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "usegetproductreviews_usegetproductreviewsquery",
       "label": "useGetProductReviewsQuery()",
       "norm_label": "usegetproductreviewsquery()",
       "source_file": "packages/storefront-webapp/src/hooks/useGetProductReviews.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usegetstore_ts",
-      "label": "useGetStore.ts",
-      "norm_label": "usegetstore.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetStore.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "usegetstore_usegetstore",
-      "label": "useGetStore()",
-      "norm_label": "usegetstore()",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetStore.ts",
       "source_location": "L4"
     },
     {
@@ -46518,6 +46599,24 @@
     {
       "community": 530,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usegetstore_ts",
+      "label": "useGetStore.ts",
+      "norm_label": "usegetstore.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetStore.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "usegetstore_usegetstore",
+      "label": "useGetStore()",
+      "norm_label": "usegetstore()",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetStore.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useinventorystatus_ts",
       "label": "useInventoryStatus.ts",
       "norm_label": "useinventorystatus.ts",
@@ -46525,7 +46624,7 @@
       "source_location": "L1"
     },
     {
-      "community": 530,
+      "community": 531,
       "file_type": "code",
       "id": "useinventorystatus_useinventorystatus",
       "label": "useInventoryStatus()",
@@ -46534,7 +46633,7 @@
       "source_location": "L9"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useleaveareviewmodal_tsx",
       "label": "useLeaveAReviewModal.tsx",
@@ -46543,7 +46642,7 @@
       "source_location": "L1"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "useleaveareviewmodal_useleaveareviewmodal",
       "label": "useLeaveAReviewModal()",
@@ -46552,7 +46651,7 @@
       "source_location": "L17"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_uselogout_ts",
       "label": "useLogout.ts",
@@ -46561,7 +46660,7 @@
       "source_location": "L1"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "uselogout_uselogout",
       "label": "useLogout()",
@@ -46570,7 +46669,7 @@
       "source_location": "L5"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usemodalstate_tsx",
       "label": "useModalState.tsx",
@@ -46579,7 +46678,7 @@
       "source_location": "L1"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "usemodalstate_usemodalstate",
       "label": "useModalState()",
@@ -46588,7 +46687,7 @@
       "source_location": "L15"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductpagelogic_ts",
       "label": "useProductPageLogic.ts",
@@ -46597,7 +46696,7 @@
       "source_location": "L1"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "useproductpagelogic_useproductpagelogic",
       "label": "useProductPageLogic()",
@@ -46606,7 +46705,7 @@
       "source_location": "L18"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductreminder_tsx",
       "label": "useProductReminder.tsx",
@@ -46615,7 +46714,7 @@
       "source_location": "L1"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "useproductreminder_useproductreminder",
       "label": "useProductReminder()",
@@ -46624,7 +46723,7 @@
       "source_location": "L9"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usepromoalert_tsx",
       "label": "usePromoAlert.tsx",
@@ -46633,7 +46732,7 @@
       "source_location": "L1"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "usepromoalert_usepromoalert",
       "label": "usePromoAlert()",
@@ -46642,7 +46741,7 @@
       "source_location": "L16"
     },
     {
-      "community": 537,
+      "community": 538,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usequeryenabled_ts",
       "label": "useQueryEnabled.ts",
@@ -46651,7 +46750,7 @@
       "source_location": "L1"
     },
     {
-      "community": 537,
+      "community": 538,
       "file_type": "code",
       "id": "usequeryenabled_usequeryenabled",
       "label": "useQueryEnabled()",
@@ -46660,7 +46759,7 @@
       "source_location": "L4"
     },
     {
-      "community": 538,
+      "community": 539,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_userewardsalert_tsx",
       "label": "useRewardsAlert.tsx",
@@ -46669,7 +46768,7 @@
       "source_location": "L1"
     },
     {
-      "community": 538,
+      "community": 539,
       "file_type": "code",
       "id": "userewardsalert_userewardsalert",
       "label": "useRewardsAlert()",
@@ -46678,31 +46777,13 @@
       "source_location": "L11"
     },
     {
-      "community": 539,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usescrolltotop_ts",
-      "label": "useScrollToTop.ts",
-      "norm_label": "usescrolltotop.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useScrollToTop.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "usescrolltotop_usescrolltotop",
-      "label": "useScrollToTop()",
-      "norm_label": "usescrolltotop()",
-      "source_file": "packages/storefront-webapp/src/hooks/useScrollToTop.ts",
-      "source_location": "L3"
-    },
-    {
       "community": 54,
       "file_type": "code",
       "id": "customerinfopanel_clearcustomer",
       "label": "clearCustomer()",
       "norm_label": "clearcustomer()",
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L155"
+      "source_location": "L156"
     },
     {
       "community": 54,
@@ -46711,7 +46792,7 @@
       "label": "handleCancelEdit()",
       "norm_label": "handlecanceledit()",
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L146"
+      "source_location": "L147"
     },
     {
       "community": 54,
@@ -46720,7 +46801,7 @@
       "label": "handleCreateCustomer()",
       "norm_label": "handlecreatecustomer()",
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L77"
+      "source_location": "L78"
     },
     {
       "community": 54,
@@ -46729,7 +46810,7 @@
       "label": "handleSaveEdit()",
       "norm_label": "handlesaveedit()",
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L115"
+      "source_location": "L116"
     },
     {
       "community": 54,
@@ -46738,7 +46819,7 @@
       "label": "handleSelectCustomer()",
       "norm_label": "handleselectcustomer()",
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L59"
+      "source_location": "L60"
     },
     {
       "community": 54,
@@ -46747,7 +46828,7 @@
       "label": "handleStartEdit()",
       "norm_label": "handlestartedit()",
       "source_file": "packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx",
-      "source_location": "L105"
+      "source_location": "L106"
     },
     {
       "community": 54,
@@ -46761,6 +46842,24 @@
     {
       "community": 540,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usescrolltotop_ts",
+      "label": "useScrollToTop.ts",
+      "norm_label": "usescrolltotop.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useScrollToTop.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "usescrolltotop_usescrolltotop",
+      "label": "useScrollToTop()",
+      "norm_label": "usescrolltotop()",
+      "source_file": "packages/storefront-webapp/src/hooks/useScrollToTop.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackaction_ts",
       "label": "useTrackAction.ts",
       "norm_label": "usetrackaction.ts",
@@ -46768,7 +46867,7 @@
       "source_location": "L1"
     },
     {
-      "community": 540,
+      "community": 541,
       "file_type": "code",
       "id": "usetrackaction_usetrackaction",
       "label": "useTrackAction()",
@@ -46777,7 +46876,7 @@
       "source_location": "L7"
     },
     {
-      "community": 541,
+      "community": 542,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackevent_ts",
       "label": "useTrackEvent.ts",
@@ -46786,7 +46885,7 @@
       "source_location": "L1"
     },
     {
-      "community": 541,
+      "community": 542,
       "file_type": "code",
       "id": "usetrackevent_usetrackevent",
       "label": "useTrackEvent()",
@@ -46795,7 +46894,7 @@
       "source_location": "L4"
     },
     {
-      "community": 542,
+      "community": 543,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useupsellmodal_tsx",
       "label": "useUpsellModal.tsx",
@@ -46804,7 +46903,7 @@
       "source_location": "L1"
     },
     {
-      "community": 542,
+      "community": 543,
       "file_type": "code",
       "id": "useupsellmodal_useupsellmodal",
       "label": "useUpsellModal()",
@@ -46813,7 +46912,7 @@
       "source_location": "L14"
     },
     {
-      "community": 543,
+      "community": 544,
       "file_type": "code",
       "id": "analytics_usepostanalytics",
       "label": "usePostAnalytics()",
@@ -46822,7 +46921,7 @@
       "source_location": "L4"
     },
     {
-      "community": 543,
+      "community": 544,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_analytics_ts",
       "label": "analytics.ts",
@@ -46831,7 +46930,7 @@
       "source_location": "L1"
     },
     {
-      "community": 544,
+      "community": 545,
       "file_type": "code",
       "id": "bag_usebagqueries",
       "label": "useBagQueries()",
@@ -46840,7 +46939,7 @@
       "source_location": "L7"
     },
     {
-      "community": 544,
+      "community": 545,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_bag_ts",
       "label": "bag.ts",
@@ -46849,7 +46948,7 @@
       "source_location": "L1"
     },
     {
-      "community": 545,
+      "community": 546,
       "file_type": "code",
       "id": "bannermessage_usebannermessagequeries",
       "label": "useBannerMessageQueries()",
@@ -46858,7 +46957,7 @@
       "source_location": "L6"
     },
     {
-      "community": 545,
+      "community": 546,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -46867,7 +46966,7 @@
       "source_location": "L1"
     },
     {
-      "community": 546,
+      "community": 547,
       "file_type": "code",
       "id": "checkout_usecheckoutsessionqueries",
       "label": "useCheckoutSessionQueries()",
@@ -46876,7 +46975,7 @@
       "source_location": "L10"
     },
     {
-      "community": 546,
+      "community": 547,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_checkout_ts",
       "label": "checkout.ts",
@@ -46885,7 +46984,7 @@
       "source_location": "L1"
     },
     {
-      "community": 547,
+      "community": 548,
       "file_type": "code",
       "id": "inventory_useinventoryqueries",
       "label": "useInventoryQueries()",
@@ -46894,7 +46993,7 @@
       "source_location": "L6"
     },
     {
-      "community": 547,
+      "community": 548,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_inventory_ts",
       "label": "inventory.ts",
@@ -46903,7 +47002,7 @@
       "source_location": "L1"
     },
     {
-      "community": 548,
+      "community": 549,
       "file_type": "code",
       "id": "onlineorder_useonlineorderqueries",
       "label": "useOnlineOrderQueries()",
@@ -46912,31 +47011,13 @@
       "source_location": "L5"
     },
     {
-      "community": 548,
+      "community": 549,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_onlineorder_ts",
       "label": "onlineOrder.ts",
       "norm_label": "onlineorder.ts",
       "source_file": "packages/storefront-webapp/src/lib/queries/onlineOrder.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_product_ts",
-      "label": "product.ts",
-      "norm_label": "product.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/product.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "product_useproductqueries",
-      "label": "useProductQueries()",
-      "norm_label": "useproductqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/product.ts",
-      "source_location": "L14"
     },
     {
       "community": 55,
@@ -47004,6 +47085,24 @@
     {
       "community": 550,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_product_ts",
+      "label": "product.ts",
+      "norm_label": "product.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/product.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 550,
+      "file_type": "code",
+      "id": "product_useproductqueries",
+      "label": "useProductQueries()",
+      "norm_label": "useproductqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/product.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_promocode_ts",
       "label": "promoCode.ts",
       "norm_label": "promocode.ts",
@@ -47011,7 +47110,7 @@
       "source_location": "L1"
     },
     {
-      "community": 550,
+      "community": 551,
       "file_type": "code",
       "id": "promocode_usepromocodesqueries",
       "label": "usePromoCodesQueries()",
@@ -47020,7 +47119,7 @@
       "source_location": "L9"
     },
     {
-      "community": 551,
+      "community": 552,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_reviews_ts",
       "label": "reviews.ts",
@@ -47029,7 +47128,7 @@
       "source_location": "L1"
     },
     {
-      "community": 551,
+      "community": 552,
       "file_type": "code",
       "id": "reviews_usereviewqueries",
       "label": "useReviewQueries()",
@@ -47038,7 +47137,7 @@
       "source_location": "L10"
     },
     {
-      "community": 552,
+      "community": 553,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_rewards_ts",
       "label": "rewards.ts",
@@ -47047,7 +47146,7 @@
       "source_location": "L1"
     },
     {
-      "community": 552,
+      "community": 553,
       "file_type": "code",
       "id": "rewards_userewardsqueries",
       "label": "useRewardsQueries()",
@@ -47056,7 +47155,7 @@
       "source_location": "L11"
     },
     {
-      "community": 553,
+      "community": 554,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_upsells_ts",
       "label": "upsells.ts",
@@ -47065,7 +47164,7 @@
       "source_location": "L1"
     },
     {
-      "community": 553,
+      "community": 554,
       "file_type": "code",
       "id": "upsells_useupsellsqueries",
       "label": "useUpsellsQueries()",
@@ -47074,7 +47173,7 @@
       "source_location": "L6"
     },
     {
-      "community": 554,
+      "community": 555,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_user_ts",
       "label": "user.ts",
@@ -47083,7 +47182,7 @@
       "source_location": "L1"
     },
     {
-      "community": 554,
+      "community": 555,
       "file_type": "code",
       "id": "user_useuserqueries",
       "label": "useUserQueries()",
@@ -47092,7 +47191,7 @@
       "source_location": "L5"
     },
     {
-      "community": 555,
+      "community": 556,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_useroffers_ts",
       "label": "userOffers.ts",
@@ -47101,7 +47200,7 @@
       "source_location": "L1"
     },
     {
-      "community": 555,
+      "community": 556,
       "file_type": "code",
       "id": "useroffers_useuseroffersqueries",
       "label": "useUserOffersQueries()",
@@ -47110,7 +47209,7 @@
       "source_location": "L6"
     },
     {
-      "community": 556,
+      "community": 557,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
@@ -47119,7 +47218,7 @@
       "source_location": "L1"
     },
     {
-      "community": 556,
+      "community": 557,
       "file_type": "code",
       "id": "storeconfig_test_buildv2config",
       "label": "buildV2Config()",
@@ -47128,7 +47227,7 @@
       "source_location": "L10"
     },
     {
-      "community": 557,
+      "community": 558,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontobservability_test_ts",
       "label": "storefrontObservability.test.ts",
@@ -47137,7 +47236,7 @@
       "source_location": "L1"
     },
     {
-      "community": 557,
+      "community": 558,
       "file_type": "code",
       "id": "storefrontobservability_test_creatememorystorage",
       "label": "createMemoryStorage()",
@@ -47146,7 +47245,7 @@
       "source_location": "L15"
     },
     {
-      "community": 558,
+      "community": 559,
       "file_type": "code",
       "id": "email_validateemail",
       "label": "validateEmail()",
@@ -47155,31 +47254,13 @@
       "source_location": "L14"
     },
     {
-      "community": 558,
+      "community": 559,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_validations_email_ts",
       "label": "email.ts",
       "norm_label": "email.ts",
       "source_file": "packages/storefront-webapp/src/lib/validations/email.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_router_tsx",
-      "label": "router.tsx",
-      "norm_label": "router.tsx",
-      "source_file": "packages/storefront-webapp/src/router.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "router_createrouter",
-      "label": "createRouter()",
-      "norm_label": "createrouter()",
-      "source_file": "packages/storefront-webapp/src/router.tsx",
-      "source_location": "L5"
     },
     {
       "community": 56,
@@ -47247,6 +47328,24 @@
     {
       "community": 560,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_router_tsx",
+      "label": "router.tsx",
+      "norm_label": "router.tsx",
+      "source_file": "packages/storefront-webapp/src/router.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "router_createrouter",
+      "label": "createRouter()",
+      "norm_label": "createrouter()",
+      "source_file": "packages/storefront-webapp/src/router.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
       "id": "homepageloader_loadhomepagedata",
       "label": "loadHomePageData()",
       "norm_label": "loadhomepagedata()",
@@ -47254,7 +47353,7 @@
       "source_location": "L13"
     },
     {
-      "community": 560,
+      "community": 561,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_ts",
       "label": "-homePageLoader.ts",
@@ -47263,7 +47362,7 @@
       "source_location": "L1"
     },
     {
-      "community": 561,
+      "community": 562,
       "file_type": "code",
       "id": "orderslayout_layoutcomponent",
       "label": "LayoutComponent()",
@@ -47272,7 +47371,7 @@
       "source_location": "L8"
     },
     {
-      "community": 561,
+      "community": 562,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_tsx",
       "label": "_ordersLayout.tsx",
@@ -47281,7 +47380,7 @@
       "source_location": "L1"
     },
     {
-      "community": 562,
+      "community": 563,
       "file_type": "code",
       "id": "contact_us_contactus",
       "label": "ContactUs()",
@@ -47290,7 +47389,7 @@
       "source_location": "L14"
     },
     {
-      "community": 562,
+      "community": 563,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_contact_us_tsx",
       "label": "contact-us.tsx",
@@ -47299,7 +47398,7 @@
       "source_location": "L1"
     },
     {
-      "community": 563,
+      "community": 564,
       "file_type": "code",
       "id": "delivery_returns_exchanges_index_onlineorderpolicy",
       "label": "OnlineOrderPolicy()",
@@ -47308,7 +47407,7 @@
       "source_location": "L13"
     },
     {
-      "community": 563,
+      "community": 564,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_delivery_returns_exchanges_index_tsx",
       "label": "delivery-returns-exchanges.index.tsx",
@@ -47317,7 +47416,7 @@
       "source_location": "L1"
     },
     {
-      "community": 564,
+      "community": 565,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_privacy_index_tsx",
       "label": "privacy.index.tsx",
@@ -47326,7 +47425,7 @@
       "source_location": "L1"
     },
     {
-      "community": 564,
+      "community": 565,
       "file_type": "code",
       "id": "privacy_index_privacypolicy",
       "label": "PrivacyPolicy()",
@@ -47335,7 +47434,7 @@
       "source_location": "L9"
     },
     {
-      "community": 565,
+      "community": 566,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_tos_index_tsx",
       "label": "tos.index.tsx",
@@ -47344,7 +47443,7 @@
       "source_location": "L1"
     },
     {
-      "community": 565,
+      "community": 566,
       "file_type": "code",
       "id": "tos_index_tossection",
       "label": "TosSection()",
@@ -47353,7 +47452,7 @@
       "source_location": "L15"
     },
     {
-      "community": 566,
+      "community": 567,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_product_productslug_tsx",
       "label": "shop.product.$productSlug.tsx",
@@ -47362,7 +47461,7 @@
       "source_location": "L1"
     },
     {
-      "community": 566,
+      "community": 567,
       "file_type": "code",
       "id": "shop_product_productslug_component",
       "label": "Component()",
@@ -47371,7 +47470,7 @@
       "source_location": "L16"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "layout_layoutcomponent",
       "label": "LayoutComponent()",
@@ -47380,7 +47479,7 @@
       "source_location": "L6"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_tsx",
       "label": "_layout.tsx",
@@ -47389,7 +47488,7 @@
       "source_location": "L1"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "index_homeroute",
       "label": "HomeRoute()",
@@ -47398,30 +47497,12 @@
       "source_location": "L10"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/storefront-webapp/src/routes/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "canceled_checkoutcanceledview",
-      "label": "CheckoutCanceledView()",
-      "norm_label": "checkoutcanceledview()",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/canceled.tsx",
-      "source_location": "L21"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_canceled_tsx",
-      "label": "canceled.tsx",
-      "norm_label": "canceled.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/canceled.tsx",
       "source_location": "L1"
     },
     {
@@ -47490,6 +47571,24 @@
     {
       "community": 570,
       "file_type": "code",
+      "id": "canceled_checkoutcanceledview",
+      "label": "CheckoutCanceledView()",
+      "norm_label": "checkoutcanceledview()",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/canceled.tsx",
+      "source_location": "L21"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_canceled_tsx",
+      "label": "canceled.tsx",
+      "norm_label": "canceled.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/canceled.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
       "id": "complete_index_checkoutcomplete",
       "label": "CheckoutComplete()",
       "norm_label": "checkoutcomplete()",
@@ -47497,7 +47596,7 @@
       "source_location": "L33"
     },
     {
-      "community": 570,
+      "community": 571,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_complete_index_tsx",
       "label": "complete.index.tsx",
@@ -47506,7 +47605,7 @@
       "source_location": "L1"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pod_confirmation_tsx",
       "label": "pod-confirmation.tsx",
@@ -47515,7 +47614,7 @@
       "source_location": "L1"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "pod_confirmation_completepodcheckoutsession",
       "label": "completePODCheckoutSession()",
@@ -47524,7 +47623,7 @@
       "source_location": "L193"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_test_connection_js",
       "label": "test-connection.js",
@@ -47533,7 +47632,7 @@
       "source_location": "L1"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "test_connection_main",
       "label": "main()",
@@ -47542,7 +47641,7 @@
       "source_location": "L7"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "architecture_boundaries_test_createsnippetlinter",
       "label": "createSnippetLinter()",
@@ -47551,7 +47650,7 @@
       "source_location": "L10"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "scripts_architecture_boundaries_test_ts",
       "label": "architecture-boundaries.test.ts",
@@ -47560,7 +47659,7 @@
       "source_location": "L1"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "architecture_boundary_check_run",
       "label": "run()",
@@ -47569,7 +47668,7 @@
       "source_location": "L32"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "scripts_architecture_boundary_check_ts",
       "label": "architecture-boundary-check.ts",
@@ -47578,7 +47677,7 @@
       "source_location": "L1"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "athena_runtime_app_shutdown",
       "label": "shutdown()",
@@ -47587,7 +47686,7 @@
       "source_location": "L211"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_athena_runtime_app_ts",
       "label": "athena-runtime-app.ts",
@@ -47596,7 +47695,7 @@
       "source_location": "L1"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "sample_app_shutdown",
       "label": "shutdown()",
@@ -47605,7 +47704,7 @@
       "source_location": "L85"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_sample_app_ts",
       "label": "sample-app.ts",
@@ -47614,7 +47713,7 @@
       "source_location": "L1"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "harness_runtime_trends_test_buildreportline",
       "label": "buildReportLine()",
@@ -47623,7 +47722,7 @@
       "source_location": "L15"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "scripts_harness_runtime_trends_test_ts",
       "label": "harness-runtime-trends.test.ts",
@@ -47632,21 +47731,12 @@
       "source_location": "L1"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_d_ts",
       "label": "api.d.ts",
       "norm_label": "api.d.ts",
       "source_file": "packages/athena-webapp/convex/_generated/api.d.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_generated_api_js",
-      "label": "api.js",
-      "norm_label": "api.js",
-      "source_file": "packages/athena-webapp/convex/_generated/api.js",
       "source_location": "L1"
     },
     {
@@ -47715,6 +47805,15 @@
     {
       "community": 580,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_generated_api_js",
+      "label": "api.js",
+      "norm_label": "api.js",
+      "source_file": "packages/athena-webapp/convex/_generated/api.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_datamodel_d_ts",
       "label": "dataModel.d.ts",
       "norm_label": "datamodel.d.ts",
@@ -47722,7 +47821,7 @@
       "source_location": "L1"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_d_ts",
       "label": "server.d.ts",
@@ -47731,7 +47830,7 @@
       "source_location": "L1"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_js",
       "label": "server.js",
@@ -47740,7 +47839,7 @@
       "source_location": "L1"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_app_ts",
       "label": "app.ts",
@@ -47749,7 +47848,7 @@
       "source_location": "L1"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_config_js",
       "label": "auth.config.js",
@@ -47758,7 +47857,7 @@
       "source_location": "L1"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_ts",
       "label": "auth.ts",
@@ -47767,7 +47866,7 @@
       "source_location": "L1"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_countries_ts",
       "label": "countries.ts",
@@ -47776,7 +47875,7 @@
       "source_location": "L1"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_email_ts",
       "label": "email.ts",
@@ -47785,21 +47884,12 @@
       "source_location": "L1"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_ghana_ts",
       "label": "ghana.ts",
       "norm_label": "ghana.ts",
       "source_file": "packages/athena-webapp/convex/constants/ghana.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_constants_payment_ts",
-      "label": "payment.ts",
-      "norm_label": "payment.ts",
-      "source_file": "packages/athena-webapp/convex/constants/payment.ts",
       "source_location": "L1"
     },
     {
@@ -47868,6 +47958,15 @@
     {
       "community": 590,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_constants_payment_ts",
+      "label": "payment.ts",
+      "norm_label": "payment.ts",
+      "source_file": "packages/athena-webapp/convex/constants/payment.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 591,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_crons_ts",
       "label": "crons.ts",
       "norm_label": "crons.ts",
@@ -47875,7 +47974,7 @@
       "source_location": "L1"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_feedbackrequest_tsx",
       "label": "FeedbackRequest.tsx",
@@ -47884,7 +47983,7 @@
       "source_location": "L1"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_neworderadmin_tsx",
       "label": "NewOrderAdmin.tsx",
@@ -47893,7 +47992,7 @@
       "source_location": "L1"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_orderemail_tsx",
       "label": "OrderEmail.tsx",
@@ -47902,7 +48001,7 @@
       "source_location": "L1"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_posreceiptemail_tsx",
       "label": "PosReceiptEmail.tsx",
@@ -47911,7 +48010,7 @@
       "source_location": "L1"
     },
     {
-      "community": 595,
+      "community": 596,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_env_ts",
       "label": "env.ts",
@@ -47920,7 +48019,7 @@
       "source_location": "L1"
     },
     {
-      "community": 596,
+      "community": 597,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_analytics_ts",
       "label": "analytics.ts",
@@ -47929,7 +48028,7 @@
       "source_location": "L1"
     },
     {
-      "community": 597,
+      "community": 598,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_auth_ts",
       "label": "auth.ts",
@@ -47938,21 +48037,12 @@
       "source_location": "L1"
     },
     {
-      "community": 598,
+      "community": 599,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_bannermessage_ts",
       "label": "bannerMessage.ts",
       "norm_label": "bannermessage.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/bannerMessage.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_categories_ts",
-      "label": "categories.ts",
-      "norm_label": "categories.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/categories.ts",
       "source_location": "L1"
     },
     {
@@ -48255,6 +48345,15 @@
     {
       "community": 600,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_categories_ts",
+      "label": "categories.ts",
+      "norm_label": "categories.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/categories.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 601,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_colors_ts",
       "label": "colors.ts",
       "norm_label": "colors.ts",
@@ -48262,7 +48361,7 @@
       "source_location": "L1"
     },
     {
-      "community": 601,
+      "community": 602,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_index_ts",
       "label": "index.ts",
@@ -48271,7 +48370,7 @@
       "source_location": "L1"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_organizations_ts",
       "label": "organizations.ts",
@@ -48280,7 +48379,7 @@
       "source_location": "L1"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_products_ts",
       "label": "products.ts",
@@ -48289,7 +48388,7 @@
       "source_location": "L1"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_stores_ts",
       "label": "stores.ts",
@@ -48298,7 +48397,7 @@
       "source_location": "L1"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_subcategories_ts",
       "label": "subcategories.ts",
@@ -48307,7 +48406,7 @@
       "source_location": "L1"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_payments_routes_index_ts",
       "label": "index.ts",
@@ -48316,7 +48415,7 @@
       "source_location": "L1"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_bag_ts",
       "label": "bag.ts",
@@ -48325,21 +48424,12 @@
       "source_location": "L1"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_guest_ts",
       "label": "guest.ts",
       "norm_label": "guest.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/guest.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/index.ts",
       "source_location": "L1"
     },
     {
@@ -48399,6 +48489,15 @@
     {
       "community": 610,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 611,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_me_ts",
       "label": "me.ts",
       "norm_label": "me.ts",
@@ -48406,7 +48505,7 @@
       "source_location": "L1"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_offers_ts",
       "label": "offers.ts",
@@ -48415,7 +48514,7 @@
       "source_location": "L1"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -48424,7 +48523,7 @@
       "source_location": "L1"
     },
     {
-      "community": 613,
+      "community": 614,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_paystack_ts",
       "label": "paystack.ts",
@@ -48433,7 +48532,7 @@
       "source_location": "L1"
     },
     {
-      "community": 614,
+      "community": 615,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_reviews_ts",
       "label": "reviews.ts",
@@ -48442,7 +48541,7 @@
       "source_location": "L1"
     },
     {
-      "community": 615,
+      "community": 616,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_rewards_ts",
       "label": "rewards.ts",
@@ -48451,7 +48550,7 @@
       "source_location": "L1"
     },
     {
-      "community": 616,
+      "community": 617,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_savedbag_ts",
       "label": "savedBag.ts",
@@ -48460,7 +48559,7 @@
       "source_location": "L1"
     },
     {
-      "community": 617,
+      "community": 618,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_test_ts",
       "label": "security.test.ts",
@@ -48469,21 +48568,12 @@
       "source_location": "L1"
     },
     {
-      "community": 618,
+      "community": 619,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_storefront_ts",
       "label": "storefront.ts",
       "norm_label": "storefront.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/storefront.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_upsells_ts",
-      "label": "upsells.ts",
-      "norm_label": "upsells.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/upsells.ts",
       "source_location": "L1"
     },
     {
@@ -48543,6 +48633,15 @@
     {
       "community": 620,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_upsells_ts",
+      "label": "upsells.ts",
+      "norm_label": "upsells.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/upsells.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 621,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_user_ts",
       "label": "user.ts",
       "norm_label": "user.ts",
@@ -48550,7 +48649,7 @@
       "source_location": "L1"
     },
     {
-      "community": 621,
+      "community": 622,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_useroffers_ts",
       "label": "userOffers.ts",
@@ -48559,7 +48658,7 @@
       "source_location": "L1"
     },
     {
-      "community": 622,
+      "community": 623,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_health_test_ts",
       "label": "health.test.ts",
@@ -48568,7 +48667,7 @@
       "source_location": "L1"
     },
     {
-      "community": 623,
+      "community": 624,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_ts",
       "label": "http.ts",
@@ -48577,7 +48676,7 @@
       "source_location": "L1"
     },
     {
-      "community": 624,
+      "community": 625,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -48586,7 +48685,7 @@
       "source_location": "L1"
     },
     {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_auth_ts",
       "label": "auth.ts",
@@ -48595,7 +48694,7 @@
       "source_location": "L1"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -48604,7 +48703,7 @@
       "source_location": "L1"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bestseller_ts",
       "label": "bestSeller.ts",
@@ -48613,21 +48712,12 @@
       "source_location": "L1"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_categories_ts",
       "label": "categories.ts",
       "norm_label": "categories.ts",
       "source_file": "packages/athena-webapp/convex/inventory/categories.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_colors_ts",
-      "label": "colors.ts",
-      "norm_label": "colors.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/colors.ts",
       "source_location": "L1"
     },
     {
@@ -48687,6 +48777,15 @@
     {
       "community": 630,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_colors_ts",
+      "label": "colors.ts",
+      "norm_label": "colors.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/colors.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 631,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
       "norm_label": "complimentaryproduct.ts",
@@ -48694,7 +48793,7 @@
       "source_location": "L1"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessionitems_ts",
       "label": "expenseSessionItems.ts",
@@ -48703,7 +48802,7 @@
       "source_location": "L1"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensetransactions_ts",
       "label": "expenseTransactions.ts",
@@ -48712,7 +48811,7 @@
       "source_location": "L1"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_featureditem_ts",
       "label": "featuredItem.ts",
@@ -48721,7 +48820,7 @@
       "source_location": "L1"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_invitecode_ts",
       "label": "inviteCode.ts",
@@ -48730,7 +48829,7 @@
       "source_location": "L1"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizationmembers_ts",
       "label": "organizationMembers.ts",
@@ -48739,7 +48838,7 @@
       "source_location": "L1"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizations_ts",
       "label": "organizations.ts",
@@ -48748,7 +48847,7 @@
       "source_location": "L1"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_poscustomers_ts",
       "label": "posCustomers.ts",
@@ -48757,21 +48856,12 @@
       "source_location": "L1"
     },
     {
-      "community": 638,
+      "community": 639,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessionitems_ts",
       "label": "posSessionItems.ts",
       "norm_label": "possessionitems.ts",
       "source_file": "packages/athena-webapp/convex/inventory/posSessionItems.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_posterminal_ts",
-      "label": "posTerminal.ts",
-      "norm_label": "posterminal.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/posTerminal.ts",
       "source_location": "L1"
     },
     {
@@ -48831,6 +48921,15 @@
     {
       "community": 640,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_posterminal_ts",
+      "label": "posTerminal.ts",
+      "norm_label": "posterminal.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/posTerminal.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 641,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productsku_ts",
       "label": "productSku.ts",
       "norm_label": "productsku.ts",
@@ -48838,7 +48937,7 @@
       "source_location": "L1"
     },
     {
-      "community": 641,
+      "community": 642,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productutil_ts",
       "label": "productUtil.ts",
@@ -48847,7 +48946,7 @@
       "source_location": "L1"
     },
     {
-      "community": 642,
+      "community": 643,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_promocode_ts",
       "label": "promoCode.ts",
@@ -48856,7 +48955,7 @@
       "source_location": "L1"
     },
     {
-      "community": 643,
+      "community": 644,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stockvalidation_ts",
       "label": "stockValidation.ts",
@@ -48865,7 +48964,7 @@
       "source_location": "L1"
     },
     {
-      "community": 644,
+      "community": 645,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_storeconfigv2_test_ts",
       "label": "storeConfigV2.test.ts",
@@ -48874,7 +48973,7 @@
       "source_location": "L1"
     },
     {
-      "community": 645,
+      "community": 646,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_subcategories_ts",
       "label": "subcategories.ts",
@@ -48883,7 +48982,7 @@
       "source_location": "L1"
     },
     {
-      "community": 646,
+      "community": 647,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_currency_test_ts",
       "label": "currency.test.ts",
@@ -48892,7 +48991,7 @@
       "source_location": "L1"
     },
     {
-      "community": 647,
+      "community": 648,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_storeinsights_ts",
       "label": "storeInsights.ts",
@@ -48901,21 +49000,12 @@
       "source_location": "L1"
     },
     {
-      "community": 648,
+      "community": 649,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_userinsights_ts",
       "label": "userInsights.ts",
       "norm_label": "userinsights.ts",
       "source_file": "packages/athena-webapp/convex/llm/userInsights.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_migrations_migrateamountstopesewas_ts",
-      "label": "migrateAmountsToPesewas.ts",
-      "norm_label": "migrateamountstopesewas.ts",
-      "source_file": "packages/athena-webapp/convex/migrations/migrateAmountsToPesewas.ts",
       "source_location": "L1"
     },
     {
@@ -48975,6 +49065,15 @@
     {
       "community": 650,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_migrations_migrateamountstopesewas_ts",
+      "label": "migrateAmountsToPesewas.ts",
+      "norm_label": "migrateamountstopesewas.ts",
+      "source_file": "packages/athena-webapp/convex/migrations/migrateAmountsToPesewas.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 651,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_client_test_ts",
       "label": "client.test.ts",
       "norm_label": "client.test.ts",
@@ -48982,7 +49081,7 @@
       "source_location": "L1"
     },
     {
-      "community": 651,
+      "community": 652,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_config_test_ts",
       "label": "config.test.ts",
@@ -48991,7 +49090,7 @@
       "source_location": "L1"
     },
     {
-      "community": 652,
+      "community": 653,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_test_ts",
       "label": "normalize.test.ts",
@@ -49000,7 +49099,7 @@
       "source_location": "L1"
     },
     {
-      "community": 653,
+      "community": 654,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_types_ts",
       "label": "types.ts",
@@ -49009,7 +49108,7 @@
       "source_location": "L1"
     },
     {
-      "community": 654,
+      "community": 655,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_resendotp_ts",
       "label": "ResendOTP.ts",
@@ -49018,7 +49117,7 @@
       "source_location": "L1"
     },
     {
-      "community": 655,
+      "community": 656,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schema_ts",
       "label": "schema.ts",
@@ -49027,7 +49126,7 @@
       "source_location": "L1"
     },
     {
-      "community": 656,
+      "community": 657,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_appverificationcode_ts",
       "label": "appVerificationCode.ts",
@@ -49036,7 +49135,7 @@
       "source_location": "L1"
     },
     {
-      "community": 657,
+      "community": 658,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -49045,21 +49144,12 @@
       "source_location": "L1"
     },
     {
-      "community": 658,
+      "community": 659,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
       "norm_label": "bannermessage.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/bannerMessage.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_bestseller_ts",
-      "label": "bestSeller.ts",
-      "norm_label": "bestseller.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/bestSeller.ts",
       "source_location": "L1"
     },
     {
@@ -49119,6 +49209,15 @@
     {
       "community": 660,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_bestseller_ts",
+      "label": "bestSeller.ts",
+      "norm_label": "bestseller.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/bestSeller.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 661,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_cashier_ts",
       "label": "cashier.ts",
       "norm_label": "cashier.ts",
@@ -49126,7 +49225,7 @@
       "source_location": "L1"
     },
     {
-      "community": 661,
+      "community": 662,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_category_ts",
       "label": "category.ts",
@@ -49135,7 +49234,7 @@
       "source_location": "L1"
     },
     {
-      "community": 662,
+      "community": 663,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_color_ts",
       "label": "color.ts",
@@ -49144,7 +49243,7 @@
       "source_location": "L1"
     },
     {
-      "community": 663,
+      "community": 664,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
@@ -49153,7 +49252,7 @@
       "source_location": "L1"
     },
     {
-      "community": 664,
+      "community": 665,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_featureditem_ts",
       "label": "featuredItem.ts",
@@ -49162,7 +49261,7 @@
       "source_location": "L1"
     },
     {
-      "community": 665,
+      "community": 666,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_index_ts",
       "label": "index.ts",
@@ -49171,7 +49270,7 @@
       "source_location": "L1"
     },
     {
-      "community": 666,
+      "community": 667,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_invitecode_ts",
       "label": "inviteCode.ts",
@@ -49180,7 +49279,7 @@
       "source_location": "L1"
     },
     {
-      "community": 667,
+      "community": 668,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organization_ts",
       "label": "organization.ts",
@@ -49189,21 +49288,12 @@
       "source_location": "L1"
     },
     {
-      "community": 668,
+      "community": 669,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organizationmember_ts",
       "label": "organizationMember.ts",
       "norm_label": "organizationmember.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/organizationMember.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_product_ts",
-      "label": "product.ts",
-      "norm_label": "product.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/product.ts",
       "source_location": "L1"
     },
     {
@@ -49263,6 +49353,15 @@
     {
       "community": 670,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_product_ts",
+      "label": "product.ts",
+      "norm_label": "product.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/product.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 671,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_promocode_ts",
       "label": "promoCode.ts",
       "norm_label": "promocode.ts",
@@ -49270,7 +49369,7 @@
       "source_location": "L1"
     },
     {
-      "community": 671,
+      "community": 672,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_redeemedpromocode_ts",
       "label": "redeemedPromoCode.ts",
@@ -49279,7 +49378,7 @@
       "source_location": "L1"
     },
     {
-      "community": 672,
+      "community": 673,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_store_ts",
       "label": "store.ts",
@@ -49288,7 +49387,7 @@
       "source_location": "L1"
     },
     {
-      "community": 673,
+      "community": 674,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_subcategory_ts",
       "label": "subcategory.ts",
@@ -49297,7 +49396,7 @@
       "source_location": "L1"
     },
     {
-      "community": 674,
+      "community": 675,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_payments_mtncollections_ts",
       "label": "mtnCollections.ts",
@@ -49306,7 +49405,7 @@
       "source_location": "L1"
     },
     {
-      "community": 675,
+      "community": 676,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_customer_ts",
       "label": "customer.ts",
@@ -49315,7 +49414,7 @@
       "source_location": "L1"
     },
     {
-      "community": 676,
+      "community": 677,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesession_ts",
       "label": "expenseSession.ts",
@@ -49324,7 +49423,7 @@
       "source_location": "L1"
     },
     {
-      "community": 677,
+      "community": 678,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesessionitem_ts",
       "label": "expenseSessionItem.ts",
@@ -49333,21 +49432,12 @@
       "source_location": "L1"
     },
     {
-      "community": 678,
+      "community": 679,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransaction_ts",
       "label": "expenseTransaction.ts",
       "norm_label": "expensetransaction.ts",
       "source_file": "packages/athena-webapp/convex/schemas/pos/expenseTransaction.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_expensetransactionitem_ts",
-      "label": "expenseTransactionItem.ts",
-      "norm_label": "expensetransactionitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/expenseTransactionItem.ts",
       "source_location": "L1"
     },
     {
@@ -49407,6 +49497,15 @@
     {
       "community": 680,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_expensetransactionitem_ts",
+      "label": "expenseTransactionItem.ts",
+      "norm_label": "expensetransactionitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/expenseTransactionItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 681,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
@@ -49414,7 +49513,7 @@
       "source_location": "L1"
     },
     {
-      "community": 681,
+      "community": 682,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possession_ts",
       "label": "posSession.ts",
@@ -49423,7 +49522,7 @@
       "source_location": "L1"
     },
     {
-      "community": 682,
+      "community": 683,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possessionitem_ts",
       "label": "posSessionItem.ts",
@@ -49432,7 +49531,7 @@
       "source_location": "L1"
     },
     {
-      "community": 683,
+      "community": 684,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_posterminal_ts",
       "label": "posTerminal.ts",
@@ -49441,7 +49540,7 @@
       "source_location": "L1"
     },
     {
-      "community": 684,
+      "community": 685,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransaction_ts",
       "label": "posTransaction.ts",
@@ -49450,7 +49549,7 @@
       "source_location": "L1"
     },
     {
-      "community": 685,
+      "community": 686,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransactionitem_ts",
       "label": "posTransactionItem.ts",
@@ -49459,7 +49558,7 @@
       "source_location": "L1"
     },
     {
-      "community": 686,
+      "community": 687,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_analytics_ts",
       "label": "analytics.ts",
@@ -49468,7 +49567,7 @@
       "source_location": "L1"
     },
     {
-      "community": 687,
+      "community": 688,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bag_ts",
       "label": "bag.ts",
@@ -49477,21 +49576,12 @@
       "source_location": "L1"
     },
     {
-      "community": 688,
+      "community": 689,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bagitem_ts",
       "label": "bagItem.ts",
       "norm_label": "bagitem.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/bagItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 689,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsession_ts",
-      "label": "checkoutSession.ts",
-      "norm_label": "checkoutsession.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/checkoutSession.ts",
       "source_location": "L1"
     },
     {
@@ -49551,6 +49641,15 @@
     {
       "community": 690,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsession_ts",
+      "label": "checkoutSession.ts",
+      "norm_label": "checkoutsession.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/checkoutSession.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 691,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsessionitem_ts",
       "label": "checkoutSessionItem.ts",
       "norm_label": "checkoutsessionitem.ts",
@@ -49558,7 +49657,7 @@
       "source_location": "L1"
     },
     {
-      "community": 691,
+      "community": 692,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_customer_ts",
       "label": "customer.ts",
@@ -49567,7 +49666,7 @@
       "source_location": "L1"
     },
     {
-      "community": 692,
+      "community": 693,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_guest_ts",
       "label": "guest.ts",
@@ -49576,7 +49675,7 @@
       "source_location": "L1"
     },
     {
-      "community": 693,
+      "community": 694,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_index_ts",
       "label": "index.ts",
@@ -49585,7 +49684,7 @@
       "source_location": "L1"
     },
     {
-      "community": 694,
+      "community": 695,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_offer_ts",
       "label": "offer.ts",
@@ -49594,7 +49693,7 @@
       "source_location": "L1"
     },
     {
-      "community": 695,
+      "community": 696,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -49603,7 +49702,7 @@
       "source_location": "L1"
     },
     {
-      "community": 696,
+      "community": 697,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
@@ -49612,7 +49711,7 @@
       "source_location": "L1"
     },
     {
-      "community": 697,
+      "community": 698,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_review_ts",
       "label": "review.ts",
@@ -49621,21 +49720,12 @@
       "source_location": "L1"
     },
     {
-      "community": 698,
+      "community": 699,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_rewards_ts",
       "label": "rewards.ts",
       "norm_label": "rewards.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/rewards.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/savedBag.ts",
       "source_location": "L1"
     },
     {
@@ -49879,7 +49969,7 @@
       "label": "getPaymentMethodLabel()",
       "norm_label": "getpaymentmethodlabel()",
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L18"
+      "source_location": "L20"
     },
     {
       "community": 70,
@@ -49888,7 +49978,7 @@
       "label": "handleCancelEdit()",
       "norm_label": "handlecanceledit()",
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L93"
+      "source_location": "L95"
     },
     {
       "community": 70,
@@ -49897,7 +49987,7 @@
       "label": "handleRemovePayment()",
       "norm_label": "handleremovepayment()",
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L98"
+      "source_location": "L100"
     },
     {
       "community": 70,
@@ -49906,7 +49996,7 @@
       "label": "handleSaveEdit()",
       "norm_label": "handlesaveedit()",
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L62"
+      "source_location": "L64"
     },
     {
       "community": 70,
@@ -49915,10 +50005,19 @@
       "label": "handleStartEdit()",
       "norm_label": "handlestartedit()",
       "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L57"
+      "source_location": "L59"
     },
     {
       "community": 700,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/savedBag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 701,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
@@ -49927,7 +50026,7 @@
       "source_location": "L1"
     },
     {
-      "community": 701,
+      "community": 702,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontsession_ts",
       "label": "storeFrontSession.ts",
@@ -49936,7 +50035,7 @@
       "source_location": "L1"
     },
     {
-      "community": 702,
+      "community": 703,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontuser_ts",
       "label": "storeFrontUser.ts",
@@ -49945,7 +50044,7 @@
       "source_location": "L1"
     },
     {
-      "community": 703,
+      "community": 704,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontverificationcode_ts",
       "label": "storeFrontVerificationCode.ts",
@@ -49954,7 +50053,7 @@
       "source_location": "L1"
     },
     {
-      "community": 704,
+      "community": 705,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_supportticket_ts",
       "label": "supportTicket.ts",
@@ -49963,7 +50062,7 @@
       "source_location": "L1"
     },
     {
-      "community": 705,
+      "community": 706,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bag_ts",
       "label": "bag.ts",
@@ -49972,7 +50071,7 @@
       "source_location": "L1"
     },
     {
-      "community": 706,
+      "community": 707,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -49981,7 +50080,7 @@
       "source_location": "L1"
     },
     {
-      "community": 707,
+      "community": 708,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customer_ts",
       "label": "customer.ts",
@@ -49990,21 +50089,12 @@
       "source_location": "L1"
     },
     {
-      "community": 708,
+      "community": 709,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_guest_ts",
       "label": "guest.ts",
       "norm_label": "guest.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/guest.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 709,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_onlineorderutilfns_ts",
-      "label": "onlineOrderUtilFns.ts",
-      "norm_label": "onlineorderutilfns.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderUtilFns.ts",
       "source_location": "L1"
     },
     {
@@ -50064,6 +50154,15 @@
     {
       "community": 710,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_onlineorderutilfns_ts",
+      "label": "onlineOrderUtilFns.ts",
+      "norm_label": "onlineorderutilfns.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderUtilFns.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 711,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_payment_ts",
       "label": "payment.ts",
       "norm_label": "payment.ts",
@@ -50071,7 +50170,7 @@
       "source_location": "L1"
     },
     {
-      "community": 711,
+      "community": 712,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_paystackactions_ts",
       "label": "paystackActions.ts",
@@ -50080,7 +50179,7 @@
       "source_location": "L1"
     },
     {
-      "community": 712,
+      "community": 713,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_rewards_ts",
       "label": "rewards.ts",
@@ -50089,7 +50188,7 @@
       "source_location": "L1"
     },
     {
-      "community": 713,
+      "community": 714,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
@@ -50098,7 +50197,7 @@
       "source_location": "L1"
     },
     {
-      "community": 714,
+      "community": 715,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_supportticket_ts",
       "label": "supportTicket.ts",
@@ -50107,7 +50206,7 @@
       "source_location": "L1"
     },
     {
-      "community": 715,
+      "community": 716,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_users_ts",
       "label": "users.ts",
@@ -50116,7 +50215,7 @@
       "source_location": "L1"
     },
     {
-      "community": 716,
+      "community": 717,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_types_payment_ts",
       "label": "payment.ts",
@@ -50125,7 +50224,7 @@
       "source_location": "L1"
     },
     {
-      "community": 717,
+      "community": 718,
       "file_type": "code",
       "id": "packages_athena_webapp_eslint_config_js",
       "label": "eslint.config.js",
@@ -50134,21 +50233,12 @@
       "source_location": "L1"
     },
     {
-      "community": 718,
+      "community": 719,
       "file_type": "code",
       "id": "packages_athena_webapp_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/athena-webapp/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 719,
-      "file_type": "code",
-      "id": "packages_athena_webapp_postcss_config_js",
-      "label": "postcss.config.js",
-      "norm_label": "postcss.config.js",
-      "source_file": "packages/athena-webapp/postcss.config.js",
       "source_location": "L1"
     },
     {
@@ -50208,6 +50298,15 @@
     {
       "community": 720,
       "file_type": "code",
+      "id": "packages_athena_webapp_postcss_config_js",
+      "label": "postcss.config.js",
+      "norm_label": "postcss.config.js",
+      "source_file": "packages/athena-webapp/postcss.config.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 721,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_genericcombobox_tsx",
       "label": "GenericComboBox.tsx",
       "norm_label": "genericcombobox.tsx",
@@ -50215,7 +50314,7 @@
       "source_location": "L1"
     },
     {
-      "community": 721,
+      "community": 722,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeaccordion_tsx",
       "label": "StoreAccordion.tsx",
@@ -50224,7 +50323,7 @@
       "source_location": "L1"
     },
     {
-      "community": 722,
+      "community": 723,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesaccordion_tsx",
       "label": "StoresAccordion.tsx",
@@ -50233,7 +50332,7 @@
       "source_location": "L1"
     },
     {
-      "community": 723,
+      "community": 724,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_themetoggle_tsx",
       "label": "ThemeToggle.tsx",
@@ -50242,7 +50341,7 @@
       "source_location": "L1"
     },
     {
-      "community": 724,
+      "community": 725,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_defaultattributestogglegroup_tsx",
       "label": "DefaultAttributesToggleGroup.tsx",
@@ -50251,7 +50350,7 @@
       "source_location": "L1"
     },
     {
-      "community": 725,
+      "community": 726,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributesview_tsx",
       "label": "ProductAttributesView.tsx",
@@ -50260,7 +50359,7 @@
       "source_location": "L1"
     },
     {
-      "community": 726,
+      "community": 727,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_constants_ts",
       "label": "constants.ts",
@@ -50269,7 +50368,7 @@
       "source_location": "L1"
     },
     {
-      "community": 727,
+      "community": 728,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -50278,21 +50377,12 @@
       "source_location": "L1"
     },
     {
-      "community": 728,
+      "community": 729,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 729,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -50352,6 +50442,15 @@
     {
       "community": 730,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 731,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
@@ -50359,7 +50458,7 @@
       "source_location": "L1"
     },
     {
-      "community": 731,
+      "community": 732,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_conversionfunnelchart_tsx",
       "label": "ConversionFunnelChart.tsx",
@@ -50368,7 +50467,7 @@
       "source_location": "L1"
     },
     {
-      "community": 732,
+      "community": 733,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_revenuechart_tsx",
       "label": "RevenueChart.tsx",
@@ -50377,7 +50476,7 @@
       "source_location": "L1"
     },
     {
-      "community": 733,
+      "community": 734,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_analytics_columns_tsx",
       "label": "analytics-columns.tsx",
@@ -50386,7 +50485,7 @@
       "source_location": "L1"
     },
     {
-      "community": 734,
+      "community": 735,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -50395,7 +50494,7 @@
       "source_location": "L1"
     },
     {
-      "community": 735,
+      "community": 736,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -50404,7 +50503,7 @@
       "source_location": "L1"
     },
     {
-      "community": 736,
+      "community": 737,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -50413,7 +50512,7 @@
       "source_location": "L1"
     },
     {
-      "community": 737,
+      "community": 738,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -50422,21 +50521,12 @@
       "source_location": "L1"
     },
     {
-      "community": 738,
+      "community": 739,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 739,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/columns.tsx",
       "source_location": "L1"
     },
     {
@@ -50496,6 +50586,15 @@
     {
       "community": 740,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 741,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
@@ -50503,7 +50602,7 @@
       "source_location": "L1"
     },
     {
-      "community": 741,
+      "community": 742,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -50512,7 +50611,7 @@
       "source_location": "L1"
     },
     {
-      "community": 742,
+      "community": 743,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -50521,7 +50620,7 @@
       "source_location": "L1"
     },
     {
-      "community": 743,
+      "community": 744,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -50530,7 +50629,7 @@
       "source_location": "L1"
     },
     {
-      "community": 744,
+      "community": 745,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -50539,7 +50638,7 @@
       "source_location": "L1"
     },
     {
-      "community": 745,
+      "community": 746,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -50548,7 +50647,7 @@
       "source_location": "L1"
     },
     {
-      "community": 746,
+      "community": 747,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -50557,7 +50656,7 @@
       "source_location": "L1"
     },
     {
-      "community": 747,
+      "community": 748,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_chart_tsx",
       "label": "chart.tsx",
@@ -50566,21 +50665,12 @@
       "source_location": "L1"
     },
     {
-      "community": 748,
+      "community": 749,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 749,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -50640,6 +50730,15 @@
     {
       "community": 750,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 751,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -50647,7 +50746,7 @@
       "source_location": "L1"
     },
     {
-      "community": 751,
+      "community": 752,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_columns_tsx",
       "label": "columns.tsx",
@@ -50656,7 +50755,7 @@
       "source_location": "L1"
     },
     {
-      "community": 752,
+      "community": 753,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_constants_ts",
       "label": "constants.ts",
@@ -50665,7 +50764,7 @@
       "source_location": "L1"
     },
     {
-      "community": 753,
+      "community": 754,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -50674,7 +50773,7 @@
       "source_location": "L1"
     },
     {
-      "community": 754,
+      "community": 755,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -50683,7 +50782,7 @@
       "source_location": "L1"
     },
     {
-      "community": 755,
+      "community": 756,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -50692,7 +50791,7 @@
       "source_location": "L1"
     },
     {
-      "community": 756,
+      "community": 757,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_ts",
       "label": "data.ts",
@@ -50701,7 +50800,7 @@
       "source_location": "L1"
     },
     {
-      "community": 757,
+      "community": 758,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -50710,21 +50809,12 @@
       "source_location": "L1"
     },
     {
-      "community": 758,
+      "community": 759,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/users-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 759,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/users-table/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -50784,6 +50874,15 @@
     {
       "community": 760,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/users-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 761,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
@@ -50791,7 +50890,7 @@
       "source_location": "L1"
     },
     {
-      "community": 761,
+      "community": 762,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -50800,7 +50899,7 @@
       "source_location": "L1"
     },
     {
-      "community": 762,
+      "community": 763,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -50809,7 +50908,7 @@
       "source_location": "L1"
     },
     {
-      "community": 763,
+      "community": 764,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -50818,7 +50917,7 @@
       "source_location": "L1"
     },
     {
-      "community": 764,
+      "community": 765,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -50827,7 +50926,7 @@
       "source_location": "L1"
     },
     {
-      "community": 765,
+      "community": 766,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -50836,7 +50935,7 @@
       "source_location": "L1"
     },
     {
-      "community": 766,
+      "community": 767,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_sidebar_tsx",
       "label": "app-sidebar.tsx",
@@ -50845,7 +50944,7 @@
       "source_location": "L1"
     },
     {
-      "community": 767,
+      "community": 768,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_assetscolumns_tsx",
       "label": "assetsColumns.tsx",
@@ -50854,21 +50953,12 @@
       "source_location": "L1"
     },
     {
-      "community": 768,
+      "community": 769,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
       "source_file": "packages/athena-webapp/src/components/assets/assets-table/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 769,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-faceted-filter.tsx",
       "source_location": "L1"
     },
     {
@@ -50928,6 +51018,15 @@
     {
       "community": 770,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 771,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
@@ -50935,7 +51034,7 @@
       "source_location": "L1"
     },
     {
-      "community": 771,
+      "community": 772,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -50944,7 +51043,7 @@
       "source_location": "L1"
     },
     {
-      "community": 772,
+      "community": 773,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_ts",
       "label": "data.ts",
@@ -50953,7 +51052,7 @@
       "source_location": "L1"
     },
     {
-      "community": 773,
+      "community": 774,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
@@ -50962,7 +51061,7 @@
       "source_location": "L1"
     },
     {
-      "community": 774,
+      "community": 775,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_loginform_tsx",
       "label": "LoginForm.tsx",
@@ -50971,7 +51070,7 @@
       "source_location": "L1"
     },
     {
-      "community": 775,
+      "community": 776,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -50980,7 +51079,7 @@
       "source_location": "L1"
     },
     {
-      "community": 776,
+      "community": 777,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -50989,7 +51088,7 @@
       "source_location": "L1"
     },
     {
-      "community": 777,
+      "community": 778,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -50998,21 +51097,12 @@
       "source_location": "L1"
     },
     {
-      "community": 778,
+      "community": 779,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 779,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
@@ -51072,6 +51162,15 @@
     {
       "community": 780,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/selectable-products-table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 781,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -51079,7 +51178,7 @@
       "source_location": "L1"
     },
     {
-      "community": 781,
+      "community": 782,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_columns_tsx",
       "label": "columns.tsx",
@@ -51088,7 +51187,7 @@
       "source_location": "L1"
     },
     {
-      "community": 782,
+      "community": 783,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_constants_ts",
       "label": "constants.ts",
@@ -51097,7 +51196,7 @@
       "source_location": "L1"
     },
     {
-      "community": 783,
+      "community": 784,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -51106,7 +51205,7 @@
       "source_location": "L1"
     },
     {
-      "community": 784,
+      "community": 785,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -51115,7 +51214,7 @@
       "source_location": "L1"
     },
     {
-      "community": 785,
+      "community": 786,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -51124,7 +51223,7 @@
       "source_location": "L1"
     },
     {
-      "community": 786,
+      "community": 787,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspage_tsx",
       "label": "BulkOperationsPage.tsx",
@@ -51133,7 +51232,7 @@
       "source_location": "L1"
     },
     {
-      "community": 787,
+      "community": 788,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cashiers_index_tsx",
       "label": "index.tsx",
@@ -51142,21 +51241,12 @@
       "source_location": "L1"
     },
     {
-      "community": 788,
+      "community": 789,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
       "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 789,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -51216,6 +51306,15 @@
     {
       "community": 790,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 791,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -51223,7 +51322,7 @@
       "source_location": "L1"
     },
     {
-      "community": 791,
+      "community": 792,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_metriccard_tsx",
       "label": "MetricCard.tsx",
@@ -51232,7 +51331,7 @@
       "source_location": "L1"
     },
     {
-      "community": 792,
+      "community": 793,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_expense_expensecompletion_tsx",
       "label": "ExpenseCompletion.tsx",
@@ -51241,7 +51340,7 @@
       "source_location": "L1"
     },
     {
-      "community": 793,
+      "community": 794,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_tsx",
       "label": "OrderStatus.tsx",
@@ -51250,7 +51349,7 @@
       "source_location": "L1"
     },
     {
-      "community": 794,
+      "community": 795,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -51259,7 +51358,7 @@
       "source_location": "L1"
     },
     {
-      "community": 795,
+      "community": 796,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_tsx",
       "label": "Orders.tsx",
@@ -51268,7 +51367,7 @@
       "source_location": "L1"
     },
     {
-      "community": 796,
+      "community": 797,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_constants_ts",
       "label": "constants.ts",
@@ -51277,7 +51376,7 @@
       "source_location": "L1"
     },
     {
-      "community": 797,
+      "community": 798,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -51286,21 +51385,12 @@
       "source_location": "L1"
     },
     {
-      "community": 798,
+      "community": 799,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 799,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -51558,6 +51648,15 @@
     {
       "community": 800,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 801,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_ts",
       "label": "data.ts",
       "norm_label": "data.ts",
@@ -51565,7 +51664,7 @@
       "source_location": "L1"
     },
     {
-      "community": 801,
+      "community": 802,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_constants_ts",
       "label": "constants.ts",
@@ -51574,7 +51673,7 @@
       "source_location": "L1"
     },
     {
-      "community": 802,
+      "community": 803,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -51583,7 +51682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 803,
+      "community": 804,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -51592,7 +51691,7 @@
       "source_location": "L1"
     },
     {
-      "community": 804,
+      "community": 805,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -51601,7 +51700,7 @@
       "source_location": "L1"
     },
     {
-      "community": 805,
+      "community": 806,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -51610,7 +51709,7 @@
       "source_location": "L1"
     },
     {
-      "community": 806,
+      "community": 807,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_ts",
       "label": "data.ts",
@@ -51619,7 +51718,7 @@
       "source_location": "L1"
     },
     {
-      "community": 807,
+      "community": 808,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_invitecolumns_tsx",
       "label": "inviteColumns.tsx",
@@ -51628,21 +51727,12 @@
       "source_location": "L1"
     },
     {
-      "community": 808,
+      "community": 809,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
       "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 809,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-faceted-filter.tsx",
       "source_location": "L1"
     },
     {
@@ -51702,6 +51792,15 @@
     {
       "community": 810,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 811,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
@@ -51709,7 +51808,7 @@
       "source_location": "L1"
     },
     {
-      "community": 811,
+      "community": 812,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -51718,7 +51817,7 @@
       "source_location": "L1"
     },
     {
-      "community": 812,
+      "community": 813,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -51727,7 +51826,7 @@
       "source_location": "L1"
     },
     {
-      "community": 813,
+      "community": 814,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_ts",
       "label": "data.ts",
@@ -51736,7 +51835,7 @@
       "source_location": "L1"
     },
     {
-      "community": 814,
+      "community": 815,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_memberscolumns_tsx",
       "label": "membersColumns.tsx",
@@ -51745,7 +51844,7 @@
       "source_location": "L1"
     },
     {
-      "community": 815,
+      "community": 816,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cartitems_tsx",
       "label": "CartItems.tsx",
@@ -51754,7 +51853,7 @@
       "source_location": "L1"
     },
     {
-      "community": 816,
+      "community": 817,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_tsx",
       "label": "CashierAuthDialog.tsx",
@@ -51763,7 +51862,7 @@
       "source_location": "L1"
     },
     {
-      "community": 817,
+      "community": 818,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productlookup_tsx",
       "label": "ProductLookup.tsx",
@@ -51772,21 +51871,12 @@
       "source_location": "L1"
     },
     {
-      "community": 818,
+      "community": 819,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_registeractions_tsx",
       "label": "RegisterActions.tsx",
       "norm_label": "registeractions.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/RegisterActions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 819,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_searchresultssection_tsx",
-      "label": "SearchResultsSection.tsx",
-      "norm_label": "searchresultssection.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/SearchResultsSection.tsx",
       "source_location": "L1"
     },
     {
@@ -51846,6 +51936,24 @@
     {
       "community": 820,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_searchresultssection_tsx",
+      "label": "SearchResultsSection.tsx",
+      "norm_label": "searchresultssection.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/SearchResultsSection.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 821,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_totalsdisplay_test_tsx",
+      "label": "TotalsDisplay.test.tsx",
+      "norm_label": "totalsdisplay.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 822,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportview_tsx",
       "label": "ExpenseReportView.tsx",
       "norm_label": "expensereportview.tsx",
@@ -51853,7 +51961,7 @@
       "source_location": "L1"
     },
     {
-      "community": 821,
+      "community": 823,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportcolumns_tsx",
       "label": "expenseReportColumns.tsx",
@@ -51862,7 +51970,7 @@
       "source_location": "L1"
     },
     {
-      "community": 822,
+      "community": 824,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "label": "TransactionView.tsx",
@@ -51871,7 +51979,7 @@
       "source_location": "L1"
     },
     {
-      "community": 823,
+      "community": 825,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_types_ts",
       "label": "types.ts",
@@ -51880,7 +51988,7 @@
       "source_location": "L1"
     },
     {
-      "community": 824,
+      "community": 826,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_analyticsinsights_tsx",
       "label": "AnalyticsInsights.tsx",
@@ -51889,7 +51997,7 @@
       "source_location": "L1"
     },
     {
-      "community": 825,
+      "community": 827,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_attributesview_tsx",
       "label": "AttributesView.tsx",
@@ -51898,7 +52006,7 @@
       "source_location": "L1"
     },
     {
-      "community": 826,
+      "community": 828,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_detailsview_tsx",
       "label": "DetailsView.tsx",
@@ -51907,30 +52015,12 @@
       "source_location": "L1"
     },
     {
-      "community": 827,
+      "community": 829,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productdetailview_tsx",
       "label": "ProductDetailView.tsx",
       "norm_label": "productdetailview.tsx",
       "source_file": "packages/athena-webapp/src/components/product/ProductDetailView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 828,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_productstatus_tsx",
-      "label": "ProductStatus.tsx",
-      "norm_label": "productstatus.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/ProductStatus.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 829,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_categorylistview_tsx",
-      "label": "CategoryListView.tsx",
-      "norm_label": "categorylistview.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/CategoryListView.tsx",
       "source_location": "L1"
     },
     {
@@ -51990,6 +52080,24 @@
     {
       "community": 830,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_productstatus_tsx",
+      "label": "ProductStatus.tsx",
+      "norm_label": "productstatus.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/ProductStatus.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 831,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_categorylistview_tsx",
+      "label": "CategoryListView.tsx",
+      "norm_label": "categorylistview.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/CategoryListView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 832,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsubcategorytogglegroup_tsx",
       "label": "ProductSubcategoryToggleGroup.tsx",
       "norm_label": "productsubcategorytogglegroup.tsx",
@@ -51997,7 +52105,7 @@
       "source_location": "L1"
     },
     {
-      "community": 831,
+      "community": 833,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_tsx",
       "label": "Products.tsx",
@@ -52006,7 +52114,7 @@
       "source_location": "L1"
     },
     {
-      "community": 832,
+      "community": 834,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproducts_tsx",
       "label": "StoreProducts.tsx",
@@ -52015,7 +52123,7 @@
       "source_location": "L1"
     },
     {
-      "community": 833,
+      "community": 835,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_unresolvedproducts_tsx",
       "label": "UnresolvedProducts.tsx",
@@ -52024,7 +52132,7 @@
       "source_location": "L1"
     },
     {
-      "community": 834,
+      "community": 836,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproducts_tsx",
       "label": "ComplimentaryProducts.tsx",
@@ -52033,7 +52141,7 @@
       "source_location": "L1"
     },
     {
-      "community": 835,
+      "community": 837,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductscolumn_tsx",
       "label": "complimentaryProductsColumn.tsx",
@@ -52042,7 +52150,7 @@
       "source_location": "L1"
     },
     {
-      "community": 836,
+      "community": 838,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -52051,30 +52159,12 @@
       "source_location": "L1"
     },
     {
-      "community": 837,
+      "community": 839,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 838,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 839,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
@@ -52134,6 +52224,24 @@
     {
       "community": 840,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 841,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 842,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -52141,7 +52249,7 @@
       "source_location": "L1"
     },
     {
-      "community": 841,
+      "community": 843,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_ts",
       "label": "data.ts",
@@ -52150,7 +52258,7 @@
       "source_location": "L1"
     },
     {
-      "community": 842,
+      "community": 844,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_productcolumns_tsx",
       "label": "productColumns.tsx",
@@ -52159,7 +52267,7 @@
       "source_location": "L1"
     },
     {
-      "community": 843,
+      "community": 845,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodepreview_tsx",
       "label": "PromoCodePreview.tsx",
@@ -52168,7 +52276,7 @@
       "source_location": "L1"
     },
     {
-      "community": 844,
+      "community": 846,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodes_tsx",
       "label": "PromoCodes.tsx",
@@ -52177,7 +52285,7 @@
       "source_location": "L1"
     },
     {
-      "community": 845,
+      "community": 847,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_analytics_promocodeanalytics_tsx",
       "label": "PromoCodeAnalytics.tsx",
@@ -52186,7 +52294,7 @@
       "source_location": "L1"
     },
     {
-      "community": 846,
+      "community": 848,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_captured_emails_columns_tsx",
       "label": "captured-emails-columns.tsx",
@@ -52195,30 +52303,12 @@
       "source_location": "L1"
     },
     {
-      "community": 847,
+      "community": 849,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 848,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_column_header_tsx",
-      "label": "data-table-column-header.tsx",
-      "norm_label": "data-table-column-header.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-column-header.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 849,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-faceted-filter.tsx",
       "source_location": "L1"
     },
     {
@@ -52278,6 +52368,24 @@
     {
       "community": 850,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_column_header_tsx",
+      "label": "data-table-column-header.tsx",
+      "norm_label": "data-table-column-header.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-column-header.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 851,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 852,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
@@ -52285,7 +52393,7 @@
       "source_location": "L1"
     },
     {
-      "community": 851,
+      "community": 853,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -52294,7 +52402,7 @@
       "source_location": "L1"
     },
     {
-      "community": 852,
+      "community": 854,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -52303,7 +52411,7 @@
       "source_location": "L1"
     },
     {
-      "community": 853,
+      "community": 855,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_columns_tsx",
       "label": "columns.tsx",
@@ -52312,7 +52420,7 @@
       "source_location": "L1"
     },
     {
-      "community": 854,
+      "community": 856,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_constants_ts",
       "label": "constants.ts",
@@ -52321,7 +52429,7 @@
       "source_location": "L1"
     },
     {
-      "community": 855,
+      "community": 857,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -52330,7 +52438,7 @@
       "source_location": "L1"
     },
     {
-      "community": 856,
+      "community": 858,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -52339,30 +52447,12 @@
       "source_location": "L1"
     },
     {
-      "community": 857,
+      "community": 859,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 858,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 859,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/types.ts",
       "source_location": "L1"
     },
     {
@@ -52422,6 +52512,24 @@
     {
       "community": 860,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 861,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/types.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 862,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_welcome_offer_card_tsx",
       "label": "welcome-offer-card.tsx",
       "norm_label": "welcome-offer-card.tsx",
@@ -52429,7 +52537,7 @@
       "source_location": "L1"
     },
     {
-      "community": 861,
+      "community": 863,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_ratingstars_tsx",
       "label": "RatingStars.tsx",
@@ -52438,7 +52546,7 @@
       "source_location": "L1"
     },
     {
-      "community": 862,
+      "community": 864,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewcard_tsx",
       "label": "ReviewCard.tsx",
@@ -52447,7 +52555,7 @@
       "source_location": "L1"
     },
     {
-      "community": 863,
+      "community": 865,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewmetadata_tsx",
       "label": "ReviewMetadata.tsx",
@@ -52456,7 +52564,7 @@
       "source_location": "L1"
     },
     {
-      "community": 864,
+      "community": 866,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_test_tsx",
       "label": "MtnMomoView.test.tsx",
@@ -52465,7 +52573,7 @@
       "source_location": "L1"
     },
     {
-      "community": 865,
+      "community": 867,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_index_tsx",
       "label": "index.tsx",
@@ -52474,7 +52582,7 @@
       "source_location": "L1"
     },
     {
-      "community": 866,
+      "community": 868,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
@@ -52483,30 +52591,12 @@
       "source_location": "L1"
     },
     {
-      "community": 867,
+      "community": 869,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_test_tsx",
       "label": "button.test.tsx",
       "norm_label": "button.test.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/button.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 868,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_button_tsx",
-      "label": "button.tsx",
-      "norm_label": "button.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/button.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 869,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_calendar_test_tsx",
-      "label": "calendar.test.tsx",
-      "norm_label": "calendar.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/calendar.test.tsx",
       "source_location": "L1"
     },
     {
@@ -52566,6 +52656,24 @@
     {
       "community": 870,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_button_tsx",
+      "label": "button.tsx",
+      "norm_label": "button.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/button.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 871,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_calendar_test_tsx",
+      "label": "calendar.test.tsx",
+      "norm_label": "calendar.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/calendar.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 872,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_tsx",
       "label": "calendar.tsx",
       "norm_label": "calendar.tsx",
@@ -52573,7 +52681,7 @@
       "source_location": "L1"
     },
     {
-      "community": 871,
+      "community": 873,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
@@ -52582,7 +52690,7 @@
       "source_location": "L1"
     },
     {
-      "community": 872,
+      "community": 874,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
@@ -52591,7 +52699,7 @@
       "source_location": "L1"
     },
     {
-      "community": 873,
+      "community": 875,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_collapsible_tsx",
       "label": "collapsible.tsx",
@@ -52600,7 +52708,7 @@
       "source_location": "L1"
     },
     {
-      "community": 874,
+      "community": 876,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
@@ -52609,7 +52717,7 @@
       "source_location": "L1"
     },
     {
-      "community": 875,
+      "community": 877,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
@@ -52618,7 +52726,7 @@
       "source_location": "L1"
     },
     {
-      "community": 876,
+      "community": 878,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
@@ -52627,30 +52735,12 @@
       "source_location": "L1"
     },
     {
-      "community": 877,
+      "community": 879,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
       "norm_label": "dropdown-menu.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/dropdown-menu.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 878,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_form_tsx",
-      "label": "form.tsx",
-      "norm_label": "form.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/form.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 879,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_icons_tsx",
-      "label": "icons.tsx",
-      "norm_label": "icons.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/icons.tsx",
       "source_location": "L1"
     },
     {
@@ -52701,6 +52791,24 @@
     {
       "community": 880,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_form_tsx",
+      "label": "form.tsx",
+      "norm_label": "form.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/form.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 881,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_icons_tsx",
+      "label": "icons.tsx",
+      "norm_label": "icons.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/icons.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 882,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
       "norm_label": "input-otp.tsx",
@@ -52708,7 +52816,7 @@
       "source_location": "L1"
     },
     {
-      "community": 881,
+      "community": 883,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
@@ -52717,7 +52825,7 @@
       "source_location": "L1"
     },
     {
-      "community": 882,
+      "community": 884,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
@@ -52726,7 +52834,7 @@
       "source_location": "L1"
     },
     {
-      "community": 883,
+      "community": 885,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -52735,7 +52843,7 @@
       "source_location": "L1"
     },
     {
-      "community": 884,
+      "community": 886,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
@@ -52744,7 +52852,7 @@
       "source_location": "L1"
     },
     {
-      "community": 885,
+      "community": 887,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
@@ -52753,7 +52861,7 @@
       "source_location": "L1"
     },
     {
-      "community": 886,
+      "community": 888,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
@@ -52762,30 +52870,12 @@
       "source_location": "L1"
     },
     {
-      "community": 887,
+      "community": 889,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
       "norm_label": "separator.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/separator.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 888,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_sheet_tsx",
-      "label": "sheet.tsx",
-      "norm_label": "sheet.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/sheet.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 889,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_switch_tsx",
-      "label": "switch.tsx",
-      "norm_label": "switch.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/switch.tsx",
       "source_location": "L1"
     },
     {
@@ -52836,6 +52926,24 @@
     {
       "community": 890,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_sheet_tsx",
+      "label": "sheet.tsx",
+      "norm_label": "sheet.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/sheet.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 891,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_switch_tsx",
+      "label": "switch.tsx",
+      "norm_label": "switch.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/switch.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 892,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
       "norm_label": "table.tsx",
@@ -52843,7 +52951,7 @@
       "source_location": "L1"
     },
     {
-      "community": 891,
+      "community": 893,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
@@ -52852,7 +52960,7 @@
       "source_location": "L1"
     },
     {
-      "community": 892,
+      "community": 894,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
@@ -52861,7 +52969,7 @@
       "source_location": "L1"
     },
     {
-      "community": 893,
+      "community": 895,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
@@ -52870,7 +52978,7 @@
       "source_location": "L1"
     },
     {
-      "community": 894,
+      "community": 896,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
@@ -52879,7 +52987,7 @@
       "source_location": "L1"
     },
     {
-      "community": 895,
+      "community": 897,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
@@ -52888,7 +52996,7 @@
       "source_location": "L1"
     },
     {
-      "community": 896,
+      "community": 898,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_upload_button_tsx",
       "label": "upload-button.tsx",
@@ -52897,30 +53005,12 @@
       "source_location": "L1"
     },
     {
-      "community": 897,
+      "community": 899,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagview_tsx",
       "label": "BagView.tsx",
       "norm_label": "bagview.tsx",
       "source_file": "packages/athena-webapp/src/components/user-bags/BagView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 898,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 899,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/constants.ts",
       "source_location": "L1"
     },
     {
@@ -53151,6 +53241,24 @@
     {
       "community": 900,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 901,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 902,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
@@ -53158,7 +53266,7 @@
       "source_location": "L1"
     },
     {
-      "community": 901,
+      "community": 903,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -53167,7 +53275,7 @@
       "source_location": "L1"
     },
     {
-      "community": 902,
+      "community": 904,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -53176,7 +53284,7 @@
       "source_location": "L1"
     },
     {
-      "community": 903,
+      "community": 905,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_ts",
       "label": "data.ts",
@@ -53185,7 +53293,7 @@
       "source_location": "L1"
     },
     {
-      "community": 904,
+      "community": 906,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bag_columns_tsx",
       "label": "bag-columns.tsx",
@@ -53194,7 +53302,7 @@
       "source_location": "L1"
     },
     {
-      "community": 905,
+      "community": 907,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
       "label": "bags-table.tsx",
@@ -53203,7 +53311,7 @@
       "source_location": "L1"
     },
     {
-      "community": 906,
+      "community": 908,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_columns_tsx",
       "label": "columns.tsx",
@@ -53212,30 +53320,12 @@
       "source_location": "L1"
     },
     {
-      "community": 907,
+      "community": 909,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
       "norm_label": "data-table-column-header.tsx",
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-column-header.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 908,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 909,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -53286,6 +53376,24 @@
     {
       "community": 910,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 911,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 912,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
       "norm_label": "data-table-toolbar.tsx",
@@ -53293,7 +53401,7 @@
       "source_location": "L1"
     },
     {
-      "community": 911,
+      "community": 913,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -53302,7 +53410,7 @@
       "source_location": "L1"
     },
     {
-      "community": 912,
+      "community": 914,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_linkedaccounts_tsx",
       "label": "LinkedAccounts.tsx",
@@ -53311,7 +53419,7 @@
       "source_location": "L1"
     },
     {
-      "community": 913,
+      "community": 915,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_test_tsx",
       "label": "TimelineEventCard.test.tsx",
@@ -53320,7 +53428,7 @@
       "source_location": "L1"
     },
     {
-      "community": 914,
+      "community": 916,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_usercheckoutsession_tsx",
       "label": "UserCheckoutSession.tsx",
@@ -53329,7 +53437,7 @@
       "source_location": "L1"
     },
     {
-      "community": 915,
+      "community": 917,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userinsightssection_tsx",
       "label": "UserInsightsSection.tsx",
@@ -53338,7 +53446,7 @@
       "source_location": "L1"
     },
     {
-      "community": 916,
+      "community": 918,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_userbehaviorinsights_tsx",
       "label": "UserBehaviorInsights.tsx",
@@ -53347,30 +53455,12 @@
       "source_location": "L1"
     },
     {
-      "community": 917,
+      "community": 919,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 918,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_config_ts",
-      "label": "config.ts",
-      "norm_label": "config.ts",
-      "source_file": "packages/athena-webapp/src/config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 919,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_contexts_themecontext_tsx",
-      "label": "ThemeContext.tsx",
-      "norm_label": "themecontext.tsx",
-      "source_file": "packages/athena-webapp/src/contexts/ThemeContext.tsx",
       "source_location": "L1"
     },
     {
@@ -53421,6 +53511,24 @@
     {
       "community": 920,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_config_ts",
+      "label": "config.ts",
+      "norm_label": "config.ts",
+      "source_file": "packages/athena-webapp/src/config.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 921,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_contexts_themecontext_tsx",
+      "label": "ThemeContext.tsx",
+      "norm_label": "themecontext.tsx",
+      "source_file": "packages/athena-webapp/src/contexts/ThemeContext.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 922,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
       "norm_label": "use-store-modal.tsx",
@@ -53428,7 +53536,7 @@
       "source_location": "L1"
     },
     {
-      "community": 921,
+      "community": 923,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
       "label": "useOrganizationModal.tsx",
@@ -53437,7 +53545,7 @@
       "source_location": "L1"
     },
     {
-      "community": 922,
+      "community": 924,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_aws_ts",
       "label": "aws.ts",
@@ -53446,7 +53554,7 @@
       "source_location": "L1"
     },
     {
-      "community": 923,
+      "community": 925,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_constants_ts",
       "label": "constants.ts",
@@ -53455,7 +53563,7 @@
       "source_location": "L1"
     },
     {
-      "community": 924,
+      "community": 926,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_countries_ts",
       "label": "countries.ts",
@@ -53464,7 +53572,7 @@
       "source_location": "L1"
     },
     {
-      "community": 925,
+      "community": 927,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -53473,7 +53581,7 @@
       "source_location": "L1"
     },
     {
-      "community": 926,
+      "community": 928,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
@@ -53482,30 +53590,12 @@
       "source_location": "L1"
     },
     {
-      "community": 927,
+      "community": 929,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 928,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_test_ts",
-      "label": "productUtils.test.ts",
-      "norm_label": "productutils.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 929,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_schemas_category_ts",
-      "label": "category.ts",
-      "norm_label": "category.ts",
-      "source_file": "packages/athena-webapp/src/lib/schemas/category.ts",
       "source_location": "L1"
     },
     {
@@ -53556,6 +53646,33 @@
     {
       "community": 930,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_displayamounts_test_ts",
+      "label": "displayAmounts.test.ts",
+      "norm_label": "displayamounts.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/displayAmounts.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 931,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_productutils_test_ts",
+      "label": "productUtils.test.ts",
+      "norm_label": "productutils.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 932,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_schemas_category_ts",
+      "label": "category.ts",
+      "norm_label": "category.ts",
+      "source_file": "packages/athena-webapp/src/lib/schemas/category.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 933,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
       "norm_label": "product.ts",
@@ -53563,7 +53680,7 @@
       "source_location": "L1"
     },
     {
-      "community": 931,
+      "community": 934,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -53572,7 +53689,7 @@
       "source_location": "L1"
     },
     {
-      "community": 932,
+      "community": 935,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
@@ -53581,7 +53698,7 @@
       "source_location": "L1"
     },
     {
-      "community": 933,
+      "community": 936,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
@@ -53590,7 +53707,7 @@
       "source_location": "L1"
     },
     {
-      "community": 934,
+      "community": 937,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
@@ -53599,7 +53716,7 @@
       "source_location": "L1"
     },
     {
-      "community": 935,
+      "community": 938,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
@@ -53608,39 +53725,12 @@
       "source_location": "L1"
     },
     {
-      "community": 936,
+      "community": 939,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
       "norm_label": "routetree.gen.ts",
       "source_file": "packages/athena-webapp/src/routeTree.gen.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 937,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_root_tsx",
-      "label": "__root.tsx",
-      "norm_label": "__root.tsx",
-      "source_file": "packages/athena-webapp/src/routes/__root.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 938,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 939,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/index.tsx",
       "source_location": "L1"
     },
     {
@@ -53691,6 +53781,33 @@
     {
       "community": 940,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_root_tsx",
+      "label": "__root.tsx",
+      "norm_label": "__root.tsx",
+      "source_file": "packages/athena-webapp/src/routes/__root.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 941,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 942,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 943,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
@@ -53698,7 +53815,7 @@
       "source_location": "L1"
     },
     {
-      "community": 941,
+      "community": 944,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_stores_storeurlslug_tsx",
       "label": "$storeUrlSlug.tsx",
@@ -53707,7 +53824,7 @@
       "source_location": "L1"
     },
     {
-      "community": 942,
+      "community": 945,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_analytics_tsx",
       "label": "analytics.tsx",
@@ -53716,7 +53833,7 @@
       "source_location": "L1"
     },
     {
-      "community": 943,
+      "community": 946,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_assets_index_tsx",
       "label": "assets.index.tsx",
@@ -53725,7 +53842,7 @@
       "source_location": "L1"
     },
     {
-      "community": 944,
+      "community": 947,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_bagid_tsx",
       "label": "bags.$bagId.tsx",
@@ -53734,7 +53851,7 @@
       "source_location": "L1"
     },
     {
-      "community": 945,
+      "community": 948,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_index_tsx",
       "label": "bags.index.tsx",
@@ -53743,39 +53860,12 @@
       "source_location": "L1"
     },
     {
-      "community": 946,
+      "community": 949,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bulk_operations_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/bulk-operations/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 947,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_checkout_sessions_index_tsx",
-      "label": "checkout-sessions.index.tsx",
-      "norm_label": "checkout-sessions.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/checkout-sessions.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 948,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_configuration_index_tsx",
-      "label": "configuration.index.tsx",
-      "norm_label": "configuration.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/configuration.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 949,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
-      "label": "dashboard.index.tsx",
-      "norm_label": "dashboard.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/dashboard.index.tsx",
       "source_location": "L1"
     },
     {
@@ -53826,6 +53916,33 @@
     {
       "community": 950,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_checkout_sessions_index_tsx",
+      "label": "checkout-sessions.index.tsx",
+      "norm_label": "checkout-sessions.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/checkout-sessions.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 951,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_configuration_index_tsx",
+      "label": "configuration.index.tsx",
+      "norm_label": "configuration.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/configuration.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 952,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
+      "label": "dashboard.index.tsx",
+      "norm_label": "dashboard.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/dashboard.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 953,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
       "label": "home.tsx",
       "norm_label": "home.tsx",
@@ -53833,7 +53950,7 @@
       "source_location": "L1"
     },
     {
-      "community": 951,
+      "community": 954,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_logid_tsx",
       "label": "logs.$logId.tsx",
@@ -53842,7 +53959,7 @@
       "source_location": "L1"
     },
     {
-      "community": 952,
+      "community": 955,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_index_tsx",
       "label": "logs.index.tsx",
@@ -53851,7 +53968,7 @@
       "source_location": "L1"
     },
     {
-      "community": 953,
+      "community": 956,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_members_index_tsx",
       "label": "members.index.tsx",
@@ -53860,7 +53977,7 @@
       "source_location": "L1"
     },
     {
-      "community": 954,
+      "community": 957,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_orderslug_index_tsx",
       "label": "index.tsx",
@@ -53869,7 +53986,7 @@
       "source_location": "L1"
     },
     {
-      "community": 955,
+      "community": 958,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_all_index_tsx",
       "label": "all.index.tsx",
@@ -53878,39 +53995,12 @@
       "source_location": "L1"
     },
     {
-      "community": 956,
+      "community": 959,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_cancelled_index_tsx",
       "label": "cancelled.index.tsx",
       "norm_label": "cancelled.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/cancelled.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 957,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
-      "label": "completed.index.tsx",
-      "norm_label": "completed.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/completed.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 958,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 959,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
-      "label": "open.index.tsx",
-      "norm_label": "open.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/open.index.tsx",
       "source_location": "L1"
     },
     {
@@ -53961,6 +54051,33 @@
     {
       "community": 960,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
+      "label": "completed.index.tsx",
+      "norm_label": "completed.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/completed.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 961,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 962,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
+      "label": "open.index.tsx",
+      "norm_label": "open.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/open.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 963,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_out_for_delivery_index_tsx",
       "label": "out-for-delivery.index.tsx",
       "norm_label": "out-for-delivery.index.tsx",
@@ -53968,7 +54085,7 @@
       "source_location": "L1"
     },
     {
-      "community": 961,
+      "community": 964,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
       "label": "ready.index.tsx",
@@ -53977,7 +54094,7 @@
       "source_location": "L1"
     },
     {
-      "community": 962,
+      "community": 965,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
       "label": "refunded.index.tsx",
@@ -53986,7 +54103,7 @@
       "source_location": "L1"
     },
     {
-      "community": 963,
+      "community": 966,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
       "label": "$reportId.tsx",
@@ -53995,7 +54112,7 @@
       "source_location": "L1"
     },
     {
-      "community": 964,
+      "community": 967,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
       "label": "expense-reports.index.tsx",
@@ -54004,7 +54121,7 @@
       "source_location": "L1"
     },
     {
-      "community": 965,
+      "community": 968,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_index_tsx",
       "label": "expense.index.tsx",
@@ -54013,39 +54130,12 @@
       "source_location": "L1"
     },
     {
-      "community": 966,
+      "community": 969,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 967,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
-      "label": "register.index.tsx",
-      "norm_label": "register.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/register.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 968,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_settings_index_tsx",
-      "label": "settings.index.tsx",
-      "norm_label": "settings.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/settings.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 969,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
-      "label": "$transactionId.tsx",
-      "norm_label": "$transactionid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId.tsx",
       "source_location": "L1"
     },
     {
@@ -54096,6 +54186,33 @@
     {
       "community": 970,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
+      "label": "register.index.tsx",
+      "norm_label": "register.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/register.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 971,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_settings_index_tsx",
+      "label": "settings.index.tsx",
+      "norm_label": "settings.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/settings.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 972,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
+      "label": "$transactionId.tsx",
+      "norm_label": "$transactionid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 973,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
       "label": "transactions.index.tsx",
       "norm_label": "transactions.index.tsx",
@@ -54103,7 +54220,7 @@
       "source_location": "L1"
     },
     {
-      "community": 971,
+      "community": 974,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_edit_tsx",
       "label": "edit.tsx",
@@ -54112,7 +54229,7 @@
       "source_location": "L1"
     },
     {
-      "community": 972,
+      "community": 975,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_index_tsx",
       "label": "index.tsx",
@@ -54121,7 +54238,7 @@
       "source_location": "L1"
     },
     {
-      "community": 973,
+      "community": 976,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_index_tsx",
       "label": "index.tsx",
@@ -54130,7 +54247,7 @@
       "source_location": "L1"
     },
     {
-      "community": 974,
+      "community": 977,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_new_tsx",
       "label": "new.tsx",
@@ -54139,7 +54256,7 @@
       "source_location": "L1"
     },
     {
-      "community": 975,
+      "community": 978,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_index_tsx",
       "label": "index.tsx",
@@ -54148,39 +54265,12 @@
       "source_location": "L1"
     },
     {
-      "community": 976,
+      "community": 979,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_new_tsx",
       "label": "new.tsx",
       "norm_label": "new.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/new.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 977,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_unresolved_tsx",
-      "label": "unresolved.tsx",
-      "norm_label": "unresolved.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/unresolved.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 978,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
-      "label": "$promoCodeSlug.tsx",
-      "norm_label": "$promocodeslug.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/$promoCodeSlug.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 979,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/index.tsx",
       "source_location": "L1"
     },
     {
@@ -54231,6 +54321,33 @@
     {
       "community": 980,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_unresolved_tsx",
+      "label": "unresolved.tsx",
+      "norm_label": "unresolved.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/unresolved.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 981,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
+      "label": "$promoCodeSlug.tsx",
+      "norm_label": "$promocodeslug.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/$promoCodeSlug.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 982,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 983,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
       "label": "new.tsx",
       "norm_label": "new.tsx",
@@ -54238,7 +54355,7 @@
       "source_location": "L1"
     },
     {
-      "community": 981,
+      "community": 984,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_index_tsx",
       "label": "index.tsx",
@@ -54247,7 +54364,7 @@
       "source_location": "L1"
     },
     {
-      "community": 982,
+      "community": 985,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_new_index_tsx",
       "label": "new.index.tsx",
@@ -54256,7 +54373,7 @@
       "source_location": "L1"
     },
     {
-      "community": 983,
+      "community": 986,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_users_userid_tsx",
       "label": "users.$userId.tsx",
@@ -54265,7 +54382,7 @@
       "source_location": "L1"
     },
     {
-      "community": 984,
+      "community": 987,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_index_tsx",
       "label": "index.tsx",
@@ -54274,7 +54391,7 @@
       "source_location": "L1"
     },
     {
-      "community": 985,
+      "community": 988,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_join_team_index_tsx",
       "label": "join-team.index.tsx",
@@ -54283,7 +54400,7 @@
       "source_location": "L1"
     },
     {
-      "community": 986,
+      "community": 989,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_test_tsx",
       "label": "_layout.index.test.tsx",
@@ -54292,7 +54409,52 @@
       "source_location": "L1"
     },
     {
-      "community": 987,
+      "community": 99,
+      "file_type": "code",
+      "id": "index_feesview",
+      "label": "FeesView()",
+      "norm_label": "feesview()",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "source_location": "L29"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "index_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L42"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "index_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L105"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 99,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 990,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storessettingsaccordion_tsx",
       "label": "StoresSettingsAccordion.tsx",
@@ -54301,7 +54463,7 @@
       "source_location": "L1"
     },
     {
-      "community": 988,
+      "community": 991,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stores_expensestore_ts",
       "label": "expenseStore.ts",
@@ -54310,7 +54472,7 @@
       "source_location": "L1"
     },
     {
-      "community": 989,
+      "community": 992,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stores_posstore_ts",
       "label": "posStore.ts",
@@ -54319,52 +54481,7 @@
       "source_location": "L1"
     },
     {
-      "community": 99,
-      "file_type": "code",
-      "id": "dashboard_getperiodrange",
-      "label": "getPeriodRange()",
-      "norm_label": "getperiodrange()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "dashboard_loadingsection",
-      "label": "LoadingSection()",
-      "norm_label": "loadingsection()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "dashboard_renderproductssection",
-      "label": "renderProductsSection()",
-      "norm_label": "renderproductssection()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L342"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "dashboard_rendersalessection",
-      "label": "renderSalesSection()",
-      "norm_label": "rendersalessection()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L322"
-    },
-    {
-      "community": 99,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
-      "label": "Dashboard.tsx",
-      "norm_label": "dashboard.tsx",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 990,
+      "community": 993,
       "file_type": "code",
       "id": "packages_athena_webapp_src_test_setup_ts",
       "label": "setup.ts",
@@ -54373,7 +54490,7 @@
       "source_location": "L1"
     },
     {
-      "community": 991,
+      "community": 994,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_useprint_test_ts",
       "label": "usePrint.test.ts",
@@ -54382,7 +54499,7 @@
       "source_location": "L1"
     },
     {
-      "community": 992,
+      "community": 995,
       "file_type": "code",
       "id": "packages_athena_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
@@ -54391,7 +54508,7 @@
       "source_location": "L1"
     },
     {
-      "community": 993,
+      "community": 996,
       "file_type": "code",
       "id": "packages_athena_webapp_types_ts",
       "label": "types.ts",
@@ -54400,7 +54517,7 @@
       "source_location": "L1"
     },
     {
-      "community": 994,
+      "community": 997,
       "file_type": "code",
       "id": "packages_athena_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
@@ -54409,7 +54526,7 @@
       "source_location": "L1"
     },
     {
-      "community": 995,
+      "community": 998,
       "file_type": "code",
       "id": "packages_athena_webapp_vitest_setup_ts",
       "label": "vitest.setup.ts",
@@ -54418,39 +54535,12 @@
       "source_location": "L1"
     },
     {
-      "community": 996,
+      "community": 999,
       "file_type": "code",
       "id": "packages_storefront_webapp_eslint_config_js",
       "label": "eslint.config.js",
       "norm_label": "eslint.config.js",
       "source_file": "packages/storefront-webapp/eslint.config.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 997,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_global_d_ts",
-      "label": "global.d.ts",
-      "norm_label": "global.d.ts",
-      "source_file": "packages/storefront-webapp/global.d.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 998,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_playwright_config_ts",
-      "label": "playwright.config.ts",
-      "norm_label": "playwright.config.ts",
-      "source_file": "packages/storefront-webapp/playwright.config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 999,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_analytics_test_ts",
-      "label": "analytics.test.ts",
-      "norm_label": "analytics.test.ts",
-      "source_file": "packages/storefront-webapp/src/api/analytics.test.ts",
       "source_location": "L1"
     }
   ]

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1215
-- Graph nodes: 2847
-- Graph edges: 2402
-- Communities: 1130
+- Code files discovered: 1218
+- Graph nodes: 2853
+- Graph edges: 2405
+- Communities: 1133
 
 ## Graph Hotspots
 - `harness-inferential-review.ts` (46 edges, Community 0) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -7,10 +7,10 @@ This key-folder index highlights the main directories agents are likely to need 
 ## Core app surfaces
 
 - [`src/routes`](../../src/routes) — TanStack route entrypoints and authenticated shells. Currently 56 file(s); key children: __root.tsx, _authed, _authed.tsx, index.tsx, join-team.index.tsx.
-- [`src/components`](../../src/components) — UI components, views, and package-local feature widgets. Currently 463 file(s); key children: GenericComboBox.tsx, Navbar.tsx, OrganizationView.tsx, OrganizationsView.tsx, PermissionGate.tsx.
+- [`src/components`](../../src/components) — UI components, views, and package-local feature widgets. Currently 464 file(s); key children: GenericComboBox.tsx, Navbar.tsx, OrganizationView.tsx, OrganizationsView.tsx, PermissionGate.tsx.
 - [`src/hooks`](../../src/hooks) — React hooks that fan out auth, shell, and feature state. Currently 43 file(s); key children: use-image-upload.ts, use-mobile.tsx, use-navigate-back.ts, use-navigation-keyboard-shortcuts.ts, use-pagination-persistence.ts.
 - [`src/contexts`](../../src/contexts) — Context providers for app-wide state and wiring. Currently 5 file(s); key children: OnlineOrderContext.tsx, PermissionsContext.tsx, ProductContext.tsx, ThemeContext.tsx, UserContext.tsx.
-- [`src/lib`](../../src/lib) — Shared frontend helpers, schemas, and package utilities. Currently 33 file(s); key children: aws.ts, behaviorUtils.ts, browserFingerprint.ts, constants.ts, countries.ts.
+- [`src/lib`](../../src/lib) — Shared frontend helpers, schemas, and package utilities. Currently 35 file(s); key children: aws.ts, behaviorUtils.ts, browserFingerprint.ts, constants.ts, countries.ts.
 - [`src/utils`](../../src/utils) — Cross-cutting browser helpers and lower-level utilities. Currently 4 file(s); key children: formatNumber.ts, index.ts, session.ts, versionChecker.ts.
 
 ## Backend and test surfaces

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -36,12 +36,14 @@ This index enumerates the current automated test files and ties them back to the
 ## Section `src`
 
 - [`src/components/bulk-operations/BulkOperationsPreview.test.tsx`](../../src/components/bulk-operations/BulkOperationsPreview.test.tsx)
+- [`src/components/pos/TotalsDisplay.test.tsx`](../../src/components/pos/TotalsDisplay.test.tsx)
 - [`src/components/store-configuration/components/MtnMomoView.test.tsx`](../../src/components/store-configuration/components/MtnMomoView.test.tsx)
 - [`src/components/ui/button.test.tsx`](../../src/components/ui/button.test.tsx)
 - [`src/components/ui/calendar.test.tsx`](../../src/components/ui/calendar.test.tsx)
 - [`src/components/users/TimelineEventCard.test.tsx`](../../src/components/users/TimelineEventCard.test.tsx)
 - [`src/hooks/useBulkOperations.test.ts`](../../src/hooks/useBulkOperations.test.ts)
 - [`src/lib/imageUtils.test.ts`](../../src/lib/imageUtils.test.ts)
+- [`src/lib/pos/displayAmounts.test.ts`](../../src/lib/pos/displayAmounts.test.ts)
 - [`src/lib/productUtils.test.ts`](../../src/lib/productUtils.test.ts)
 - [`src/lib/storeConfig.test.ts`](../../src/lib/storeConfig.test.ts)
 - [`src/lib/utils.test.ts`](../../src/lib/utils.test.ts)

--- a/packages/athena-webapp/src/components/pos/CartItems.tsx
+++ b/packages/athena-webapp/src/components/pos/CartItems.tsx
@@ -14,6 +14,7 @@ import { currencyFormatter } from "~/convex/utils";
 import useGetActiveStore from "~/src/hooks/useGetActiveStore";
 import { capitalizeWords } from "~/src/lib/utils";
 import { Id } from "~/convex/_generated/dataModel";
+import { formatStoredAmount } from "~/src/lib/pos/displayAmounts";
 
 interface CartItemsProps {
   cartItems: CartItem[];
@@ -124,7 +125,7 @@ export function CartItems({
                     )}
 
                     <p className="text-sm font-medium pt-2">
-                      {formatter.format(item.price)}
+                      {formatStoredAmount(formatter, item.price)}
                     </p>
                   </div>
                 </div>
@@ -177,7 +178,10 @@ export function CartItems({
                 {/* Total Price */}
                 <div className="col-span-2 text-right">
                   <p className="font-semibold text-sm">
-                    {formatter.format(item.price * item.quantity)}
+                    {formatStoredAmount(
+                      formatter,
+                      item.price * item.quantity
+                    )}
                   </p>
                 </div>
 

--- a/packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx
+++ b/packages/athena-webapp/src/components/pos/CustomerInfoPanel.tsx
@@ -25,6 +25,7 @@ import { useState } from "react";
 import { POS_MESSAGES, showValidationError } from "../../lib/pos/toastService";
 import { currencyFormatter } from "~/convex/utils";
 import { POSCustomerSummary } from "~/types";
+import { formatStoredAmount } from "~/src/lib/pos/displayAmounts";
 
 interface CustomerInfoPanelProps {
   isOpen: boolean;
@@ -316,7 +317,10 @@ export function CustomerInfoPanel({
                                   customer.totalSpent > 0 && (
                                     <span className="flex items-center gap-1">
                                       <Package className="w-3 h-3" />
-                                      {formatter.format(customer.totalSpent)}
+                                      {formatStoredAmount(
+                                        formatter,
+                                        customer.totalSpent
+                                      )}
                                     </span>
                                   )}
                                 {customer.transactionCount &&

--- a/packages/athena-webapp/src/components/pos/OrderSummary.tsx
+++ b/packages/athena-webapp/src/components/pos/OrderSummary.tsx
@@ -27,6 +27,7 @@ import { usePOSStore } from "~/src/stores/posStore";
 import { PaymentView, type SelectedPaymentMethod } from "./PaymentView";
 import { TotalsDisplay } from "./TotalsDisplay";
 import { PaymentsAddedList } from "./PaymentsAddedList";
+import { formatStoredAmount } from "~/src/lib/pos/displayAmounts";
 
 interface OrderSummaryProps {
   cartItems: CartItem[];
@@ -219,8 +220,11 @@ export function OrderSummary({
 
         return {
           name: capitalizeWords(item.name),
-          totalPrice: formatter.format(item.price * item.quantity),
-          quantityLabel: `${item.quantity} × ${formatter.format(item.price)}`,
+          totalPrice: formatStoredAmount(
+            formatter,
+            item.price * item.quantity
+          ),
+          quantityLabel: `${item.quantity} × ${formatStoredAmount(formatter, item.price)}`,
           skuOrBarcode: item.sku || item.barcode,
           attributes:
             attributeParts.length > 0 ? attributeParts.join(" • ") : undefined,
@@ -250,7 +254,7 @@ export function OrderSummary({
         paymentsToFormat && paymentsToFormat.length > 0
           ? paymentsToFormat.map((payment: Payment) => ({
               method: payment.method,
-              amount: formatter.format(payment.amount),
+              amount: formatStoredAmount(formatter, payment.amount),
             }))
           : undefined;
 
@@ -265,7 +269,10 @@ export function OrderSummary({
         formattedPayments &&
         formattedPayments.length > 0 &&
         totalPaidFromPayments > completedData.total
-          ? formatter.format(totalPaidFromPayments - completedData.total)
+          ? formatStoredAmount(
+              formatter,
+              totalPaidFromPayments - completedData.total
+            )
           : undefined;
 
       const storeContact = activeStore.config?.contactInfo;
@@ -274,7 +281,7 @@ export function OrderSummary({
 
       const receiptHTML = await render(
         <PosReceiptEmail
-          amountPaid={formatter.format(totalPaidFromPayments)}
+          amountPaid={formatStoredAmount(formatter, totalPaidFromPayments)}
           storeName={activeStore.name || "Store Name"}
           storeContact={
             activeStore.config
@@ -312,13 +319,13 @@ export function OrderSummary({
           registerNumber={registerNumber || undefined}
           customerInfo={completedData.customerInfo}
           items={receiptItems}
-          subtotal={formatter.format(completedData.subtotal)}
+          subtotal={formatStoredAmount(formatter, completedData.subtotal)}
           tax={
             completedData.tax > 0
-              ? formatter.format(completedData.tax)
+              ? formatStoredAmount(formatter, completedData.tax)
               : undefined
           }
-          total={formatter.format(completedData.total)}
+          total={formatStoredAmount(formatter, completedData.total)}
           paymentMethodLabel={paymentMethodLabel}
           payments={formattedPayments}
           changeGiven={changeGiven}
@@ -399,7 +406,7 @@ export function OrderSummary({
                   ? [
                       {
                         label: "Change Due",
-                        value: -changeDue,
+                        value: changeDue,
                         formatter,
                         highlight: true,
                       },

--- a/packages/athena-webapp/src/components/pos/PaymentView.tsx
+++ b/packages/athena-webapp/src/components/pos/PaymentView.tsx
@@ -22,6 +22,10 @@ import {
   validatePaymentAmount,
   canCompleteTransaction,
 } from "~/src/lib/pos/validation";
+import {
+  formatStoredAmount,
+  parseDisplayAmountInput,
+} from "~/src/lib/pos/displayAmounts";
 import { cn } from "~/src/lib/utils";
 
 export type SelectedPaymentMethod = "cash" | "mobile_money" | "card";
@@ -142,7 +146,7 @@ export const PaymentView = ({
   // Update display value when currentAmount changes
   useEffect(() => {
     if (currentAmount !== undefined) {
-      setDisplayValue(formatter.format(currentAmount));
+      setDisplayValue(formatStoredAmount(formatter, currentAmount));
     } else {
       setDisplayValue("");
     }
@@ -223,37 +227,25 @@ export const PaymentView = ({
 
   const handleAmountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const rawValue = e.target.value;
-    // Remove all non-numeric characters except decimal point
-    const numericValue = rawValue.replace(/[^\d.]/g, "");
+    const parsedAmount = parseDisplayAmountInput(rawValue);
 
-    // Handle empty input
-    if (numericValue === "" || numericValue === ".") {
+    if (parsedAmount === undefined) {
       setDisplayValue("");
       setCurrentAmount(undefined);
       return;
     }
 
-    // Parse the numeric value
-    const numValue = parseFloat(numericValue);
-
-    // Validate the number
-    if (!isNaN(numValue) && numValue >= 0) {
-      // Check max constraint for non-cash payments
-      if (selectedPaymentMethod !== "cash" && numValue > remainingDue) {
-        // Don't update if exceeds max for non-cash
-        return;
-      }
-
-      setCurrentAmount(numValue);
-      // Format with commas for display
-      setDisplayValue(formatter.format(numValue));
+    if (selectedPaymentMethod !== "cash" && parsedAmount > remainingDue) {
+      return;
     }
+
+    setCurrentAmount(parsedAmount);
+    setDisplayValue(formatStoredAmount(formatter, parsedAmount));
   };
 
   const handleAmountBlur = () => {
-    // Ensure display is properly formatted on blur
     if (currentAmount !== undefined) {
-      setDisplayValue(formatter.format(currentAmount));
+      setDisplayValue(formatStoredAmount(formatter, currentAmount));
     }
   };
 
@@ -320,7 +312,9 @@ export const PaymentView = ({
                 </div>
                 {currentAmount && (
                   <span className="font-semibold">
-                    {currentAmount ? formatter.format(currentAmount) : "0.00"}
+                    {currentAmount
+                      ? formatStoredAmount(formatter, currentAmount)
+                      : "0.00"}
                   </span>
                 )}
               </div>

--- a/packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx
+++ b/packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx
@@ -5,9 +5,11 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { usePOSStore } from "~/src/stores/posStore";
 import { validatePaymentAmount } from "~/src/lib/pos/validation";
+import { formatStoredAmount, parseDisplayAmountInput } from "~/src/lib/pos/displayAmounts";
 import { Payment } from "./types";
 import { SelectedPaymentMethod } from "./PaymentView";
 import { usePOSOperations } from "~/src/hooks/usePOSOperations";
+import { toDisplayAmount } from "~/convex/lib/currency";
 
 interface PaymentsAddedListProps {
   formatter: Intl.NumberFormat;
@@ -119,12 +121,17 @@ export const PaymentsAddedList = ({
                 </span>
                 <Input
                   type="number"
-                  value={editingAmount || undefined}
+                  value={
+                    editingAmount !== undefined
+                      ? toDisplayAmount(editingAmount)
+                      : ""
+                  }
                   onChange={(e) =>
-                    setEditingAmount(Number(e.target.value) || undefined)
+                    setEditingAmount(parseDisplayAmountInput(e.target.value))
                   }
                   className="h-8 flex-1"
                   min={0}
+                  step="0.01"
                 />
                 <Button
                   size="sm"
@@ -142,7 +149,7 @@ export const PaymentsAddedList = ({
                 <div className="flex items-center gap-2 text-lg">
                   {getPaymentMethodLabel(payment.method)}
                   <span className="font-semibold">
-                    {formatter.format(payment.amount)}
+                    {formatStoredAmount(formatter, payment.amount)}
                   </span>
                 </div>
                 {!state.isTransactionCompleted && !readOnly && (

--- a/packages/athena-webapp/src/components/pos/ProductLookup.tsx
+++ b/packages/athena-webapp/src/components/pos/ProductLookup.tsx
@@ -7,6 +7,7 @@ import { Product } from "./types";
 import { usePOSProductSearch } from "@/hooks/usePOSProducts";
 import useGetActiveStore from "@/hooks/useGetActiveStore";
 import { currencyFormatter } from "~/convex/utils";
+import { formatStoredAmount } from "~/src/lib/pos/displayAmounts";
 
 interface ProductLookupProps {
   isOpen: boolean;
@@ -94,7 +95,7 @@ export function ProductLookup({
                           )}
                           <div className="flex items-center gap-2">
                             <p className="text-sm font-semibold">
-                              {formatter.format(product.price)}
+                              {formatStoredAmount(formatter, product.price)}
                             </p>
                             {product.quantityAvailable && (
                               <span className="text-xs text-muted-foreground">

--- a/packages/athena-webapp/src/components/pos/TotalsDisplay.test.tsx
+++ b/packages/athena-webapp/src/components/pos/TotalsDisplay.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { TotalsDisplay } from "./TotalsDisplay";
+
+const formatter = new Intl.NumberFormat("en-GH", {
+  style: "currency",
+  currency: "GHS",
+});
+
+describe("TotalsDisplay", () => {
+  it("formats stored pesewas values before rendering", () => {
+    render(
+      <TotalsDisplay
+        items={[{ label: "Total", value: 15000, formatter, highlight: true }]}
+      />
+    );
+
+    expect(screen.getByText("Total")).toBeInTheDocument();
+    expect(screen.getByText(formatter.format(150))).toBeInTheDocument();
+    expect(screen.queryByText(formatter.format(15000))).not.toBeInTheDocument();
+  });
+});

--- a/packages/athena-webapp/src/components/pos/TotalsDisplay.tsx
+++ b/packages/athena-webapp/src/components/pos/TotalsDisplay.tsx
@@ -1,3 +1,5 @@
+import { formatStoredAmount } from "~/src/lib/pos/displayAmounts";
+
 interface TotalsDisplayItem {
   label: string;
   value: number;
@@ -31,7 +33,7 @@ export const TotalsDisplay = ({ items }: TotalsDisplayProps) => {
                 : "text-3xl font-semibold"
             }
           >
-            {item.formatter.format(item.value)}
+            {formatStoredAmount(item.formatter, item.value)}
           </span>
         </div>
       ))}

--- a/packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx
+++ b/packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx
@@ -12,6 +12,7 @@ import { currencyFormatter } from "~/convex/utils";
 import { expenseReportColumns, ExpenseReportRow } from "./expenseReportColumns";
 import { SimplePageHeader } from "../../common/PageHeader";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { formatStoredAmount } from "~/src/lib/pos/displayAmounts";
 
 // Helper to check if timestamp is today
 const isToday = (timestamp: number) => {
@@ -40,7 +41,7 @@ export function ExpenseReportsView() {
     return expenseTransactions.map((transaction: any) => ({
       _id: transaction._id,
       transactionNumber: transaction.transactionNumber,
-      formattedTotal: formatter.format(transaction.totalValue),
+      formattedTotal: formatStoredAmount(formatter, transaction.totalValue),
       cashierName: transaction.cashierName,
       itemCount: transaction.itemCount,
       completedAt: transaction.completedAt,

--- a/packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx
+++ b/packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx
@@ -6,6 +6,7 @@ import { Users, ShoppingCart, PlayCircle, Ban, Clock } from "lucide-react";
 import { Id } from "../../../../convex/_generated/dataModel";
 import { useGetCurrencyFormatter } from "~/src/hooks/useGetCurrencyFormatter";
 import { usePOSStore } from "~/src/stores/posStore";
+import { formatStoredAmount } from "~/src/lib/pos/displayAmounts";
 
 interface HeldSession {
   _id: Id<"posSession">;
@@ -97,7 +98,9 @@ export function HeldSessionsList({
                     <ShoppingCart className="h-3 w-3" />
                     {getSessionCartItemsCount(session)}
                   </span>
-                  {session.total && <b>{formatter.format(session.total)}</b>}
+                  {session.total && (
+                    <b>{formatStoredAmount(formatter, session.total)}</b>
+                  )}
                   {/* <span>
                     Held at {formatTime(session.heldAt || session.updatedAt)}
                   </span> */}

--- a/packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx
@@ -27,6 +27,7 @@ import type { Id } from "~/convex/_generated/dataModel";
 import { Card, CardContent, CardHeader, CardTitle } from "../../ui/card";
 import { EmptyState } from "../../states/empty/empty-state";
 import { currencyFormatter } from "~/convex/utils";
+import { formatStoredAmount } from "~/src/lib/pos/displayAmounts";
 
 type RouteParams =
   | {
@@ -170,7 +171,10 @@ export function TransactionView() {
                         transaction.changeGiven > 0 && (
                           <p className="text-xs text-muted-foreground">
                             Change given:{" "}
-                            {formatter.format(transaction.changeGiven)}
+                            {formatStoredAmount(
+                              formatter,
+                              transaction.changeGiven
+                            )}
                           </p>
                         )}
                     </div>

--- a/packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx
@@ -15,6 +15,7 @@ import {
 } from "./transactionColumns";
 import { SimplePageHeader } from "../../common/PageHeader";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { formatStoredAmount } from "~/src/lib/pos/displayAmounts";
 
 function formatPaymentMethod(method: string | null) {
   if (!method) return "Unknown";
@@ -48,7 +49,7 @@ export function TransactionsView() {
     return transactions.map((transaction: any) => ({
       _id: transaction._id,
       transactionNumber: transaction.transactionNumber,
-      formattedTotal: formatter.format(transaction.total),
+      formattedTotal: formatStoredAmount(formatter, transaction.total),
       paymentMethodLabel: formatPaymentMethod(transaction.paymentMethod),
       paymentMethod: transaction.paymentMethod || "cash",
       cashierName: transaction.cashierName,

--- a/packages/athena-webapp/src/lib/pos/displayAmounts.test.ts
+++ b/packages/athena-webapp/src/lib/pos/displayAmounts.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { formatStoredAmount, parseDisplayAmountInput } from "./displayAmounts";
+import { validatePaymentAmount, validatePayments } from "./validation";
+
+const formatter = new Intl.NumberFormat("en-GH", {
+  style: "currency",
+  currency: "GHS",
+});
+
+describe("POS display amounts", () => {
+  it("formats stored pesewas values in display units", () => {
+    expect(formatStoredAmount(formatter, 15000)).toBe(formatter.format(150));
+    expect(formatStoredAmount(formatter, 15000)).not.toBe(
+      formatter.format(15000)
+    );
+  });
+
+  it("parses display input back to stored pesewas", () => {
+    expect(parseDisplayAmountInput("GH₵150.50")).toBe(15050);
+    expect(parseDisplayAmountInput("0.75")).toBe(75);
+    expect(parseDisplayAmountInput("")).toBeUndefined();
+  });
+
+  it("renders payment validation errors in display units", () => {
+    const validation = validatePaymentAmount(15000, 10000, formatter, "card");
+
+    expect(validation.isValid).toBe(false);
+    expect(validation.errors[0]).toContain(formatter.format(150));
+    expect(validation.errors[0]).toContain(formatter.format(100));
+    expect(validation.errors[0]).not.toContain(formatter.format(15000));
+  });
+
+  it("renders total-paid validation errors in display units", () => {
+    const validation = validatePayments([{ amount: 15000 }], 20000, formatter);
+
+    expect(validation.isValid).toBe(false);
+    expect(validation.errors[0]).toContain(formatter.format(200));
+    expect(validation.errors[0]).toContain(formatter.format(150));
+    expect(validation.errors[0]).not.toContain(formatter.format(20000));
+  });
+});

--- a/packages/athena-webapp/src/lib/pos/displayAmounts.ts
+++ b/packages/athena-webapp/src/lib/pos/displayAmounts.ts
@@ -1,0 +1,26 @@
+import { toDisplayAmount, toPesewas } from "~/convex/lib/currency";
+
+export function formatStoredAmount(
+  formatter: Intl.NumberFormat,
+  amount: number
+): string {
+  return formatter.format(toDisplayAmount(amount));
+}
+
+export function parseDisplayAmountInput(
+  rawValue: string
+): number | undefined {
+  const numericValue = rawValue.replace(/[^\d.]/g, "");
+
+  if (numericValue === "" || numericValue === ".") {
+    return undefined;
+  }
+
+  const displayAmount = Number.parseFloat(numericValue);
+
+  if (!Number.isFinite(displayAmount) || displayAmount < 0) {
+    return undefined;
+  }
+
+  return toPesewas(displayAmount);
+}

--- a/packages/athena-webapp/src/lib/pos/validation.ts
+++ b/packages/athena-webapp/src/lib/pos/validation.ts
@@ -9,6 +9,7 @@ import { CartItem } from "@/components/pos/types";
 import { Product, CustomerInfo } from "@/components/pos/types";
 import { POSSession } from "../../../types";
 import { logger } from "../logger";
+import { formatStoredAmount } from "./displayAmounts";
 
 export interface ValidationResult {
   isValid: boolean;
@@ -330,7 +331,7 @@ export function validatePaymentAmount(
   // For card and mobile_money, amount cannot exceed remaining due
   if (amount > remainingDue && paymentMethod !== "cash") {
     errors.push(
-      `Payment amount (${formatter.format(amount)}) cannot exceed remaining due (${formatter.format(remainingDue)})`
+      `Payment amount (${formatStoredAmount(formatter, amount)}) cannot exceed remaining due (${formatStoredAmount(formatter, remainingDue)})`
     );
   }
 
@@ -371,7 +372,7 @@ export function validatePayments(
 
   if (totalPaid < totalDue) {
     errors.push(
-      `Insufficient payment. Total due: ${formatter.format(totalDue)}, Total paid: ${formatter.format(totalPaid)}`
+      `Insufficient payment. Total due: ${formatStoredAmount(formatter, totalDue)}, Total paid: ${formatStoredAmount(formatter, totalPaid)}`
     );
   }
 


### PR DESCRIPTION
## Summary
- add a POS stored-amount display helper plus regression tests for pesewa-to-display conversion
- route POS totals, product/cart/transaction/customer amount displays through the stored-amount formatter
- keep payment entry/editing in sync by parsing display-unit input back to stored pesewas and regenerate harness/graph docs

## Why
- POS surfaces were formatting stored pesewa values directly, so cashiers saw raw minor-unit amounts instead of user-facing currency values
- payment validation errors and summary views needed the same display-boundary fix to keep the workflow coherent

## Validation
- `bun run --filter '@athena/webapp' test`
- `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`
- `bun run --filter '@athena/webapp' lint:architecture`
- `bun run harness:review`
- `bun run graphify:rebuild`
- `bun run pr:athena`
- `bun run harness:behavior --scenario athena-admin-shell-boot --record-video`

https://linear.app/v26-labs/issue/V26-263/format-pos-amount-displays-from-pesewas-before-rendering
