### PR TITLE
[V26-267]: Build Athena admin shell patterns in Storybook

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1227 files · ~0 words
+- 1230 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 2882 nodes · 2427 edges · 1142 communities detected
+- 2887 nodes · 2429 edges · 1145 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1152,6 +1152,9 @@
 - [[_COMMUNITY_Community 1139|Community 1139]]
 - [[_COMMUNITY_Community 1140|Community 1140]]
 - [[_COMMUNITY_Community 1141|Community 1141]]
+- [[_COMMUNITY_Community 1142|Community 1142]]
+- [[_COMMUNITY_Community 1143|Community 1143]]
+- [[_COMMUNITY_Community 1144|Community 1144]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -1412,12 +1415,12 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 58 - "Community 58"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
-
-### Community 59 - "Community 59"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
+
+### Community 59 - "Community 59"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
 
 ### Community 60 - "Community 60"
 Cohesion: 0.52
@@ -1476,16 +1479,16 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 74 - "Community 74"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 75 - "Community 75"
-Cohesion: 0.4
-Nodes (2): useBulkOperations(), validateOperationValue()
-
-### Community 76 - "Community 76"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 76 - "Community 76"
+Cohesion: 0.4
+Nodes (2): useBulkOperations(), validateOperationValue()
 
 ### Community 77 - "Community 77"
 Cohesion: 0.33
@@ -1500,32 +1503,32 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 80 - "Community 80"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 81 - "Community 81"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 82 - "Community 82"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 83 - "Community 83"
-Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
-
-### Community 84 - "Community 84"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 84 - "Community 84"
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
 ### Community 85 - "Community 85"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 86 - "Community 86"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 87 - "Community 87"
 Cohesion: 0.53
@@ -1589,19 +1592,19 @@ Nodes (0):
 
 ### Community 102 - "Community 102"
 Cohesion: 0.4
-Nodes (1): Header()
+Nodes (0):
 
 ### Community 103 - "Community 103"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 104 - "Community 104"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 105 - "Community 105"
 Cohesion: 0.5
 Nodes (2): handleFileSelect(), validateFile()
+
+### Community 105 - "Community 105"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 106 - "Community 106"
 Cohesion: 0.4
@@ -1613,7 +1616,7 @@ Nodes (0):
 
 ### Community 108 - "Community 108"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): Header()
 
 ### Community 109 - "Community 109"
 Cohesion: 0.4
@@ -1704,20 +1707,20 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 131 - "Community 131"
+Cohesion: 0.67
+Nodes (2): toDisplayAmount(), toPesewas()
+
+### Community 132 - "Community 132"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 132 - "Community 132"
+### Community 133 - "Community 133"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 133 - "Community 133"
+### Community 134 - "Community 134"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 134 - "Community 134"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 135 - "Community 135"
 Cohesion: 0.5
@@ -1736,12 +1739,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 139 - "Community 139"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
-
-### Community 140 - "Community 140"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 140 - "Community 140"
+Cohesion: 0.67
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 141 - "Community 141"
 Cohesion: 0.5
@@ -1768,32 +1771,32 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 147 - "Community 147"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
-
-### Community 148 - "Community 148"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 148 - "Community 148"
+Cohesion: 0.67
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 149 - "Community 149"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 150 - "Community 150"
-Cohesion: 0.83
-Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 151 - "Community 151"
 Cohesion: 0.83
-Nodes (3): getAllStores(), getBaseUrl(), getStore()
+Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 152 - "Community 152"
 Cohesion: 0.83
-Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
 ### Community 153 - "Community 153"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
 
 ### Community 154 - "Community 154"
 Cohesion: 0.5
@@ -1816,8 +1819,8 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 159 - "Community 159"
-Cohesion: 0.67
-Nodes (2): toDisplayAmount(), toPesewas()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 160 - "Community 160"
 Cohesion: 0.67
@@ -2116,48 +2119,48 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 234 - "Community 234"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 235 - "Community 235"
 Cohesion: 1.0
 Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
-### Community 235 - "Community 235"
+### Community 236 - "Community 236"
 Cohesion: 0.67
 Nodes (1): hashPassword()
 
-### Community 236 - "Community 236"
+### Community 237 - "Community 237"
 Cohesion: 0.67
 Nodes (1): useAppSession()
 
-### Community 237 - "Community 237"
+### Community 238 - "Community 238"
 Cohesion: 0.67
 Nodes (1): createVersionChecker()
 
-### Community 238 - "Community 238"
+### Community 239 - "Community 239"
 Cohesion: 0.67
 Nodes (1): manualChunks()
 
-### Community 239 - "Community 239"
+### Community 240 - "Community 240"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 240 - "Community 240"
+### Community 241 - "Community 241"
 Cohesion: 1.0
 Nodes (2): getAllColors(), getBaseUrl()
 
-### Community 241 - "Community 241"
+### Community 242 - "Community 242"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 242 - "Community 242"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 243 - "Community 243"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 244 - "Community 244"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 245 - "Community 245"
 Cohesion: 0.67
@@ -2168,12 +2171,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 247 - "Community 247"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 248 - "Community 248"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 248 - "Community 248"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 249 - "Community 249"
 Cohesion: 0.67
@@ -2184,12 +2187,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 251 - "Community 251"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 252 - "Community 252"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 252 - "Community 252"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 253 - "Community 253"
 Cohesion: 0.67
@@ -2268,16 +2271,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 272 - "Community 272"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
-
-### Community 273 - "Community 273"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 274 - "Community 274"
+### Community 273 - "Community 273"
 Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
+
+### Community 274 - "Community 274"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 275 - "Community 275"
 Cohesion: 1.0
@@ -2292,11 +2295,11 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 278 - "Community 278"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 279 - "Community 279"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0):
 
 ### Community 280 - "Community 280"
@@ -5747,1732 +5750,1748 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1142 - "Community 1142"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1143 - "Community 1143"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1144 - "Community 1144"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
-- **Thin community `Community 279`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 280`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 280`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 281`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 281`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 282`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 282`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 283`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 283`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 284`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 284`** (2 nodes): `authenticateHandler()`, `cashier.ts`
+- **Thin community `Community 285`** (2 nodes): `authenticateHandler()`, `cashier.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 285`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 286`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 286`** (2 nodes): `sessionQueryIndexes.test.ts`, `readProjectFile()`
+- **Thin community `Community 287`** (2 nodes): `sessionQueryIndexes.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 287`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 288`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 288`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 289`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 289`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 290`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 290`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 291`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 291`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 292`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 292`** (2 nodes): `VerificationCodeEmail.tsx`, `VerificationCodeEmail()`
+- **Thin community `Community 293`** (2 nodes): `VerificationCodeEmail.tsx`, `VerificationCodeEmail()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 293`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 294`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 294`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 295`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 295`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 296`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 296`** (2 nodes): `listOrderItems()`, `onlineOrder.ts`
+- **Thin community `Community 297`** (2 nodes): `listOrderItems()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 297`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 298`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 298`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 299`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 299`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 300`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 300`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 301`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 301`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 302`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 302`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 303`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 303`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 304`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 304`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 305`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 305`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 306`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 306`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 307`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 307`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 308`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 308`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 309`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 309`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 310`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 310`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 311`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 311`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 312`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 312`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 313`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 313`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 314`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 314`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 315`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 315`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 316`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 316`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
+- **Thin community `Community 317`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 317`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 318`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 318`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 319`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 319`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 320`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 320`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 321`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 321`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 322`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 322`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 323`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 323`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 324`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 324`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 325`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 325`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 326`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 326`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 327`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 327`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 328`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 328`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 329`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 329`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 330`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 330`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 331`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 331`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 332`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 332`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 333`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 333`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 334`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 334`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 335`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 335`** (2 nodes): `Login()`, `index.tsx`
+- **Thin community `Community 336`** (2 nodes): `Login()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 336`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 337`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 337`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 338`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 338`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 339`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 339`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 340`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 340`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 341`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 341`** (2 nodes): `PageHeader.tsx`, `PageHeader()`
+- **Thin community `Community 342`** (2 nodes): `PageHeader.tsx`, `PageHeader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 342`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 343`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 343`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 344`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 344`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 345`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 345`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 346`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 346`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 347`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 347`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 348`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 348`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 349`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 349`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 350`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 350`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 351`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 351`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 352`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 352`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 353`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 353`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 354`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 354`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 355`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 355`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 356`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 356`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 357`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 357`** (2 nodes): `handleSignOut()`, `CashierView.tsx`
+- **Thin community `Community 358`** (2 nodes): `handleSignOut()`, `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 358`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 359`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 359`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 360`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 360`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 361`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 361`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
+- **Thin community `Community 362`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 362`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 363`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 363`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
+- **Thin community `Community 364`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 364`** (2 nodes): `ProductEntry.tsx`, `handleClearSearch()`
+- **Thin community `Community 365`** (2 nodes): `ProductEntry.tsx`, `handleClearSearch()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 365`** (2 nodes): `QuickActionsBar.tsx`, `QuickActionsBar()`
+- **Thin community `Community 366`** (2 nodes): `QuickActionsBar.tsx`, `QuickActionsBar()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 366`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 367`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 367`** (2 nodes): `TotalsDisplay.tsx`, `TotalsDisplay()`
+- **Thin community `Community 368`** (2 nodes): `TotalsDisplay.tsx`, `TotalsDisplay()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 368`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
+- **Thin community `Community 369`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 369`** (2 nodes): `usePOSCashier()`, `hooks.ts`
+- **Thin community `Community 370`** (2 nodes): `usePOSCashier()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 370`** (2 nodes): `HoldSessionDialog()`, `HoldSessionDialog.tsx`
+- **Thin community `Community 371`** (2 nodes): `HoldSessionDialog()`, `HoldSessionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 371`** (2 nodes): `VoidSessionDialog.tsx`, `VoidSessionDialog()`
+- **Thin community `Community 372`** (2 nodes): `VoidSessionDialog.tsx`, `VoidSessionDialog()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 372`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 373`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 373`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 374`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 374`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 375`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 375`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 376`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 376`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 377`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 377`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
+- **Thin community `Community 378`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 378`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 379`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 379`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 380`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 380`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 381`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 381`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 382`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 382`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 383`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 383`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 384`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 384`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 385`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 385`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 386`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 386`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 387`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 387`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 388`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 388`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 389`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 389`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 390`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 390`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 391`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 391`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 392`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 392`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 393`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 393`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 394`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 394`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 395`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 395`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 396`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 396`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 397`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 397`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 398`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 398`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 399`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 399`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 400`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 400`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 401`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 401`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 402`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 402`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 403`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 403`** (2 nodes): `DateTimePicker()`, `date-time-picker.tsx`
+- **Thin community `Community 404`** (2 nodes): `DateTimePicker()`, `date-time-picker.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 404`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 405`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 405`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 406`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 406`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 407`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 407`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 408`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 408`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 409`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 409`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 410`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 410`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 411`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 411`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 412`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 412`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 413`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 413`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 414`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 414`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 415`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 415`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 416`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 416`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 417`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 417`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 418`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 418`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 419`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 419`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 420`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 420`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 421`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 421`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 422`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 422`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 423`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 423`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 424`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 424`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 425`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 425`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 426`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 426`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 427`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 427`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 428`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 428`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 429`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 429`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 430`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 430`** (2 nodes): `useCartOperations.ts`, `useCartOperations()`
+- **Thin community `Community 431`** (2 nodes): `useCartOperations.ts`, `useCartOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 431`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 432`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 432`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 433`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 433`** (2 nodes): `useCustomerOperations.ts`, `useCustomerOperations()`
+- **Thin community `Community 434`** (2 nodes): `useCustomerOperations.ts`, `useCustomerOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 434`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 435`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 435`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
+- **Thin community `Community 436`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 436`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 437`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 437`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 438`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 438`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 439`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 439`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 440`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 440`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 441`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 441`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 442`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 442`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 443`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 443`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 444`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 444`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 445`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 445`** (2 nodes): `usePrint.ts`, `usePrint()`
+- **Thin community `Community 446`** (2 nodes): `usePrint.ts`, `usePrint()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 446`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 447`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 447`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 448`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 448`** (2 nodes): `useSessionManagement.ts`, `useSessionManagement()`
+- **Thin community `Community 449`** (2 nodes): `useSessionManagement.ts`, `useSessionManagement()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 449`** (2 nodes): `useSessionManagementExpense.ts`, `useSessionManagementExpense()`
+- **Thin community `Community 450`** (2 nodes): `useSessionManagementExpense.ts`, `useSessionManagementExpense()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 450`** (2 nodes): `useSessionManagerOperations.ts`, `useSessionManagerOperations()`
+- **Thin community `Community 451`** (2 nodes): `useSessionManagerOperations.ts`, `useSessionManagerOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 451`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 452`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 452`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 453`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 453`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 454`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 454`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 455`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 455`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 456`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 456`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 457`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 457`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 458`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 458`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 459`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 459`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 460`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 460`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 461`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 461`** (2 nodes): `LoginLayout()`, `_layout.tsx`
+- **Thin community `Community 462`** (2 nodes): `LoginLayout()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 462`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 463`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 463`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 464`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 464`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 465`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 465`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 466`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 466`** (2 nodes): `storybook-theme-decorator.tsx`, `withAthenaTheme()`
+- **Thin community `Community 467`** (2 nodes): `storybook-theme-decorator.tsx`, `withAthenaTheme()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 467`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 468`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 468`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 469`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 469`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 470`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 470`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 471`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 471`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 472`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 472`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 473`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 473`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 474`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 474`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 475`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 475`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 476`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 476`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 477`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 477`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 478`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 478`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
+- **Thin community `Community 479`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 479`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 480`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 480`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 481`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 481`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 482`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 482`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 483`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 483`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 484`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 484`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 485`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 485`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 486`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 486`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 487`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 487`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 488`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 488`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 489`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 489`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 490`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 490`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 491`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 491`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 492`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 492`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 493`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 493`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 494`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 494`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 495`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 495`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 496`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 496`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 497`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 497`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 498`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 498`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 499`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 499`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 500`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 500`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 501`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 501`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 502`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 502`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 503`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 503`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 504`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 504`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 505`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 505`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 506`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 506`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 507`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 507`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 508`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 508`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 509`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 509`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 510`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 510`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 511`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 511`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 512`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 512`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 513`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 513`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 514`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 514`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 515`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 515`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 516`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 516`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 517`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 517`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 518`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 518`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 519`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 519`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 520`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 520`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 521`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 521`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 522`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 522`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 523`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 523`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 524`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 524`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 525`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 525`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 526`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 526`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 527`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 527`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 528`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 528`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 529`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 529`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 530`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 530`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 531`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 531`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 532`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 532`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 533`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 533`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 534`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 534`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 535`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 535`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 536`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 536`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 537`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 537`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 538`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 538`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 539`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 539`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 540`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 540`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 541`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 541`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 542`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 542`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 543`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 543`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 544`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 544`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 545`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 545`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 546`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 546`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 547`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 547`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 548`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 548`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 549`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 550`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 551`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 552`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 553`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 554`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 555`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 556`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 557`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 558`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 559`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 560`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 561`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 562`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 563`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 564`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 565`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 566`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 567`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 568`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 569`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 570`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 571`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 572`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 573`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 574`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 575`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 576`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 577`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 578`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 579`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 580`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 581`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 582`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 583`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 584`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 585`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (1 nodes): `api.d.ts`
+- **Thin community `Community 586`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (1 nodes): `api.js`
+- **Thin community `Community 587`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 588`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (1 nodes): `server.d.ts`
+- **Thin community `Community 589`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (1 nodes): `server.js`
+- **Thin community `Community 590`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (1 nodes): `app.ts`
+- **Thin community `Community 591`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (1 nodes): `auth.config.js`
+- **Thin community `Community 592`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (1 nodes): `auth.ts`
+- **Thin community `Community 593`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (1 nodes): `countries.ts`
+- **Thin community `Community 594`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (1 nodes): `email.ts`
+- **Thin community `Community 595`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (1 nodes): `ghana.ts`
+- **Thin community `Community 596`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (1 nodes): `payment.ts`
+- **Thin community `Community 597`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (1 nodes): `crons.ts`
+- **Thin community `Community 598`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 599`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 600`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 601`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 602`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (1 nodes): `env.ts`
+- **Thin community `Community 603`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (1 nodes): `analytics.ts`
+- **Thin community `Community 604`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (1 nodes): `auth.ts`
+- **Thin community `Community 605`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 606`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (1 nodes): `categories.ts`
+- **Thin community `Community 607`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (1 nodes): `colors.ts`
+- **Thin community `Community 608`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (1 nodes): `index.ts`
+- **Thin community `Community 609`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (1 nodes): `organizations.ts`
+- **Thin community `Community 610`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (1 nodes): `products.ts`
+- **Thin community `Community 611`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (1 nodes): `stores.ts`
+- **Thin community `Community 612`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 613`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (1 nodes): `index.ts`
+- **Thin community `Community 614`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (1 nodes): `bag.ts`
+- **Thin community `Community 615`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (1 nodes): `guest.ts`
+- **Thin community `Community 616`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (1 nodes): `index.ts`
+- **Thin community `Community 617`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (1 nodes): `me.ts`
+- **Thin community `Community 618`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (1 nodes): `offers.ts`
+- **Thin community `Community 619`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 620`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (1 nodes): `paystack.ts`
+- **Thin community `Community 621`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (1 nodes): `reviews.ts`
+- **Thin community `Community 622`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (1 nodes): `rewards.ts`
+- **Thin community `Community 623`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 624`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (1 nodes): `security.test.ts`
+- **Thin community `Community 625`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (1 nodes): `storefront.ts`
+- **Thin community `Community 626`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (1 nodes): `upsells.ts`
+- **Thin community `Community 627`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (1 nodes): `user.ts`
+- **Thin community `Community 628`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 629`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (1 nodes): `health.test.ts`
+- **Thin community `Community 630`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (1 nodes): `http.ts`
+- **Thin community `Community 631`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 632`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (1 nodes): `auth.ts`
+- **Thin community `Community 633`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 634`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 635`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (1 nodes): `categories.ts`
+- **Thin community `Community 636`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (1 nodes): `colors.ts`
+- **Thin community `Community 637`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 638`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (1 nodes): `expenseSessionItems.ts`
+- **Thin community `Community 639`** (1 nodes): `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (1 nodes): `expenseTransactions.ts`
+- **Thin community `Community 640`** (1 nodes): `expenseTransactions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 641`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 642`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 643`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (1 nodes): `organizations.ts`
+- **Thin community `Community 644`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 645`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (1 nodes): `posSessionItems.ts`
+- **Thin community `Community 646`** (1 nodes): `posSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 647`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (1 nodes): `productSku.ts`
+- **Thin community `Community 648`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (1 nodes): `productUtil.ts`
+- **Thin community `Community 649`** (1 nodes): `productUtil.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 650`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 651`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 652`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 653`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 654`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 655`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 656`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 657`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (1 nodes): `client.test.ts`
+- **Thin community `Community 658`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (1 nodes): `config.test.ts`
+- **Thin community `Community 659`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 660`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (1 nodes): `types.ts`
+- **Thin community `Community 661`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (1 nodes): `ResendOTP.ts`
+- **Thin community `Community 662`** (1 nodes): `ResendOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (1 nodes): `schema.ts`
+- **Thin community `Community 663`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 664`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 665`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 666`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 667`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (1 nodes): `cashier.ts`
+- **Thin community `Community 668`** (1 nodes): `cashier.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (1 nodes): `category.ts`
+- **Thin community `Community 669`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (1 nodes): `color.ts`
+- **Thin community `Community 670`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 671`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 672`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (1 nodes): `index.ts`
+- **Thin community `Community 673`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 674`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (1 nodes): `organization.ts`
+- **Thin community `Community 675`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 676`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (1 nodes): `product.ts`
+- **Thin community `Community 677`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 678`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 679`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (1 nodes): `store.ts`
+- **Thin community `Community 680`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 681`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 682`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (1 nodes): `customer.ts`
+- **Thin community `Community 683`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 684`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 685`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 686`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 687`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (1 nodes): `index.ts`
+- **Thin community `Community 688`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (1 nodes): `posSession.ts`
+- **Thin community `Community 689`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 690`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 691`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 692`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 693`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (1 nodes): `analytics.ts`
+- **Thin community `Community 694`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (1 nodes): `bag.ts`
+- **Thin community `Community 695`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 696`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 697`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 698`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (1 nodes): `customer.ts`
+- **Thin community `Community 699`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (1 nodes): `guest.ts`
+- **Thin community `Community 700`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (1 nodes): `index.ts`
+- **Thin community `Community 701`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (1 nodes): `offer.ts`
+- **Thin community `Community 702`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 703`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 704`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (1 nodes): `review.ts`
+- **Thin community `Community 705`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (1 nodes): `rewards.ts`
+- **Thin community `Community 706`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 707`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 708`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 709`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 710`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 711`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 712`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (1 nodes): `bag.ts`
+- **Thin community `Community 713`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 714`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (1 nodes): `customer.ts`
+- **Thin community `Community 715`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (1 nodes): `guest.ts`
+- **Thin community `Community 716`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 717`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (1 nodes): `payment.ts`
+- **Thin community `Community 718`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 719`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (1 nodes): `rewards.ts`
+- **Thin community `Community 720`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 721`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 722`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (1 nodes): `users.ts`
+- **Thin community `Community 723`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (1 nodes): `payment.ts`
+- **Thin community `Community 724`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 725`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (1 nodes): `index.ts`
+- **Thin community `Community 726`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 727`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 728`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 729`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 730`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 731`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 732`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 733`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (1 nodes): `constants.ts`
+- **Thin community `Community 734`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 735`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 736`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 737`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (1 nodes): `types.ts`
+- **Thin community `Community 738`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 739`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 740`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 741`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 742`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 743`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 744`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 745`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 746`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (1 nodes): `columns.tsx`
+- **Thin community `Community 747`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 748`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 749`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 750`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 751`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (1 nodes): `columns.tsx`
+- **Thin community `Community 752`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 753`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 754`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (1 nodes): `chart.tsx`
+- **Thin community `Community 755`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (1 nodes): `columns.tsx`
+- **Thin community `Community 756`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 757`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 758`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (1 nodes): `columns.tsx`
+- **Thin community `Community 759`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (1 nodes): `constants.ts`
+- **Thin community `Community 760`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 761`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 762`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 763`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (1 nodes): `data.ts`
+- **Thin community `Community 764`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (1 nodes): `columns.tsx`
+- **Thin community `Community 765`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 766`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 767`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (1 nodes): `columns.tsx`
+- **Thin community `Community 768`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 769`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 770`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 771`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 772`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 773`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (1 nodes): `app-sidebar.tsx`
+- **Thin community `Community 774`** (1 nodes): `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 775`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (1 nodes): `constants.ts`
+- **Thin community `Community 776`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 777`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 778`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 779`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (1 nodes): `data.ts`
+- **Thin community `Community 780`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 781`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 782`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (1 nodes): `columns.tsx`
+- **Thin community `Community 783`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 784`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 785`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 786`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 787`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 788`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (1 nodes): `columns.tsx`
+- **Thin community `Community 789`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (1 nodes): `constants.ts`
+- **Thin community `Community 790`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 791`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 792`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 793`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 794`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (1 nodes): `index.tsx`
+- **Thin community `Community 795`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (1 nodes): `columns.tsx`
+- **Thin community `Community 796`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 797`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 798`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 799`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (1 nodes): `ExpenseCompletion.tsx`
+- **Thin community `Community 800`** (1 nodes): `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 801`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 802`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 803`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (1 nodes): `constants.ts`
+- **Thin community `Community 804`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 805`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 806`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 807`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (1 nodes): `data.ts`
+- **Thin community `Community 808`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (1 nodes): `constants.ts`
+- **Thin community `Community 809`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 810`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 811`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 812`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 813`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (1 nodes): `data.ts`
+- **Thin community `Community 814`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 815`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (1 nodes): `constants.ts`
+- **Thin community `Community 816`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 817`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 818`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 819`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 820`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (1 nodes): `data.ts`
+- **Thin community `Community 821`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 822`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (1 nodes): `CartItems.tsx`
+- **Thin community `Community 823`** (1 nodes): `CartItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (1 nodes): `CashierAuthDialog.tsx`
+- **Thin community `Community 824`** (1 nodes): `CashierAuthDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 825`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 826`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (1 nodes): `SearchResultsSection.tsx`
+- **Thin community `Community 827`** (1 nodes): `SearchResultsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 828`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (1 nodes): `ExpenseReportView.tsx`
+- **Thin community `Community 829`** (1 nodes): `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 830`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (1 nodes): `TransactionView.tsx`
+- **Thin community `Community 831`** (1 nodes): `TransactionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (1 nodes): `types.ts`
+- **Thin community `Community 832`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 833`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 834`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 835`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (1 nodes): `ProductDetailView.tsx`
+- **Thin community `Community 836`** (1 nodes): `ProductDetailView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (1 nodes): `ProductStatus.tsx`
+- **Thin community `Community 837`** (1 nodes): `ProductStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (1 nodes): `CategoryListView.tsx`
+- **Thin community `Community 838`** (1 nodes): `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 839`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (1 nodes): `Products.tsx`
+- **Thin community `Community 840`** (1 nodes): `Products.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 841`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 842`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 843`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 844`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 845`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 846`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 847`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 848`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 849`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (1 nodes): `data.ts`
+- **Thin community `Community 850`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 851`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (1 nodes): `PromoCodePreview.tsx`
+- **Thin community `Community 852`** (1 nodes): `PromoCodePreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 853`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 854`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 855`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (1 nodes): `columns.tsx`
+- **Thin community `Community 856`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 857`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 858`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 859`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 860`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 861`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (1 nodes): `columns.tsx`
+- **Thin community `Community 862`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (1 nodes): `constants.ts`
+- **Thin community `Community 863`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 864`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 865`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 866`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (1 nodes): `data.ts`
+- **Thin community `Community 867`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (1 nodes): `types.ts`
+- **Thin community `Community 868`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 869`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 870`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 871`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 872`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 873`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (1 nodes): `index.tsx`
+- **Thin community `Community 874`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 875`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 876`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (1 nodes): `button.tsx`
+- **Thin community `Community 877`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 878`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (1 nodes): `calendar.tsx`
+- **Thin community `Community 879`** (1 nodes): `calendar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (1 nodes): `card.tsx`
+- **Thin community `Community 880`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 881`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 882`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (1 nodes): `command.tsx`
+- **Thin community `Community 883`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 884`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 885`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 886`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (1 nodes): `form.tsx`
+- **Thin community `Community 887`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (1 nodes): `icons.tsx`
+- **Thin community `Community 888`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 889`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (1 nodes): `input.tsx`
+- **Thin community `Community 890`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 891`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (1 nodes): `popover.tsx`
+- **Thin community `Community 892`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 893`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 894`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (1 nodes): `select.tsx`
+- **Thin community `Community 895`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (1 nodes): `separator.tsx`
+- **Thin community `Community 896`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 897`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (1 nodes): `switch.tsx`
+- **Thin community `Community 898`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (1 nodes): `table.tsx`
+- **Thin community `Community 899`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 900`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 901`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 902`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 903`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 904`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 905`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 906`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (1 nodes): `columns.tsx`
+- **Thin community `Community 907`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (1 nodes): `constants.ts`
+- **Thin community `Community 908`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 909`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 910`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 911`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (1 nodes): `data.ts`
+- **Thin community `Community 912`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 913`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 914`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (1 nodes): `columns.tsx`
+- **Thin community `Community 915`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 916`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 917`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 918`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 919`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 920`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 921`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 922`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 923`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 924`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (1 nodes): `UserBehaviorInsights.tsx`
+- **Thin community `Community 925`** (1 nodes): `UserBehaviorInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (1 nodes): `index.ts`
+- **Thin community `Community 926`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (1 nodes): `config.ts`
+- **Thin community `Community 927`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 928`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 929`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 930`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (1 nodes): `aws.ts`
+- **Thin community `Community 931`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (1 nodes): `constants.ts`
+- **Thin community `Community 932`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (1 nodes): `countries.ts`
+- **Thin community `Community 933`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (1 nodes): `ghana.ts`
+- **Thin community `Community 934`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 935`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `constants.ts`
+- **Thin community `Community 936`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 937`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 938`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `category.ts`
+- **Thin community `Community 939`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `product.ts`
+- **Thin community `Community 940`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `store.ts`
+- **Thin community `Community 941`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 942`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `user.ts`
+- **Thin community `Community 943`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 944`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 945`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 946`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `__root.tsx`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `index.tsx`
+- **Thin community `Community 947`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 948`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 949`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 950`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 951`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 952`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 953`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 954`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `index.tsx`
+- **Thin community `Community 955`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 956`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 957`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 958`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `home.tsx`
+- **Thin community `Community 959`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 960`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 961`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 962`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `index.tsx`
+- **Thin community `Community 963`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 964`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 965`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 966`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `index.tsx`
+- **Thin community `Community 967`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 968`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 969`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 970`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 971`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 972`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 973`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `expense.index.tsx`
+- **Thin community `Community 974`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `index.tsx`
+- **Thin community `Community 975`** (1 nodes): `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 976`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 977`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 978`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 979`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `edit.tsx`
+- **Thin community `Community 980`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `index.tsx`
+- **Thin community `Community 981`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 982`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `new.tsx`
+- **Thin community `Community 983`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `index.tsx`
+- **Thin community `Community 984`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `new.tsx`
+- **Thin community `Community 985`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 986`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 987`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `index.tsx`
+- **Thin community `Community 988`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (1 nodes): `new.tsx`
+- **Thin community `Community 989`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (1 nodes): `index.tsx`
+- **Thin community `Community 990`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 991`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 992`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `index.tsx`
+- **Thin community `Community 993`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 994`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 995`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 996`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 997`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `posStore.ts`
+- **Thin community `Community 998`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 999`** (1 nodes): `posStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1000`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1001`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `setup.ts`
+- **Thin community `Community 1002`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `usePrint.test.ts`
+- **Thin community `Community 1003`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1004`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `types.ts`
+- **Thin community `Community 1005`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1006`** (1 nodes): `usePrint.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1007`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1008`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1009`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1010`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1011`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `types.ts`
+- **Thin community `Community 1012`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1013`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `client.tsx`
+- **Thin community `Community 1014`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1015`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1016`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1017`** (1 nodes): `client.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1018`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1019`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1020`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1021`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1022`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `schema.ts`
+- **Thin community `Community 1023`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1024`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1025`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1026`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1027`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1028`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1029`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1030`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1031`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1032`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `types.ts`
+- **Thin community `Community 1033`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1034`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1035`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1036`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1037`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1038`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1039`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1040`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `constants.ts`
+- **Thin community `Community 1041`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1042`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `About.tsx`
+- **Thin community `Community 1043`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1044`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1045`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1046`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1047`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1048`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1049`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1050`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1051`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1052`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `types.ts`
+- **Thin community `Community 1053`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1054`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1055`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1056`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1057`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1058`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1059`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1060`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1061`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1062`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1063`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `button.tsx`
+- **Thin community `Community 1064`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `card.tsx`
+- **Thin community `Community 1065`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1066`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `command.tsx`
+- **Thin community `Community 1067`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1068`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1069`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1070`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `form.tsx`
+- **Thin community `Community 1071`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1072`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1073`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1074`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1075`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `input.tsx`
+- **Thin community `Community 1076`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `label.tsx`
+- **Thin community `Community 1077`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1078`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1079`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1080`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `index.ts`
+- **Thin community `Community 1081`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `types.ts`
+- **Thin community `Community 1082`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1083`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1084`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1085`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1086`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `select.tsx`
+- **Thin community `Community 1087`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1088`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1089`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `table.tsx`
+- **Thin community `Community 1090`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1091`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1092`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1093`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1094`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1095`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `config.ts`
+- **Thin community `Community 1096`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1097`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1098`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1099`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `constants.ts`
+- **Thin community `Community 1100`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `countries.ts`
+- **Thin community `Community 1101`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1102`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1103`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1104`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1105`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `index.ts`
+- **Thin community `Community 1106`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `store.ts`
+- **Thin community `Community 1107`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `bag.ts`
+- **Thin community `Community 1108`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1109`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `category.ts`
+- **Thin community `Community 1110`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `organization.ts`
+- **Thin community `Community 1111`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `product.ts`
+- **Thin community `Community 1112`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `store.ts`
+- **Thin community `Community 1113`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1114`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `user.ts`
+- **Thin community `Community 1115`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `states.ts`
+- **Thin community `Community 1116`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1117`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1118`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1119`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1120`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1121`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1122`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1123`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `index.tsx`
+- **Thin community `Community 1124`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1125`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `index.tsx`
+- **Thin community `Community 1126`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1127`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1128`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1129`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1130`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1131`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `index.tsx`
+- **Thin community `Community 1132`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1133`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `ssr.tsx`
+- **Thin community `Community 1134`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1135`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1136`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1137`** (1 nodes): `ssr.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `index.js`
+- **Thin community `Community 1138`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1139`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1140`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1141`** (1 nodes): `index.js`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1142`** (1 nodes): `harness-app-registry.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1143`** (1 nodes): `valkey-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1144`** (1 nodes): `harness-behavior-scenarios.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -16324,6 +16324,30 @@
       "weight": 1
     },
     {
+      "_src": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_tsx",
+      "_tgt": "admin_shell_patterns_patterncard",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_tsx",
+      "source_file": "packages/athena-webapp/src/stories/Patterns/admin-shell-patterns.tsx",
+      "source_location": "L127",
+      "target": "admin_shell_patterns_patterncard",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_tsx",
+      "_tgt": "admin_shell_patterns_patternshell",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_tsx",
+      "source_file": "packages/athena-webapp/src/stories/Patterns/admin-shell-patterns.tsx",
+      "source_location": "L106",
+      "target": "admin_shell_patterns_patternshell",
+      "weight": 1
+    },
+    {
       "_src": "packages_athena_webapp_src_stories_patterns_overview_stories_tsx",
       "_tgt": "overview_stories_patternsoverview",
       "confidence": "EXTRACTED",
@@ -30195,6 +30219,15 @@
     {
       "community": 1000,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_foundations_overview_stories_tsx",
+      "label": "Overview.stories.tsx",
+      "norm_label": "overview.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/Overview.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1001,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_foundations_content_test_tsx",
       "label": "foundations-content.test.tsx",
       "norm_label": "foundations-content.test.tsx",
@@ -30202,7 +30235,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1001,
+      "community": 1002,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_stories_tsx",
       "label": "Introduction.stories.tsx",
@@ -30211,7 +30244,25 @@
       "source_location": "L1"
     },
     {
-      "community": 1002,
+      "community": 1003,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_patterns_adminshell_stories_tsx",
+      "label": "AdminShell.stories.tsx",
+      "norm_label": "adminshell.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Patterns/AdminShell.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1004,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_test_tsx",
+      "label": "admin-shell-patterns.test.tsx",
+      "norm_label": "admin-shell-patterns.test.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Patterns/admin-shell-patterns.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1005,
       "file_type": "code",
       "id": "packages_athena_webapp_src_test_setup_ts",
       "label": "setup.ts",
@@ -30220,7 +30271,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1003,
+      "community": 1006,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_useprint_test_ts",
       "label": "usePrint.test.ts",
@@ -30229,7 +30280,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1004,
+      "community": 1007,
       "file_type": "code",
       "id": "packages_athena_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
@@ -30238,7 +30289,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1005,
+      "community": 1008,
       "file_type": "code",
       "id": "packages_athena_webapp_types_ts",
       "label": "types.ts",
@@ -30247,39 +30298,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1006,
+      "community": 1009,
       "file_type": "code",
       "id": "packages_athena_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
       "norm_label": "vitest.config.ts",
       "source_file": "packages/athena-webapp/vitest.config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1007,
-      "file_type": "code",
-      "id": "packages_athena_webapp_vitest_setup_ts",
-      "label": "vitest.setup.ts",
-      "norm_label": "vitest.setup.ts",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1008,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_eslint_config_js",
-      "label": "eslint.config.js",
-      "norm_label": "eslint.config.js",
-      "source_file": "packages/storefront-webapp/eslint.config.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 1009,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_global_d_ts",
-      "label": "global.d.ts",
-      "norm_label": "global.d.ts",
-      "source_file": "packages/storefront-webapp/global.d.ts",
       "source_location": "L1"
     },
     {
@@ -30330,6 +30354,33 @@
     {
       "community": 1010,
       "file_type": "code",
+      "id": "packages_athena_webapp_vitest_setup_ts",
+      "label": "vitest.setup.ts",
+      "norm_label": "vitest.setup.ts",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1011,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_eslint_config_js",
+      "label": "eslint.config.js",
+      "norm_label": "eslint.config.js",
+      "source_file": "packages/storefront-webapp/eslint.config.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 1012,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_global_d_ts",
+      "label": "global.d.ts",
+      "norm_label": "global.d.ts",
+      "source_file": "packages/storefront-webapp/global.d.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1013,
+      "file_type": "code",
       "id": "packages_storefront_webapp_playwright_config_ts",
       "label": "playwright.config.ts",
       "norm_label": "playwright.config.ts",
@@ -30337,7 +30388,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1011,
+      "community": 1014,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_test_ts",
       "label": "analytics.test.ts",
@@ -30346,7 +30397,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1012,
+      "community": 1015,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_types_ts",
       "label": "types.ts",
@@ -30355,7 +30406,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1013,
+      "community": 1016,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_assets_icons_hearticonfilled_tsx",
       "label": "HeartIconFilled.tsx",
@@ -30364,7 +30415,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1014,
+      "community": 1017,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_client_tsx",
       "label": "client.tsx",
@@ -30373,7 +30424,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1015,
+      "community": 1018,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
@@ -30382,7 +30433,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1016,
+      "community": 1019,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_test_tsx",
       "label": "HomePage.test.tsx",
@@ -30391,169 +30442,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1017,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_productcard_test_tsx",
-      "label": "ProductCard.test.tsx",
-      "norm_label": "productcard.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ProductCard.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1018,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_productcard_tsx",
-      "label": "ProductCard.tsx",
-      "norm_label": "productcard.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ProductCard.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1019,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_upsell_tsx",
-      "label": "Upsell.tsx",
-      "norm_label": "upsell.tsx",
-      "source_file": "packages/storefront-webapp/src/components/Upsell.tsx",
-      "source_location": "L1"
-    },
-    {
       "community": 102,
-      "file_type": "code",
-      "id": "index_feesview",
-      "label": "FeesView()",
-      "norm_label": "feesview()",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
-      "source_location": "L29"
-    },
-    {
-      "community": 102,
-      "file_type": "code",
-      "id": "index_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L42"
-    },
-    {
-      "community": 102,
-      "file_type": "code",
-      "id": "index_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 102,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 102,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1020,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_checkout_test_tsx",
-      "label": "Checkout.test.tsx",
-      "norm_label": "checkout.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/Checkout.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1021,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_checkout_tsx",
-      "label": "Checkout.tsx",
-      "norm_label": "checkout.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/Checkout.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1022,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_customerinfosection_tsx",
-      "label": "CustomerInfoSection.tsx",
-      "norm_label": "customerinfosection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/CustomerInfoSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1023,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_schema_ts",
-      "label": "schema.ts",
-      "norm_label": "schema.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/schema.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1024,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_deliverydetailssection_tsx",
-      "label": "DeliveryDetailsSection.tsx",
-      "norm_label": "deliverydetailssection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetailsSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1025,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_test_ts",
-      "label": "checkoutStorage.test.ts",
-      "norm_label": "checkoutstorage.test.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1026,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_test_ts",
-      "label": "deliveryFees.test.ts",
-      "norm_label": "deliveryfees.test.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1027,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_test_ts",
-      "label": "deriveCheckoutState.test.ts",
-      "norm_label": "derivecheckoutstate.test.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1028,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_billingdetailsschema_ts",
-      "label": "billingDetailsSchema.ts",
-      "norm_label": "billingdetailsschema.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/billingDetailsSchema.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1029,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutformschema_ts",
-      "label": "checkoutFormSchema.ts",
-      "norm_label": "checkoutformschema.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutFormSchema.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 103,
       "file_type": "code",
       "id": "dashboard_getperiodrange",
       "label": "getPeriodRange()",
@@ -30562,7 +30451,7 @@
       "source_location": "L20"
     },
     {
-      "community": 103,
+      "community": 102,
       "file_type": "code",
       "id": "dashboard_loadingsection",
       "label": "LoadingSection()",
@@ -30571,7 +30460,7 @@
       "source_location": "L50"
     },
     {
-      "community": 103,
+      "community": 102,
       "file_type": "code",
       "id": "dashboard_renderproductssection",
       "label": "renderProductsSection()",
@@ -30580,7 +30469,7 @@
       "source_location": "L342"
     },
     {
-      "community": 103,
+      "community": 102,
       "file_type": "code",
       "id": "dashboard_rendersalessection",
       "label": "renderSalesSection()",
@@ -30589,7 +30478,7 @@
       "source_location": "L322"
     },
     {
-      "community": 103,
+      "community": 102,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
       "label": "Dashboard.tsx",
@@ -30598,97 +30487,97 @@
       "source_location": "L1"
     },
     {
-      "community": 1030,
+      "community": 1020,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_customerdetailsschema_ts",
-      "label": "customerDetailsSchema.ts",
-      "norm_label": "customerdetailsschema.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/customerDetailsSchema.ts",
+      "id": "packages_storefront_webapp_src_components_productcard_test_tsx",
+      "label": "ProductCard.test.tsx",
+      "norm_label": "productcard.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ProductCard.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1031,
+      "community": 1021,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_deliverydetailsschema_ts",
-      "label": "deliveryDetailsSchema.ts",
-      "norm_label": "deliverydetailsschema.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/deliveryDetailsSchema.ts",
+      "id": "packages_storefront_webapp_src_components_productcard_tsx",
+      "label": "ProductCard.tsx",
+      "norm_label": "productcard.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ProductCard.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1032,
+      "community": 1022,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_ts",
-      "label": "webOrderSchema.ts",
-      "norm_label": "weborderschema.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.ts",
+      "id": "packages_storefront_webapp_src_components_upsell_tsx",
+      "label": "Upsell.tsx",
+      "norm_label": "upsell.tsx",
+      "source_file": "packages/storefront-webapp/src/components/Upsell.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1033,
+      "community": 1023,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/types.ts",
+      "id": "packages_storefront_webapp_src_components_checkout_checkout_test_tsx",
+      "label": "Checkout.test.tsx",
+      "norm_label": "checkout.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/Checkout.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1034,
+      "community": 1024,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_utils_test_ts",
-      "label": "utils.test.ts",
-      "norm_label": "utils.test.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.test.ts",
+      "id": "packages_storefront_webapp_src_components_checkout_checkout_tsx",
+      "label": "Checkout.tsx",
+      "norm_label": "checkout.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/Checkout.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1035,
+      "community": 1025,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_filter_productfilterbar_tsx",
-      "label": "ProductFilterBar.tsx",
-      "norm_label": "productfilterbar.tsx",
-      "source_file": "packages/storefront-webapp/src/components/filter/ProductFilterBar.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_customerinfosection_tsx",
+      "label": "CustomerInfoSection.tsx",
+      "norm_label": "customerinfosection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/CustomerInfoSection.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1036,
+      "community": 1026,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_bestsellerssection_test_tsx",
-      "label": "BestSellersSection.test.tsx",
-      "norm_label": "bestsellerssection.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.test.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_schema_ts",
+      "label": "schema.ts",
+      "norm_label": "schema.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/schema.ts",
       "source_location": "L1"
     },
     {
-      "community": 1037,
+      "community": 1027,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_homehero_tsx",
-      "label": "HomeHero.tsx",
-      "norm_label": "homehero.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/HomeHero.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_deliverydetailssection_tsx",
+      "label": "DeliveryDetailsSection.tsx",
+      "norm_label": "deliverydetailssection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetailsSection.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1038,
+      "community": 1028,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_homeherosection_tsx",
-      "label": "HomeHeroSection.tsx",
-      "norm_label": "homeherosection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/HomeHeroSection.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_test_ts",
+      "label": "checkoutStorage.test.ts",
+      "norm_label": "checkoutstorage.test.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1039,
+      "community": 1029,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_homepagecontent_test_ts",
-      "label": "homePageContent.test.ts",
-      "norm_label": "homepagecontent.test.ts",
-      "source_file": "packages/storefront-webapp/src/components/home/homePageContent.test.ts",
+      "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_test_ts",
+      "label": "deliveryFees.test.ts",
+      "norm_label": "deliveryfees.test.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 104,
+      "community": 103,
       "file_type": "code",
       "id": "herosectiontabs_handledisplaytypechange",
       "label": "handleDisplayTypeChange()",
@@ -30697,7 +30586,7 @@
       "source_location": "L61"
     },
     {
-      "community": 104,
+      "community": 103,
       "file_type": "code",
       "id": "herosectiontabs_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -30706,7 +30595,7 @@
       "source_location": "L57"
     },
     {
-      "community": 104,
+      "community": 103,
       "file_type": "code",
       "id": "herosectiontabs_handleoverlaytoggle",
       "label": "handleOverlayToggle()",
@@ -30715,7 +30604,7 @@
       "source_location": "L98"
     },
     {
-      "community": 104,
+      "community": 103,
       "file_type": "code",
       "id": "herosectiontabs_handletexttoggle",
       "label": "handleTextToggle()",
@@ -30724,7 +30613,7 @@
       "source_location": "L134"
     },
     {
-      "community": 104,
+      "community": 103,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
       "label": "HeroSectionTabs.tsx",
@@ -30733,97 +30622,97 @@
       "source_location": "L1"
     },
     {
-      "community": 1040,
+      "community": 1030,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_mobilemenu_tsx",
-      "label": "MobileMenu.tsx",
-      "norm_label": "mobilemenu.tsx",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileMenu.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_test_ts",
+      "label": "deriveCheckoutState.test.ts",
+      "norm_label": "derivecheckoutstate.test.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1041,
+      "community": 1031,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/constants.ts",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_billingdetailsschema_ts",
+      "label": "billingDetailsSchema.ts",
+      "norm_label": "billingdetailsschema.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/billingDetailsSchema.ts",
       "source_location": "L1"
     },
     {
-      "community": 1042,
+      "community": 1032,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_navbarconstants_ts",
-      "label": "navBarConstants.ts",
-      "norm_label": "navbarconstants.ts",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarConstants.ts",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutformschema_ts",
+      "label": "checkoutFormSchema.ts",
+      "norm_label": "checkoutformschema.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutFormSchema.ts",
       "source_location": "L1"
     },
     {
-      "community": 1043,
+      "community": 1033,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_about_tsx",
-      "label": "About.tsx",
-      "norm_label": "about.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/About.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_customerdetailsschema_ts",
+      "label": "customerDetailsSchema.ts",
+      "norm_label": "customerdetailsschema.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/customerDetailsSchema.ts",
       "source_location": "L1"
     },
     {
-      "community": 1044,
+      "community": 1034,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_aboutproduct_tsx",
-      "label": "AboutProduct.tsx",
-      "norm_label": "aboutproduct.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/AboutProduct.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_deliverydetailsschema_ts",
+      "label": "deliveryDetailsSchema.ts",
+      "norm_label": "deliverydetailsschema.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/deliveryDetailsSchema.ts",
       "source_location": "L1"
     },
     {
-      "community": 1045,
+      "community": 1035,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productactions_test_tsx",
-      "label": "ProductActions.test.tsx",
-      "norm_label": "productactions.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.test.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_ts",
+      "label": "webOrderSchema.ts",
+      "norm_label": "weborderschema.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.ts",
       "source_location": "L1"
     },
     {
-      "community": 1046,
+      "community": 1036,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productinfo_tsx",
-      "label": "ProductInfo.tsx",
-      "norm_label": "productinfo.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductInfo.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/types.ts",
       "source_location": "L1"
     },
     {
-      "community": 1047,
+      "community": 1037,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productreviews_tsx",
-      "label": "ProductReviews.tsx",
-      "norm_label": "productreviews.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductReviews.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_utils_test_ts",
+      "label": "utils.test.ts",
+      "norm_label": "utils.test.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1048,
+      "community": 1038,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productsnavigationbar_tsx",
-      "label": "ProductsNavigationBar.tsx",
-      "norm_label": "productsnavigationbar.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductsNavigationBar.tsx",
+      "id": "packages_storefront_webapp_src_components_filter_productfilterbar_tsx",
+      "label": "ProductFilterBar.tsx",
+      "norm_label": "productfilterbar.tsx",
+      "source_file": "packages/storefront-webapp/src/components/filter/ProductFilterBar.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1049,
+      "community": 1039,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_errormessage_tsx",
-      "label": "ErrorMessage.tsx",
-      "norm_label": "errormessage.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/ErrorMessage.tsx",
+      "id": "packages_storefront_webapp_src_components_home_bestsellerssection_test_tsx",
+      "label": "BestSellersSection.test.tsx",
+      "norm_label": "bestsellerssection.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 105,
+      "community": 104,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
       "label": "ReelUploader.tsx",
@@ -30832,7 +30721,7 @@
       "source_location": "L1"
     },
     {
-      "community": 105,
+      "community": 104,
       "file_type": "code",
       "id": "reeluploader_formatfilesize",
       "label": "formatFileSize()",
@@ -30841,7 +30730,7 @@
       "source_location": "L38"
     },
     {
-      "community": 105,
+      "community": 104,
       "file_type": "code",
       "id": "reeluploader_handlefileselect",
       "label": "handleFileSelect()",
@@ -30850,7 +30739,7 @@
       "source_location": "L64"
     },
     {
-      "community": 105,
+      "community": 104,
       "file_type": "code",
       "id": "reeluploader_handleupload",
       "label": "handleUpload()",
@@ -30859,7 +30748,7 @@
       "source_location": "L135"
     },
     {
-      "community": 105,
+      "community": 104,
       "file_type": "code",
       "id": "reeluploader_validatefile",
       "label": "validateFile()",
@@ -30868,97 +30757,97 @@
       "source_location": "L43"
     },
     {
-      "community": 1050,
+      "community": 1040,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_existingreviewmessage_tsx",
-      "label": "ExistingReviewMessage.tsx",
-      "norm_label": "existingreviewmessage.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/ExistingReviewMessage.tsx",
+      "id": "packages_storefront_webapp_src_components_home_homehero_tsx",
+      "label": "HomeHero.tsx",
+      "norm_label": "homehero.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/HomeHero.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1051,
+      "community": 1041,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_reviewform_tsx",
-      "label": "ReviewForm.tsx",
-      "norm_label": "reviewform.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewForm.tsx",
+      "id": "packages_storefront_webapp_src_components_home_homeherosection_tsx",
+      "label": "HomeHeroSection.tsx",
+      "norm_label": "homeherosection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/HomeHeroSection.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1052,
+      "community": 1042,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_successmessage_tsx",
-      "label": "SuccessMessage.tsx",
-      "norm_label": "successmessage.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/SuccessMessage.tsx",
+      "id": "packages_storefront_webapp_src_components_home_homepagecontent_test_ts",
+      "label": "homePageContent.test.ts",
+      "norm_label": "homepagecontent.test.ts",
+      "source_file": "packages/storefront-webapp/src/components/home/homePageContent.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1053,
+      "community": 1043,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/types.ts",
+      "id": "packages_storefront_webapp_src_components_navigation_bar_mobilemenu_tsx",
+      "label": "MobileMenu.tsx",
+      "norm_label": "mobilemenu.tsx",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileMenu.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1054,
+      "community": 1044,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_saved_items_savedbag_tsx",
-      "label": "SavedBag.tsx",
-      "norm_label": "savedbag.tsx",
-      "source_file": "packages/storefront-webapp/src/components/saved-items/SavedBag.tsx",
+      "id": "packages_storefront_webapp_src_components_navigation_bar_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/constants.ts",
       "source_location": "L1"
     },
     {
-      "community": 1055,
+      "community": 1045,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_saved_items_savedicon_tsx",
-      "label": "SavedIcon.tsx",
-      "norm_label": "savedicon.tsx",
-      "source_file": "packages/storefront-webapp/src/components/saved-items/SavedIcon.tsx",
+      "id": "packages_storefront_webapp_src_components_navigation_bar_navbarconstants_ts",
+      "label": "navBarConstants.ts",
+      "norm_label": "navbarconstants.ts",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarConstants.ts",
       "source_location": "L1"
     },
     {
-      "community": 1056,
+      "community": 1046,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_shopping_bag_carticon_tsx",
-      "label": "CartIcon.tsx",
-      "norm_label": "carticon.tsx",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/CartIcon.tsx",
+      "id": "packages_storefront_webapp_src_components_product_page_about_tsx",
+      "label": "About.tsx",
+      "norm_label": "about.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/About.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1057,
+      "community": 1047,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_test_tsx",
-      "label": "ShoppingBag.test.tsx",
-      "norm_label": "shoppingbag.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.test.tsx",
+      "id": "packages_storefront_webapp_src_components_product_page_aboutproduct_tsx",
+      "label": "AboutProduct.tsx",
+      "norm_label": "aboutproduct.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/AboutProduct.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1058,
+      "community": 1048,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_empty_empty_state_tsx",
-      "label": "empty-state.tsx",
-      "norm_label": "empty-state.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/empty/empty-state.tsx",
+      "id": "packages_storefront_webapp_src_components_product_page_productactions_test_tsx",
+      "label": "ProductActions.test.tsx",
+      "norm_label": "productactions.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1059,
+      "community": 1049,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_tsx",
-      "label": "Maintenance.tsx",
-      "norm_label": "maintenance.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/maintenance/Maintenance.tsx",
+      "id": "packages_storefront_webapp_src_components_product_page_productinfo_tsx",
+      "label": "ProductInfo.tsx",
+      "norm_label": "productinfo.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductInfo.tsx",
       "source_location": "L1"
     },
     {
-      "community": 106,
+      "community": 105,
       "file_type": "code",
       "id": "activityview_iscreatedaction",
       "label": "isCreatedAction()",
@@ -30967,7 +30856,7 @@
       "source_location": "L58"
     },
     {
-      "community": 106,
+      "community": 105,
       "file_type": "code",
       "id": "activityview_isfeedbackrequestaction",
       "label": "isFeedbackRequestAction()",
@@ -30976,7 +30865,7 @@
       "source_location": "L63"
     },
     {
-      "community": 106,
+      "community": 105,
       "file_type": "code",
       "id": "activityview_isrefundaction",
       "label": "isRefundAction()",
@@ -30985,7 +30874,7 @@
       "source_location": "L50"
     },
     {
-      "community": 106,
+      "community": 105,
       "file_type": "code",
       "id": "activityview_istransitionaction",
       "label": "isTransitionAction()",
@@ -30994,7 +30883,7 @@
       "source_location": "L53"
     },
     {
-      "community": 106,
+      "community": 105,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
       "label": "ActivityView.tsx",
@@ -31003,97 +30892,97 @@
       "source_location": "L1"
     },
     {
-      "community": 1060,
+      "community": 1050,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_animatedcard_tsx",
-      "label": "AnimatedCard.tsx",
-      "norm_label": "animatedcard.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/AnimatedCard.tsx",
+      "id": "packages_storefront_webapp_src_components_product_page_productreviews_tsx",
+      "label": "ProductReviews.tsx",
+      "norm_label": "productreviews.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductReviews.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1061,
+      "community": 1051,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_accordion_tsx",
-      "label": "accordion.tsx",
-      "norm_label": "accordion.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/accordion.tsx",
+      "id": "packages_storefront_webapp_src_components_product_page_productsnavigationbar_tsx",
+      "label": "ProductsNavigationBar.tsx",
+      "norm_label": "productsnavigationbar.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductsNavigationBar.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1062,
+      "community": 1052,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_alert_tsx",
-      "label": "alert.tsx",
-      "norm_label": "alert.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/alert.tsx",
+      "id": "packages_storefront_webapp_src_components_product_reviews_errormessage_tsx",
+      "label": "ErrorMessage.tsx",
+      "norm_label": "errormessage.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/ErrorMessage.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1063,
+      "community": 1053,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_breadcrumb_tsx",
-      "label": "breadcrumb.tsx",
-      "norm_label": "breadcrumb.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/breadcrumb.tsx",
+      "id": "packages_storefront_webapp_src_components_product_reviews_existingreviewmessage_tsx",
+      "label": "ExistingReviewMessage.tsx",
+      "norm_label": "existingreviewmessage.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/ExistingReviewMessage.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1064,
+      "community": 1054,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_button_tsx",
-      "label": "button.tsx",
-      "norm_label": "button.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/button.tsx",
+      "id": "packages_storefront_webapp_src_components_product_reviews_reviewform_tsx",
+      "label": "ReviewForm.tsx",
+      "norm_label": "reviewform.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewForm.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1065,
+      "community": 1055,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_card_tsx",
-      "label": "card.tsx",
-      "norm_label": "card.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/card.tsx",
+      "id": "packages_storefront_webapp_src_components_product_reviews_successmessage_tsx",
+      "label": "SuccessMessage.tsx",
+      "norm_label": "successmessage.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/SuccessMessage.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1066,
+      "community": 1056,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_checkbox_tsx",
-      "label": "checkbox.tsx",
-      "norm_label": "checkbox.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/checkbox.tsx",
+      "id": "packages_storefront_webapp_src_components_product_reviews_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/types.ts",
       "source_location": "L1"
     },
     {
-      "community": 1067,
+      "community": 1057,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_command_tsx",
-      "label": "command.tsx",
-      "norm_label": "command.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/command.tsx",
+      "id": "packages_storefront_webapp_src_components_saved_items_savedbag_tsx",
+      "label": "SavedBag.tsx",
+      "norm_label": "savedbag.tsx",
+      "source_file": "packages/storefront-webapp/src/components/saved-items/SavedBag.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1068,
+      "community": 1058,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_context_menu_tsx",
-      "label": "context-menu.tsx",
-      "norm_label": "context-menu.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/context-menu.tsx",
+      "id": "packages_storefront_webapp_src_components_saved_items_savedicon_tsx",
+      "label": "SavedIcon.tsx",
+      "norm_label": "savedicon.tsx",
+      "source_file": "packages/storefront-webapp/src/components/saved-items/SavedIcon.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1069,
+      "community": 1059,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_dialog_tsx",
-      "label": "dialog.tsx",
-      "norm_label": "dialog.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/dialog.tsx",
+      "id": "packages_storefront_webapp_src_components_shopping_bag_carticon_tsx",
+      "label": "CartIcon.tsx",
+      "norm_label": "carticon.tsx",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/CartIcon.tsx",
       "source_location": "L1"
     },
     {
-      "community": 107,
+      "community": 106,
       "file_type": "code",
       "id": "orderdetailsview_fetchtransactions",
       "label": "fetchTransactions()",
@@ -31102,7 +30991,7 @@
       "source_location": "L138"
     },
     {
-      "community": 107,
+      "community": 106,
       "file_type": "code",
       "id": "orderdetailsview_handlemarkasverified",
       "label": "handleMarkAsVerified()",
@@ -31111,7 +31000,7 @@
       "source_location": "L175"
     },
     {
-      "community": 107,
+      "community": 106,
       "file_type": "code",
       "id": "orderdetailsview_handlemarkpaymentcollected",
       "label": "handleMarkPaymentCollected()",
@@ -31120,7 +31009,7 @@
       "source_location": "L189"
     },
     {
-      "community": 107,
+      "community": 106,
       "file_type": "code",
       "id": "orderdetailsview_verifiedbadge",
       "label": "VerifiedBadge()",
@@ -31129,7 +31018,7 @@
       "source_location": "L43"
     },
     {
-      "community": 107,
+      "community": 106,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
       "label": "OrderDetailsView.tsx",
@@ -31138,97 +31027,97 @@
       "source_location": "L1"
     },
     {
-      "community": 1070,
+      "community": 1060,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_dropdown_menu_tsx",
-      "label": "dropdown-menu.tsx",
-      "norm_label": "dropdown-menu.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/dropdown-menu.tsx",
+      "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_test_tsx",
+      "label": "ShoppingBag.test.tsx",
+      "norm_label": "shoppingbag.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1071,
+      "community": 1061,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_form_tsx",
-      "label": "form.tsx",
-      "norm_label": "form.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/form.tsx",
+      "id": "packages_storefront_webapp_src_components_states_empty_empty_state_tsx",
+      "label": "empty-state.tsx",
+      "norm_label": "empty-state.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/empty/empty-state.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1072,
+      "community": 1062,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_icons_tsx",
-      "label": "icons.tsx",
-      "norm_label": "icons.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/icons.tsx",
+      "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_tsx",
+      "label": "Maintenance.tsx",
+      "norm_label": "maintenance.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/maintenance/Maintenance.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1073,
+      "community": 1063,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_with_fallback_tsx",
-      "label": "image-with-fallback.tsx",
-      "norm_label": "image-with-fallback.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-with-fallback.tsx",
+      "id": "packages_storefront_webapp_src_components_ui_animatedcard_tsx",
+      "label": "AnimatedCard.tsx",
+      "norm_label": "animatedcard.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/AnimatedCard.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1074,
+      "community": 1064,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_input_otp_tsx",
-      "label": "input-otp.tsx",
-      "norm_label": "input-otp.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/input-otp.tsx",
+      "id": "packages_storefront_webapp_src_components_ui_accordion_tsx",
+      "label": "accordion.tsx",
+      "norm_label": "accordion.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/accordion.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1075,
+      "community": 1065,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_input_with_end_button_tsx",
-      "label": "input-with-end-button.tsx",
-      "norm_label": "input-with-end-button.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/input-with-end-button.tsx",
+      "id": "packages_storefront_webapp_src_components_ui_alert_tsx",
+      "label": "alert.tsx",
+      "norm_label": "alert.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/alert.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1076,
+      "community": 1066,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_input_tsx",
-      "label": "input.tsx",
-      "norm_label": "input.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/input.tsx",
+      "id": "packages_storefront_webapp_src_components_ui_breadcrumb_tsx",
+      "label": "breadcrumb.tsx",
+      "norm_label": "breadcrumb.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/breadcrumb.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1077,
+      "community": 1067,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_label_tsx",
-      "label": "label.tsx",
-      "norm_label": "label.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/label.tsx",
+      "id": "packages_storefront_webapp_src_components_ui_button_tsx",
+      "label": "button.tsx",
+      "norm_label": "button.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/button.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1078,
+      "community": 1068,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodalform_tsx",
-      "label": "LeaveAReviewModalForm.tsx",
-      "norm_label": "leaveareviewmodalform.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModalForm.tsx",
+      "id": "packages_storefront_webapp_src_components_ui_card_tsx",
+      "label": "card.tsx",
+      "norm_label": "card.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/card.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1079,
+      "community": 1069,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_action_modal_tsx",
-      "label": "action-modal.tsx",
-      "norm_label": "action-modal.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/action-modal.tsx",
+      "id": "packages_storefront_webapp_src_components_ui_checkbox_tsx",
+      "label": "checkbox.tsx",
+      "norm_label": "checkbox.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/checkbox.tsx",
       "source_location": "L1"
     },
     {
-      "community": 108,
+      "community": 107,
       "file_type": "code",
       "id": "orderitemsview_handlerequestfeedback",
       "label": "handleRequestFeedback()",
@@ -31237,7 +31126,7 @@
       "source_location": "L77"
     },
     {
-      "community": 108,
+      "community": 107,
       "file_type": "code",
       "id": "orderitemsview_handlerestockall",
       "label": "handleRestockAll()",
@@ -31246,7 +31135,7 @@
       "source_location": "L295"
     },
     {
-      "community": 108,
+      "community": 107,
       "file_type": "code",
       "id": "orderitemsview_handlereturnitemtostock",
       "label": "handleReturnItemToStock()",
@@ -31255,7 +31144,7 @@
       "source_location": "L61"
     },
     {
-      "community": 108,
+      "community": 107,
       "file_type": "code",
       "id": "orderitemsview_handleupdateorderitem",
       "label": "handleUpdateOrderItem()",
@@ -31264,7 +31153,7 @@
       "source_location": "L47"
     },
     {
-      "community": 108,
+      "community": 107,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
       "label": "OrderItemsView.tsx",
@@ -31273,7 +31162,169 @@
       "source_location": "L1"
     },
     {
+      "community": 1070,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_command_tsx",
+      "label": "command.tsx",
+      "norm_label": "command.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/command.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1071,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_context_menu_tsx",
+      "label": "context-menu.tsx",
+      "norm_label": "context-menu.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/context-menu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1072,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_dialog_tsx",
+      "label": "dialog.tsx",
+      "norm_label": "dialog.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/dialog.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1073,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_dropdown_menu_tsx",
+      "label": "dropdown-menu.tsx",
+      "norm_label": "dropdown-menu.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/dropdown-menu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1074,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_form_tsx",
+      "label": "form.tsx",
+      "norm_label": "form.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/form.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1075,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_icons_tsx",
+      "label": "icons.tsx",
+      "norm_label": "icons.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/icons.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1076,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_image_with_fallback_tsx",
+      "label": "image-with-fallback.tsx",
+      "norm_label": "image-with-fallback.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-with-fallback.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1077,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_input_otp_tsx",
+      "label": "input-otp.tsx",
+      "norm_label": "input-otp.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/input-otp.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1078,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_input_with_end_button_tsx",
+      "label": "input-with-end-button.tsx",
+      "norm_label": "input-with-end-button.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/input-with-end-button.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1079,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_input_tsx",
+      "label": "input.tsx",
+      "norm_label": "input.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/input.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "index_feesview",
+      "label": "FeesView()",
+      "norm_label": "feesview()",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "source_location": "L29"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "index_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L42"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "index_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L105"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 108,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L1"
+    },
+    {
       "community": 1080,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_label_tsx",
+      "label": "label.tsx",
+      "norm_label": "label.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/label.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1081,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodalform_tsx",
+      "label": "LeaveAReviewModalForm.tsx",
+      "norm_label": "leaveareviewmodalform.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModalForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1082,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_action_modal_tsx",
+      "label": "action-modal.tsx",
+      "norm_label": "action-modal.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/action-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1083,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_animations_welcomebackmodalanimations_ts",
       "label": "welcomeBackModalAnimations.ts",
@@ -31282,7 +31333,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1081,
+      "community": 1084,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_index_ts",
       "label": "index.ts",
@@ -31291,7 +31342,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1082,
+      "community": 1085,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_types_ts",
       "label": "types.ts",
@@ -31300,7 +31351,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1083,
+      "community": 1086,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_navigation_menu_tsx",
       "label": "navigation-menu.tsx",
@@ -31309,7 +31360,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1084,
+      "community": 1087,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -31318,7 +31369,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1085,
+      "community": 1088,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
@@ -31327,39 +31378,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1086,
+      "community": 1089,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
       "norm_label": "scroll-area.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/scroll-area.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1087,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_select_tsx",
-      "label": "select.tsx",
-      "norm_label": "select.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/select.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1088,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_separator_tsx",
-      "label": "separator.tsx",
-      "norm_label": "separator.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/separator.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1089,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_sheet_tsx",
-      "label": "sheet.tsx",
-      "norm_label": "sheet.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/sheet.tsx",
       "source_location": "L1"
     },
     {
@@ -31410,6 +31434,33 @@
     {
       "community": 1090,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_select_tsx",
+      "label": "select.tsx",
+      "norm_label": "select.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/select.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1091,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_separator_tsx",
+      "label": "separator.tsx",
+      "norm_label": "separator.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/separator.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1092,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_sheet_tsx",
+      "label": "sheet.tsx",
+      "norm_label": "sheet.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/sheet.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1093,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
       "norm_label": "table.tsx",
@@ -31417,7 +31468,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1091,
+      "community": 1094,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
@@ -31426,7 +31477,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1092,
+      "community": 1095,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
@@ -31435,7 +31486,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1093,
+      "community": 1096,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
@@ -31444,7 +31495,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1094,
+      "community": 1097,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
@@ -31453,7 +31504,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1095,
+      "community": 1098,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
@@ -31462,39 +31513,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1096,
+      "community": 1099,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_config_ts",
       "label": "config.ts",
       "norm_label": "config.ts",
       "source_file": "packages/storefront-webapp/src/config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1097,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_use_store_modal_tsx",
-      "label": "use-store-modal.tsx",
-      "norm_label": "use-store-modal.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/use-store-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1098,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useorganizationmodal_tsx",
-      "label": "useOrganizationModal.tsx",
-      "norm_label": "useorganizationmodal.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useOrganizationModal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1099,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usestorefrontobservability_ts",
-      "label": "useStorefrontObservability.ts",
-      "norm_label": "usestorefrontobservability.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useStorefrontObservability.ts",
       "source_location": "L1"
     },
     {
@@ -31725,6 +31749,33 @@
     {
       "community": 1100,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_use_store_modal_tsx",
+      "label": "use-store-modal.tsx",
+      "norm_label": "use-store-modal.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/use-store-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1101,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useorganizationmodal_tsx",
+      "label": "useOrganizationModal.tsx",
+      "norm_label": "useorganizationmodal.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useOrganizationModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1102,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usestorefrontobservability_ts",
+      "label": "useStorefrontObservability.ts",
+      "norm_label": "usestorefrontobservability.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useStorefrontObservability.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1103,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
@@ -31732,7 +31783,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1101,
+      "community": 1104,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_countries_ts",
       "label": "countries.ts",
@@ -31741,7 +31792,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1102,
+      "community": 1105,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_feeutils_test_ts",
       "label": "feeUtils.test.ts",
@@ -31750,7 +31801,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1103,
+      "community": 1106,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -31759,7 +31810,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1104,
+      "community": 1107,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
@@ -31768,7 +31819,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1105,
+      "community": 1108,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_test_ts",
       "label": "maintenanceUtils.test.ts",
@@ -31777,39 +31828,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1106,
+      "community": 1109,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/storefront-webapp/src/lib/mutations.ts/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1107,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_store_ts",
-      "label": "store.ts",
-      "norm_label": "store.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/store.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1108,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_bag_ts",
-      "label": "bag.ts",
-      "norm_label": "bag.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/bag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1109,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_bagitem_ts",
-      "label": "bagItem.ts",
-      "norm_label": "bagitem.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/bagItem.ts",
       "source_location": "L1"
     },
     {
@@ -31860,6 +31884,33 @@
     {
       "community": 1110,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_store_ts",
+      "label": "store.ts",
+      "norm_label": "store.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/store.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1111,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_bag_ts",
+      "label": "bag.ts",
+      "norm_label": "bag.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/bag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1112,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_bagitem_ts",
+      "label": "bagItem.ts",
+      "norm_label": "bagitem.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/bagItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1113,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
       "norm_label": "category.ts",
@@ -31867,7 +31918,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1111,
+      "community": 1114,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_organization_ts",
       "label": "organization.ts",
@@ -31876,7 +31927,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1112,
+      "community": 1115,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
@@ -31885,7 +31936,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1113,
+      "community": 1116,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -31894,7 +31945,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1114,
+      "community": 1117,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
@@ -31903,7 +31954,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1115,
+      "community": 1118,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
@@ -31912,39 +31963,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1116,
+      "community": 1119,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_states_ts",
       "label": "states.ts",
       "norm_label": "states.ts",
       "source_file": "packages/storefront-webapp/src/lib/states.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1117,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_test_ts",
-      "label": "storefrontFailureObservability.test.ts",
-      "norm_label": "storefrontfailureobservability.test.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1118,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storefrontjourneyevents_test_ts",
-      "label": "storefrontJourneyEvents.test.ts",
-      "norm_label": "storefrontjourneyevents.test.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1119,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_utils_test_ts",
-      "label": "utils.test.ts",
-      "norm_label": "utils.test.ts",
-      "source_file": "packages/storefront-webapp/src/lib/utils.test.ts",
       "source_location": "L1"
     },
     {
@@ -31995,6 +32019,33 @@
     {
       "community": 1120,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_test_ts",
+      "label": "storefrontFailureObservability.test.ts",
+      "norm_label": "storefrontfailureobservability.test.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontFailureObservability.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1121,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_storefrontjourneyevents_test_ts",
+      "label": "storefrontJourneyEvents.test.ts",
+      "norm_label": "storefrontjourneyevents.test.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1122,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_utils_test_ts",
+      "label": "utils.test.ts",
+      "norm_label": "utils.test.ts",
+      "source_file": "packages/storefront-webapp/src/lib/utils.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1123,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
       "norm_label": "routetree.gen.ts",
@@ -32002,7 +32053,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1121,
+      "community": 1124,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_test_ts",
       "label": "-homePageLoader.test.ts",
@@ -32011,7 +32062,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1122,
+      "community": 1125,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -32020,7 +32071,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1123,
+      "community": 1126,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_orderitemid_review_tsx",
       "label": "$orderItemId.review.tsx",
@@ -32029,7 +32080,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1124,
+      "community": 1127,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_index_tsx",
       "label": "index.tsx",
@@ -32038,7 +32089,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1125,
+      "community": 1128,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_subcategoryslug_tsx",
       "label": "$subcategorySlug.tsx",
@@ -32047,39 +32098,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1126,
+      "community": 1129,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout/shop/$categorySlug/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1127,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_rewards_index_tsx",
-      "label": "rewards.index.tsx",
-      "norm_label": "rewards.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/rewards.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1128,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_shop_saved_index_tsx",
-      "label": "shop.saved.index.tsx",
-      "norm_label": "shop.saved.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/shop.saved.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1129,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_bag_index_tsx",
-      "label": "bag.index.tsx",
-      "norm_label": "bag.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/bag.index.tsx",
       "source_location": "L1"
     },
     {
@@ -32130,6 +32154,33 @@
     {
       "community": 1130,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_rewards_index_tsx",
+      "label": "rewards.index.tsx",
+      "norm_label": "rewards.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/rewards.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1131,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_shop_saved_index_tsx",
+      "label": "shop.saved.index.tsx",
+      "norm_label": "shop.saved.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/shop.saved.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1132,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_bag_index_tsx",
+      "label": "bag.index.tsx",
+      "norm_label": "bag.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/bag.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1133,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_complete_tsx",
       "label": "complete.tsx",
       "norm_label": "complete.tsx",
@@ -32137,7 +32188,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1131,
+      "community": 1134,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_incomplete_tsx",
       "label": "incomplete.tsx",
@@ -32146,7 +32197,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1132,
+      "community": 1135,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_index_tsx",
       "label": "index.tsx",
@@ -32155,7 +32206,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1133,
+      "community": 1136,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pending_tsx",
       "label": "pending.tsx",
@@ -32164,7 +32215,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1134,
+      "community": 1137,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_ssr_tsx",
       "label": "ssr.tsx",
@@ -32173,7 +32224,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1135,
+      "community": 1138,
       "file_type": "code",
       "id": "packages_storefront_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
@@ -32182,39 +32233,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1136,
+      "community": 1139,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
       "norm_label": "vitest.config.ts",
       "source_file": "packages/storefront-webapp/vitest.config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1137,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_vitest_setup_ts",
-      "label": "vitest.setup.ts",
-      "norm_label": "vitest.setup.ts",
-      "source_file": "packages/storefront-webapp/vitest.setup.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1138,
-      "file_type": "code",
-      "id": "packages_valkey_proxy_server_index_js",
-      "label": "index.js",
-      "norm_label": "index.js",
-      "source_file": "packages/valkey-proxy-server/index.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 1139,
-      "file_type": "code",
-      "id": "scripts_harness_app_registry_test_ts",
-      "label": "harness-app-registry.test.ts",
-      "norm_label": "harness-app-registry.test.ts",
-      "source_file": "scripts/harness-app-registry.test.ts",
       "source_location": "L1"
     },
     {
@@ -32265,6 +32289,33 @@
     {
       "community": 1140,
       "file_type": "code",
+      "id": "packages_storefront_webapp_vitest_setup_ts",
+      "label": "vitest.setup.ts",
+      "norm_label": "vitest.setup.ts",
+      "source_file": "packages/storefront-webapp/vitest.setup.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1141,
+      "file_type": "code",
+      "id": "packages_valkey_proxy_server_index_js",
+      "label": "index.js",
+      "norm_label": "index.js",
+      "source_file": "packages/valkey-proxy-server/index.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 1142,
+      "file_type": "code",
+      "id": "scripts_harness_app_registry_test_ts",
+      "label": "harness-app-registry.test.ts",
+      "norm_label": "harness-app-registry.test.ts",
+      "source_file": "scripts/harness-app-registry.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1143,
+      "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_test_ts",
       "label": "valkey-runtime-app.test.ts",
       "norm_label": "valkey-runtime-app.test.ts",
@@ -32272,7 +32323,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1141,
+      "community": 1144,
       "file_type": "code",
       "id": "scripts_harness_behavior_scenarios_test_ts",
       "label": "harness-behavior-scenarios.test.ts",
@@ -33291,6 +33342,42 @@
     {
       "community": 131,
       "file_type": "code",
+      "id": "currency_todisplayamount",
+      "label": "toDisplayAmount()",
+      "norm_label": "todisplayamount()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "currency_topesewas",
+      "label": "toPesewas()",
+      "norm_label": "topesewas()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_lib_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/athena-webapp/convex/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 131,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 132,
+      "file_type": "code",
       "id": "collections_getcachedtokenrecord",
       "label": "getCachedTokenRecord()",
       "norm_label": "getcachedtokenrecord()",
@@ -33298,7 +33385,7 @@
       "source_location": "L26"
     },
     {
-      "community": 131,
+      "community": 132,
       "file_type": "code",
       "id": "collections_resolveaccesstokenforstore",
       "label": "resolveAccessTokenForStore()",
@@ -33307,7 +33394,7 @@
       "source_location": "L79"
     },
     {
-      "community": 131,
+      "community": 132,
       "file_type": "code",
       "id": "collections_resolveconfigforstore",
       "label": "resolveConfigForStore()",
@@ -33316,7 +33403,7 @@
       "source_location": "L33"
     },
     {
-      "community": 131,
+      "community": 132,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_collections_ts",
       "label": "collections.ts",
@@ -33325,7 +33412,7 @@
       "source_location": "L1"
     },
     {
-      "community": 132,
+      "community": 133,
       "file_type": "code",
       "id": "normalize_maskmtnpartyid",
       "label": "maskMtnPartyId()",
@@ -33334,7 +33421,7 @@
       "source_location": "L10"
     },
     {
-      "community": 132,
+      "community": 133,
       "file_type": "code",
       "id": "normalize_normalizecollectionstransaction",
       "label": "normalizeCollectionsTransaction()",
@@ -33343,7 +33430,7 @@
       "source_location": "L18"
     },
     {
-      "community": 132,
+      "community": 133,
       "file_type": "code",
       "id": "normalize_parsecollectionsnotificationrequest",
       "label": "parseCollectionsNotificationRequest()",
@@ -33352,7 +33439,7 @@
       "source_location": "L52"
     },
     {
-      "community": 132,
+      "community": 133,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_ts",
       "label": "normalize.ts",
@@ -33361,7 +33448,7 @@
       "source_location": "L1"
     },
     {
-      "community": 133,
+      "community": 134,
       "file_type": "code",
       "id": "commercequeryindexes_test_expectindex",
       "label": "expectIndex()",
@@ -33370,7 +33457,7 @@
       "source_location": "L19"
     },
     {
-      "community": 133,
+      "community": 134,
       "file_type": "code",
       "id": "commercequeryindexes_test_getsource",
       "label": "getSource()",
@@ -33379,7 +33466,7 @@
       "source_location": "L26"
     },
     {
-      "community": 133,
+      "community": 134,
       "file_type": "code",
       "id": "commercequeryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -33388,7 +33475,7 @@
       "source_location": "L12"
     },
     {
-      "community": 133,
+      "community": 134,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_commercequeryindexes_test_ts",
       "label": "commerceQueryIndexes.test.ts",
@@ -33397,7 +33484,7 @@
       "source_location": "L1"
     },
     {
-      "community": 134,
+      "community": 135,
       "file_type": "code",
       "id": "attributesmanager_attributesmanager",
       "label": "AttributesManager()",
@@ -33406,7 +33493,7 @@
       "source_location": "L228"
     },
     {
-      "community": 134,
+      "community": 135,
       "file_type": "code",
       "id": "attributesmanager_colormanager",
       "label": "ColorManager()",
@@ -33415,7 +33502,7 @@
       "source_location": "L45"
     },
     {
-      "community": 134,
+      "community": 135,
       "file_type": "code",
       "id": "attributesmanager_sidebar",
       "label": "Sidebar()",
@@ -33424,7 +33511,7 @@
       "source_location": "L26"
     },
     {
-      "community": 134,
+      "community": 135,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributesmanager_tsx",
       "label": "AttributesManager.tsx",
@@ -33433,7 +33520,7 @@
       "source_location": "L1"
     },
     {
-      "community": 135,
+      "community": 136,
       "file_type": "code",
       "id": "attributestable_getproductattribute",
       "label": "getProductAttribute()",
@@ -33442,7 +33529,7 @@
       "source_location": "L55"
     },
     {
-      "community": 135,
+      "community": 136,
       "file_type": "code",
       "id": "attributestable_handlechange",
       "label": "handleChange()",
@@ -33451,7 +33538,7 @@
       "source_location": "L32"
     },
     {
-      "community": 135,
+      "community": 136,
       "file_type": "code",
       "id": "attributestable_onsubmit",
       "label": "onSubmit()",
@@ -33460,7 +33547,7 @@
       "source_location": "L210"
     },
     {
-      "community": 135,
+      "community": 136,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributestable_tsx",
       "label": "AttributesTable.tsx",
@@ -33469,7 +33556,7 @@
       "source_location": "L1"
     },
     {
-      "community": 136,
+      "community": 137,
       "file_type": "code",
       "id": "categorysubcategorymanager_categorymanager",
       "label": "CategoryManager()",
@@ -33478,7 +33565,7 @@
       "source_location": "L51"
     },
     {
-      "community": 136,
+      "community": 137,
       "file_type": "code",
       "id": "categorysubcategorymanager_sidebar",
       "label": "Sidebar()",
@@ -33487,7 +33574,7 @@
       "source_location": "L26"
     },
     {
-      "community": 136,
+      "community": 137,
       "file_type": "code",
       "id": "categorysubcategorymanager_subcategorymanager",
       "label": "SubcategoryManager()",
@@ -33496,7 +33583,7 @@
       "source_location": "L290"
     },
     {
-      "community": 136,
+      "community": 137,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_categorysubcategorymanager_tsx",
       "label": "CategorySubcategoryManager.tsx",
@@ -33505,7 +33592,7 @@
       "source_location": "L1"
     },
     {
-      "community": 137,
+      "community": 138,
       "file_type": "code",
       "id": "analyticsview_activecheckoutsessions",
       "label": "ActiveCheckoutSessions()",
@@ -33514,7 +33601,7 @@
       "source_location": "L48"
     },
     {
-      "community": 137,
+      "community": 138,
       "file_type": "code",
       "id": "analyticsview_analyticsview",
       "label": "AnalyticsView()",
@@ -33523,7 +33610,7 @@
       "source_location": "L88"
     },
     {
-      "community": 137,
+      "community": 138,
       "file_type": "code",
       "id": "analyticsview_storevisitors",
       "label": "StoreVisitors()",
@@ -33532,7 +33619,7 @@
       "source_location": "L14"
     },
     {
-      "community": 137,
+      "community": 138,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsview_tsx",
       "label": "AnalyticsView.tsx",
@@ -33541,7 +33628,7 @@
       "source_location": "L1"
     },
     {
-      "community": 138,
+      "community": 139,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storefrontobservabilitypanel_tsx",
       "label": "StorefrontObservabilityPanel.tsx",
@@ -33550,7 +33637,7 @@
       "source_location": "L1"
     },
     {
-      "community": 138,
+      "community": 139,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_formatlabel",
       "label": "formatLabel()",
@@ -33559,7 +33646,7 @@
       "source_location": "L15"
     },
     {
-      "community": 138,
+      "community": 139,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_gettrafficsourcebadge",
       "label": "getTrafficSourceBadge()",
@@ -33568,49 +33655,13 @@
       "source_location": "L28"
     },
     {
-      "community": 138,
+      "community": 139,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_summarycard",
       "label": "SummaryCard()",
       "norm_label": "summarycard()",
       "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
       "source_location": "L19"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "utils_countgroupedanalytics",
-      "label": "countGroupedAnalytics()",
-      "norm_label": "countgroupedanalytics()",
-      "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "utils_groupanalytics",
-      "label": "groupAnalytics()",
-      "norm_label": "groupanalytics()",
-      "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "utils_groupproductviewsbyday",
-      "label": "groupProductViewsByDay()",
-      "norm_label": "groupproductviewsbyday()",
-      "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
-      "source_location": "L90"
     },
     {
       "community": 14,
@@ -33768,6 +33819,42 @@
     {
       "community": 140,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "utils_countgroupedanalytics",
+      "label": "countGroupedAnalytics()",
+      "norm_label": "countgroupedanalytics()",
+      "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "utils_groupanalytics",
+      "label": "groupAnalytics()",
+      "norm_label": "groupanalytics()",
+      "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "utils_groupproductviewsbyday",
+      "label": "groupProductViewsByDay()",
+      "norm_label": "groupproductviewsbyday()",
+      "source_file": "packages/athena-webapp/src/components/analytics/utils.ts",
+      "source_location": "L90"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
       "id": "maintenancemessageeditor_getcountdownstatus",
       "label": "getCountdownStatus()",
       "norm_label": "getcountdownstatus()",
@@ -33775,7 +33862,7 @@
       "source_location": "L86"
     },
     {
-      "community": 140,
+      "community": 141,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlecountdownchange",
       "label": "handleCountdownChange()",
@@ -33784,7 +33871,7 @@
       "source_location": "L76"
     },
     {
-      "community": 140,
+      "community": 141,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlesave",
       "label": "handleSave()",
@@ -33793,7 +33880,7 @@
       "source_location": "L52"
     },
     {
-      "community": 140,
+      "community": 141,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_maintenancemessageeditor_tsx",
       "label": "MaintenanceMessageEditor.tsx",
@@ -33802,7 +33889,7 @@
       "source_location": "L1"
     },
     {
-      "community": 141,
+      "community": 142,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplook_tsx",
       "label": "ShopLook.tsx",
@@ -33811,7 +33898,7 @@
       "source_location": "L1"
     },
     {
-      "community": 141,
+      "community": 142,
       "file_type": "code",
       "id": "shoplook_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -33820,7 +33907,7 @@
       "source_location": "L67"
     },
     {
-      "community": 141,
+      "community": 142,
       "file_type": "code",
       "id": "shoplook_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -33829,7 +33916,7 @@
       "source_location": "L90"
     },
     {
-      "community": 141,
+      "community": 142,
       "file_type": "code",
       "id": "shoplook_ondragend",
       "label": "onDragEnd()",
@@ -33838,7 +33925,7 @@
       "source_location": "L73"
     },
     {
-      "community": 142,
+      "community": 143,
       "file_type": "code",
       "id": "newtransactionview_handlequickstart",
       "label": "handleQuickStart()",
@@ -33847,7 +33934,7 @@
       "source_location": "L91"
     },
     {
-      "community": 142,
+      "community": 143,
       "file_type": "code",
       "id": "newtransactionview_handlestarttransaction",
       "label": "handleStartTransaction()",
@@ -33856,7 +33943,7 @@
       "source_location": "L68"
     },
     {
-      "community": 142,
+      "community": 143,
       "file_type": "code",
       "id": "newtransactionview_navigation",
       "label": "Navigation()",
@@ -33865,7 +33952,7 @@
       "source_location": "L22"
     },
     {
-      "community": 142,
+      "community": 143,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
       "label": "NewTransactionView.tsx",
@@ -33874,7 +33961,7 @@
       "source_location": "L1"
     },
     {
-      "community": 143,
+      "community": 144,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_tsx",
       "label": "POSSettingsView.tsx",
@@ -33883,7 +33970,7 @@
       "source_location": "L1"
     },
     {
-      "community": 143,
+      "community": 144,
       "file_type": "code",
       "id": "possettingsview_handleregisterterminal",
       "label": "handleRegisterTerminal()",
@@ -33892,7 +33979,7 @@
       "source_location": "L247"
     },
     {
-      "community": 143,
+      "community": 144,
       "file_type": "code",
       "id": "possettingsview_handleupdateexistingterminal",
       "label": "handleUpdateExistingTerminal()",
@@ -33901,7 +33988,7 @@
       "source_location": "L284"
     },
     {
-      "community": 143,
+      "community": 144,
       "file_type": "code",
       "id": "possettingsview_loadfingerprint",
       "label": "loadFingerprint()",
@@ -33910,7 +33997,7 @@
       "source_location": "L166"
     },
     {
-      "community": 144,
+      "community": 145,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstock_tsx",
       "label": "ProductStock.tsx",
@@ -33919,7 +34006,7 @@
       "source_location": "L1"
     },
     {
-      "community": 144,
+      "community": 145,
       "file_type": "code",
       "id": "productstock_lowstockstatus",
       "label": "LowStockStatus()",
@@ -33928,7 +34015,7 @@
       "source_location": "L63"
     },
     {
-      "community": 144,
+      "community": 145,
       "file_type": "code",
       "id": "productstock_outofstockstatus",
       "label": "OutOfStockStatus()",
@@ -33937,7 +34024,7 @@
       "source_location": "L54"
     },
     {
-      "community": 144,
+      "community": 145,
       "file_type": "code",
       "id": "productstock_productstockstatus",
       "label": "ProductStockStatus()",
@@ -33946,7 +34033,7 @@
       "source_location": "L11"
     },
     {
-      "community": 145,
+      "community": 146,
       "file_type": "code",
       "id": "complimentaryproductsview_body",
       "label": "Body()",
@@ -33955,7 +34042,7 @@
       "source_location": "L16"
     },
     {
-      "community": 145,
+      "community": 146,
       "file_type": "code",
       "id": "complimentaryproductsview_complimentaryproductsview",
       "label": "ComplimentaryProductsView()",
@@ -33964,7 +34051,7 @@
       "source_location": "L35"
     },
     {
-      "community": 145,
+      "community": 146,
       "file_type": "code",
       "id": "complimentaryproductsview_navigation",
       "label": "Navigation()",
@@ -33973,7 +34060,7 @@
       "source_location": "L6"
     },
     {
-      "community": 145,
+      "community": 146,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
       "label": "ComplimentaryProductsView.tsx",
@@ -33982,7 +34069,7 @@
       "source_location": "L1"
     },
     {
-      "community": 146,
+      "community": 147,
       "file_type": "code",
       "id": "engagementmetrics_formatlastactivity",
       "label": "formatLastActivity()",
@@ -33991,7 +34078,7 @@
       "source_location": "L75"
     },
     {
-      "community": 146,
+      "community": 147,
       "file_type": "code",
       "id": "engagementmetrics_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -34000,7 +34087,7 @@
       "source_location": "L82"
     },
     {
-      "community": 146,
+      "community": 147,
       "file_type": "code",
       "id": "engagementmetrics_getdevicelabel",
       "label": "getDeviceLabel()",
@@ -34009,7 +34096,7 @@
       "source_location": "L93"
     },
     {
-      "community": 146,
+      "community": 147,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_engagementmetrics_tsx",
       "label": "EngagementMetrics.tsx",
@@ -34018,7 +34105,7 @@
       "source_location": "L1"
     },
     {
-      "community": 147,
+      "community": 148,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
       "label": "RiskIndicators.tsx",
@@ -34027,7 +34114,7 @@
       "source_location": "L1"
     },
     {
-      "community": 147,
+      "community": 148,
       "file_type": "code",
       "id": "riskindicators_getriskicon",
       "label": "getRiskIcon()",
@@ -34036,7 +34123,7 @@
       "source_location": "L15"
     },
     {
-      "community": 147,
+      "community": 148,
       "file_type": "code",
       "id": "riskindicators_getriskstyles",
       "label": "getRiskStyles()",
@@ -34045,7 +34132,7 @@
       "source_location": "L28"
     },
     {
-      "community": 147,
+      "community": 148,
       "file_type": "code",
       "id": "riskindicators_riskindicators",
       "label": "RiskIndicators()",
@@ -34054,7 +34141,7 @@
       "source_location": "L54"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "customerobservabilitytimeline_formatobservabilitylabel",
       "label": "formatObservabilityLabel()",
@@ -34063,7 +34150,7 @@
       "source_location": "L59"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -34072,7 +34159,7 @@
       "source_location": "L114"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
       "label": "getObservabilityStatusStyles()",
@@ -34081,48 +34168,12 @@
       "source_location": "L67"
     },
     {
-      "community": 148,
+      "community": 149,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_customerobservabilitytimeline_ts",
       "label": "customerObservabilityTimeline.ts",
       "norm_label": "customerobservabilitytimeline.ts",
       "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "barcodeutils_extractbarcodefrominput",
-      "label": "extractBarcodeFromInput()",
-      "norm_label": "extractbarcodefrominput()",
-      "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "barcodeutils_isurlorbarcode",
-      "label": "isUrlOrBarcode()",
-      "norm_label": "isurlorbarcode()",
-      "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
-      "source_location": "L92"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "barcodeutils_isvalidconvexid",
-      "label": "isValidConvexId()",
-      "norm_label": "isvalidconvexid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_barcodeutils_ts",
-      "label": "barcodeUtils.ts",
-      "norm_label": "barcodeutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
       "source_location": "L1"
     },
     {
@@ -34281,6 +34332,42 @@
     {
       "community": 150,
       "file_type": "code",
+      "id": "barcodeutils_extractbarcodefrominput",
+      "label": "extractBarcodeFromInput()",
+      "norm_label": "extractbarcodefrominput()",
+      "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "barcodeutils_isurlorbarcode",
+      "label": "isUrlOrBarcode()",
+      "norm_label": "isurlorbarcode()",
+      "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
+      "source_location": "L92"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "barcodeutils_isvalidconvexid",
+      "label": "isValidConvexId()",
+      "norm_label": "isvalidconvexid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_barcodeutils_ts",
+      "label": "barcodeUtils.ts",
+      "norm_label": "barcodeutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/barcodeUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
       "id": "offers_getbaseurl",
       "label": "getBaseUrl()",
       "norm_label": "getbaseurl()",
@@ -34288,7 +34375,7 @@
       "source_location": "L13"
     },
     {
-      "community": 150,
+      "community": 151,
       "file_type": "code",
       "id": "offers_getuserredeemedoffers",
       "label": "getUserRedeemedOffers()",
@@ -34297,7 +34384,7 @@
       "source_location": "L46"
     },
     {
-      "community": 150,
+      "community": 151,
       "file_type": "code",
       "id": "offers_submitoffer",
       "label": "submitOffer()",
@@ -34306,7 +34393,7 @@
       "source_location": "L21"
     },
     {
-      "community": 150,
+      "community": 151,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_offers_ts",
       "label": "offers.ts",
@@ -34315,7 +34402,7 @@
       "source_location": "L1"
     },
     {
-      "community": 151,
+      "community": 152,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_stores_ts",
       "label": "stores.ts",
@@ -34324,7 +34411,7 @@
       "source_location": "L1"
     },
     {
-      "community": 151,
+      "community": 152,
       "file_type": "code",
       "id": "stores_getallstores",
       "label": "getAllStores()",
@@ -34333,7 +34420,7 @@
       "source_location": "L8"
     },
     {
-      "community": 151,
+      "community": 152,
       "file_type": "code",
       "id": "stores_getbaseurl",
       "label": "getBaseUrl()",
@@ -34342,7 +34429,7 @@
       "source_location": "L5"
     },
     {
-      "community": 151,
+      "community": 152,
       "file_type": "code",
       "id": "stores_getstore",
       "label": "getStore()",
@@ -34351,7 +34438,7 @@
       "source_location": "L20"
     },
     {
-      "community": 152,
+      "community": 153,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_subcategory_ts",
       "label": "subcategory.ts",
@@ -34360,7 +34447,7 @@
       "source_location": "L1"
     },
     {
-      "community": 152,
+      "community": 153,
       "file_type": "code",
       "id": "subcategory_getallsubcategories",
       "label": "getAllSubcategories()",
@@ -34369,7 +34456,7 @@
       "source_location": "L11"
     },
     {
-      "community": 152,
+      "community": 153,
       "file_type": "code",
       "id": "subcategory_getbaseurl",
       "label": "getBaseUrl()",
@@ -34378,7 +34465,7 @@
       "source_location": "L9"
     },
     {
-      "community": 152,
+      "community": 153,
       "file_type": "code",
       "id": "subcategory_getsubategory",
       "label": "getSubategory()",
@@ -34387,7 +34474,7 @@
       "source_location": "L25"
     },
     {
-      "community": 153,
+      "community": 154,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productactionbar_tsx",
       "label": "ProductActionBar.tsx",
@@ -34396,7 +34483,7 @@
       "source_location": "L1"
     },
     {
-      "community": 153,
+      "community": 154,
       "file_type": "code",
       "id": "productactionbar_checkscroll",
       "label": "checkScroll()",
@@ -34405,7 +34492,7 @@
       "source_location": "L50"
     },
     {
-      "community": 153,
+      "community": 154,
       "file_type": "code",
       "id": "productactionbar_handleaction",
       "label": "handleAction()",
@@ -34414,7 +34501,7 @@
       "source_location": "L92"
     },
     {
-      "community": 153,
+      "community": 154,
       "file_type": "code",
       "id": "productactionbar_handledismiss",
       "label": "handleDismiss()",
@@ -34423,7 +34510,7 @@
       "source_location": "L74"
     },
     {
-      "community": 154,
+      "community": 155,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productreminderbar_tsx",
       "label": "ProductReminderBar.tsx",
@@ -34432,7 +34519,7 @@
       "source_location": "L1"
     },
     {
-      "community": 154,
+      "community": 155,
       "file_type": "code",
       "id": "productreminderbar_checkscroll",
       "label": "checkScroll()",
@@ -34441,7 +34528,7 @@
       "source_location": "L62"
     },
     {
-      "community": 154,
+      "community": 155,
       "file_type": "code",
       "id": "productreminderbar_handleaddtobag",
       "label": "handleAddToBag()",
@@ -34450,7 +34537,7 @@
       "source_location": "L109"
     },
     {
-      "community": 154,
+      "community": 155,
       "file_type": "code",
       "id": "productreminderbar_handledismiss",
       "label": "handleDismiss()",
@@ -34459,7 +34546,7 @@
       "source_location": "L177"
     },
     {
-      "community": 155,
+      "community": 156,
       "file_type": "code",
       "id": "billingdetailssection_clearform",
       "label": "clearForm()",
@@ -34468,7 +34555,7 @@
       "source_location": "L18"
     },
     {
-      "community": 155,
+      "community": 156,
       "file_type": "code",
       "id": "billingdetailssection_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -34477,7 +34564,7 @@
       "source_location": "L52"
     },
     {
-      "community": 155,
+      "community": 156,
       "file_type": "code",
       "id": "billingdetailssection_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -34486,7 +34573,7 @@
       "source_location": "L68"
     },
     {
-      "community": 155,
+      "community": 156,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetailssection_tsx",
       "label": "BillingDetailsSection.tsx",
@@ -34495,7 +34582,7 @@
       "source_location": "L1"
     },
     {
-      "community": 156,
+      "community": 157,
       "file_type": "code",
       "id": "hooks_usegetshopsearchparams",
       "label": "useGetShopSearchParams()",
@@ -34504,7 +34591,7 @@
       "source_location": "L68"
     },
     {
-      "community": 156,
+      "community": 157,
       "file_type": "code",
       "id": "hooks_usegetstorecategories",
       "label": "useGetStoreCategories()",
@@ -34513,7 +34600,7 @@
       "source_location": "L26"
     },
     {
-      "community": 156,
+      "community": 157,
       "file_type": "code",
       "id": "hooks_usegetstoresubcategories",
       "label": "useGetStoreSubcategories()",
@@ -34522,7 +34609,7 @@
       "source_location": "L7"
     },
     {
-      "community": 156,
+      "community": 157,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
       "label": "hooks.ts",
@@ -34531,7 +34618,7 @@
       "source_location": "L1"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -34540,7 +34627,7 @@
       "source_location": "L1"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "productdetails_bagproduct",
       "label": "BagProduct()",
@@ -34549,7 +34636,7 @@
       "source_location": "L43"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "productdetails_pickupdetails",
       "label": "PickupDetails()",
@@ -34558,7 +34645,7 @@
       "source_location": "L13"
     },
     {
-      "community": 157,
+      "community": 158,
       "file_type": "code",
       "id": "productdetails_shippingpolicy",
       "label": "ShippingPolicy()",
@@ -34567,7 +34654,7 @@
       "source_location": "L88"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
       "label": "UpsellModal.tsx",
@@ -34576,7 +34663,7 @@
       "source_location": "L1"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "upsellmodal_handleclose",
       "label": "handleClose()",
@@ -34585,7 +34672,7 @@
       "source_location": "L111"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "upsellmodal_handlescroll",
       "label": "handleScroll()",
@@ -34594,49 +34681,13 @@
       "source_location": "L66"
     },
     {
-      "community": 158,
+      "community": 159,
       "file_type": "code",
       "id": "upsellmodal_handlesuccess",
       "label": "handleSuccess()",
       "norm_label": "handlesuccess()",
       "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
       "source_location": "L127"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "currency_todisplayamount",
-      "label": "toDisplayAmount()",
-      "norm_label": "todisplayamount()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "currency_topesewas",
-      "label": "toPesewas()",
-      "norm_label": "topesewas()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_lib_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/athena-webapp/convex/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L1"
     },
     {
       "community": 16,
@@ -38070,6 +38121,33 @@
     {
       "community": 234,
       "file_type": "code",
+      "id": "admin_shell_patterns_patterncard",
+      "label": "PatternCard()",
+      "norm_label": "patterncard()",
+      "source_file": "packages/athena-webapp/src/stories/Patterns/admin-shell-patterns.tsx",
+      "source_location": "L127"
+    },
+    {
+      "community": 234,
+      "file_type": "code",
+      "id": "admin_shell_patterns_patternshell",
+      "label": "PatternShell()",
+      "norm_label": "patternshell()",
+      "source_file": "packages/athena-webapp/src/stories/Patterns/admin-shell-patterns.tsx",
+      "source_location": "L106"
+    },
+    {
+      "community": 234,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_tsx",
+      "label": "admin-shell-patterns.tsx",
+      "norm_label": "admin-shell-patterns.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Patterns/admin-shell-patterns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 235,
+      "file_type": "code",
       "id": "inventoryvalidationlogic_test_mockgetsku",
       "label": "mockGetSku()",
       "norm_label": "mockgetsku()",
@@ -38077,7 +38155,7 @@
       "source_location": "L66"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "inventoryvalidationlogic_test_validateinventoryfortransaction",
       "label": "validateInventoryForTransaction()",
@@ -38086,7 +38164,7 @@
       "source_location": "L20"
     },
     {
-      "community": 234,
+      "community": 235,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_inventoryvalidationlogic_test_ts",
       "label": "inventoryValidationLogic.test.ts",
@@ -38095,7 +38173,7 @@
       "source_location": "L1"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "index_hashpassword",
       "label": "hashPassword()",
@@ -38104,7 +38182,7 @@
       "source_location": "L1"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -38113,7 +38191,7 @@
       "source_location": "L1"
     },
     {
-      "community": 235,
+      "community": 236,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -38122,7 +38200,7 @@
       "source_location": "L1"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_session_ts",
       "label": "session.ts",
@@ -38131,7 +38209,7 @@
       "source_location": "L1"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_session_ts",
       "label": "session.ts",
@@ -38140,7 +38218,7 @@
       "source_location": "L1"
     },
     {
-      "community": 236,
+      "community": 237,
       "file_type": "code",
       "id": "session_useappsession",
       "label": "useAppSession()",
@@ -38149,7 +38227,7 @@
       "source_location": "L8"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -38158,7 +38236,7 @@
       "source_location": "L1"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -38167,7 +38245,7 @@
       "source_location": "L1"
     },
     {
-      "community": 237,
+      "community": 238,
       "file_type": "code",
       "id": "versionchecker_createversionchecker",
       "label": "createVersionChecker()",
@@ -38176,7 +38254,7 @@
       "source_location": "L16"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "packages_athena_webapp_vite_config_ts",
       "label": "vite.config.ts",
@@ -38185,7 +38263,7 @@
       "source_location": "L1"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "packages_storefront_webapp_vite_config_ts",
       "label": "vite.config.ts",
@@ -38194,40 +38272,13 @@
       "source_location": "L1"
     },
     {
-      "community": 238,
+      "community": 239,
       "file_type": "code",
       "id": "vite_config_manualchunks",
       "label": "manualChunks()",
       "norm_label": "manualchunks()",
       "source_file": "packages/storefront-webapp/vite.config.ts",
       "source_location": "L19"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "auth_logout",
-      "label": "logout()",
-      "norm_label": "logout()",
-      "source_file": "packages/storefront-webapp/src/api/auth.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "auth_verifyuseraccount",
-      "label": "verifyUserAccount()",
-      "norm_label": "verifyuseraccount()",
-      "source_file": "packages/storefront-webapp/src/api/auth.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_auth_ts",
-      "label": "auth.ts",
-      "norm_label": "auth.ts",
-      "source_file": "packages/storefront-webapp/src/api/auth.ts",
-      "source_location": "L1"
     },
     {
       "community": 24,
@@ -38331,6 +38382,33 @@
     {
       "community": 240,
       "file_type": "code",
+      "id": "auth_logout",
+      "label": "logout()",
+      "norm_label": "logout()",
+      "source_file": "packages/storefront-webapp/src/api/auth.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "auth_verifyuseraccount",
+      "label": "verifyUserAccount()",
+      "norm_label": "verifyuseraccount()",
+      "source_file": "packages/storefront-webapp/src/api/auth.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_auth_ts",
+      "label": "auth.ts",
+      "norm_label": "auth.ts",
+      "source_file": "packages/storefront-webapp/src/api/auth.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
       "id": "color_getallcolors",
       "label": "getAllColors()",
       "norm_label": "getallcolors()",
@@ -38338,7 +38416,7 @@
       "source_location": "L7"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "color_getbaseurl",
       "label": "getBaseUrl()",
@@ -38347,7 +38425,7 @@
       "source_location": "L5"
     },
     {
-      "community": 240,
+      "community": 241,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_color_ts",
       "label": "color.ts",
@@ -38356,7 +38434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "organization_getallorganizations",
       "label": "getAllOrganizations()",
@@ -38365,7 +38443,7 @@
       "source_location": "L6"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "organization_getorganization",
       "label": "getOrganization()",
@@ -38374,7 +38452,7 @@
       "source_location": "L18"
     },
     {
-      "community": 241,
+      "community": 242,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_organization_ts",
       "label": "organization.ts",
@@ -38383,7 +38461,7 @@
       "source_location": "L1"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_upsells_ts",
       "label": "upsells.ts",
@@ -38392,7 +38470,7 @@
       "source_location": "L1"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "upsells_getbaseurl",
       "label": "getBaseUrl()",
@@ -38401,7 +38479,7 @@
       "source_location": "L3"
     },
     {
-      "community": 242,
+      "community": 243,
       "file_type": "code",
       "id": "upsells_getlastviewedproduct",
       "label": "getLastViewedProduct()",
@@ -38410,7 +38488,7 @@
       "source_location": "L5"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_useroffers_ts",
       "label": "userOffers.ts",
@@ -38419,7 +38497,7 @@
       "source_location": "L1"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "useroffers_getbaseurl",
       "label": "getBaseUrl()",
@@ -38428,7 +38506,7 @@
       "source_location": "L18"
     },
     {
-      "community": 243,
+      "community": 244,
       "file_type": "code",
       "id": "useroffers_getuserofferseligibility",
       "label": "getUserOffersEligibility()",
@@ -38437,7 +38515,7 @@
       "source_location": "L23"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "customerdetails_enteredcustomerdetails",
       "label": "EnteredCustomerDetails()",
@@ -38446,7 +38524,7 @@
       "source_location": "L22"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "customerdetails_onsubmit",
       "label": "onSubmit()",
@@ -38455,7 +38533,7 @@
       "source_location": "L55"
     },
     {
-      "community": 244,
+      "community": 245,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerdetails_tsx",
       "label": "CustomerDetails.tsx",
@@ -38464,7 +38542,7 @@
       "source_location": "L1"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "deliveryoptionsselector_handlechange",
       "label": "handleChange()",
@@ -38473,7 +38551,7 @@
       "source_location": "L77"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "deliveryoptionsselector_storeselector",
       "label": "StoreSelector()",
@@ -38482,7 +38560,7 @@
       "source_location": "L11"
     },
     {
-      "community": 245,
+      "community": 246,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliveryoptionsselector_tsx",
       "label": "DeliveryOptionsSelector.tsx",
@@ -38491,7 +38569,7 @@
       "source_location": "L1"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "deliverysection_deliverydetails",
       "label": "DeliveryDetails()",
@@ -38500,7 +38578,7 @@
       "source_location": "L11"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "deliverysection_deliveryoptions",
       "label": "DeliveryOptions()",
@@ -38509,7 +38587,7 @@
       "source_location": "L22"
     },
     {
-      "community": 246,
+      "community": 247,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliverysection_tsx",
       "label": "DeliverySection.tsx",
@@ -38518,7 +38596,7 @@
       "source_location": "L1"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "mobilebagsummary_handlekeydown",
       "label": "handleKeyDown()",
@@ -38527,7 +38605,7 @@
       "source_location": "L110"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "mobilebagsummary_handleredeempromocode",
       "label": "handleRedeemPromoCode()",
@@ -38536,7 +38614,7 @@
       "source_location": "L89"
     },
     {
-      "community": 247,
+      "community": 248,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_mobilebagsummary_tsx",
       "label": "MobileBagSummary.tsx",
@@ -38545,7 +38623,7 @@
       "source_location": "L1"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "checkoutstorage_loadcheckoutstate",
       "label": "loadCheckoutState()",
@@ -38554,7 +38632,7 @@
       "source_location": "L4"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "checkoutstorage_savecheckoutstate",
       "label": "saveCheckoutState()",
@@ -38563,39 +38641,12 @@
       "source_location": "L24"
     },
     {
-      "community": 248,
+      "community": 249,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_ts",
       "label": "checkoutStorage.ts",
       "norm_label": "checkoutstorage.ts",
       "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "footer_enablecategories",
-      "label": "enableCategories()",
-      "norm_label": "enablecategories()",
-      "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
-      "source_location": "L131"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "footer_linkgroup",
-      "label": "LinkGroup()",
-      "norm_label": "linkgroup()",
-      "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_footer_footer_tsx",
-      "label": "Footer.tsx",
-      "norm_label": "footer.tsx",
-      "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
       "source_location": "L1"
     },
     {
@@ -38700,6 +38751,33 @@
     {
       "community": 250,
       "file_type": "code",
+      "id": "footer_enablecategories",
+      "label": "enableCategories()",
+      "norm_label": "enablecategories()",
+      "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
+      "source_location": "L131"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "footer_linkgroup",
+      "label": "LinkGroup()",
+      "norm_label": "linkgroup()",
+      "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_footer_footer_tsx",
+      "label": "Footer.tsx",
+      "norm_label": "footer.tsx",
+      "source_file": "packages/storefront-webapp/src/components/footer/Footer.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
       "id": "featuredproductssection_featuredproductssection",
       "label": "FeaturedProductsSection()",
       "norm_label": "featuredproductssection()",
@@ -38707,7 +38785,7 @@
       "source_location": "L20"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "featuredproductssection_featuredsection",
       "label": "FeaturedSection()",
@@ -38716,7 +38794,7 @@
       "source_location": "L46"
     },
     {
-      "community": 250,
+      "community": 251,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_featuredproductssection_tsx",
       "label": "FeaturedProductsSection.tsx",
@@ -38725,7 +38803,7 @@
       "source_location": "L1"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_promoalert_tsx",
       "label": "PromoAlert.tsx",
@@ -38734,7 +38812,7 @@
       "source_location": "L1"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "promoalert_getpromoalertcopy",
       "label": "getPromoAlertCopy()",
@@ -38743,7 +38821,7 @@
       "source_location": "L20"
     },
     {
-      "community": 251,
+      "community": 252,
       "file_type": "code",
       "id": "promoalert_promoalert",
       "label": "PromoAlert()",
@@ -38752,7 +38830,7 @@
       "source_location": "L59"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_rewardsalert_tsx",
       "label": "RewardsAlert.tsx",
@@ -38761,7 +38839,7 @@
       "source_location": "L1"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "rewardsalert_handleshopnow",
       "label": "handleShopNow()",
@@ -38770,7 +38848,7 @@
       "source_location": "L25"
     },
     {
-      "community": 252,
+      "community": 253,
       "file_type": "code",
       "id": "rewardsalert_onrewardsalertclose",
       "label": "onRewardsAlertClose()",
@@ -38779,7 +38857,7 @@
       "source_location": "L20"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "navigationbar_navigationbar",
       "label": "NavigationBar()",
@@ -38788,7 +38866,7 @@
       "source_location": "L30"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "navigationbar_storecategoriessubmenu",
       "label": "StoreCategoriesSubmenu()",
@@ -38797,7 +38875,7 @@
       "source_location": "L95"
     },
     {
-      "community": 253,
+      "community": 254,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navigationbar_tsx",
       "label": "NavigationBar.tsx",
@@ -38806,7 +38884,7 @@
       "source_location": "L1"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattribute_tsx",
       "label": "ProductAttribute.tsx",
@@ -38815,7 +38893,7 @@
       "source_location": "L1"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "productattribute_findsize",
       "label": "findSize()",
@@ -38824,7 +38902,7 @@
       "source_location": "L61"
     },
     {
-      "community": 254,
+      "community": 255,
       "file_type": "code",
       "id": "productattribute_handleclick",
       "label": "handleClick()",
@@ -38833,7 +38911,7 @@
       "source_location": "L65"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_revieweditor_tsx",
       "label": "ReviewEditor.tsx",
@@ -38842,7 +38920,7 @@
       "source_location": "L1"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "revieweditor_handleformdatachange",
       "label": "handleFormDataChange()",
@@ -38851,7 +38929,7 @@
       "source_location": "L150"
     },
     {
-      "community": 255,
+      "community": 256,
       "file_type": "code",
       "id": "revieweditor_handlesubmit",
       "label": "handleSubmit()",
@@ -38860,7 +38938,7 @@
       "source_location": "L157"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalform_tsx",
       "label": "UpsellModalForm.tsx",
@@ -38869,7 +38947,7 @@
       "source_location": "L1"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "upsellmodalform_handleinputchange",
       "label": "handleInputChange()",
@@ -38878,7 +38956,7 @@
       "source_location": "L63"
     },
     {
-      "community": 256,
+      "community": 257,
       "file_type": "code",
       "id": "upsellmodalform_handlesubmit",
       "label": "handleSubmit()",
@@ -38887,7 +38965,7 @@
       "source_location": "L48"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodal_tsx",
       "label": "WelcomeBackModal.tsx",
@@ -38896,7 +38974,7 @@
       "source_location": "L1"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "welcomebackmodal_handleclose",
       "label": "handleClose()",
@@ -38905,7 +38983,7 @@
       "source_location": "L63"
     },
     {
-      "community": 257,
+      "community": 258,
       "file_type": "code",
       "id": "welcomebackmodal_handlesuccess",
       "label": "handleSuccess()",
@@ -38914,7 +38992,7 @@
       "source_location": "L76"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalform_tsx",
       "label": "WelcomeBackModalForm.tsx",
@@ -38923,7 +39001,7 @@
       "source_location": "L1"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "welcomebackmodalform_handleinputchange",
       "label": "handleInputChange()",
@@ -38932,40 +39010,13 @@
       "source_location": "L51"
     },
     {
-      "community": 258,
+      "community": 259,
       "file_type": "code",
       "id": "welcomebackmodalform_handlesubmit",
       "label": "handleSubmit()",
       "norm_label": "handlesubmit()",
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalForm.tsx",
       "source_location": "L36"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "navigationbarprovider_navigationbarprovider",
-      "label": "NavigationBarProvider()",
-      "norm_label": "navigationbarprovider()",
-      "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "navigationbarprovider_usenavigationbarcontext",
-      "label": "useNavigationBarContext()",
-      "norm_label": "usenavigationbarcontext()",
-      "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
-      "source_location": "L39"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_contexts_navigationbarprovider_tsx",
-      "label": "NavigationBarProvider.tsx",
-      "norm_label": "navigationbarprovider.tsx",
-      "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
-      "source_location": "L1"
     },
     {
       "community": 26,
@@ -39069,6 +39120,33 @@
     {
       "community": 260,
       "file_type": "code",
+      "id": "navigationbarprovider_navigationbarprovider",
+      "label": "NavigationBarProvider()",
+      "norm_label": "navigationbarprovider()",
+      "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "navigationbarprovider_usenavigationbarcontext",
+      "label": "useNavigationBarContext()",
+      "norm_label": "usenavigationbarcontext()",
+      "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
+      "source_location": "L39"
+    },
+    {
+      "community": 260,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_contexts_navigationbarprovider_tsx",
+      "label": "NavigationBarProvider.tsx",
+      "norm_label": "navigationbarprovider.tsx",
+      "source_file": "packages/storefront-webapp/src/contexts/NavigationBarProvider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storecontext_tsx",
       "label": "StoreContext.tsx",
       "norm_label": "storecontext.tsx",
@@ -39076,7 +39154,7 @@
       "source_location": "L1"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "storecontext_storeprovider",
       "label": "StoreProvider()",
@@ -39085,7 +39163,7 @@
       "source_location": "L25"
     },
     {
-      "community": 260,
+      "community": 261,
       "file_type": "code",
       "id": "storecontext_usestorecontext",
       "label": "useStoreContext()",
@@ -39094,7 +39172,7 @@
       "source_location": "L82"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_tsx",
       "label": "StorefrontObservabilityProvider.tsx",
@@ -39103,7 +39181,7 @@
       "source_location": "L1"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
       "label": "StorefrontObservabilityProvider()",
@@ -39112,7 +39190,7 @@
       "source_location": "L20"
     },
     {
-      "community": 261,
+      "community": 262,
       "file_type": "code",
       "id": "storefrontobservabilityprovider_usestorefrontobservability",
       "label": "useStorefrontObservability()",
@@ -39121,7 +39199,7 @@
       "source_location": "L55"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductdiscount_ts",
       "label": "useProductDiscount.ts",
@@ -39130,7 +39208,7 @@
       "source_location": "L1"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "useproductdiscount_useproductdiscount",
       "label": "useProductDiscount()",
@@ -39139,7 +39217,7 @@
       "source_location": "L107"
     },
     {
-      "community": 262,
+      "community": 263,
       "file_type": "code",
       "id": "useproductdiscount_useproductdiscounts",
       "label": "useProductDiscounts()",
@@ -39148,7 +39226,7 @@
       "source_location": "L25"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useshoppingbag_ts",
       "label": "useShoppingBag.ts",
@@ -39157,7 +39235,7 @@
       "source_location": "L1"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "useshoppingbag_isunavailableproductlist",
       "label": "isUnavailableProductList()",
@@ -39166,7 +39244,7 @@
       "source_location": "L556"
     },
     {
-      "community": 263,
+      "community": 264,
       "file_type": "code",
       "id": "useshoppingbag_useshoppingbag",
       "label": "useShoppingBag()",
@@ -39175,7 +39253,7 @@
       "source_location": "L52"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "index_getordermessage",
       "label": "getOrderMessage()",
@@ -39184,7 +39262,7 @@
       "source_location": "L429"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "index_getpaymenttext",
       "label": "getPaymentText()",
@@ -39193,7 +39271,7 @@
       "source_location": "L102"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_index_tsx",
       "label": "index.tsx",
@@ -39202,7 +39280,7 @@
       "source_location": "L1"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_review_tsx",
       "label": "review.tsx",
@@ -39211,7 +39289,7 @@
       "source_location": "L1"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "review_getordermessage",
       "label": "getOrderMessage()",
@@ -39220,7 +39298,7 @@
       "source_location": "L250"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "review_ordernavigation",
       "label": "OrderNavigation()",
@@ -39229,7 +39307,7 @@
       "source_location": "L46"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "account_accountbeforeload",
       "label": "accountBeforeLoad()",
@@ -39238,7 +39316,7 @@
       "source_location": "L17"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "account_handleonsubmitform",
       "label": "handleOnSubmitForm()",
@@ -39247,7 +39325,7 @@
       "source_location": "L63"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_account_tsx",
       "label": "account.tsx",
@@ -39256,7 +39334,7 @@
       "source_location": "L1"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "login_loginbeforeload",
       "label": "loginBeforeLoad()",
@@ -39265,7 +39343,7 @@
       "source_location": "L47"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "login_onsubmit",
       "label": "onSubmit()",
@@ -39274,7 +39352,7 @@
       "source_location": "L141"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_login_tsx",
       "label": "login.tsx",
@@ -39283,7 +39361,7 @@
       "source_location": "L1"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_verify_index_tsx",
       "label": "verify.index.tsx",
@@ -39292,7 +39370,7 @@
       "source_location": "L1"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "verify_index_verify",
       "label": "Verify()",
@@ -39301,40 +39379,13 @@
       "source_location": "L21"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "verify_index_verifycheckoutsessionpayment",
       "label": "VerifyCheckoutSessionPayment()",
       "norm_label": "verifycheckoutsessionpayment()",
       "source_file": "packages/storefront-webapp/src/routes/shop/checkout/verify.index.tsx",
       "source_location": "L107"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_signup_tsx",
-      "label": "signup.tsx",
-      "norm_label": "signup.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "signup_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
-      "source_location": "L161"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "signup_signupbeforeload",
-      "label": "signupBeforeLoad()",
-      "norm_label": "signupbeforeload()",
-      "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
-      "source_location": "L66"
     },
     {
       "community": 27,
@@ -39438,6 +39489,33 @@
     {
       "community": 270,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_signup_tsx",
+      "label": "signup.tsx",
+      "norm_label": "signup.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "signup_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
+      "source_location": "L161"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "signup_signupbeforeload",
+      "label": "signupBeforeLoad()",
+      "norm_label": "signupbeforeload()",
+      "source_file": "packages/storefront-webapp/src/routes/signup.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 271,
+      "file_type": "code",
       "id": "env_optionalnumberenv",
       "label": "optionalNumberEnv()",
       "norm_label": "optionalnumberenv()",
@@ -39445,7 +39523,7 @@
       "source_location": "L11"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "env_requireenv",
       "label": "requireEnv()",
@@ -39454,7 +39532,7 @@
       "source_location": "L1"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_env_ts",
       "label": "env.ts",
@@ -39463,7 +39541,7 @@
       "source_location": "L1"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "graphify_wiki_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -39472,7 +39550,7 @@
       "source_location": "L16"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "graphify_wiki_test_write",
       "label": "write()",
@@ -39481,7 +39559,7 @@
       "source_location": "L10"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "scripts_graphify_wiki_test_ts",
       "label": "graphify-wiki.test.ts",
@@ -39490,7 +39568,7 @@
       "source_location": "L1"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "harness_audit_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -39499,7 +39577,7 @@
       "source_location": "L17"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "harness_audit_test_write",
       "label": "write()",
@@ -39508,7 +39586,7 @@
       "source_location": "L11"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "scripts_harness_audit_test_ts",
       "label": "harness-audit.test.ts",
@@ -39517,7 +39595,7 @@
       "source_location": "L1"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "harness_behavior_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -39526,7 +39604,7 @@
       "source_location": "L21"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "harness_behavior_test_write",
       "label": "write()",
@@ -39535,7 +39613,7 @@
       "source_location": "L15"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "scripts_harness_behavior_test_ts",
       "label": "harness-behavior.test.ts",
@@ -39544,7 +39622,7 @@
       "source_location": "L1"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "harness_check_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -39553,7 +39631,7 @@
       "source_location": "L48"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "harness_check_test_write",
       "label": "write()",
@@ -39562,7 +39640,7 @@
       "source_location": "L42"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "scripts_harness_check_test_ts",
       "label": "harness-check.test.ts",
@@ -39571,7 +39649,7 @@
       "source_location": "L1"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "harness_generate_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -39580,7 +39658,7 @@
       "source_location": "L16"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "harness_generate_test_write",
       "label": "write()",
@@ -39589,7 +39667,7 @@
       "source_location": "L10"
     },
     {
-      "community": 275,
+      "community": 276,
       "file_type": "code",
       "id": "scripts_harness_generate_test_ts",
       "label": "harness-generate.test.ts",
@@ -39598,7 +39676,7 @@
       "source_location": "L1"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "harness_inferential_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -39607,7 +39685,7 @@
       "source_location": "L19"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "harness_inferential_review_test_write",
       "label": "write()",
@@ -39616,7 +39694,7 @@
       "source_location": "L13"
     },
     {
-      "community": 276,
+      "community": 277,
       "file_type": "code",
       "id": "scripts_harness_inferential_review_test_ts",
       "label": "harness-inferential-review.test.ts",
@@ -39625,7 +39703,7 @@
       "source_location": "L1"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "harness_self_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -39634,7 +39712,7 @@
       "source_location": "L16"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "harness_self_review_test_write",
       "label": "write()",
@@ -39643,7 +39721,7 @@
       "source_location": "L10"
     },
     {
-      "community": 277,
+      "community": 278,
       "file_type": "code",
       "id": "scripts_harness_self_review_test_ts",
       "label": "harness-self-review.test.ts",
@@ -39652,7 +39730,7 @@
       "source_location": "L1"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "harness_test_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -39661,7 +39739,7 @@
       "source_location": "L20"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "harness_test_test_write",
       "label": "write()",
@@ -39670,31 +39748,13 @@
       "source_location": "L14"
     },
     {
-      "community": 278,
+      "community": 279,
       "file_type": "code",
       "id": "scripts_harness_test_test_ts",
       "label": "harness-test.test.ts",
       "norm_label": "harness-test.test.ts",
       "source_file": "scripts/harness-test.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_cloudflare_stream_ts",
-      "label": "stream.ts",
-      "norm_label": "stream.ts",
-      "source_file": "packages/athena-webapp/convex/cloudflare/stream.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "stream_getcloudflareconfig",
-      "label": "getCloudflareConfig()",
-      "norm_label": "getcloudflareconfig()",
-      "source_file": "packages/athena-webapp/convex/cloudflare/stream.ts",
-      "source_location": "L8"
     },
     {
       "community": 28,
@@ -39789,6 +39849,24 @@
     {
       "community": 280,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_cloudflare_stream_ts",
+      "label": "stream.ts",
+      "norm_label": "stream.ts",
+      "source_file": "packages/athena-webapp/convex/cloudflare/stream.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 280,
+      "file_type": "code",
+      "id": "stream_getcloudflareconfig",
+      "label": "getCloudflareConfig()",
+      "norm_label": "getcloudflareconfig()",
+      "source_file": "packages/athena-webapp/convex/cloudflare/stream.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
       "id": "convexauditscript_test_createcommandshimbin",
       "label": "createCommandShimBin()",
       "norm_label": "createcommandshimbin()",
@@ -39796,7 +39874,7 @@
       "source_location": "L10"
     },
     {
-      "community": 280,
+      "community": 281,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_convexauditscript_test_ts",
       "label": "convexAuditScript.test.ts",
@@ -39805,7 +39883,7 @@
       "source_location": "L1"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_verificationcode_tsx",
       "label": "VerificationCode.tsx",
@@ -39814,7 +39892,7 @@
       "source_location": "L1"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "verificationcode_verificationcode",
       "label": "VerificationCode()",
@@ -39823,7 +39901,7 @@
       "source_location": "L18"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "mtnmomo_handlecollectionnotification",
       "label": "handleCollectionNotification()",
@@ -39832,7 +39910,7 @@
       "source_location": "L10"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_payments_routes_mtnmomo_ts",
       "label": "mtnMomo.ts",
@@ -39841,7 +39919,7 @@
       "source_location": "L1"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_routercomposition_test_ts",
       "label": "routerComposition.test.ts",
@@ -39850,7 +39928,7 @@
       "source_location": "L1"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "routercomposition_test_readprojectfile",
       "label": "readProjectFile()",
@@ -39859,7 +39937,7 @@
       "source_location": "L6"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "cashier_authenticatehandler",
       "label": "authenticateHandler()",
@@ -39868,7 +39946,7 @@
       "source_location": "L239"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_cashier_ts",
       "label": "cashier.ts",
@@ -39877,7 +39955,7 @@
       "source_location": "L1"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posquerycleanup_test_ts",
       "label": "posQueryCleanup.test.ts",
@@ -39886,7 +39964,7 @@
       "source_location": "L1"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "posquerycleanup_test_readprojectfile",
       "label": "readProjectFile()",
@@ -39895,7 +39973,7 @@
       "source_location": "L8"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_sessionqueryindexes_test_ts",
       "label": "sessionQueryIndexes.test.ts",
@@ -39904,7 +39982,7 @@
       "source_location": "L1"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "sessionqueryindexes_test_readprojectfile",
       "label": "readProjectFile()",
@@ -39913,7 +39991,7 @@
       "source_location": "L6"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stores_ts",
       "label": "stores.ts",
@@ -39922,7 +40000,7 @@
       "source_location": "L1"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "stores_tov2onlyconfig",
       "label": "toV2OnlyConfig()",
@@ -39931,7 +40009,7 @@
       "source_location": "L27"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "callllmprovider_callllmprovider",
       "label": "callLlmProvider()",
@@ -39940,30 +40018,12 @@
       "source_location": "L4"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_callllmprovider_ts",
       "label": "callLlmProvider.ts",
       "norm_label": "callllmprovider.ts",
       "source_file": "packages/athena-webapp/convex/llm/callLlmProvider.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "anthropic_callanthropic",
-      "label": "callAnthropic()",
-      "norm_label": "callanthropic()",
-      "source_file": "packages/athena-webapp/convex/llm/providers/anthropic.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_llm_providers_anthropic_ts",
-      "label": "anthropic.ts",
-      "norm_label": "anthropic.ts",
-      "source_file": "packages/athena-webapp/convex/llm/providers/anthropic.ts",
       "source_location": "L1"
     },
     {
@@ -40059,6 +40119,24 @@
     {
       "community": 290,
       "file_type": "code",
+      "id": "anthropic_callanthropic",
+      "label": "callAnthropic()",
+      "norm_label": "callanthropic()",
+      "source_file": "packages/athena-webapp/convex/llm/providers/anthropic.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_llm_providers_anthropic_ts",
+      "label": "anthropic.ts",
+      "norm_label": "anthropic.ts",
+      "source_file": "packages/athena-webapp/convex/llm/providers/anthropic.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 291,
+      "file_type": "code",
       "id": "openai_callopenai",
       "label": "callOpenAi()",
       "norm_label": "callopenai()",
@@ -40066,7 +40144,7 @@
       "source_location": "L3"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_openai_ts",
       "label": "openai.ts",
@@ -40075,7 +40153,7 @@
       "source_location": "L1"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "foundation_test_readprojectfile",
       "label": "readProjectFile()",
@@ -40084,7 +40162,7 @@
       "source_location": "L6"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_foundation_test_ts",
       "label": "foundation.test.ts",
@@ -40093,7 +40171,7 @@
       "source_location": "L1"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_verificationcodeemail_tsx",
       "label": "VerificationCodeEmail.tsx",
@@ -40102,7 +40180,7 @@
       "source_location": "L1"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "verificationcodeemail_verificationcodeemail",
       "label": "VerificationCodeEmail()",
@@ -40111,7 +40189,7 @@
       "source_location": "L11"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "auth_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -40120,7 +40198,7 @@
       "source_location": "L15"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_auth_ts",
       "label": "auth.ts",
@@ -40129,7 +40207,7 @@
       "source_location": "L1"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "customerobservabilitytimeline_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -40138,7 +40216,7 @@
       "source_location": "L17"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerobservabilitytimeline_test_ts",
       "label": "customerObservabilityTimeline.test.ts",
@@ -40147,7 +40225,7 @@
       "source_location": "L1"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "helperorchestration_test_readprojectfile",
       "label": "readProjectFile()",
@@ -40156,7 +40234,7 @@
       "source_location": "L6"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helperorchestration_test_ts",
       "label": "helperOrchestration.test.ts",
@@ -40165,7 +40243,7 @@
       "source_location": "L1"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "onlineorder_listorderitems",
       "label": "listOrderItems()",
@@ -40174,7 +40252,7 @@
       "source_location": "L27"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -40183,7 +40261,7 @@
       "source_location": "L1"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "onlineorderitem_updateonlineorderitem",
       "label": "updateOnlineOrderItem()",
@@ -40192,7 +40270,7 @@
       "source_location": "L21"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
@@ -40201,7 +40279,7 @@
       "source_location": "L1"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_reviews_ts",
       "label": "reviews.ts",
@@ -40210,31 +40288,13 @@
       "source_location": "L1"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "reviews_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
       "norm_label": "getstorefrontactorbyid()",
       "source_file": "packages/athena-webapp/convex/storeFront/reviews.ts",
       "source_location": "L17"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_savedbag_ts",
-      "label": "savedBag.ts",
-      "norm_label": "savedbag.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/savedBag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "savedbag_listsavedbagitems",
-      "label": "listSavedBagItems()",
-      "norm_label": "listsavedbagitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/savedBag.ts",
-      "source_location": "L14"
     },
     {
       "community": 3,
@@ -40608,6 +40668,24 @@
     {
       "community": 300,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_savedbag_ts",
+      "label": "savedBag.ts",
+      "norm_label": "savedbag.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/savedBag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "savedbag_listsavedbagitems",
+      "label": "listSavedBagItems()",
+      "norm_label": "listsavedbagitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/savedBag.ts",
+      "source_location": "L14"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_test_ts",
       "label": "storefrontObservabilityReport.test.ts",
       "norm_label": "storefrontobservabilityreport.test.ts",
@@ -40615,7 +40693,7 @@
       "source_location": "L1"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "storefrontobservabilityreport_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -40624,7 +40702,7 @@
       "source_location": "L8"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_syntheticmonitor_ts",
       "label": "syntheticMonitor.ts",
@@ -40633,7 +40711,7 @@
       "source_location": "L1"
     },
     {
-      "community": 301,
+      "community": 302,
       "file_type": "code",
       "id": "syntheticmonitor_issyntheticmonitororigin",
       "label": "isSyntheticMonitorOrigin()",
@@ -40642,7 +40720,7 @@
       "source_location": "L3"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_timequeryrefactors_test_ts",
       "label": "timeQueryRefactors.test.ts",
@@ -40651,7 +40729,7 @@
       "source_location": "L1"
     },
     {
-      "community": 302,
+      "community": 303,
       "file_type": "code",
       "id": "timequeryrefactors_test_readsource",
       "label": "readSource()",
@@ -40660,7 +40738,7 @@
       "source_location": "L5"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_user_ts",
       "label": "user.ts",
@@ -40669,7 +40747,7 @@
       "source_location": "L1"
     },
     {
-      "community": 303,
+      "community": 304,
       "file_type": "code",
       "id": "user_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -40678,7 +40756,7 @@
       "source_location": "L16"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_useroffers_ts",
       "label": "userOffers.ts",
@@ -40687,7 +40765,7 @@
       "source_location": "L1"
     },
     {
-      "community": 304,
+      "community": 305,
       "file_type": "code",
       "id": "useroffers_determineoffereligibility",
       "label": "determineOfferEligibility()",
@@ -40696,7 +40774,7 @@
       "source_location": "L30"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "organizationview_navigation",
       "label": "Navigation()",
@@ -40705,7 +40783,7 @@
       "source_location": "L7"
     },
     {
-      "community": 305,
+      "community": 306,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationview_tsx",
       "label": "OrganizationView.tsx",
@@ -40714,7 +40792,7 @@
       "source_location": "L1"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "organizationsview_navigation",
       "label": "Navigation()",
@@ -40723,7 +40801,7 @@
       "source_location": "L12"
     },
     {
-      "community": 306,
+      "community": 307,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationsview_tsx",
       "label": "OrganizationsView.tsx",
@@ -40732,7 +40810,7 @@
       "source_location": "L1"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_permissiongate_tsx",
       "label": "PermissionGate.tsx",
@@ -40741,7 +40819,7 @@
       "source_location": "L1"
     },
     {
-      "community": 307,
+      "community": 308,
       "file_type": "code",
       "id": "permissiongate_permissiongate",
       "label": "PermissionGate()",
@@ -40750,7 +40828,7 @@
       "source_location": "L11"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_protectedroute_tsx",
       "label": "ProtectedRoute.tsx",
@@ -40759,31 +40837,13 @@
       "source_location": "L1"
     },
     {
-      "community": 308,
+      "community": 309,
       "file_type": "code",
       "id": "protectedroute_protectedroute",
       "label": "ProtectedRoute()",
       "norm_label": "protectedroute()",
       "source_file": "packages/athena-webapp/src/components/ProtectedRoute.tsx",
       "source_location": "L11"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_settingsview_tsx",
-      "label": "SettingsView.tsx",
-      "norm_label": "settingsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/SettingsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "settingsview_settingsview",
-      "label": "SettingsView()",
-      "norm_label": "settingsview()",
-      "source_file": "packages/athena-webapp/src/components/SettingsView.tsx",
-      "source_location": "L3"
     },
     {
       "community": 31,
@@ -40878,6 +40938,24 @@
     {
       "community": 310,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_settingsview_tsx",
+      "label": "SettingsView.tsx",
+      "norm_label": "settingsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/SettingsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "settingsview_settingsview",
+      "label": "SettingsView()",
+      "norm_label": "settingsview()",
+      "source_file": "packages/athena-webapp/src/components/SettingsView.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeactions_tsx",
       "label": "StoreActions.tsx",
       "norm_label": "storeactions.tsx",
@@ -40885,7 +40963,7 @@
       "source_location": "L1"
     },
     {
-      "community": 310,
+      "community": 311,
       "file_type": "code",
       "id": "storeactions_storeactions",
       "label": "StoreActions()",
@@ -40894,7 +40972,7 @@
       "source_location": "L12"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storedropdown_tsx",
       "label": "StoreDropdown.tsx",
@@ -40903,7 +40981,7 @@
       "source_location": "L1"
     },
     {
-      "community": 311,
+      "community": 312,
       "file_type": "code",
       "id": "storedropdown_storedropdown",
       "label": "StoreDropdown()",
@@ -40912,7 +40990,7 @@
       "source_location": "L42"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeview_tsx",
       "label": "StoreView.tsx",
@@ -40921,7 +40999,7 @@
       "source_location": "L1"
     },
     {
-      "community": 312,
+      "community": 313,
       "file_type": "code",
       "id": "storeview_navigation",
       "label": "Navigation()",
@@ -40930,7 +41008,7 @@
       "source_location": "L13"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesdropdown_tsx",
       "label": "StoresDropdown.tsx",
@@ -40939,7 +41017,7 @@
       "source_location": "L1"
     },
     {
-      "community": 313,
+      "community": 314,
       "file_type": "code",
       "id": "storesdropdown_storesdropdown",
       "label": "StoresDropdown()",
@@ -40948,7 +41026,7 @@
       "source_location": "L42"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "barcodeqrviewer_handleprint",
       "label": "handlePrint()",
@@ -40957,7 +41035,7 @@
       "source_location": "L31"
     },
     {
-      "community": 314,
+      "community": 315,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_barcodeqrviewer_tsx",
       "label": "BarcodeQRViewer.tsx",
@@ -40966,7 +41044,7 @@
       "source_location": "L1"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_processingfees_tsx",
       "label": "ProcessingFees.tsx",
@@ -40975,7 +41053,7 @@
       "source_location": "L1"
     },
     {
-      "community": 315,
+      "community": 316,
       "file_type": "code",
       "id": "processingfees_processingfeesview",
       "label": "ProcessingFeesView()",
@@ -40984,7 +41062,7 @@
       "source_location": "L10"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributes_tsx",
       "label": "ProductAttributes.tsx",
@@ -40993,7 +41071,7 @@
       "source_location": "L1"
     },
     {
-      "community": 316,
+      "community": 317,
       "file_type": "code",
       "id": "productattributes_isallowedattribute",
       "label": "isAllowedAttribute()",
@@ -41002,7 +41080,7 @@
       "source_location": "L14"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailabilitytogglegroup_tsx",
       "label": "ProductAvailabilityToggleGroup.tsx",
@@ -41011,7 +41089,7 @@
       "source_location": "L1"
     },
     {
-      "community": 317,
+      "community": 318,
       "file_type": "code",
       "id": "productavailabilitytogglegroup_productavailabilitytogglegroup",
       "label": "ProductAvailabilityToggleGroup()",
@@ -41020,7 +41098,7 @@
       "source_location": "L5"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -41029,31 +41107,13 @@
       "source_location": "L1"
     },
     {
-      "community": 318,
+      "community": 319,
       "file_type": "code",
       "id": "productdetails_handlenamechange",
       "label": "handleNameChange()",
       "norm_label": "handlenamechange()",
       "source_file": "packages/athena-webapp/src/components/add-product/ProductDetails.tsx",
       "source_location": "L10"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productimages_tsx",
-      "label": "ProductImages.tsx",
-      "norm_label": "productimages.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductImages.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "productimages_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductImages.tsx",
-      "source_location": "L15"
     },
     {
       "community": 32,
@@ -41148,6 +41208,24 @@
     {
       "community": 320,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_productimages_tsx",
+      "label": "ProductImages.tsx",
+      "norm_label": "productimages.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductImages.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "productimages_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductImages.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productpage_tsx",
       "label": "ProductPage.tsx",
       "norm_label": "productpage.tsx",
@@ -41155,7 +41233,7 @@
       "source_location": "L1"
     },
     {
-      "community": 320,
+      "community": 321,
       "file_type": "code",
       "id": "productpage_productpage",
       "label": "ProductPage()",
@@ -41164,7 +41242,7 @@
       "source_location": "L13"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "copyimagesview_setisupdatingsku",
       "label": "setIsUpdatingSku()",
@@ -41173,7 +41251,7 @@
       "source_location": "L116"
     },
     {
-      "community": 321,
+      "community": 322,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesview_tsx",
       "label": "CopyImagesView.tsx",
@@ -41182,7 +41260,7 @@
       "source_location": "L1"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_product_variant_columns_tsx",
       "label": "product-variant-columns.tsx",
@@ -41191,7 +41269,7 @@
       "source_location": "L1"
     },
     {
-      "community": 322,
+      "community": 323,
       "file_type": "code",
       "id": "product_variant_columns_setsourcevariant",
       "label": "setSourceVariant()",
@@ -41200,7 +41278,7 @@
       "source_location": "L47"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "activitytimeline_capitalizefirstletter",
       "label": "capitalizeFirstLetter()",
@@ -41209,7 +41287,7 @@
       "source_location": "L151"
     },
     {
-      "community": 323,
+      "community": 324,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_activitytimeline_tsx",
       "label": "ActivityTimeline.tsx",
@@ -41218,7 +41296,7 @@
       "source_location": "L1"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "analyticsitems_analyticsitems",
       "label": "AnalyticsItems()",
@@ -41227,7 +41305,7 @@
       "source_location": "L6"
     },
     {
-      "community": 324,
+      "community": 325,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsitems_tsx",
       "label": "AnalyticsItems.tsx",
@@ -41236,7 +41314,7 @@
       "source_location": "L1"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "analyticsproducts_analyticsproducts",
       "label": "AnalyticsProducts()",
@@ -41245,7 +41323,7 @@
       "source_location": "L19"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsproducts_tsx",
       "label": "AnalyticsProducts.tsx",
@@ -41254,7 +41332,7 @@
       "source_location": "L1"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "analyticsusers_analyticsusers",
       "label": "AnalyticsUsers()",
@@ -41263,7 +41341,7 @@
       "source_location": "L7"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsusers_tsx",
       "label": "AnalyticsUsers.tsx",
@@ -41272,7 +41350,7 @@
       "source_location": "L1"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "enhancedanalyticsview_getdaterangemilliseconds",
       "label": "getDateRangeMilliseconds()",
@@ -41281,7 +41359,7 @@
       "source_location": "L42"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_enhancedanalyticsview_tsx",
       "label": "EnhancedAnalyticsView.tsx",
@@ -41290,7 +41368,7 @@
       "source_location": "L1"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storeinsights_tsx",
       "label": "StoreInsights.tsx",
@@ -41299,31 +41377,13 @@
       "source_location": "L1"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "storeinsights_gettrendicon",
       "label": "getTrendIcon()",
       "norm_label": "gettrendicon()",
       "source_file": "packages/athena-webapp/src/components/analytics/StoreInsights.tsx",
       "source_location": "L66"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_visitorchart_tsx",
-      "label": "VisitorChart.tsx",
-      "norm_label": "visitorchart.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/VisitorChart.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "visitorchart_formathour",
-      "label": "formatHour()",
-      "norm_label": "formathour()",
-      "source_file": "packages/athena-webapp/src/components/analytics/VisitorChart.tsx",
-      "source_location": "L18"
     },
     {
       "community": 33,
@@ -41418,6 +41478,24 @@
     {
       "community": 330,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_visitorchart_tsx",
+      "label": "VisitorChart.tsx",
+      "norm_label": "visitorchart.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/VisitorChart.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "visitorchart_formathour",
+      "label": "formatHour()",
+      "norm_label": "formathour()",
+      "source_file": "packages/athena-webapp/src/components/analytics/VisitorChart.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
       "id": "logitems_logitems",
       "label": "LogItems()",
       "norm_label": "logitems()",
@@ -41425,7 +41503,7 @@
       "source_location": "L6"
     },
     {
-      "community": 330,
+      "community": 331,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logitems_tsx",
       "label": "LogItems.tsx",
@@ -41434,7 +41512,7 @@
       "source_location": "L1"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "logview_header",
       "label": "Header()",
@@ -41443,7 +41521,7 @@
       "source_location": "L10"
     },
     {
-      "community": 331,
+      "community": 332,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logview_tsx",
       "label": "LogView.tsx",
@@ -41452,7 +41530,7 @@
       "source_location": "L1"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "logsview_navigation",
       "label": "Navigation()",
@@ -41461,7 +41539,7 @@
       "source_location": "L27"
     },
     {
-      "community": 332,
+      "community": 333,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logsview_tsx",
       "label": "LogsView.tsx",
@@ -41470,7 +41548,7 @@
       "source_location": "L1"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_hooks_useloadlogitems_ts",
       "label": "useLoadLogItems.ts",
@@ -41479,7 +41557,7 @@
       "source_location": "L1"
     },
     {
-      "community": 333,
+      "community": 334,
       "file_type": "code",
       "id": "useloadlogitems_useloadlogitems",
       "label": "useLoadLogItems()",
@@ -41488,7 +41566,7 @@
       "source_location": "L12"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "auth_auth",
       "label": "Auth()",
@@ -41497,7 +41575,7 @@
       "source_location": "L3"
     },
     {
-      "community": 334,
+      "community": 335,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -41506,7 +41584,7 @@
       "source_location": "L1"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "index_login",
       "label": "Login()",
@@ -41515,7 +41593,7 @@
       "source_location": "L5"
     },
     {
-      "community": 335,
+      "community": 336,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_index_tsx",
       "label": "index.tsx",
@@ -41524,7 +41602,7 @@
       "source_location": "L1"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "bulkoperationsfilters_handleloadproducts",
       "label": "handleLoadProducts()",
@@ -41533,7 +41611,7 @@
       "source_location": "L49"
     },
     {
-      "community": 336,
+      "community": 337,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationsfilters_tsx",
       "label": "BulkOperationsFilters.tsx",
@@ -41542,7 +41620,7 @@
       "source_location": "L1"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "bulkoperationspreview_test_makerow",
       "label": "makeRow()",
@@ -41551,7 +41629,7 @@
       "source_location": "L23"
     },
     {
-      "community": 337,
+      "community": 338,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_test_tsx",
       "label": "BulkOperationsPreview.test.tsx",
@@ -41560,7 +41638,7 @@
       "source_location": "L1"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "bulkoperationspreview_formatprice",
       "label": "formatPrice()",
@@ -41569,30 +41647,12 @@
       "source_location": "L50"
     },
     {
-      "community": 338,
+      "community": 339,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_tsx",
       "label": "BulkOperationsPreview.tsx",
       "norm_label": "bulkoperationspreview.tsx",
       "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "checkoutsessionstable_checkoutsessionstable",
-      "label": "CheckoutSessionsTable()",
-      "norm_label": "checkoutsessionstable()",
-      "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSessionsTable.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsessionstable_tsx",
-      "label": "CheckoutSessionsTable.tsx",
-      "norm_label": "checkoutsessionstable.tsx",
-      "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSessionsTable.tsx",
       "source_location": "L1"
     },
     {
@@ -41688,6 +41748,24 @@
     {
       "community": 340,
       "file_type": "code",
+      "id": "checkoutsessionstable_checkoutsessionstable",
+      "label": "CheckoutSessionsTable()",
+      "norm_label": "checkoutsessionstable()",
+      "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSessionsTable.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsessionstable_tsx",
+      "label": "CheckoutSessionsTable.tsx",
+      "norm_label": "checkoutsessionstable.tsx",
+      "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSessionsTable.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
       "id": "checkoutsesssionsview_navigation",
       "label": "Navigation()",
       "norm_label": "navigation()",
@@ -41695,7 +41773,7 @@
       "source_location": "L11"
     },
     {
-      "community": 340,
+      "community": 341,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsesssionsview_tsx",
       "label": "CheckoutSesssionsView.tsx",
@@ -41704,7 +41782,7 @@
       "source_location": "L1"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
       "label": "PageHeader.tsx",
@@ -41713,7 +41791,7 @@
       "source_location": "L1"
     },
     {
-      "community": 341,
+      "community": 342,
       "file_type": "code",
       "id": "pageheader_pageheader",
       "label": "PageHeader()",
@@ -41722,7 +41800,7 @@
       "source_location": "L7"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "bestsellersdialog_handleaddbestseller",
       "label": "handleAddBestSeller()",
@@ -41731,7 +41809,7 @@
       "source_location": "L29"
     },
     {
-      "community": 342,
+      "community": 343,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellersdialog_tsx",
       "label": "BestSellersDialog.tsx",
@@ -41740,7 +41818,7 @@
       "source_location": "L1"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "featuredsectiondialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
@@ -41749,7 +41827,7 @@
       "source_location": "L37"
     },
     {
-      "community": 343,
+      "community": 344,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsectiondialog_tsx",
       "label": "FeaturedSectionDialog.tsx",
@@ -41758,7 +41836,7 @@
       "source_location": "L1"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "home_navigation",
       "label": "Navigation()",
@@ -41767,7 +41845,7 @@
       "source_location": "L25"
     },
     {
-      "community": 344,
+      "community": 345,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_home_tsx",
       "label": "Home.tsx",
@@ -41776,7 +41854,7 @@
       "source_location": "L1"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "landingpagereelversion_handleupdateconfig",
       "label": "handleUpdateConfig()",
@@ -41785,7 +41863,7 @@
       "source_location": "L83"
     },
     {
-      "community": 345,
+      "community": 346,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_landingpagereelversion_tsx",
       "label": "LandingPageReelVersion.tsx",
@@ -41794,7 +41872,7 @@
       "source_location": "L1"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookdialog_tsx",
       "label": "ShopLookDialog.tsx",
@@ -41803,7 +41881,7 @@
       "source_location": "L1"
     },
     {
-      "community": 346,
+      "community": 347,
       "file_type": "code",
       "id": "shoplookdialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
@@ -41812,7 +41890,7 @@
       "source_location": "L35"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookimageuploader_tsx",
       "label": "ShopLookImageUploader.tsx",
@@ -41821,7 +41899,7 @@
       "source_location": "L1"
     },
     {
-      "community": 347,
+      "community": 348,
       "file_type": "code",
       "id": "shoplookimageuploader_shoplookimageuploader",
       "label": "ShopLookImageUploader()",
@@ -41830,7 +41908,7 @@
       "source_location": "L28"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "index_jointeam",
       "label": "JoinTeam()",
@@ -41839,30 +41917,12 @@
       "source_location": "L11"
     },
     {
-      "community": 348,
+      "community": 349,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_join_team_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/components/join-team/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "customerdetailsview_customerdetailsview",
-      "label": "CustomerDetailsView()",
-      "norm_label": "customerdetailsview()",
-      "source_file": "packages/athena-webapp/src/components/orders/CustomerDetailsView.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_customerdetailsview_tsx",
-      "label": "CustomerDetailsView.tsx",
-      "norm_label": "customerdetailsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/CustomerDetailsView.tsx",
       "source_location": "L1"
     },
     {
@@ -41949,6 +42009,24 @@
     {
       "community": 350,
       "file_type": "code",
+      "id": "customerdetailsview_customerdetailsview",
+      "label": "CustomerDetailsView()",
+      "norm_label": "customerdetailsview()",
+      "source_file": "packages/athena-webapp/src/components/orders/CustomerDetailsView.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_customerdetailsview_tsx",
+      "label": "CustomerDetailsView.tsx",
+      "norm_label": "customerdetailsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/CustomerDetailsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
       "id": "emailstatusview_handlesendorderemail",
       "label": "handleSendOrderEmail()",
       "norm_label": "handlesendorderemail()",
@@ -41956,7 +42034,7 @@
       "source_location": "L41"
     },
     {
-      "community": 350,
+      "community": 351,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_emailstatusview_tsx",
       "label": "EmailStatusView.tsx",
@@ -41965,7 +42043,7 @@
       "source_location": "L1"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "ordermetricspanel_handletimerangechange",
       "label": "handleTimeRangeChange()",
@@ -41974,7 +42052,7 @@
       "source_location": "L33"
     },
     {
-      "community": 351,
+      "community": 352,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordermetricspanel_tsx",
       "label": "OrderMetricsPanel.tsx",
@@ -41983,7 +42061,7 @@
       "source_location": "L1"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "ordersview_gettimefilter",
       "label": "getTimeFilter()",
@@ -41992,7 +42070,7 @@
       "source_location": "L35"
     },
     {
-      "community": 352,
+      "community": 353,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersview_tsx",
       "label": "OrdersView.tsx",
@@ -42001,7 +42079,7 @@
       "source_location": "L1"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_refundsview_tsx",
       "label": "RefundsView.tsx",
@@ -42010,7 +42088,7 @@
       "source_location": "L1"
     },
     {
-      "community": 353,
+      "community": 354,
       "file_type": "code",
       "id": "refundsview_handlerefundorder",
       "label": "handleRefundOrder()",
@@ -42019,7 +42097,7 @@
       "source_location": "L79"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_hooks_usegetactiveonlineorder_ts",
       "label": "useGetActiveOnlineOrder.ts",
@@ -42028,7 +42106,7 @@
       "source_location": "L1"
     },
     {
-      "community": 354,
+      "community": 355,
       "file_type": "code",
       "id": "usegetactiveonlineorder_usegetactiveonlineorder",
       "label": "useGetActiveOnlineOrder()",
@@ -42037,7 +42115,7 @@
       "source_location": "L6"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "data_table_toolbar_handleclearfilters",
       "label": "handleClearFilters()",
@@ -42046,7 +42124,7 @@
       "source_location": "L34"
     },
     {
-      "community": 355,
+      "community": 356,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -42055,7 +42133,7 @@
       "source_location": "L1"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "ordercolumns_if",
       "label": "if()",
@@ -42064,7 +42142,7 @@
       "source_location": "L89"
     },
     {
-      "community": 356,
+      "community": 357,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_ordercolumns_tsx",
       "label": "orderColumns.tsx",
@@ -42073,7 +42151,7 @@
       "source_location": "L1"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "cashierview_handlesignout",
       "label": "handleSignOut()",
@@ -42082,7 +42160,7 @@
       "source_location": "L63"
     },
     {
-      "community": 357,
+      "community": 358,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierview_tsx",
       "label": "CashierView.tsx",
@@ -42091,7 +42169,7 @@
       "source_location": "L1"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "debugproducts_debugproducts",
       "label": "DebugProducts()",
@@ -42100,30 +42178,12 @@
       "source_location": "L5"
     },
     {
-      "community": 358,
+      "community": 359,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_debugproducts_tsx",
       "label": "DebugProducts.tsx",
       "norm_label": "debugproducts.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/DebugProducts.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "noresultsmessage_noresultsmessage",
-      "label": "NoResultsMessage()",
-      "norm_label": "noresultsmessage()",
-      "source_file": "packages/athena-webapp/src/components/pos/NoResultsMessage.tsx",
-      "source_location": "L7"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_noresultsmessage_tsx",
-      "label": "NoResultsMessage.tsx",
-      "norm_label": "noresultsmessage.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/NoResultsMessage.tsx",
       "source_location": "L1"
     },
     {
@@ -42210,6 +42270,24 @@
     {
       "community": 360,
       "file_type": "code",
+      "id": "noresultsmessage_noresultsmessage",
+      "label": "NoResultsMessage()",
+      "norm_label": "noresultsmessage()",
+      "source_file": "packages/athena-webapp/src/components/pos/NoResultsMessage.tsx",
+      "source_location": "L7"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_noresultsmessage_tsx",
+      "label": "NoResultsMessage.tsx",
+      "norm_label": "noresultsmessage.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/NoResultsMessage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pininput_tsx",
       "label": "PinInput.tsx",
       "norm_label": "pininput.tsx",
@@ -42217,7 +42295,7 @@
       "source_location": "L1"
     },
     {
-      "community": 360,
+      "community": 361,
       "file_type": "code",
       "id": "pininput_pininput",
       "label": "PinInput()",
@@ -42226,7 +42304,7 @@
       "source_location": "L13"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
       "label": "PointOfSaleView.tsx",
@@ -42235,7 +42313,7 @@
       "source_location": "L1"
     },
     {
-      "community": 361,
+      "community": 362,
       "file_type": "code",
       "id": "pointofsaleview_navigation",
       "label": "Navigation()",
@@ -42244,7 +42322,7 @@
       "source_location": "L34"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_printinstructions_tsx",
       "label": "PrintInstructions.tsx",
@@ -42253,7 +42331,7 @@
       "source_location": "L1"
     },
     {
-      "community": 362,
+      "community": 363,
       "file_type": "code",
       "id": "printinstructions_printinstructions",
       "label": "PrintInstructions()",
@@ -42262,7 +42340,7 @@
       "source_location": "L3"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productcard_tsx",
       "label": "ProductCard.tsx",
@@ -42271,7 +42349,7 @@
       "source_location": "L1"
     },
     {
-      "community": 363,
+      "community": 364,
       "file_type": "code",
       "id": "productcard_productcard",
       "label": "ProductCard()",
@@ -42280,7 +42358,7 @@
       "source_location": "L14"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productentry_tsx",
       "label": "ProductEntry.tsx",
@@ -42289,7 +42367,7 @@
       "source_location": "L1"
     },
     {
-      "community": 364,
+      "community": 365,
       "file_type": "code",
       "id": "productentry_handleclearsearch",
       "label": "handleClearSearch()",
@@ -42298,7 +42376,7 @@
       "source_location": "L86"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_quickactionsbar_tsx",
       "label": "QuickActionsBar.tsx",
@@ -42307,7 +42385,7 @@
       "source_location": "L1"
     },
     {
-      "community": 365,
+      "community": 366,
       "file_type": "code",
       "id": "quickactionsbar_quickactionsbar",
       "label": "QuickActionsBar()",
@@ -42316,7 +42394,7 @@
       "source_location": "L11"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessiondemo_tsx",
       "label": "SessionDemo.tsx",
@@ -42325,7 +42403,7 @@
       "source_location": "L1"
     },
     {
-      "community": 366,
+      "community": 367,
       "file_type": "code",
       "id": "sessiondemo_sessiondemo",
       "label": "SessionDemo()",
@@ -42334,7 +42412,7 @@
       "source_location": "L15"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_tsx",
       "label": "TotalsDisplay.tsx",
@@ -42343,7 +42421,7 @@
       "source_location": "L1"
     },
     {
-      "community": 367,
+      "community": 368,
       "file_type": "code",
       "id": "totalsdisplay_totalsdisplay",
       "label": "TotalsDisplay()",
@@ -42352,7 +42430,7 @@
       "source_location": "L14"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "expensereportsview_istoday",
       "label": "isToday()",
@@ -42361,30 +42439,12 @@
       "source_location": "L18"
     },
     {
-      "community": 368,
+      "community": 369,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_tsx",
       "label": "ExpenseReportsView.tsx",
       "norm_label": "expensereportsview.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "hooks_useposcashier",
-      "label": "usePOSCashier()",
-      "norm_label": "useposcashier()",
-      "source_file": "packages/athena-webapp/src/components/pos/hooks.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_hooks_ts",
-      "label": "hooks.ts",
-      "norm_label": "hooks.ts",
-      "source_file": "packages/athena-webapp/src/components/pos/hooks.ts",
       "source_location": "L1"
     },
     {
@@ -42471,6 +42531,24 @@
     {
       "community": 370,
       "file_type": "code",
+      "id": "hooks_useposcashier",
+      "label": "usePOSCashier()",
+      "norm_label": "useposcashier()",
+      "source_file": "packages/athena-webapp/src/components/pos/hooks.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_hooks_ts",
+      "label": "hooks.ts",
+      "norm_label": "hooks.ts",
+      "source_file": "packages/athena-webapp/src/components/pos/hooks.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 371,
+      "file_type": "code",
       "id": "holdsessiondialog_holdsessiondialog",
       "label": "HoldSessionDialog()",
       "norm_label": "holdsessiondialog()",
@@ -42478,7 +42556,7 @@
       "source_location": "L19"
     },
     {
-      "community": 370,
+      "community": 371,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_holdsessiondialog_tsx",
       "label": "HoldSessionDialog.tsx",
@@ -42487,7 +42565,7 @@
       "source_location": "L1"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_voidsessiondialog_tsx",
       "label": "VoidSessionDialog.tsx",
@@ -42496,7 +42574,7 @@
       "source_location": "L1"
     },
     {
-      "community": 371,
+      "community": 372,
       "file_type": "code",
       "id": "voidsessiondialog_voidsessiondialog",
       "label": "VoidSessionDialog()",
@@ -42505,7 +42583,7 @@
       "source_location": "L19"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_tsx",
       "label": "transactionColumns.tsx",
@@ -42514,7 +42592,7 @@
       "source_location": "L1"
     },
     {
-      "community": 372,
+      "community": 373,
       "file_type": "code",
       "id": "transactioncolumns_getpaymentmethodicon",
       "label": "getPaymentMethodIcon()",
@@ -42523,7 +42601,7 @@
       "source_location": "L22"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "barcodeview_barcodeview",
       "label": "BarcodeView()",
@@ -42532,7 +42610,7 @@
       "source_location": "L14"
     },
     {
-      "community": 373,
+      "community": 374,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_barcodeview_tsx",
       "label": "BarcodeView.tsx",
@@ -42541,7 +42619,7 @@
       "source_location": "L1"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "categorizationview_categorizationview",
       "label": "CategorizationView()",
@@ -42550,7 +42628,7 @@
       "source_location": "L6"
     },
     {
-      "community": 374,
+      "community": 375,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_categorizationview_tsx",
       "label": "CategorizationView.tsx",
@@ -42559,7 +42637,7 @@
       "source_location": "L1"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "imagesview_handlekeydown",
       "label": "handleKeyDown()",
@@ -42568,7 +42646,7 @@
       "source_location": "L38"
     },
     {
-      "community": 375,
+      "community": 376,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_imagesview_tsx",
       "label": "ImagesView.tsx",
@@ -42577,7 +42655,7 @@
       "source_location": "L1"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_skuselector_tsx",
       "label": "SKUSelector.tsx",
@@ -42586,7 +42664,7 @@
       "source_location": "L1"
     },
     {
-      "community": 376,
+      "community": 377,
       "file_type": "code",
       "id": "skuselector_skuselector",
       "label": "SKUSelector()",
@@ -42595,7 +42673,7 @@
       "source_location": "L10"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_actions_tsx",
       "label": "product-actions.tsx",
@@ -42604,7 +42682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 377,
+      "community": 378,
       "file_type": "code",
       "id": "product_actions_usedeleteproduct",
       "label": "useDeleteProduct()",
@@ -42613,7 +42691,7 @@
       "source_location": "L6"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsview_tsx",
       "label": "ProductsView.tsx",
@@ -42622,31 +42700,13 @@
       "source_location": "L1"
     },
     {
-      "community": 378,
+      "community": 379,
       "file_type": "code",
       "id": "productsview_productsview",
       "label": "ProductsView()",
       "norm_label": "productsview()",
       "source_file": "packages/athena-webapp/src/components/products/ProductsView.tsx",
       "source_location": "L5"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "add_product_command_addproductcommand",
-      "label": "AddProductCommand()",
-      "norm_label": "addproductcommand()",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/add-product-command.tsx",
-      "source_location": "L17"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_add_product_command_tsx",
-      "label": "add-product-command.tsx",
-      "norm_label": "add-product-command.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/add-product-command.tsx",
-      "source_location": "L1"
     },
     {
       "community": 38,
@@ -42732,6 +42792,24 @@
     {
       "community": 380,
       "file_type": "code",
+      "id": "add_product_command_addproductcommand",
+      "label": "AddProductCommand()",
+      "norm_label": "addproductcommand()",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/add-product-command.tsx",
+      "source_location": "L17"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_add_product_command_tsx",
+      "label": "add-product-command.tsx",
+      "norm_label": "add-product-command.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/add-product-command.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 381,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_products_tsx",
       "label": "Products.tsx",
       "norm_label": "products.tsx",
@@ -42739,7 +42817,7 @@
       "source_location": "L1"
     },
     {
-      "community": 380,
+      "community": 381,
       "file_type": "code",
       "id": "products_products",
       "label": "Products()",
@@ -42748,7 +42826,7 @@
       "source_location": "L4"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeform_tsx",
       "label": "PromoCodeForm.tsx",
@@ -42757,7 +42835,7 @@
       "source_location": "L1"
     },
     {
-      "community": 381,
+      "community": 382,
       "file_type": "code",
       "id": "promocodeform_togglediscounttype",
       "label": "toggleDiscountType()",
@@ -42766,7 +42844,7 @@
       "source_location": "L84"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_tsx",
       "label": "PromoCodeHeader.tsx",
@@ -42775,7 +42853,7 @@
       "source_location": "L1"
     },
     {
-      "community": 382,
+      "community": 383,
       "file_type": "code",
       "id": "promocodeheader_handledeletepromocode",
       "label": "handleDeletePromoCode()",
@@ -42784,7 +42862,7 @@
       "source_location": "L22"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodesview_tsx",
       "label": "PromoCodesView.tsx",
@@ -42793,7 +42871,7 @@
       "source_location": "L1"
     },
     {
-      "community": 383,
+      "community": 384,
       "file_type": "code",
       "id": "promocodesview_promocodesview",
       "label": "PromoCodesView()",
@@ -42802,7 +42880,7 @@
       "source_location": "L9"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectablecategories_tsx",
       "label": "SelectableCategories.tsx",
@@ -42811,7 +42889,7 @@
       "source_location": "L1"
     },
     {
-      "community": 384,
+      "community": 385,
       "file_type": "code",
       "id": "selectablecategories_toggle",
       "label": "toggle()",
@@ -42820,7 +42898,7 @@
       "source_location": "L23"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "discounttypetogglegroup_discounttypetogglegroup",
       "label": "DiscountTypeToggleGroup()",
@@ -42829,7 +42907,7 @@
       "source_location": "L5"
     },
     {
-      "community": 385,
+      "community": 386,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_discounttypetogglegroup_tsx",
       "label": "DiscountTypeToggleGroup.tsx",
@@ -42838,7 +42916,7 @@
       "source_location": "L1"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_promocodespantogglegroup_tsx",
       "label": "PromoCodeSpanToggleGroup.tsx",
@@ -42847,7 +42925,7 @@
       "source_location": "L1"
     },
     {
-      "community": 386,
+      "community": 387,
       "file_type": "code",
       "id": "promocodespantogglegroup_promocodespantogglegroup",
       "label": "PromoCodeSpanToggleGroup()",
@@ -42856,7 +42934,7 @@
       "source_location": "L4"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "capturedemails_capturedemails",
       "label": "CapturedEmails()",
@@ -42865,7 +42943,7 @@
       "source_location": "L13"
     },
     {
-      "community": 387,
+      "community": 388,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_capturedemails_tsx",
       "label": "CapturedEmails.tsx",
@@ -42874,7 +42952,7 @@
       "source_location": "L1"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_promo_code_modal_tsx",
       "label": "promo-code-modal.tsx",
@@ -42883,31 +42961,13 @@
       "source_location": "L1"
     },
     {
-      "community": 388,
+      "community": 389,
       "file_type": "code",
       "id": "promo_code_modal_promocodemodal",
       "label": "PromoCodeModal()",
       "norm_label": "promocodemodal()",
       "source_file": "packages/athena-webapp/src/components/promo-codes/modals/promo-code-modal.tsx",
       "source_location": "L29"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reviews_reviewactions_tsx",
-      "label": "ReviewActions.tsx",
-      "norm_label": "reviewactions.tsx",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewActions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "reviewactions_reviewactions",
-      "label": "ReviewActions()",
-      "norm_label": "reviewactions()",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewActions.tsx",
-      "source_location": "L20"
     },
     {
       "community": 39,
@@ -42993,6 +43053,24 @@
     {
       "community": 390,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_reviews_reviewactions_tsx",
+      "label": "ReviewActions.tsx",
+      "norm_label": "reviewactions.tsx",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewActions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "reviewactions_reviewactions",
+      "label": "ReviewActions()",
+      "norm_label": "reviewactions()",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewActions.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 391,
+      "file_type": "code",
       "id": "empty_state_onclick",
       "label": "onClick()",
       "norm_label": "onclick()",
@@ -43000,7 +43078,7 @@
       "source_location": "L29"
     },
     {
-      "community": 390,
+      "community": 391,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
@@ -43009,7 +43087,7 @@
       "source_location": "L1"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "nopermission_nopermission",
       "label": "NoPermission()",
@@ -43018,7 +43096,7 @@
       "source_location": "L3"
     },
     {
-      "community": 391,
+      "community": 392,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermission_tsx",
       "label": "NoPermission.tsx",
@@ -43027,7 +43105,7 @@
       "source_location": "L1"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "nopermissionview_nopermissionview",
       "label": "NoPermissionView()",
@@ -43036,7 +43114,7 @@
       "source_location": "L4"
     },
     {
-      "community": 392,
+      "community": 393,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermissionview_tsx",
       "label": "NoPermissionView.tsx",
@@ -43045,7 +43123,7 @@
       "source_location": "L1"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "notfoundview_notfoundview",
       "label": "NotFoundView()",
@@ -43054,7 +43132,7 @@
       "source_location": "L4"
     },
     {
-      "community": 393,
+      "community": 394,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfoundview_tsx",
       "label": "NotFoundView.tsx",
@@ -43063,7 +43141,7 @@
       "source_location": "L1"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "contactview_contactview",
       "label": "ContactView()",
@@ -43072,7 +43150,7 @@
       "source_location": "L9"
     },
     {
-      "community": 394,
+      "community": 395,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_contactview_tsx",
       "label": "ContactView.tsx",
@@ -43081,7 +43159,7 @@
       "source_location": "L1"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "header_header",
       "label": "Header()",
@@ -43090,7 +43168,7 @@
       "source_location": "L1"
     },
     {
-      "community": 395,
+      "community": 396,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_header_tsx",
       "label": "Header.tsx",
@@ -43099,7 +43177,7 @@
       "source_location": "L1"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "maintenanceview_maintenanceview",
       "label": "MaintenanceView()",
@@ -43108,7 +43186,7 @@
       "source_location": "L13"
     },
     {
-      "community": 396,
+      "community": 397,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_tsx",
       "label": "MaintenanceView.tsx",
@@ -43117,7 +43195,7 @@
       "source_location": "L1"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_taxview_tsx",
       "label": "TaxView.tsx",
@@ -43126,7 +43204,7 @@
       "source_location": "L1"
     },
     {
-      "community": 397,
+      "community": 398,
       "file_type": "code",
       "id": "taxview_handleupdatetaxsettings",
       "label": "handleUpdateTaxSettings()",
@@ -43135,7 +43213,7 @@
       "source_location": "L25"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_ts",
       "label": "useStoreConfigUpdate.ts",
@@ -43144,31 +43222,13 @@
       "source_location": "L1"
     },
     {
-      "community": 398,
+      "community": 399,
       "file_type": "code",
       "id": "usestoreconfigupdate_usestoreconfigupdate",
       "label": "useStoreConfigUpdate()",
       "norm_label": "usestoreconfigupdate()",
       "source_file": "packages/athena-webapp/src/components/store-configuration/hooks/useStoreConfigUpdate.ts",
       "source_location": "L19"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_switcher_tsx",
-      "label": "store-switcher.tsx",
-      "norm_label": "store-switcher.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-switcher.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "store_switcher_onstoreselect",
-      "label": "onStoreSelect()",
-      "norm_label": "onstoreselect()",
-      "source_file": "packages/athena-webapp/src/components/store-switcher.tsx",
-      "source_location": "L63"
     },
     {
       "community": 4,
@@ -43506,6 +43566,24 @@
     {
       "community": 400,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_switcher_tsx",
+      "label": "store-switcher.tsx",
+      "norm_label": "store-switcher.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-switcher.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "store_switcher_onstoreselect",
+      "label": "onStoreSelect()",
+      "norm_label": "onstoreselect()",
+      "source_file": "packages/athena-webapp/src/components/store-switcher.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 401,
+      "file_type": "code",
       "id": "chart_usechart",
       "label": "useChart()",
       "norm_label": "usechart()",
@@ -43513,7 +43591,7 @@
       "source_location": "L25"
     },
     {
-      "community": 400,
+      "community": 401,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_chart_tsx",
       "label": "chart.tsx",
@@ -43522,7 +43600,7 @@
       "source_location": "L1"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "copy_button_handlecopy",
       "label": "handleCopy()",
@@ -43531,7 +43609,7 @@
       "source_location": "L15"
     },
     {
-      "community": 401,
+      "community": 402,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_copy_button_tsx",
       "label": "copy-button.tsx",
@@ -43540,7 +43618,7 @@
       "source_location": "L1"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "copy_wrapper_handlecopy",
       "label": "handleCopy()",
@@ -43549,7 +43627,7 @@
       "source_location": "L21"
     },
     {
-      "community": 402,
+      "community": 403,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_copy_wrapper_tsx",
       "label": "copy-wrapper.tsx",
@@ -43558,7 +43636,7 @@
       "source_location": "L1"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "date_time_picker_datetimepicker",
       "label": "DateTimePicker()",
@@ -43567,7 +43645,7 @@
       "source_location": "L21"
     },
     {
-      "community": 403,
+      "community": 404,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
       "label": "date-time-picker.tsx",
@@ -43576,7 +43654,7 @@
       "source_location": "L1"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "label_label",
       "label": "Label()",
@@ -43585,7 +43663,7 @@
       "source_location": "L6"
     },
     {
-      "community": 404,
+      "community": 405,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
@@ -43594,7 +43672,7 @@
       "source_location": "L1"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "custom_modal_custommodal",
       "label": "CustomModal()",
@@ -43603,7 +43681,7 @@
       "source_location": "L25"
     },
     {
-      "community": 405,
+      "community": 406,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_tsx",
       "label": "custom-modal.tsx",
@@ -43612,7 +43690,7 @@
       "source_location": "L1"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "organization_modal_onsubmit",
       "label": "onSubmit()",
@@ -43621,7 +43699,7 @@
       "source_location": "L49"
     },
     {
-      "community": 406,
+      "community": 407,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_organization_modal_tsx",
       "label": "organization-modal.tsx",
@@ -43630,7 +43708,7 @@
       "source_location": "L1"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_store_modal_tsx",
       "label": "store-modal.tsx",
@@ -43639,7 +43717,7 @@
       "source_location": "L1"
     },
     {
-      "community": 407,
+      "community": 408,
       "file_type": "code",
       "id": "store_modal_onsubmit",
       "label": "onSubmit()",
@@ -43648,7 +43726,7 @@
       "source_location": "L63"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_example_tsx",
       "label": "welcome-back-modal-example.tsx",
@@ -43657,31 +43735,13 @@
       "source_location": "L1"
     },
     {
-      "community": 408,
+      "community": 409,
       "file_type": "code",
       "id": "welcome_back_modal_example_welcomebackmodalexample",
       "label": "WelcomeBackModalExample()",
       "norm_label": "welcomebackmodalexample()",
       "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal-example.tsx",
       "source_location": "L5"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_tsx",
-      "label": "welcome-back-modal.tsx",
-      "norm_label": "welcome-back-modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "welcome_back_modal_welcomebackmodal",
-      "label": "WelcomeBackModal()",
-      "norm_label": "welcomebackmodal()",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal.tsx",
-      "source_location": "L12"
     },
     {
       "community": 41,
@@ -43758,6 +43818,24 @@
     {
       "community": 410,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_tsx",
+      "label": "welcome-back-modal.tsx",
+      "norm_label": "welcome-back-modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "welcome_back_modal_welcomebackmodal",
+      "label": "WelcomeBackModal()",
+      "norm_label": "welcomebackmodal()",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/welcome-back-modal.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 411,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_native_tsx",
       "label": "select-native.tsx",
       "norm_label": "select-native.tsx",
@@ -43765,7 +43843,7 @@
       "source_location": "L1"
     },
     {
-      "community": 410,
+      "community": 411,
       "file_type": "code",
       "id": "select_native_cn",
       "label": "cn()",
@@ -43774,7 +43852,7 @@
       "source_location": "L15"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_timeline_item_tsx",
       "label": "timeline-item.tsx",
@@ -43783,7 +43861,7 @@
       "source_location": "L1"
     },
     {
-      "community": 411,
+      "community": 412,
       "file_type": "code",
       "id": "timeline_item_timelineitem",
       "label": "TimelineItem()",
@@ -43792,7 +43870,7 @@
       "source_location": "L3"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_webp_image_tsx",
       "label": "webp-image.tsx",
@@ -43801,7 +43879,7 @@
       "source_location": "L1"
     },
     {
-      "community": 412,
+      "community": 413,
       "file_type": "code",
       "id": "webp_image_webpimage",
       "label": "WebpImage()",
@@ -43810,7 +43888,7 @@
       "source_location": "L1"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "bagitems_bagitems",
       "label": "BagItems()",
@@ -43819,7 +43897,7 @@
       "source_location": "L5"
     },
     {
-      "community": 413,
+      "community": 414,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagitems_tsx",
       "label": "BagItems.tsx",
@@ -43828,7 +43906,7 @@
       "source_location": "L1"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "bagitemsview_bagitemsview",
       "label": "BagItemsView()",
@@ -43837,7 +43915,7 @@
       "source_location": "L11"
     },
     {
-      "community": 414,
+      "community": 415,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagitemsview_tsx",
       "label": "BagItemsView.tsx",
@@ -43846,7 +43924,7 @@
       "source_location": "L1"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "bags_bags",
       "label": "Bags()",
@@ -43855,7 +43933,7 @@
       "source_location": "L4"
     },
     {
-      "community": 415,
+      "community": 416,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bags_tsx",
       "label": "Bags.tsx",
@@ -43864,7 +43942,7 @@
       "source_location": "L1"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "customerbehaviortimeline_string",
       "label": "String()",
@@ -43873,7 +43951,7 @@
       "source_location": "L110"
     },
     {
-      "community": 416,
+      "community": 417,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_customerbehaviortimeline_tsx",
       "label": "CustomerBehaviorTimeline.tsx",
@@ -43882,7 +43960,7 @@
       "source_location": "L1"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useranalyticsname_tsx",
       "label": "UserAnalyticsName.tsx",
@@ -43891,7 +43969,7 @@
       "source_location": "L1"
     },
     {
-      "community": 417,
+      "community": 418,
       "file_type": "code",
       "id": "useranalyticsname_useranalyticsname",
       "label": "UserAnalyticsName()",
@@ -43900,7 +43978,7 @@
       "source_location": "L13"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userbag_tsx",
       "label": "UserBag.tsx",
@@ -43909,31 +43987,13 @@
       "source_location": "L1"
     },
     {
-      "community": 418,
+      "community": 419,
       "file_type": "code",
       "id": "userbag_userbag",
       "label": "UserBag()",
       "norm_label": "userbag()",
       "source_file": "packages/athena-webapp/src/components/users/UserBag.tsx",
       "source_location": "L7"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_useronlineorders_tsx",
-      "label": "UserOnlineOrders.tsx",
-      "norm_label": "useronlineorders.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/UserOnlineOrders.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "useronlineorders_useronlineorders",
-      "label": "UserOnlineOrders()",
-      "norm_label": "useronlineorders()",
-      "source_file": "packages/athena-webapp/src/components/users/UserOnlineOrders.tsx",
-      "source_location": "L11"
     },
     {
       "community": 42,
@@ -44010,6 +44070,24 @@
     {
       "community": 420,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_useronlineorders_tsx",
+      "label": "UserOnlineOrders.tsx",
+      "norm_label": "useronlineorders.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/UserOnlineOrders.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "useronlineorders_useronlineorders",
+      "label": "UserOnlineOrders()",
+      "norm_label": "useronlineorders()",
+      "source_file": "packages/athena-webapp/src/components/users/UserOnlineOrders.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 421,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userstatus_tsx",
       "label": "UserStatus.tsx",
       "norm_label": "userstatus.tsx",
@@ -44017,7 +44095,7 @@
       "source_location": "L1"
     },
     {
-      "community": 420,
+      "community": 421,
       "file_type": "code",
       "id": "userstatus_userstatus",
       "label": "UserStatus()",
@@ -44026,7 +44104,7 @@
       "source_location": "L7"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userview_tsx",
       "label": "UserView.tsx",
@@ -44035,7 +44113,7 @@
       "source_location": "L1"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "userview_useractions",
       "label": "UserActions()",
@@ -44044,7 +44122,7 @@
       "source_location": "L45"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "customerjourneystage_customerjourneystagecard",
       "label": "CustomerJourneyStageCard()",
@@ -44053,7 +44131,7 @@
       "source_location": "L13"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_customerjourneystage_tsx",
       "label": "CustomerJourneyStage.tsx",
@@ -44062,7 +44140,7 @@
       "source_location": "L1"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_image_upload_ts",
       "label": "use-image-upload.ts",
@@ -44071,7 +44149,7 @@
       "source_location": "L1"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "use_image_upload_useimageupload",
       "label": "useImageUpload()",
@@ -44080,7 +44158,7 @@
       "source_location": "L7"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_mobile_tsx",
       "label": "use-mobile.tsx",
@@ -44089,7 +44167,7 @@
       "source_location": "L1"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "use_mobile_useismobile",
       "label": "useIsMobile()",
@@ -44098,7 +44176,7 @@
       "source_location": "L5"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_navigate_back_ts",
       "label": "use-navigate-back.ts",
@@ -44107,7 +44185,7 @@
       "source_location": "L1"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "use_navigate_back_usenavigateback",
       "label": "useNavigateBack()",
@@ -44116,7 +44194,7 @@
       "source_location": "L5"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_navigation_keyboard_shortcuts_ts",
       "label": "use-navigation-keyboard-shortcuts.ts",
@@ -44125,7 +44203,7 @@
       "source_location": "L1"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "use_navigation_keyboard_shortcuts_usenavigationkeyboardshortcuts",
       "label": "useNavigationKeyboardShortcuts()",
@@ -44134,7 +44212,7 @@
       "source_location": "L7"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_pagination_persistence_ts",
       "label": "use-pagination-persistence.ts",
@@ -44143,7 +44221,7 @@
       "source_location": "L1"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "use_pagination_persistence_usepaginationpersistence",
       "label": "usePaginationPersistence()",
@@ -44152,7 +44230,7 @@
       "source_location": "L9"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_table_keyboard_pagination_ts",
       "label": "use-table-keyboard-pagination.ts",
@@ -44161,31 +44239,13 @@
       "source_location": "L1"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "use_table_keyboard_pagination_usetablekeyboardpagination",
       "label": "useTableKeyboardPagination()",
       "norm_label": "usetablekeyboardpagination()",
       "source_file": "packages/athena-webapp/src/hooks/use-table-keyboard-pagination.ts",
       "source_location": "L6"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usebulkoperations_test_ts",
-      "label": "useBulkOperations.test.ts",
-      "norm_label": "usebulkoperations.test.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "usebulkoperations_test_makesku",
-      "label": "makeSku()",
-      "norm_label": "makesku()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.test.ts",
-      "source_location": "L168"
     },
     {
       "community": 43,
@@ -44262,6 +44322,24 @@
     {
       "community": 430,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usebulkoperations_test_ts",
+      "label": "useBulkOperations.test.ts",
+      "norm_label": "usebulkoperations.test.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "usebulkoperations_test_makesku",
+      "label": "makeSku()",
+      "norm_label": "makesku()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.test.ts",
+      "source_location": "L168"
+    },
+    {
+      "community": 431,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecartoperations_ts",
       "label": "useCartOperations.ts",
       "norm_label": "usecartoperations.ts",
@@ -44269,7 +44347,7 @@
       "source_location": "L1"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "usecartoperations_usecartoperations",
       "label": "useCartOperations()",
@@ -44278,7 +44356,7 @@
       "source_location": "L23"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecopytext_ts",
       "label": "useCopyText.ts",
@@ -44287,7 +44365,7 @@
       "source_location": "L1"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "usecopytext_usecopytext",
       "label": "useCopyText()",
@@ -44296,7 +44374,7 @@
       "source_location": "L1"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecreatecomplimentaryproduct_ts",
       "label": "useCreateComplimentaryProduct.ts",
@@ -44305,7 +44383,7 @@
       "source_location": "L1"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "usecreatecomplimentaryproduct_usecreatecomplimentaryproduct",
       "label": "useCreateComplimentaryProduct()",
@@ -44314,7 +44392,7 @@
       "source_location": "L6"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecustomeroperations_ts",
       "label": "useCustomerOperations.ts",
@@ -44323,7 +44401,7 @@
       "source_location": "L1"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "usecustomeroperations_usecustomeroperations",
       "label": "useCustomerOperations()",
@@ -44332,7 +44410,7 @@
       "source_location": "L21"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usedebounce_ts",
       "label": "useDebounce.ts",
@@ -44341,7 +44419,7 @@
       "source_location": "L1"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "usedebounce_usedebounce",
       "label": "useDebounce()",
@@ -44350,7 +44428,7 @@
       "source_location": "L12"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
       "label": "useExpenseOperations.ts",
@@ -44359,7 +44437,7 @@
       "source_location": "L1"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "useexpenseoperations_useexpenseoperations",
       "label": "useExpenseOperations()",
@@ -44368,7 +44446,7 @@
       "source_location": "L23"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetactiveproduct_ts",
       "label": "useGetActiveProduct.ts",
@@ -44377,7 +44455,7 @@
       "source_location": "L1"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "usegetactiveproduct_usegetactiveproduct",
       "label": "useGetActiveProduct()",
@@ -44386,7 +44464,7 @@
       "source_location": "L6"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetautheduser_ts",
       "label": "useGetAuthedUser.ts",
@@ -44395,7 +44473,7 @@
       "source_location": "L1"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "usegetautheduser_usegetautheduser",
       "label": "useGetAuthedUser()",
@@ -44404,7 +44482,7 @@
       "source_location": "L4"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcategories_ts",
       "label": "useGetCategories.ts",
@@ -44413,30 +44491,12 @@
       "source_location": "L1"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "usegetcategories_usegetcategories",
       "label": "useGetCategories()",
       "norm_label": "usegetcategories()",
       "source_file": "packages/athena-webapp/src/hooks/useGetCategories.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usegetcomplimentaryproducts_ts",
-      "label": "useGetComplimentaryProducts.ts",
-      "norm_label": "usegetcomplimentaryproducts.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useGetComplimentaryProducts.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "usegetcomplimentaryproducts_usegetcomplimentaryproducts",
-      "label": "useGetComplimentaryProducts()",
-      "norm_label": "usegetcomplimentaryproducts()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetComplimentaryProducts.ts",
       "source_location": "L5"
     },
     {
@@ -44514,6 +44574,24 @@
     {
       "community": 440,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usegetcomplimentaryproducts_ts",
+      "label": "useGetComplimentaryProducts.ts",
+      "norm_label": "usegetcomplimentaryproducts.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useGetComplimentaryProducts.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "usegetcomplimentaryproducts_usegetcomplimentaryproducts",
+      "label": "useGetComplimentaryProducts()",
+      "norm_label": "usegetcomplimentaryproducts()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetComplimentaryProducts.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 441,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcurrencyformatter_ts",
       "label": "useGetCurrencyFormatter.ts",
       "norm_label": "usegetcurrencyformatter.ts",
@@ -44521,7 +44599,7 @@
       "source_location": "L1"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "usegetcurrencyformatter_usegetcurrencyformatter",
       "label": "useGetCurrencyFormatter()",
@@ -44530,7 +44608,7 @@
       "source_location": "L4"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetsubcategories_ts",
       "label": "useGetSubcategories.ts",
@@ -44539,7 +44617,7 @@
       "source_location": "L1"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "usegetsubcategories_usegetsubcategories",
       "label": "useGetSubcategories()",
@@ -44548,7 +44626,7 @@
       "source_location": "L5"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetterminal_ts",
       "label": "useGetTerminal.ts",
@@ -44557,7 +44635,7 @@
       "source_location": "L1"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "usegetterminal_usegetterminal",
       "label": "useGetTerminal()",
@@ -44566,7 +44644,7 @@
       "source_location": "L6"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usenewordernotification_ts",
       "label": "useNewOrderNotification.ts",
@@ -44575,7 +44653,7 @@
       "source_location": "L1"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "usenewordernotification_usenewordernotification",
       "label": "useNewOrderNotification()",
@@ -44584,7 +44662,7 @@
       "source_location": "L8"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usepermissions_ts",
       "label": "usePermissions.ts",
@@ -44593,7 +44671,7 @@
       "source_location": "L1"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "usepermissions_usepermissions",
       "label": "usePermissions()",
@@ -44602,7 +44680,7 @@
       "source_location": "L12"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useprint_ts",
       "label": "usePrint.ts",
@@ -44611,7 +44689,7 @@
       "source_location": "L1"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "useprint_useprint",
       "label": "usePrint()",
@@ -44620,7 +44698,7 @@
       "source_location": "L3"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useproductsearchresults_ts",
       "label": "useProductSearchResults.ts",
@@ -44629,7 +44707,7 @@
       "source_location": "L1"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "useproductsearchresults_useproductsearchresults",
       "label": "useProductSearchResults()",
@@ -44638,7 +44716,7 @@
       "source_location": "L26"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useproductwithnoimagesnotification_tsx",
       "label": "useProductWithNoImagesNotification.tsx",
@@ -44647,7 +44725,7 @@
       "source_location": "L1"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "useproductwithnoimagesnotification_useproductwithnoimagesnotification",
       "label": "useProductWithNoImagesNotification()",
@@ -44656,7 +44734,7 @@
       "source_location": "L7"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usesessionmanagement_ts",
       "label": "useSessionManagement.ts",
@@ -44665,30 +44743,12 @@
       "source_location": "L1"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "usesessionmanagement_usesessionmanagement",
       "label": "useSessionManagement()",
       "norm_label": "usesessionmanagement()",
       "source_file": "packages/athena-webapp/src/hooks/useSessionManagement.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usesessionmanagementexpense_ts",
-      "label": "useSessionManagementExpense.ts",
-      "norm_label": "usesessionmanagementexpense.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useSessionManagementExpense.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "usesessionmanagementexpense_usesessionmanagementexpense",
-      "label": "useSessionManagementExpense()",
-      "norm_label": "usesessionmanagementexpense()",
-      "source_file": "packages/athena-webapp/src/hooks/useSessionManagementExpense.ts",
       "source_location": "L17"
     },
     {
@@ -44766,6 +44826,24 @@
     {
       "community": 450,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usesessionmanagementexpense_ts",
+      "label": "useSessionManagementExpense.ts",
+      "norm_label": "usesessionmanagementexpense.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useSessionManagementExpense.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "usesessionmanagementexpense_usesessionmanagementexpense",
+      "label": "useSessionManagementExpense()",
+      "norm_label": "usesessionmanagementexpense()",
+      "source_file": "packages/athena-webapp/src/hooks/useSessionManagementExpense.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 451,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usesessionmanageroperations_ts",
       "label": "useSessionManagerOperations.ts",
       "norm_label": "usesessionmanageroperations.ts",
@@ -44773,7 +44851,7 @@
       "source_location": "L1"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "usesessionmanageroperations_usesessionmanageroperations",
       "label": "useSessionManagerOperations()",
@@ -44782,7 +44860,7 @@
       "source_location": "L16"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedincheckout_ts",
       "label": "useSkusReservedInCheckout.ts",
@@ -44791,7 +44869,7 @@
       "source_location": "L1"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "useskusreservedincheckout_useskusreservedincheckout",
       "label": "useSkusReservedInCheckout()",
@@ -44800,7 +44878,7 @@
       "source_location": "L12"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedinpossession_ts",
       "label": "useSkusReservedInPosSession.ts",
@@ -44809,7 +44887,7 @@
       "source_location": "L1"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "useskusreservedinpossession_useskusreservedinpossession",
       "label": "useSkusReservedInPosSession()",
@@ -44818,7 +44896,7 @@
       "source_location": "L12"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usetogglecomplimentaryproductactive_ts",
       "label": "useToggleComplimentaryProductActive.ts",
@@ -44827,7 +44905,7 @@
       "source_location": "L1"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "usetogglecomplimentaryproductactive_usetogglecomplimentaryproductactive",
       "label": "useToggleComplimentaryProductActive()",
@@ -44836,7 +44914,7 @@
       "source_location": "L5"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "navigationutils_getorigin",
       "label": "getOrigin()",
@@ -44845,7 +44923,7 @@
       "source_location": "L1"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_navigationutils_ts",
       "label": "navigationUtils.ts",
@@ -44854,7 +44932,7 @@
       "source_location": "L1"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "calculations_calculatecarttotals",
       "label": "calculateCartTotals()",
@@ -44863,7 +44941,7 @@
       "source_location": "L10"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_calculations_ts",
       "label": "calculations.ts",
@@ -44872,7 +44950,7 @@
       "source_location": "L1"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_security_pinhash_ts",
       "label": "pinHash.ts",
@@ -44881,7 +44959,7 @@
       "source_location": "L1"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "pinhash_hashpin",
       "label": "hashPin()",
@@ -44890,7 +44968,7 @@
       "source_location": "L12"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "index_storerootredirect",
       "label": "StoreRootRedirect()",
@@ -44899,7 +44977,7 @@
       "source_location": "L13"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_index_tsx",
       "label": "index.tsx",
@@ -44908,7 +44986,7 @@
       "source_location": "L1"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_published_index_tsx",
       "label": "published.index.tsx",
@@ -44917,31 +44995,13 @@
       "source_location": "L1"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "published_index_routecomponent",
       "label": "RouteComponent()",
       "norm_label": "routecomponent()",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/published.index.tsx",
       "source_location": "L9"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "index_index",
-      "label": "Index()",
-      "norm_label": "index()",
-      "source_file": "packages/athena-webapp/src/routes/index.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/index.tsx",
-      "source_location": "L1"
     },
     {
       "community": 46,
@@ -45018,6 +45078,24 @@
     {
       "community": 460,
       "file_type": "code",
+      "id": "index_index",
+      "label": "Index()",
+      "norm_label": "index()",
+      "source_file": "packages/athena-webapp/src/routes/index.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
       "id": "layout_index_athenaloginreadyview",
       "label": "AthenaLoginReadyView()",
       "norm_label": "athenaloginreadyview()",
@@ -45025,7 +45103,7 @@
       "source_location": "L4"
     },
     {
-      "community": 460,
+      "community": 461,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_tsx",
       "label": "_layout.index.tsx",
@@ -45034,7 +45112,7 @@
       "source_location": "L1"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "layout_loginlayout",
       "label": "LoginLayout()",
@@ -45043,7 +45121,7 @@
       "source_location": "L36"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_tsx",
       "label": "_layout.tsx",
@@ -45052,7 +45130,7 @@
       "source_location": "L1"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "organizationssettingsaccordion_organizationsettingsaccordion",
       "label": "OrganizationSettingsAccordion()",
@@ -45061,7 +45139,7 @@
       "source_location": "L13"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationssettingsaccordion_tsx",
       "label": "OrganizationsSettingsAccordion.tsx",
@@ -45070,7 +45148,7 @@
       "source_location": "L1"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "overview_stories_patternsoverview",
       "label": "PatternsOverview()",
@@ -45079,7 +45157,7 @@
       "source_location": "L5"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -45088,7 +45166,7 @@
       "source_location": "L1"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "overview_stories_primitivesoverview",
       "label": "PrimitivesOverview()",
@@ -45097,7 +45175,7 @@
       "source_location": "L5"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -45106,7 +45184,7 @@
       "source_location": "L1"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "overview_stories_templatesoverview",
       "label": "TemplatesOverview()",
@@ -45115,7 +45193,7 @@
       "source_location": "L5"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -45124,7 +45202,7 @@
       "source_location": "L1"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_tsx",
       "label": "storybook-theme-decorator.tsx",
@@ -45133,7 +45211,7 @@
       "source_location": "L1"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "storybook_theme_decorator_withathenatheme",
       "label": "withAthenaTheme()",
@@ -45142,7 +45220,7 @@
       "source_location": "L17"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "formatnumber_formatnumber",
       "label": "formatNumber()",
@@ -45151,7 +45229,7 @@
       "source_location": "L1"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_formatnumber_ts",
       "label": "formatNumber.ts",
@@ -45160,7 +45238,7 @@
       "source_location": "L1"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "bannermessage_getbannermessage",
       "label": "getBannerMessage()",
@@ -45169,30 +45247,12 @@
       "source_location": "L4"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_bannermessage_ts",
       "label": "bannerMessage.ts",
       "norm_label": "bannermessage.ts",
       "source_file": "packages/storefront-webapp/src/api/bannerMessage.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "checkoutsession_test_jsonresponse",
-      "label": "jsonResponse()",
-      "norm_label": "jsonresponse()",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.test.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_checkoutsession_test_ts",
-      "label": "checkoutSession.test.ts",
-      "norm_label": "checkoutsession.test.ts",
-      "source_file": "packages/storefront-webapp/src/api/checkoutSession.test.ts",
       "source_location": "L1"
     },
     {
@@ -45270,6 +45330,24 @@
     {
       "community": 470,
       "file_type": "code",
+      "id": "checkoutsession_test_jsonresponse",
+      "label": "jsonResponse()",
+      "norm_label": "jsonresponse()",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.test.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_checkoutsession_test_ts",
+      "label": "checkoutSession.test.ts",
+      "norm_label": "checkoutsession.test.ts",
+      "source_file": "packages/storefront-webapp/src/api/checkoutSession.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
       "id": "guest_updateguest",
       "label": "updateGuest()",
       "norm_label": "updateguest()",
@@ -45277,7 +45355,7 @@
       "source_location": "L4"
     },
     {
-      "community": 470,
+      "community": 471,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_guest_ts",
       "label": "guest.ts",
@@ -45286,7 +45364,7 @@
       "source_location": "L1"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefront_ts",
       "label": "storefront.ts",
@@ -45295,7 +45373,7 @@
       "source_location": "L1"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "storefront_getstore",
       "label": "getStore()",
@@ -45304,7 +45382,7 @@
       "source_location": "L5"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "entitypage_entitypage",
       "label": "EntityPage()",
@@ -45313,7 +45391,7 @@
       "source_location": "L10"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_entitypage_tsx",
       "label": "EntityPage.tsx",
@@ -45322,7 +45400,7 @@
       "source_location": "L1"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productspage_tsx",
       "label": "ProductsPage.tsx",
@@ -45331,7 +45409,7 @@
       "source_location": "L1"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "productspage_productcardloadingskeleton",
       "label": "ProductCardLoadingSkeleton()",
@@ -45340,7 +45418,7 @@
       "source_location": "L10"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "auth_authcomponent",
       "label": "AuthComponent()",
@@ -45349,7 +45427,7 @@
       "source_location": "L4"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -45358,7 +45436,7 @@
       "source_location": "L1"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "bagsummary_tobagsummaryitems",
       "label": "toBagSummaryItems()",
@@ -45367,7 +45445,7 @@
       "source_location": "L39"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_bagsummary_tsx",
       "label": "BagSummary.tsx",
@@ -45376,7 +45454,7 @@
       "source_location": "L1"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "checkoutform_checkoutform",
       "label": "CheckoutForm()",
@@ -45385,7 +45463,7 @@
       "source_location": "L18"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutform_tsx",
       "label": "CheckoutForm.tsx",
@@ -45394,7 +45472,7 @@
       "source_location": "L1"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "checkoutprovider_checkoutprovider",
       "label": "CheckoutProvider()",
@@ -45403,7 +45481,7 @@
       "source_location": "L71"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutprovider_tsx",
       "label": "CheckoutProvider.tsx",
@@ -45412,7 +45490,7 @@
       "source_location": "L1"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_pickupoptions_tsx",
       "label": "PickupOptions.tsx",
@@ -45421,31 +45499,13 @@
       "source_location": "L1"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "pickupoptions_iswithinrestrictiontime",
       "label": "isWithinRestrictionTime()",
       "norm_label": "iswithinrestrictiontime()",
       "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/PickupOptions.tsx",
       "source_location": "L12"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "enteredbillingaddressdetails_enteredbillingaddressdetails",
-      "label": "EnteredBillingAddressDetails()",
-      "norm_label": "enteredbillingaddressdetails()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/EnteredBillingAddressDetails.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_enteredbillingaddressdetails_tsx",
-      "label": "EnteredBillingAddressDetails.tsx",
-      "norm_label": "enteredbillingaddressdetails.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/EnteredBillingAddressDetails.tsx",
-      "source_location": "L1"
     },
     {
       "community": 48,
@@ -45522,6 +45582,24 @@
     {
       "community": 480,
       "file_type": "code",
+      "id": "enteredbillingaddressdetails_enteredbillingaddressdetails",
+      "label": "EnteredBillingAddressDetails()",
+      "norm_label": "enteredbillingaddressdetails()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/EnteredBillingAddressDetails.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_enteredbillingaddressdetails_tsx",
+      "label": "EnteredBillingAddressDetails.tsx",
+      "norm_label": "enteredbillingaddressdetails.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/EnteredBillingAddressDetails.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
       "id": "ordersummary_ordersummary",
       "label": "OrderSummary()",
       "norm_label": "ordersummary()",
@@ -45529,7 +45607,7 @@
       "source_location": "L18"
     },
     {
-      "community": 480,
+      "community": 481,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -45538,7 +45616,7 @@
       "source_location": "L1"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "index_pickupdetails",
       "label": "PickupDetails()",
@@ -45547,7 +45625,7 @@
       "source_location": "L10"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_index_tsx",
       "label": "index.tsx",
@@ -45556,7 +45634,7 @@
       "source_location": "L1"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_paymentmethodsection_tsx",
       "label": "PaymentMethodSection.tsx",
@@ -45565,7 +45643,7 @@
       "source_location": "L1"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "paymentmethodsection_paymentmethodsection",
       "label": "PaymentMethodSection()",
@@ -45574,7 +45652,7 @@
       "source_location": "L8"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_paymentsection_tsx",
       "label": "PaymentSection.tsx",
@@ -45583,7 +45661,7 @@
       "source_location": "L1"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "paymentsection_paymentsection",
       "label": "PaymentSection()",
@@ -45592,7 +45670,7 @@
       "source_location": "L27"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "deliveryfees_calculatedeliveryfee",
       "label": "calculateDeliveryFee()",
@@ -45601,7 +45679,7 @@
       "source_location": "L40"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_ts",
       "label": "deliveryFees.ts",
@@ -45610,7 +45688,7 @@
       "source_location": "L1"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "derivecheckoutstate_derivecheckoutstate",
       "label": "deriveCheckoutState()",
@@ -45619,7 +45697,7 @@
       "source_location": "L3"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_ts",
       "label": "deriveCheckoutState.ts",
@@ -45628,7 +45706,7 @@
       "source_location": "L1"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "checkoutschemas_test_getissuemap",
       "label": "getIssueMap()",
@@ -45637,7 +45715,7 @@
       "source_location": "L8"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutschemas_test_ts",
       "label": "checkoutSchemas.test.ts",
@@ -45646,7 +45724,7 @@
       "source_location": "L1"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_test_ts",
       "label": "webOrderSchema.test.ts",
@@ -45655,7 +45733,7 @@
       "source_location": "L1"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "weborderschema_test_getissuemap",
       "label": "getIssueMap()",
@@ -45664,7 +45742,7 @@
       "source_location": "L12"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "customerdetailsform_onsubmit",
       "label": "onSubmit()",
@@ -45673,30 +45751,12 @@
       "source_location": "L77"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_forms_customerdetailsform_tsx",
       "label": "CustomerDetailsForm.tsx",
       "norm_label": "customerdetailsform.tsx",
       "source_file": "packages/storefront-webapp/src/components/common/forms/CustomerDetailsForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "deliverydetailsform_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/components/common/forms/DeliveryDetailsForm.tsx",
-      "source_location": "L161"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_common_forms_deliverydetailsform_tsx",
-      "label": "DeliveryDetailsForm.tsx",
-      "norm_label": "deliverydetailsform.tsx",
-      "source_file": "packages/storefront-webapp/src/components/common/forms/DeliveryDetailsForm.tsx",
       "source_location": "L1"
     },
     {
@@ -45774,6 +45834,24 @@
     {
       "community": 490,
       "file_type": "code",
+      "id": "deliverydetailsform_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/components/common/forms/DeliveryDetailsForm.tsx",
+      "source_location": "L161"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_common_forms_deliverydetailsform_tsx",
+      "label": "DeliveryDetailsForm.tsx",
+      "norm_label": "deliverydetailsform.tsx",
+      "source_file": "packages/storefront-webapp/src/components/common/forms/DeliveryDetailsForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
       "id": "hooks_usecountdown",
       "label": "useCountdown()",
       "norm_label": "usecountdown()",
@@ -45781,7 +45859,7 @@
       "source_location": "L3"
     },
     {
-      "community": 490,
+      "community": 491,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_hooks_ts",
       "label": "hooks.ts",
@@ -45790,7 +45868,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_communication_trustsignals_tsx",
       "label": "TrustSignals.tsx",
@@ -45799,7 +45877,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "trustsignals_trustsignals",
       "label": "TrustSignals()",
@@ -45808,7 +45886,7 @@
       "source_location": "L4"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilter_tsx",
       "label": "ProductFilter.tsx",
@@ -45817,7 +45895,7 @@
       "source_location": "L1"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "productfilter_productfilter",
       "label": "ProductFilter()",
@@ -45826,7 +45904,7 @@
       "source_location": "L14"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "filter_handlecheckboxchange",
       "label": "handleCheckboxChange()",
@@ -45835,7 +45913,7 @@
       "source_location": "L27"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_footer_filter_tsx",
       "label": "Filter.tsx",
@@ -45844,7 +45922,7 @@
       "source_location": "L1"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "bestsellerssection_bestsellerssection",
       "label": "BestSellersSection()",
@@ -45853,7 +45931,7 @@
       "source_location": "L17"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_tsx",
       "label": "BestSellersSection.tsx",
@@ -45862,7 +45940,7 @@
       "source_location": "L1"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "homepagecontent_resolvehomepagecontent",
       "label": "resolveHomepageContent()",
@@ -45871,7 +45949,7 @@
       "source_location": "L13"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_ts",
       "label": "homePageContent.ts",
@@ -45880,7 +45958,7 @@
       "source_location": "L1"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "bagmenu_handleonlinkclick",
       "label": "handleOnLinkClick()",
@@ -45889,7 +45967,7 @@
       "source_location": "L47"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_bagmenu_tsx",
       "label": "BagMenu.tsx",
@@ -45898,7 +45976,7 @@
       "source_location": "L1"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "mobilebagmenu_mobilebagmenu",
       "label": "MobileBagMenu()",
@@ -45907,7 +45985,7 @@
       "source_location": "L7"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilebagmenu_tsx",
       "label": "MobileBagMenu.tsx",
@@ -45916,7 +45994,7 @@
       "source_location": "L1"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_sitebanner_tsx",
       "label": "SiteBanner.tsx",
@@ -45925,31 +46003,13 @@
       "source_location": "L1"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "sitebanner_sitebanner",
       "label": "SiteBanner()",
       "norm_label": "sitebanner()",
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/SiteBanner.tsx",
       "source_location": "L17"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "notificationpill_notificationpill",
-      "label": "NotificationPill()",
-      "norm_label": "notificationpill()",
-      "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_notification_notificationpill_tsx",
-      "label": "NotificationPill.tsx",
-      "norm_label": "notificationpill.tsx",
-      "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
-      "source_location": "L1"
     },
     {
       "community": 5,
@@ -46278,6 +46338,24 @@
     {
       "community": 500,
       "file_type": "code",
+      "id": "notificationpill_notificationpill",
+      "label": "NotificationPill()",
+      "norm_label": "notificationpill()",
+      "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_notification_notificationpill_tsx",
+      "label": "NotificationPill.tsx",
+      "norm_label": "notificationpill.tsx",
+      "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
       "id": "dimensionbar_mapvaluetolabelindex",
       "label": "mapValueToLabelIndex()",
       "norm_label": "mapvaluetolabelindex()",
@@ -46285,7 +46363,7 @@
       "source_location": "L12"
     },
     {
-      "community": 500,
+      "community": 501,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_dimensionbar_tsx",
       "label": "DimensionBar.tsx",
@@ -46294,7 +46372,7 @@
       "source_location": "L1"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "discountbadge_discountbadge",
       "label": "DiscountBadge()",
@@ -46303,7 +46381,7 @@
       "source_location": "L7"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_discountbadge_tsx",
       "label": "DiscountBadge.tsx",
@@ -46312,7 +46390,7 @@
       "source_location": "L1"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "galleryviewer_handleclickonpreview",
       "label": "handleClickOnPreview()",
@@ -46321,7 +46399,7 @@
       "source_location": "L45"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_galleryviewer_tsx",
       "label": "GalleryViewer.tsx",
@@ -46330,7 +46408,7 @@
       "source_location": "L1"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "onsaleproduct_onsaleproduct",
       "label": "OnsaleProduct()",
@@ -46339,7 +46417,7 @@
       "source_location": "L5"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_onsaleproduct_tsx",
       "label": "OnSaleProduct.tsx",
@@ -46348,7 +46426,7 @@
       "source_location": "L1"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_tsx",
       "label": "ProductActions.tsx",
@@ -46357,7 +46435,7 @@
       "source_location": "L1"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "productactions_productactions",
       "label": "ProductActions()",
@@ -46366,7 +46444,7 @@
       "source_location": "L17"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattributes_tsx",
       "label": "ProductAttributes.tsx",
@@ -46375,7 +46453,7 @@
       "source_location": "L1"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "productattributes_productattributes",
       "label": "ProductAttributes()",
@@ -46384,7 +46462,7 @@
       "source_location": "L3"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productpage_tsx",
       "label": "ProductPage.tsx",
@@ -46393,7 +46471,7 @@
       "source_location": "L1"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "productpage_showshippingpolicy",
       "label": "showShippingPolicy()",
@@ -46402,7 +46480,7 @@
       "source_location": "L78"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreview_tsx",
       "label": "ProductReview.tsx",
@@ -46411,7 +46489,7 @@
       "source_location": "L1"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "productreview_handlehelpful",
       "label": "handleHelpful()",
@@ -46420,7 +46498,7 @@
       "source_location": "L87"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_reviewsummary_tsx",
       "label": "ReviewSummary.tsx",
@@ -46429,31 +46507,13 @@
       "source_location": "L1"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "reviewsummary_reviewsummary",
       "label": "ReviewSummary()",
       "norm_label": "reviewsummary()",
       "source_file": "packages/storefront-webapp/src/components/product-page/ReviewSummary.tsx",
       "source_location": "L8"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "orderitem_orderitem",
-      "label": "OrderItem()",
-      "norm_label": "orderitem()",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_tsx",
-      "label": "OrderItem.tsx",
-      "norm_label": "orderitem.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
-      "source_location": "L1"
     },
     {
       "community": 51,
@@ -46530,6 +46590,24 @@
     {
       "community": 510,
       "file_type": "code",
+      "id": "orderitem_orderitem",
+      "label": "OrderItem()",
+      "norm_label": "orderitem()",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_tsx",
+      "label": "OrderItem.tsx",
+      "norm_label": "orderitem.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_ratingselector_tsx",
       "label": "RatingSelector.tsx",
       "norm_label": "ratingselector.tsx",
@@ -46537,7 +46615,7 @@
       "source_location": "L1"
     },
     {
-      "community": 510,
+      "community": 511,
       "file_type": "code",
       "id": "ratingselector_ratingselector",
       "label": "RatingSelector()",
@@ -46546,7 +46624,7 @@
       "source_location": "L18"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "guestrewardsprompt_guestrewardsprompt",
       "label": "GuestRewardsPrompt()",
@@ -46555,7 +46633,7 @@
       "source_location": "L10"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_guestrewardsprompt_tsx",
       "label": "GuestRewardsPrompt.tsx",
@@ -46564,7 +46642,7 @@
       "source_location": "L1"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "orderpointsdisplay_orderpointsdisplay",
       "label": "OrderPointsDisplay()",
@@ -46573,7 +46651,7 @@
       "source_location": "L11"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_orderpointsdisplay_tsx",
       "label": "OrderPointsDisplay.tsx",
@@ -46582,7 +46660,7 @@
       "source_location": "L1"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_pastordersrewards_tsx",
       "label": "PastOrdersRewards.tsx",
@@ -46591,7 +46669,7 @@
       "source_location": "L1"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "pastordersrewards_handleclaimpoints",
       "label": "handleClaimPoints()",
@@ -46600,7 +46678,7 @@
       "source_location": "L59"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_rewardspanel_tsx",
       "label": "RewardsPanel.tsx",
@@ -46609,7 +46687,7 @@
       "source_location": "L1"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "rewardspanel_handleredeemreward",
       "label": "handleRedeemReward()",
@@ -46618,7 +46696,7 @@
       "source_location": "L33"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "bagitem_bagitem",
       "label": "BagItem()",
@@ -46627,7 +46705,7 @@
       "source_location": "L19"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_bagitem_tsx",
       "label": "BagItem.tsx",
@@ -46636,7 +46714,7 @@
       "source_location": "L1"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "checkoutunavailable_checkoutunavailable",
       "label": "CheckoutUnavailable()",
@@ -46645,7 +46723,7 @@
       "source_location": "L4"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_unavailable_checkoutunavailable_tsx",
       "label": "CheckoutUnavailable.tsx",
@@ -46654,7 +46732,7 @@
       "source_location": "L1"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "errorboundary_errorboundary",
       "label": "ErrorBoundary()",
@@ -46663,7 +46741,7 @@
       "source_location": "L22"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_errorboundary_tsx",
       "label": "ErrorBoundary.tsx",
@@ -46672,7 +46750,7 @@
       "source_location": "L1"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scrolldownbutton_tsx",
       "label": "ScrollDownButton.tsx",
@@ -46681,31 +46759,13 @@
       "source_location": "L1"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "scrolldownbutton_scrolldownbutton",
       "label": "ScrollDownButton()",
       "norm_label": "scrolldownbutton()",
       "source_file": "packages/storefront-webapp/src/components/ui/ScrollDownButton.tsx",
       "source_location": "L11"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "country_select_countryselect",
-      "label": "CountrySelect()",
-      "norm_label": "countryselect()",
-      "source_file": "packages/storefront-webapp/src/components/ui/country-select.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_country_select_tsx",
-      "label": "country-select.tsx",
-      "norm_label": "country-select.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/country-select.tsx",
-      "source_location": "L1"
     },
     {
       "community": 52,
@@ -46773,6 +46833,24 @@
     {
       "community": 520,
       "file_type": "code",
+      "id": "country_select_countryselect",
+      "label": "CountrySelect()",
+      "norm_label": "countryselect()",
+      "source_file": "packages/storefront-webapp/src/components/ui/country-select.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_country_select_tsx",
+      "label": "country-select.tsx",
+      "norm_label": "country-select.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/country-select.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
       "id": "ghana_region_select_ghanaregionselect",
       "label": "GhanaRegionSelect()",
       "norm_label": "ghanaregionselect()",
@@ -46780,7 +46858,7 @@
       "source_location": "L3"
     },
     {
-      "community": 520,
+      "community": 521,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghana_region_select_tsx",
       "label": "ghana-region-select.tsx",
@@ -46789,7 +46867,7 @@
       "source_location": "L1"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "ghost_button_ghostbutton",
       "label": "GhostButton()",
@@ -46798,7 +46876,7 @@
       "source_location": "L9"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghost_button_tsx",
       "label": "ghost-button.tsx",
@@ -46807,7 +46885,7 @@
       "source_location": "L1"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "leaveareviewmodal_handleclose",
       "label": "handleClose()",
@@ -46816,7 +46894,7 @@
       "source_location": "L66"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodal_tsx",
       "label": "LeaveAReviewModal.tsx",
@@ -46825,7 +46903,7 @@
       "source_location": "L1"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalsuccess_tsx",
       "label": "UpsellModalSuccess.tsx",
@@ -46834,7 +46912,7 @@
       "source_location": "L1"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "upsellmodalsuccess_upsellmodalsuccess",
       "label": "UpsellModalSuccess()",
@@ -46843,7 +46921,7 @@
       "source_location": "L19"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalsuccess_tsx",
       "label": "WelcomeBackModalSuccess.tsx",
@@ -46852,7 +46930,7 @@
       "source_location": "L1"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "welcomebackmodalsuccess_welcomebackmodalsuccess",
       "label": "WelcomeBackModalSuccess()",
@@ -46861,7 +46939,7 @@
       "source_location": "L13"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "leavereviewmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -46870,7 +46948,7 @@
       "source_location": "L46"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_leavereviewmodalconfig_tsx",
       "label": "leaveReviewModalConfig.tsx",
@@ -46879,7 +46957,7 @@
       "source_location": "L1"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_welcomebackmodalconfig_tsx",
       "label": "welcomeBackModalConfig.tsx",
@@ -46888,7 +46966,7 @@
       "source_location": "L1"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "welcomebackmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -46897,7 +46975,7 @@
       "source_location": "L46"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_webp_jpg_tsx",
       "label": "webp-jpg.tsx",
@@ -46906,7 +46984,7 @@
       "source_location": "L1"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "webp_jpg_webpimage",
       "label": "WebpImage()",
@@ -46915,7 +46993,7 @@
       "source_location": "L1"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "formsubmissionprovider_useformsubmission",
       "label": "useFormSubmission()",
@@ -46924,31 +47002,13 @@
       "source_location": "L15"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_formsubmissionprovider_tsx",
       "label": "FormSubmissionProvider.tsx",
       "norm_label": "formsubmissionprovider.tsx",
       "source_file": "packages/storefront-webapp/src/contexts/FormSubmissionProvider.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usecheckout_ts",
-      "label": "useCheckout.ts",
-      "norm_label": "usecheckout.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useCheckout.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "usecheckout_usecheckout",
-      "label": "useCheckout()",
-      "norm_label": "usecheckout()",
-      "source_file": "packages/storefront-webapp/src/hooks/useCheckout.ts",
-      "source_location": "L5"
     },
     {
       "community": 53,
@@ -47016,6 +47076,24 @@
     {
       "community": 530,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usecheckout_ts",
+      "label": "useCheckout.ts",
+      "norm_label": "usecheckout.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useCheckout.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "usecheckout_usecheckout",
+      "label": "useCheckout()",
+      "norm_label": "usecheckout()",
+      "source_file": "packages/storefront-webapp/src/hooks/useCheckout.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usediscountcodealert_tsx",
       "label": "useDiscountCodeAlert.tsx",
       "norm_label": "usediscountcodealert.tsx",
@@ -47023,7 +47101,7 @@
       "source_location": "L1"
     },
     {
-      "community": 530,
+      "community": 531,
       "file_type": "code",
       "id": "usediscountcodealert_usediscountcodealert",
       "label": "useDiscountCodeAlert()",
@@ -47032,7 +47110,7 @@
       "source_location": "L14"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useenhancedtracking_ts",
       "label": "useEnhancedTracking.ts",
@@ -47041,7 +47119,7 @@
       "source_location": "L1"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "useenhancedtracking_useenhancedtracking",
       "label": "useEnhancedTracking()",
@@ -47050,7 +47128,7 @@
       "source_location": "L29"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetactivecheckoutsession_tsx",
       "label": "useGetActiveCheckoutSession.tsx",
@@ -47059,7 +47137,7 @@
       "source_location": "L1"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "usegetactivecheckoutsession_usegetactivecheckoutsession",
       "label": "useGetActiveCheckoutSession()",
@@ -47068,7 +47146,7 @@
       "source_location": "L5"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproduct_tsx",
       "label": "useGetProduct.tsx",
@@ -47077,7 +47155,7 @@
       "source_location": "L1"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "usegetproduct_usegetproductquery",
       "label": "useGetProductQuery()",
@@ -47086,7 +47164,7 @@
       "source_location": "L5"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductfilters_ts",
       "label": "useGetProductFilters.ts",
@@ -47095,7 +47173,7 @@
       "source_location": "L1"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "usegetproductfilters_usegetproductfilters",
       "label": "useGetProductFilters()",
@@ -47104,7 +47182,7 @@
       "source_location": "L3"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductreviews_ts",
       "label": "useGetProductReviews.ts",
@@ -47113,7 +47191,7 @@
       "source_location": "L1"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "usegetproductreviews_usegetproductreviewsquery",
       "label": "useGetProductReviewsQuery()",
@@ -47122,7 +47200,7 @@
       "source_location": "L4"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetstore_ts",
       "label": "useGetStore.ts",
@@ -47131,7 +47209,7 @@
       "source_location": "L1"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "usegetstore_usegetstore",
       "label": "useGetStore()",
@@ -47140,7 +47218,7 @@
       "source_location": "L4"
     },
     {
-      "community": 537,
+      "community": 538,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useinventorystatus_ts",
       "label": "useInventoryStatus.ts",
@@ -47149,7 +47227,7 @@
       "source_location": "L1"
     },
     {
-      "community": 537,
+      "community": 538,
       "file_type": "code",
       "id": "useinventorystatus_useinventorystatus",
       "label": "useInventoryStatus()",
@@ -47158,7 +47236,7 @@
       "source_location": "L9"
     },
     {
-      "community": 538,
+      "community": 539,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useleaveareviewmodal_tsx",
       "label": "useLeaveAReviewModal.tsx",
@@ -47167,31 +47245,13 @@
       "source_location": "L1"
     },
     {
-      "community": 538,
+      "community": 539,
       "file_type": "code",
       "id": "useleaveareviewmodal_useleaveareviewmodal",
       "label": "useLeaveAReviewModal()",
       "norm_label": "useleaveareviewmodal()",
       "source_file": "packages/storefront-webapp/src/hooks/useLeaveAReviewModal.tsx",
       "source_location": "L17"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_uselogout_ts",
-      "label": "useLogout.ts",
-      "norm_label": "uselogout.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useLogout.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "uselogout_uselogout",
-      "label": "useLogout()",
-      "norm_label": "uselogout()",
-      "source_file": "packages/storefront-webapp/src/hooks/useLogout.ts",
-      "source_location": "L5"
     },
     {
       "community": 54,
@@ -47259,6 +47319,24 @@
     {
       "community": 540,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_uselogout_ts",
+      "label": "useLogout.ts",
+      "norm_label": "uselogout.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useLogout.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "uselogout_uselogout",
+      "label": "useLogout()",
+      "norm_label": "uselogout()",
+      "source_file": "packages/storefront-webapp/src/hooks/useLogout.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usemodalstate_tsx",
       "label": "useModalState.tsx",
       "norm_label": "usemodalstate.tsx",
@@ -47266,7 +47344,7 @@
       "source_location": "L1"
     },
     {
-      "community": 540,
+      "community": 541,
       "file_type": "code",
       "id": "usemodalstate_usemodalstate",
       "label": "useModalState()",
@@ -47275,7 +47353,7 @@
       "source_location": "L15"
     },
     {
-      "community": 541,
+      "community": 542,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductpagelogic_ts",
       "label": "useProductPageLogic.ts",
@@ -47284,7 +47362,7 @@
       "source_location": "L1"
     },
     {
-      "community": 541,
+      "community": 542,
       "file_type": "code",
       "id": "useproductpagelogic_useproductpagelogic",
       "label": "useProductPageLogic()",
@@ -47293,7 +47371,7 @@
       "source_location": "L18"
     },
     {
-      "community": 542,
+      "community": 543,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductreminder_tsx",
       "label": "useProductReminder.tsx",
@@ -47302,7 +47380,7 @@
       "source_location": "L1"
     },
     {
-      "community": 542,
+      "community": 543,
       "file_type": "code",
       "id": "useproductreminder_useproductreminder",
       "label": "useProductReminder()",
@@ -47311,7 +47389,7 @@
       "source_location": "L9"
     },
     {
-      "community": 543,
+      "community": 544,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usepromoalert_tsx",
       "label": "usePromoAlert.tsx",
@@ -47320,7 +47398,7 @@
       "source_location": "L1"
     },
     {
-      "community": 543,
+      "community": 544,
       "file_type": "code",
       "id": "usepromoalert_usepromoalert",
       "label": "usePromoAlert()",
@@ -47329,7 +47407,7 @@
       "source_location": "L16"
     },
     {
-      "community": 544,
+      "community": 545,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usequeryenabled_ts",
       "label": "useQueryEnabled.ts",
@@ -47338,7 +47416,7 @@
       "source_location": "L1"
     },
     {
-      "community": 544,
+      "community": 545,
       "file_type": "code",
       "id": "usequeryenabled_usequeryenabled",
       "label": "useQueryEnabled()",
@@ -47347,7 +47425,7 @@
       "source_location": "L4"
     },
     {
-      "community": 545,
+      "community": 546,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_userewardsalert_tsx",
       "label": "useRewardsAlert.tsx",
@@ -47356,7 +47434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 545,
+      "community": 546,
       "file_type": "code",
       "id": "userewardsalert_userewardsalert",
       "label": "useRewardsAlert()",
@@ -47365,7 +47443,7 @@
       "source_location": "L11"
     },
     {
-      "community": 546,
+      "community": 547,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usescrolltotop_ts",
       "label": "useScrollToTop.ts",
@@ -47374,7 +47452,7 @@
       "source_location": "L1"
     },
     {
-      "community": 546,
+      "community": 547,
       "file_type": "code",
       "id": "usescrolltotop_usescrolltotop",
       "label": "useScrollToTop()",
@@ -47383,7 +47461,7 @@
       "source_location": "L3"
     },
     {
-      "community": 547,
+      "community": 548,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackaction_ts",
       "label": "useTrackAction.ts",
@@ -47392,7 +47470,7 @@
       "source_location": "L1"
     },
     {
-      "community": 547,
+      "community": 548,
       "file_type": "code",
       "id": "usetrackaction_usetrackaction",
       "label": "useTrackAction()",
@@ -47401,7 +47479,7 @@
       "source_location": "L7"
     },
     {
-      "community": 548,
+      "community": 549,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackevent_ts",
       "label": "useTrackEvent.ts",
@@ -47410,31 +47488,13 @@
       "source_location": "L1"
     },
     {
-      "community": 548,
+      "community": 549,
       "file_type": "code",
       "id": "usetrackevent_usetrackevent",
       "label": "useTrackEvent()",
       "norm_label": "usetrackevent()",
       "source_file": "packages/storefront-webapp/src/hooks/useTrackEvent.ts",
       "source_location": "L4"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useupsellmodal_tsx",
-      "label": "useUpsellModal.tsx",
-      "norm_label": "useupsellmodal.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useUpsellModal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "useupsellmodal_useupsellmodal",
-      "label": "useUpsellModal()",
-      "norm_label": "useupsellmodal()",
-      "source_file": "packages/storefront-webapp/src/hooks/useUpsellModal.tsx",
-      "source_location": "L14"
     },
     {
       "community": 55,
@@ -47502,6 +47562,24 @@
     {
       "community": 550,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useupsellmodal_tsx",
+      "label": "useUpsellModal.tsx",
+      "norm_label": "useupsellmodal.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useUpsellModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 550,
+      "file_type": "code",
+      "id": "useupsellmodal_useupsellmodal",
+      "label": "useUpsellModal()",
+      "norm_label": "useupsellmodal()",
+      "source_file": "packages/storefront-webapp/src/hooks/useUpsellModal.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
       "id": "analytics_usepostanalytics",
       "label": "usePostAnalytics()",
       "norm_label": "usepostanalytics()",
@@ -47509,7 +47587,7 @@
       "source_location": "L4"
     },
     {
-      "community": 550,
+      "community": 551,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_analytics_ts",
       "label": "analytics.ts",
@@ -47518,7 +47596,7 @@
       "source_location": "L1"
     },
     {
-      "community": 551,
+      "community": 552,
       "file_type": "code",
       "id": "bag_usebagqueries",
       "label": "useBagQueries()",
@@ -47527,7 +47605,7 @@
       "source_location": "L7"
     },
     {
-      "community": 551,
+      "community": 552,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_bag_ts",
       "label": "bag.ts",
@@ -47536,7 +47614,7 @@
       "source_location": "L1"
     },
     {
-      "community": 552,
+      "community": 553,
       "file_type": "code",
       "id": "bannermessage_usebannermessagequeries",
       "label": "useBannerMessageQueries()",
@@ -47545,7 +47623,7 @@
       "source_location": "L6"
     },
     {
-      "community": 552,
+      "community": 553,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -47554,7 +47632,7 @@
       "source_location": "L1"
     },
     {
-      "community": 553,
+      "community": 554,
       "file_type": "code",
       "id": "checkout_usecheckoutsessionqueries",
       "label": "useCheckoutSessionQueries()",
@@ -47563,7 +47641,7 @@
       "source_location": "L10"
     },
     {
-      "community": 553,
+      "community": 554,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_checkout_ts",
       "label": "checkout.ts",
@@ -47572,7 +47650,7 @@
       "source_location": "L1"
     },
     {
-      "community": 554,
+      "community": 555,
       "file_type": "code",
       "id": "inventory_useinventoryqueries",
       "label": "useInventoryQueries()",
@@ -47581,7 +47659,7 @@
       "source_location": "L6"
     },
     {
-      "community": 554,
+      "community": 555,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_inventory_ts",
       "label": "inventory.ts",
@@ -47590,7 +47668,7 @@
       "source_location": "L1"
     },
     {
-      "community": 555,
+      "community": 556,
       "file_type": "code",
       "id": "onlineorder_useonlineorderqueries",
       "label": "useOnlineOrderQueries()",
@@ -47599,7 +47677,7 @@
       "source_location": "L5"
     },
     {
-      "community": 555,
+      "community": 556,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -47608,7 +47686,7 @@
       "source_location": "L1"
     },
     {
-      "community": 556,
+      "community": 557,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_product_ts",
       "label": "product.ts",
@@ -47617,7 +47695,7 @@
       "source_location": "L1"
     },
     {
-      "community": 556,
+      "community": 557,
       "file_type": "code",
       "id": "product_useproductqueries",
       "label": "useProductQueries()",
@@ -47626,7 +47704,7 @@
       "source_location": "L14"
     },
     {
-      "community": 557,
+      "community": 558,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_promocode_ts",
       "label": "promoCode.ts",
@@ -47635,7 +47713,7 @@
       "source_location": "L1"
     },
     {
-      "community": 557,
+      "community": 558,
       "file_type": "code",
       "id": "promocode_usepromocodesqueries",
       "label": "usePromoCodesQueries()",
@@ -47644,7 +47722,7 @@
       "source_location": "L9"
     },
     {
-      "community": 558,
+      "community": 559,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_reviews_ts",
       "label": "reviews.ts",
@@ -47653,31 +47731,13 @@
       "source_location": "L1"
     },
     {
-      "community": 558,
+      "community": 559,
       "file_type": "code",
       "id": "reviews_usereviewqueries",
       "label": "useReviewQueries()",
       "norm_label": "usereviewqueries()",
       "source_file": "packages/storefront-webapp/src/lib/queries/reviews.ts",
       "source_location": "L10"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_rewards_ts",
-      "label": "rewards.ts",
-      "norm_label": "rewards.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/rewards.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "rewards_userewardsqueries",
-      "label": "useRewardsQueries()",
-      "norm_label": "userewardsqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/rewards.ts",
-      "source_location": "L11"
     },
     {
       "community": 56,
@@ -47745,6 +47805,24 @@
     {
       "community": 560,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_rewards_ts",
+      "label": "rewards.ts",
+      "norm_label": "rewards.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/rewards.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "rewards_userewardsqueries",
+      "label": "useRewardsQueries()",
+      "norm_label": "userewardsqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/rewards.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_upsells_ts",
       "label": "upsells.ts",
       "norm_label": "upsells.ts",
@@ -47752,7 +47830,7 @@
       "source_location": "L1"
     },
     {
-      "community": 560,
+      "community": 561,
       "file_type": "code",
       "id": "upsells_useupsellsqueries",
       "label": "useUpsellsQueries()",
@@ -47761,7 +47839,7 @@
       "source_location": "L6"
     },
     {
-      "community": 561,
+      "community": 562,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_user_ts",
       "label": "user.ts",
@@ -47770,7 +47848,7 @@
       "source_location": "L1"
     },
     {
-      "community": 561,
+      "community": 562,
       "file_type": "code",
       "id": "user_useuserqueries",
       "label": "useUserQueries()",
@@ -47779,7 +47857,7 @@
       "source_location": "L5"
     },
     {
-      "community": 562,
+      "community": 563,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_useroffers_ts",
       "label": "userOffers.ts",
@@ -47788,7 +47866,7 @@
       "source_location": "L1"
     },
     {
-      "community": 562,
+      "community": 563,
       "file_type": "code",
       "id": "useroffers_useuseroffersqueries",
       "label": "useUserOffersQueries()",
@@ -47797,7 +47875,7 @@
       "source_location": "L6"
     },
     {
-      "community": 563,
+      "community": 564,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
@@ -47806,7 +47884,7 @@
       "source_location": "L1"
     },
     {
-      "community": 563,
+      "community": 564,
       "file_type": "code",
       "id": "storeconfig_test_buildv2config",
       "label": "buildV2Config()",
@@ -47815,7 +47893,7 @@
       "source_location": "L10"
     },
     {
-      "community": 564,
+      "community": 565,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontobservability_test_ts",
       "label": "storefrontObservability.test.ts",
@@ -47824,7 +47902,7 @@
       "source_location": "L1"
     },
     {
-      "community": 564,
+      "community": 565,
       "file_type": "code",
       "id": "storefrontobservability_test_creatememorystorage",
       "label": "createMemoryStorage()",
@@ -47833,7 +47911,7 @@
       "source_location": "L15"
     },
     {
-      "community": 565,
+      "community": 566,
       "file_type": "code",
       "id": "email_validateemail",
       "label": "validateEmail()",
@@ -47842,7 +47920,7 @@
       "source_location": "L14"
     },
     {
-      "community": 565,
+      "community": 566,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_validations_email_ts",
       "label": "email.ts",
@@ -47851,7 +47929,7 @@
       "source_location": "L1"
     },
     {
-      "community": 566,
+      "community": 567,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_router_tsx",
       "label": "router.tsx",
@@ -47860,7 +47938,7 @@
       "source_location": "L1"
     },
     {
-      "community": 566,
+      "community": 567,
       "file_type": "code",
       "id": "router_createrouter",
       "label": "createRouter()",
@@ -47869,7 +47947,7 @@
       "source_location": "L5"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "homepageloader_loadhomepagedata",
       "label": "loadHomePageData()",
@@ -47878,7 +47956,7 @@
       "source_location": "L13"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_ts",
       "label": "-homePageLoader.ts",
@@ -47887,7 +47965,7 @@
       "source_location": "L1"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "orderslayout_layoutcomponent",
       "label": "LayoutComponent()",
@@ -47896,30 +47974,12 @@
       "source_location": "L8"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_tsx",
       "label": "_ordersLayout.tsx",
       "norm_label": "_orderslayout.tsx",
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "contact_us_contactus",
-      "label": "ContactUs()",
-      "norm_label": "contactus()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/contact-us.tsx",
-      "source_location": "L14"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_contact_us_tsx",
-      "label": "contact-us.tsx",
-      "norm_label": "contact-us.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/contact-us.tsx",
       "source_location": "L1"
     },
     {
@@ -47988,6 +48048,24 @@
     {
       "community": 570,
       "file_type": "code",
+      "id": "contact_us_contactus",
+      "label": "ContactUs()",
+      "norm_label": "contactus()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/contact-us.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_contact_us_tsx",
+      "label": "contact-us.tsx",
+      "norm_label": "contact-us.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/contact-us.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
       "id": "delivery_returns_exchanges_index_onlineorderpolicy",
       "label": "OnlineOrderPolicy()",
       "norm_label": "onlineorderpolicy()",
@@ -47995,7 +48073,7 @@
       "source_location": "L13"
     },
     {
-      "community": 570,
+      "community": 571,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_delivery_returns_exchanges_index_tsx",
       "label": "delivery-returns-exchanges.index.tsx",
@@ -48004,7 +48082,7 @@
       "source_location": "L1"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_privacy_index_tsx",
       "label": "privacy.index.tsx",
@@ -48013,7 +48091,7 @@
       "source_location": "L1"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "privacy_index_privacypolicy",
       "label": "PrivacyPolicy()",
@@ -48022,7 +48100,7 @@
       "source_location": "L9"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_tos_index_tsx",
       "label": "tos.index.tsx",
@@ -48031,7 +48109,7 @@
       "source_location": "L1"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "tos_index_tossection",
       "label": "TosSection()",
@@ -48040,7 +48118,7 @@
       "source_location": "L15"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_product_productslug_tsx",
       "label": "shop.product.$productSlug.tsx",
@@ -48049,7 +48127,7 @@
       "source_location": "L1"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "shop_product_productslug_component",
       "label": "Component()",
@@ -48058,7 +48136,7 @@
       "source_location": "L16"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "layout_layoutcomponent",
       "label": "LayoutComponent()",
@@ -48067,7 +48145,7 @@
       "source_location": "L6"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_tsx",
       "label": "_layout.tsx",
@@ -48076,7 +48154,7 @@
       "source_location": "L1"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "index_homeroute",
       "label": "HomeRoute()",
@@ -48085,7 +48163,7 @@
       "source_location": "L10"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -48094,7 +48172,7 @@
       "source_location": "L1"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "canceled_checkoutcanceledview",
       "label": "CheckoutCanceledView()",
@@ -48103,7 +48181,7 @@
       "source_location": "L21"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_canceled_tsx",
       "label": "canceled.tsx",
@@ -48112,7 +48190,7 @@
       "source_location": "L1"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "complete_index_checkoutcomplete",
       "label": "CheckoutComplete()",
@@ -48121,7 +48199,7 @@
       "source_location": "L33"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_complete_index_tsx",
       "label": "complete.index.tsx",
@@ -48130,7 +48208,7 @@
       "source_location": "L1"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pod_confirmation_tsx",
       "label": "pod-confirmation.tsx",
@@ -48139,7 +48217,7 @@
       "source_location": "L1"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "pod_confirmation_completepodcheckoutsession",
       "label": "completePODCheckoutSession()",
@@ -48148,223 +48226,7 @@
       "source_location": "L193"
     },
     {
-      "community": 579,
-      "file_type": "code",
-      "id": "packages_valkey_proxy_server_test_connection_js",
-      "label": "test-connection.js",
-      "norm_label": "test-connection.js",
-      "source_file": "packages/valkey-proxy-server/test-connection.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "test_connection_main",
-      "label": "main()",
-      "norm_label": "main()",
-      "source_file": "packages/valkey-proxy-server/test-connection.js",
-      "source_location": "L7"
-    },
-    {
       "community": 58,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 58,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 58,
-      "file_type": "code",
-      "id": "productutils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 58,
-      "file_type": "code",
-      "id": "productutils_haslowstock",
-      "label": "hasLowStock()",
-      "norm_label": "haslowstock()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 58,
-      "file_type": "code",
-      "id": "productutils_issoldout",
-      "label": "isSoldOut()",
-      "norm_label": "issoldout()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 58,
-      "file_type": "code",
-      "id": "productutils_sortproduct",
-      "label": "sortProduct()",
-      "norm_label": "sortproduct()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L66"
-    },
-    {
-      "community": 58,
-      "file_type": "code",
-      "id": "productutils_sortskusbylength",
-      "label": "sortSkusByLength()",
-      "norm_label": "sortskusbylength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 580,
-      "file_type": "code",
-      "id": "architecture_boundaries_test_createsnippetlinter",
-      "label": "createSnippetLinter()",
-      "norm_label": "createsnippetlinter()",
-      "source_file": "scripts/architecture-boundaries.test.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 580,
-      "file_type": "code",
-      "id": "scripts_architecture_boundaries_test_ts",
-      "label": "architecture-boundaries.test.ts",
-      "norm_label": "architecture-boundaries.test.ts",
-      "source_file": "scripts/architecture-boundaries.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 581,
-      "file_type": "code",
-      "id": "architecture_boundary_check_run",
-      "label": "run()",
-      "norm_label": "run()",
-      "source_file": "scripts/architecture-boundary-check.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 581,
-      "file_type": "code",
-      "id": "scripts_architecture_boundary_check_ts",
-      "label": "architecture-boundary-check.ts",
-      "norm_label": "architecture-boundary-check.ts",
-      "source_file": "scripts/architecture-boundary-check.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 582,
-      "file_type": "code",
-      "id": "athena_runtime_app_shutdown",
-      "label": "shutdown()",
-      "norm_label": "shutdown()",
-      "source_file": "scripts/harness-behavior-fixtures/athena-runtime-app.ts",
-      "source_location": "L211"
-    },
-    {
-      "community": 582,
-      "file_type": "code",
-      "id": "scripts_harness_behavior_fixtures_athena_runtime_app_ts",
-      "label": "athena-runtime-app.ts",
-      "norm_label": "athena-runtime-app.ts",
-      "source_file": "scripts/harness-behavior-fixtures/athena-runtime-app.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 583,
-      "file_type": "code",
-      "id": "sample_app_shutdown",
-      "label": "shutdown()",
-      "norm_label": "shutdown()",
-      "source_file": "scripts/harness-behavior-fixtures/sample-app.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 583,
-      "file_type": "code",
-      "id": "scripts_harness_behavior_fixtures_sample_app_ts",
-      "label": "sample-app.ts",
-      "norm_label": "sample-app.ts",
-      "source_file": "scripts/harness-behavior-fixtures/sample-app.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 584,
-      "file_type": "code",
-      "id": "harness_runtime_trends_test_buildreportline",
-      "label": "buildReportLine()",
-      "norm_label": "buildreportline()",
-      "source_file": "scripts/harness-runtime-trends.test.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 584,
-      "file_type": "code",
-      "id": "scripts_harness_runtime_trends_test_ts",
-      "label": "harness-runtime-trends.test.ts",
-      "norm_label": "harness-runtime-trends.test.ts",
-      "source_file": "scripts/harness-runtime-trends.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 585,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_generated_api_d_ts",
-      "label": "api.d.ts",
-      "norm_label": "api.d.ts",
-      "source_file": "packages/athena-webapp/convex/_generated/api.d.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 586,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_generated_api_js",
-      "label": "api.js",
-      "norm_label": "api.js",
-      "source_file": "packages/athena-webapp/convex/_generated/api.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 587,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_generated_datamodel_d_ts",
-      "label": "dataModel.d.ts",
-      "norm_label": "datamodel.d.ts",
-      "source_file": "packages/athena-webapp/convex/_generated/dataModel.d.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 588,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_generated_server_d_ts",
-      "label": "server.d.ts",
-      "norm_label": "server.d.ts",
-      "source_file": "packages/athena-webapp/convex/_generated/server.d.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_generated_server_js",
-      "label": "server.js",
-      "norm_label": "server.js",
-      "source_file": "packages/athena-webapp/convex/_generated/server.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 59,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_savedbag_ts",
       "label": "savedBag.ts",
@@ -48373,7 +48235,7 @@
       "source_location": "L1"
     },
     {
-      "community": 59,
+      "community": 58,
       "file_type": "code",
       "id": "savedbag_additemtosavedbag",
       "label": "addItemToSavedBag()",
@@ -48382,7 +48244,7 @@
       "source_location": "L25"
     },
     {
-      "community": 59,
+      "community": 58,
       "file_type": "code",
       "id": "savedbag_getactivesavedbag",
       "label": "getActiveSavedBag()",
@@ -48391,7 +48253,7 @@
       "source_location": "L10"
     },
     {
-      "community": 59,
+      "community": 58,
       "file_type": "code",
       "id": "savedbag_getbaseurl",
       "label": "getBaseUrl()",
@@ -48400,7 +48262,7 @@
       "source_location": "L8"
     },
     {
-      "community": 59,
+      "community": 58,
       "file_type": "code",
       "id": "savedbag_removeitemfromsavedbag",
       "label": "removeItemFromSavedBag()",
@@ -48409,7 +48271,7 @@
       "source_location": "L91"
     },
     {
-      "community": 59,
+      "community": 58,
       "file_type": "code",
       "id": "savedbag_updatesavedbagitem",
       "label": "updateSavedBagItem()",
@@ -48418,7 +48280,7 @@
       "source_location": "L61"
     },
     {
-      "community": 59,
+      "community": 58,
       "file_type": "code",
       "id": "savedbag_updatesavedbagowner",
       "label": "updateSavedBagOwner()",
@@ -48427,7 +48289,223 @@
       "source_location": "L109"
     },
     {
+      "community": 580,
+      "file_type": "code",
+      "id": "packages_valkey_proxy_server_test_connection_js",
+      "label": "test-connection.js",
+      "norm_label": "test-connection.js",
+      "source_file": "packages/valkey-proxy-server/test-connection.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "test_connection_main",
+      "label": "main()",
+      "norm_label": "main()",
+      "source_file": "packages/valkey-proxy-server/test-connection.js",
+      "source_location": "L7"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
+      "id": "architecture_boundaries_test_createsnippetlinter",
+      "label": "createSnippetLinter()",
+      "norm_label": "createsnippetlinter()",
+      "source_file": "scripts/architecture-boundaries.test.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
+      "id": "scripts_architecture_boundaries_test_ts",
+      "label": "architecture-boundaries.test.ts",
+      "norm_label": "architecture-boundaries.test.ts",
+      "source_file": "scripts/architecture-boundaries.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 582,
+      "file_type": "code",
+      "id": "architecture_boundary_check_run",
+      "label": "run()",
+      "norm_label": "run()",
+      "source_file": "scripts/architecture-boundary-check.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 582,
+      "file_type": "code",
+      "id": "scripts_architecture_boundary_check_ts",
+      "label": "architecture-boundary-check.ts",
+      "norm_label": "architecture-boundary-check.ts",
+      "source_file": "scripts/architecture-boundary-check.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 583,
+      "file_type": "code",
+      "id": "athena_runtime_app_shutdown",
+      "label": "shutdown()",
+      "norm_label": "shutdown()",
+      "source_file": "scripts/harness-behavior-fixtures/athena-runtime-app.ts",
+      "source_location": "L211"
+    },
+    {
+      "community": 583,
+      "file_type": "code",
+      "id": "scripts_harness_behavior_fixtures_athena_runtime_app_ts",
+      "label": "athena-runtime-app.ts",
+      "norm_label": "athena-runtime-app.ts",
+      "source_file": "scripts/harness-behavior-fixtures/athena-runtime-app.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 584,
+      "file_type": "code",
+      "id": "sample_app_shutdown",
+      "label": "shutdown()",
+      "norm_label": "shutdown()",
+      "source_file": "scripts/harness-behavior-fixtures/sample-app.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 584,
+      "file_type": "code",
+      "id": "scripts_harness_behavior_fixtures_sample_app_ts",
+      "label": "sample-app.ts",
+      "norm_label": "sample-app.ts",
+      "source_file": "scripts/harness-behavior-fixtures/sample-app.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 585,
+      "file_type": "code",
+      "id": "harness_runtime_trends_test_buildreportline",
+      "label": "buildReportLine()",
+      "norm_label": "buildreportline()",
+      "source_file": "scripts/harness-runtime-trends.test.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 585,
+      "file_type": "code",
+      "id": "scripts_harness_runtime_trends_test_ts",
+      "label": "harness-runtime-trends.test.ts",
+      "norm_label": "harness-runtime-trends.test.ts",
+      "source_file": "scripts/harness-runtime-trends.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 586,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_generated_api_d_ts",
+      "label": "api.d.ts",
+      "norm_label": "api.d.ts",
+      "source_file": "packages/athena-webapp/convex/_generated/api.d.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 587,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_generated_api_js",
+      "label": "api.js",
+      "norm_label": "api.js",
+      "source_file": "packages/athena-webapp/convex/_generated/api.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 588,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_generated_datamodel_d_ts",
+      "label": "dataModel.d.ts",
+      "norm_label": "datamodel.d.ts",
+      "source_file": "packages/athena-webapp/convex/_generated/dataModel.d.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 589,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_generated_server_d_ts",
+      "label": "server.d.ts",
+      "norm_label": "server.d.ts",
+      "source_file": "packages/athena-webapp/convex/_generated/server.d.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 59,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 59,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 59,
+      "file_type": "code",
+      "id": "productutils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 59,
+      "file_type": "code",
+      "id": "productutils_haslowstock",
+      "label": "hasLowStock()",
+      "norm_label": "haslowstock()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 59,
+      "file_type": "code",
+      "id": "productutils_issoldout",
+      "label": "isSoldOut()",
+      "norm_label": "issoldout()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 59,
+      "file_type": "code",
+      "id": "productutils_sortproduct",
+      "label": "sortProduct()",
+      "norm_label": "sortproduct()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 59,
+      "file_type": "code",
+      "id": "productutils_sortskusbylength",
+      "label": "sortSkusByLength()",
+      "norm_label": "sortskusbylength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L62"
+    },
+    {
       "community": 590,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_generated_server_js",
+      "label": "server.js",
+      "norm_label": "server.js",
+      "source_file": "packages/athena-webapp/convex/_generated/server.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 591,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_app_ts",
       "label": "app.ts",
@@ -48436,7 +48514,7 @@
       "source_location": "L1"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_config_js",
       "label": "auth.config.js",
@@ -48445,7 +48523,7 @@
       "source_location": "L1"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_ts",
       "label": "auth.ts",
@@ -48454,7 +48532,7 @@
       "source_location": "L1"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_countries_ts",
       "label": "countries.ts",
@@ -48463,7 +48541,7 @@
       "source_location": "L1"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_email_ts",
       "label": "email.ts",
@@ -48472,7 +48550,7 @@
       "source_location": "L1"
     },
     {
-      "community": 595,
+      "community": 596,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_ghana_ts",
       "label": "ghana.ts",
@@ -48481,7 +48559,7 @@
       "source_location": "L1"
     },
     {
-      "community": 596,
+      "community": 597,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_payment_ts",
       "label": "payment.ts",
@@ -48490,7 +48568,7 @@
       "source_location": "L1"
     },
     {
-      "community": 597,
+      "community": 598,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_crons_ts",
       "label": "crons.ts",
@@ -48499,21 +48577,12 @@
       "source_location": "L1"
     },
     {
-      "community": 598,
+      "community": 599,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_feedbackrequest_tsx",
       "label": "FeedbackRequest.tsx",
       "norm_label": "feedbackrequest.tsx",
       "source_file": "packages/athena-webapp/convex/emails/FeedbackRequest.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_emails_neworderadmin_tsx",
-      "label": "NewOrderAdmin.tsx",
-      "norm_label": "neworderadmin.tsx",
-      "source_file": "packages/athena-webapp/convex/emails/NewOrderAdmin.tsx",
       "source_location": "L1"
     },
     {
@@ -48816,6 +48885,15 @@
     {
       "community": 600,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_neworderadmin_tsx",
+      "label": "NewOrderAdmin.tsx",
+      "norm_label": "neworderadmin.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/NewOrderAdmin.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 601,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_orderemail_tsx",
       "label": "OrderEmail.tsx",
       "norm_label": "orderemail.tsx",
@@ -48823,7 +48901,7 @@
       "source_location": "L1"
     },
     {
-      "community": 601,
+      "community": 602,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_posreceiptemail_tsx",
       "label": "PosReceiptEmail.tsx",
@@ -48832,7 +48910,7 @@
       "source_location": "L1"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_env_ts",
       "label": "env.ts",
@@ -48841,7 +48919,7 @@
       "source_location": "L1"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_analytics_ts",
       "label": "analytics.ts",
@@ -48850,7 +48928,7 @@
       "source_location": "L1"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_auth_ts",
       "label": "auth.ts",
@@ -48859,7 +48937,7 @@
       "source_location": "L1"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -48868,7 +48946,7 @@
       "source_location": "L1"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_categories_ts",
       "label": "categories.ts",
@@ -48877,7 +48955,7 @@
       "source_location": "L1"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_colors_ts",
       "label": "colors.ts",
@@ -48886,21 +48964,12 @@
       "source_location": "L1"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_organizations_ts",
-      "label": "organizations.ts",
-      "norm_label": "organizations.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/organizations.ts",
       "source_location": "L1"
     },
     {
@@ -48969,6 +49038,15 @@
     {
       "community": 610,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_organizations_ts",
+      "label": "organizations.ts",
+      "norm_label": "organizations.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/organizations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 611,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_products_ts",
       "label": "products.ts",
       "norm_label": "products.ts",
@@ -48976,7 +49054,7 @@
       "source_location": "L1"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_stores_ts",
       "label": "stores.ts",
@@ -48985,7 +49063,7 @@
       "source_location": "L1"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_subcategories_ts",
       "label": "subcategories.ts",
@@ -48994,7 +49072,7 @@
       "source_location": "L1"
     },
     {
-      "community": 613,
+      "community": 614,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_payments_routes_index_ts",
       "label": "index.ts",
@@ -49003,7 +49081,7 @@
       "source_location": "L1"
     },
     {
-      "community": 614,
+      "community": 615,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_bag_ts",
       "label": "bag.ts",
@@ -49012,7 +49090,7 @@
       "source_location": "L1"
     },
     {
-      "community": 615,
+      "community": 616,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_guest_ts",
       "label": "guest.ts",
@@ -49021,7 +49099,7 @@
       "source_location": "L1"
     },
     {
-      "community": 616,
+      "community": 617,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_index_ts",
       "label": "index.ts",
@@ -49030,7 +49108,7 @@
       "source_location": "L1"
     },
     {
-      "community": 617,
+      "community": 618,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_me_ts",
       "label": "me.ts",
@@ -49039,21 +49117,12 @@
       "source_location": "L1"
     },
     {
-      "community": 618,
+      "community": 619,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_offers_ts",
       "label": "offers.ts",
       "norm_label": "offers.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/offers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_onlineorder_ts",
-      "label": "onlineOrder.ts",
-      "norm_label": "onlineorder.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/onlineOrder.ts",
       "source_location": "L1"
     },
     {
@@ -49122,6 +49191,15 @@
     {
       "community": 620,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_onlineorder_ts",
+      "label": "onlineOrder.ts",
+      "norm_label": "onlineorder.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/onlineOrder.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 621,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_paystack_ts",
       "label": "paystack.ts",
       "norm_label": "paystack.ts",
@@ -49129,7 +49207,7 @@
       "source_location": "L1"
     },
     {
-      "community": 621,
+      "community": 622,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_reviews_ts",
       "label": "reviews.ts",
@@ -49138,7 +49216,7 @@
       "source_location": "L1"
     },
     {
-      "community": 622,
+      "community": 623,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_rewards_ts",
       "label": "rewards.ts",
@@ -49147,7 +49225,7 @@
       "source_location": "L1"
     },
     {
-      "community": 623,
+      "community": 624,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_savedbag_ts",
       "label": "savedBag.ts",
@@ -49156,7 +49234,7 @@
       "source_location": "L1"
     },
     {
-      "community": 624,
+      "community": 625,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_test_ts",
       "label": "security.test.ts",
@@ -49165,7 +49243,7 @@
       "source_location": "L1"
     },
     {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_storefront_ts",
       "label": "storefront.ts",
@@ -49174,7 +49252,7 @@
       "source_location": "L1"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_upsells_ts",
       "label": "upsells.ts",
@@ -49183,7 +49261,7 @@
       "source_location": "L1"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_user_ts",
       "label": "user.ts",
@@ -49192,21 +49270,12 @@
       "source_location": "L1"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_useroffers_ts",
       "label": "userOffers.ts",
       "norm_label": "useroffers.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/userOffers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_health_test_ts",
-      "label": "health.test.ts",
-      "norm_label": "health.test.ts",
-      "source_file": "packages/athena-webapp/convex/http/health.test.ts",
       "source_location": "L1"
     },
     {
@@ -49266,6 +49335,15 @@
     {
       "community": 630,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_health_test_ts",
+      "label": "health.test.ts",
+      "norm_label": "health.test.ts",
+      "source_file": "packages/athena-webapp/convex/http/health.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 631,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_ts",
       "label": "http.ts",
       "norm_label": "http.ts",
@@ -49273,7 +49351,7 @@
       "source_location": "L1"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -49282,7 +49360,7 @@
       "source_location": "L1"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_auth_ts",
       "label": "auth.ts",
@@ -49291,7 +49369,7 @@
       "source_location": "L1"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -49300,7 +49378,7 @@
       "source_location": "L1"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bestseller_ts",
       "label": "bestSeller.ts",
@@ -49309,7 +49387,7 @@
       "source_location": "L1"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_categories_ts",
       "label": "categories.ts",
@@ -49318,7 +49396,7 @@
       "source_location": "L1"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_colors_ts",
       "label": "colors.ts",
@@ -49327,7 +49405,7 @@
       "source_location": "L1"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
@@ -49336,21 +49414,12 @@
       "source_location": "L1"
     },
     {
-      "community": 638,
+      "community": 639,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessionitems_ts",
       "label": "expenseSessionItems.ts",
       "norm_label": "expensesessionitems.ts",
       "source_file": "packages/athena-webapp/convex/inventory/expenseSessionItems.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_expensetransactions_ts",
-      "label": "expenseTransactions.ts",
-      "norm_label": "expensetransactions.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.ts",
       "source_location": "L1"
     },
     {
@@ -49410,6 +49479,15 @@
     {
       "community": 640,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_expensetransactions_ts",
+      "label": "expenseTransactions.ts",
+      "norm_label": "expensetransactions.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 641,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_featureditem_ts",
       "label": "featuredItem.ts",
       "norm_label": "featureditem.ts",
@@ -49417,7 +49495,7 @@
       "source_location": "L1"
     },
     {
-      "community": 641,
+      "community": 642,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_invitecode_ts",
       "label": "inviteCode.ts",
@@ -49426,7 +49504,7 @@
       "source_location": "L1"
     },
     {
-      "community": 642,
+      "community": 643,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizationmembers_ts",
       "label": "organizationMembers.ts",
@@ -49435,7 +49513,7 @@
       "source_location": "L1"
     },
     {
-      "community": 643,
+      "community": 644,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizations_ts",
       "label": "organizations.ts",
@@ -49444,7 +49522,7 @@
       "source_location": "L1"
     },
     {
-      "community": 644,
+      "community": 645,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_poscustomers_ts",
       "label": "posCustomers.ts",
@@ -49453,7 +49531,7 @@
       "source_location": "L1"
     },
     {
-      "community": 645,
+      "community": 646,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessionitems_ts",
       "label": "posSessionItems.ts",
@@ -49462,7 +49540,7 @@
       "source_location": "L1"
     },
     {
-      "community": 646,
+      "community": 647,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posterminal_ts",
       "label": "posTerminal.ts",
@@ -49471,7 +49549,7 @@
       "source_location": "L1"
     },
     {
-      "community": 647,
+      "community": 648,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productsku_ts",
       "label": "productSku.ts",
@@ -49480,21 +49558,12 @@
       "source_location": "L1"
     },
     {
-      "community": 648,
+      "community": 649,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productutil_ts",
       "label": "productUtil.ts",
       "norm_label": "productutil.ts",
       "source_file": "packages/athena-webapp/convex/inventory/productUtil.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_promocode_ts",
-      "label": "promoCode.ts",
-      "norm_label": "promocode.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/promoCode.ts",
       "source_location": "L1"
     },
     {
@@ -49554,6 +49623,15 @@
     {
       "community": 650,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_promocode_ts",
+      "label": "promoCode.ts",
+      "norm_label": "promocode.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/promoCode.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 651,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stockvalidation_ts",
       "label": "stockValidation.ts",
       "norm_label": "stockvalidation.ts",
@@ -49561,7 +49639,7 @@
       "source_location": "L1"
     },
     {
-      "community": 651,
+      "community": 652,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_storeconfigv2_test_ts",
       "label": "storeConfigV2.test.ts",
@@ -49570,7 +49648,7 @@
       "source_location": "L1"
     },
     {
-      "community": 652,
+      "community": 653,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_subcategories_ts",
       "label": "subcategories.ts",
@@ -49579,7 +49657,7 @@
       "source_location": "L1"
     },
     {
-      "community": 653,
+      "community": 654,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_currency_test_ts",
       "label": "currency.test.ts",
@@ -49588,7 +49666,7 @@
       "source_location": "L1"
     },
     {
-      "community": 654,
+      "community": 655,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_storeinsights_ts",
       "label": "storeInsights.ts",
@@ -49597,7 +49675,7 @@
       "source_location": "L1"
     },
     {
-      "community": 655,
+      "community": 656,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_userinsights_ts",
       "label": "userInsights.ts",
@@ -49606,7 +49684,7 @@
       "source_location": "L1"
     },
     {
-      "community": 656,
+      "community": 657,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_migrateamountstopesewas_ts",
       "label": "migrateAmountsToPesewas.ts",
@@ -49615,7 +49693,7 @@
       "source_location": "L1"
     },
     {
-      "community": 657,
+      "community": 658,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_client_test_ts",
       "label": "client.test.ts",
@@ -49624,21 +49702,12 @@
       "source_location": "L1"
     },
     {
-      "community": 658,
+      "community": 659,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_config_test_ts",
       "label": "config.test.ts",
       "norm_label": "config.test.ts",
       "source_file": "packages/athena-webapp/convex/mtn/config.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_normalize_test_ts",
-      "label": "normalize.test.ts",
-      "norm_label": "normalize.test.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/normalize.test.ts",
       "source_location": "L1"
     },
     {
@@ -49698,6 +49767,15 @@
     {
       "community": 660,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_normalize_test_ts",
+      "label": "normalize.test.ts",
+      "norm_label": "normalize.test.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/normalize.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 661,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_types_ts",
       "label": "types.ts",
       "norm_label": "types.ts",
@@ -49705,7 +49783,7 @@
       "source_location": "L1"
     },
     {
-      "community": 661,
+      "community": 662,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_resendotp_ts",
       "label": "ResendOTP.ts",
@@ -49714,7 +49792,7 @@
       "source_location": "L1"
     },
     {
-      "community": 662,
+      "community": 663,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schema_ts",
       "label": "schema.ts",
@@ -49723,7 +49801,7 @@
       "source_location": "L1"
     },
     {
-      "community": 663,
+      "community": 664,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_appverificationcode_ts",
       "label": "appVerificationCode.ts",
@@ -49732,7 +49810,7 @@
       "source_location": "L1"
     },
     {
-      "community": 664,
+      "community": 665,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -49741,7 +49819,7 @@
       "source_location": "L1"
     },
     {
-      "community": 665,
+      "community": 666,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -49750,7 +49828,7 @@
       "source_location": "L1"
     },
     {
-      "community": 666,
+      "community": 667,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bestseller_ts",
       "label": "bestSeller.ts",
@@ -49759,7 +49837,7 @@
       "source_location": "L1"
     },
     {
-      "community": 667,
+      "community": 668,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_cashier_ts",
       "label": "cashier.ts",
@@ -49768,21 +49846,12 @@
       "source_location": "L1"
     },
     {
-      "community": 668,
+      "community": 669,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_category_ts",
       "label": "category.ts",
       "norm_label": "category.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/category.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_color_ts",
-      "label": "color.ts",
-      "norm_label": "color.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/color.ts",
       "source_location": "L1"
     },
     {
@@ -49842,6 +49911,15 @@
     {
       "community": 670,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_color_ts",
+      "label": "color.ts",
+      "norm_label": "color.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/color.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 671,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
       "norm_label": "complimentaryproduct.ts",
@@ -49849,7 +49927,7 @@
       "source_location": "L1"
     },
     {
-      "community": 671,
+      "community": 672,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_featureditem_ts",
       "label": "featuredItem.ts",
@@ -49858,7 +49936,7 @@
       "source_location": "L1"
     },
     {
-      "community": 672,
+      "community": 673,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_index_ts",
       "label": "index.ts",
@@ -49867,7 +49945,7 @@
       "source_location": "L1"
     },
     {
-      "community": 673,
+      "community": 674,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_invitecode_ts",
       "label": "inviteCode.ts",
@@ -49876,7 +49954,7 @@
       "source_location": "L1"
     },
     {
-      "community": 674,
+      "community": 675,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organization_ts",
       "label": "organization.ts",
@@ -49885,7 +49963,7 @@
       "source_location": "L1"
     },
     {
-      "community": 675,
+      "community": 676,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organizationmember_ts",
       "label": "organizationMember.ts",
@@ -49894,7 +49972,7 @@
       "source_location": "L1"
     },
     {
-      "community": 676,
+      "community": 677,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_product_ts",
       "label": "product.ts",
@@ -49903,7 +49981,7 @@
       "source_location": "L1"
     },
     {
-      "community": 677,
+      "community": 678,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_promocode_ts",
       "label": "promoCode.ts",
@@ -49912,21 +49990,12 @@
       "source_location": "L1"
     },
     {
-      "community": 678,
+      "community": 679,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_redeemedpromocode_ts",
       "label": "redeemedPromoCode.ts",
       "norm_label": "redeemedpromocode.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/redeemedPromoCode.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_store_ts",
-      "label": "store.ts",
-      "norm_label": "store.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/store.ts",
       "source_location": "L1"
     },
     {
@@ -49986,6 +50055,15 @@
     {
       "community": 680,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_store_ts",
+      "label": "store.ts",
+      "norm_label": "store.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/store.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 681,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_subcategory_ts",
       "label": "subcategory.ts",
       "norm_label": "subcategory.ts",
@@ -49993,7 +50071,7 @@
       "source_location": "L1"
     },
     {
-      "community": 681,
+      "community": 682,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_payments_mtncollections_ts",
       "label": "mtnCollections.ts",
@@ -50002,7 +50080,7 @@
       "source_location": "L1"
     },
     {
-      "community": 682,
+      "community": 683,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_customer_ts",
       "label": "customer.ts",
@@ -50011,7 +50089,7 @@
       "source_location": "L1"
     },
     {
-      "community": 683,
+      "community": 684,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesession_ts",
       "label": "expenseSession.ts",
@@ -50020,7 +50098,7 @@
       "source_location": "L1"
     },
     {
-      "community": 684,
+      "community": 685,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesessionitem_ts",
       "label": "expenseSessionItem.ts",
@@ -50029,7 +50107,7 @@
       "source_location": "L1"
     },
     {
-      "community": 685,
+      "community": 686,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransaction_ts",
       "label": "expenseTransaction.ts",
@@ -50038,7 +50116,7 @@
       "source_location": "L1"
     },
     {
-      "community": 686,
+      "community": 687,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransactionitem_ts",
       "label": "expenseTransactionItem.ts",
@@ -50047,7 +50125,7 @@
       "source_location": "L1"
     },
     {
-      "community": 687,
+      "community": 688,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_index_ts",
       "label": "index.ts",
@@ -50056,21 +50134,12 @@
       "source_location": "L1"
     },
     {
-      "community": 688,
+      "community": 689,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possession_ts",
       "label": "posSession.ts",
       "norm_label": "possession.ts",
       "source_file": "packages/athena-webapp/convex/schemas/pos/posSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 689,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_possessionitem_ts",
-      "label": "posSessionItem.ts",
-      "norm_label": "possessionitem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/posSessionItem.ts",
       "source_location": "L1"
     },
     {
@@ -50130,6 +50199,15 @@
     {
       "community": 690,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_possessionitem_ts",
+      "label": "posSessionItem.ts",
+      "norm_label": "possessionitem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/posSessionItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 691,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_posterminal_ts",
       "label": "posTerminal.ts",
       "norm_label": "posterminal.ts",
@@ -50137,7 +50215,7 @@
       "source_location": "L1"
     },
     {
-      "community": 691,
+      "community": 692,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransaction_ts",
       "label": "posTransaction.ts",
@@ -50146,7 +50224,7 @@
       "source_location": "L1"
     },
     {
-      "community": 692,
+      "community": 693,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransactionitem_ts",
       "label": "posTransactionItem.ts",
@@ -50155,7 +50233,7 @@
       "source_location": "L1"
     },
     {
-      "community": 693,
+      "community": 694,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_analytics_ts",
       "label": "analytics.ts",
@@ -50164,7 +50242,7 @@
       "source_location": "L1"
     },
     {
-      "community": 694,
+      "community": 695,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bag_ts",
       "label": "bag.ts",
@@ -50173,7 +50251,7 @@
       "source_location": "L1"
     },
     {
-      "community": 695,
+      "community": 696,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -50182,7 +50260,7 @@
       "source_location": "L1"
     },
     {
-      "community": 696,
+      "community": 697,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsession_ts",
       "label": "checkoutSession.ts",
@@ -50191,7 +50269,7 @@
       "source_location": "L1"
     },
     {
-      "community": 697,
+      "community": 698,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsessionitem_ts",
       "label": "checkoutSessionItem.ts",
@@ -50200,21 +50278,12 @@
       "source_location": "L1"
     },
     {
-      "community": 698,
+      "community": 699,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_customer_ts",
       "label": "customer.ts",
       "norm_label": "customer.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/customer.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_guest_ts",
-      "label": "guest.ts",
-      "norm_label": "guest.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/guest.ts",
       "source_location": "L1"
     },
     {
@@ -50499,6 +50568,15 @@
     {
       "community": 700,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_guest_ts",
+      "label": "guest.ts",
+      "norm_label": "guest.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/guest.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 701,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
@@ -50506,7 +50584,7 @@
       "source_location": "L1"
     },
     {
-      "community": 701,
+      "community": 702,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_offer_ts",
       "label": "offer.ts",
@@ -50515,7 +50593,7 @@
       "source_location": "L1"
     },
     {
-      "community": 702,
+      "community": 703,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -50524,7 +50602,7 @@
       "source_location": "L1"
     },
     {
-      "community": 703,
+      "community": 704,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
@@ -50533,7 +50611,7 @@
       "source_location": "L1"
     },
     {
-      "community": 704,
+      "community": 705,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_review_ts",
       "label": "review.ts",
@@ -50542,7 +50620,7 @@
       "source_location": "L1"
     },
     {
-      "community": 705,
+      "community": 706,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_rewards_ts",
       "label": "rewards.ts",
@@ -50551,7 +50629,7 @@
       "source_location": "L1"
     },
     {
-      "community": 706,
+      "community": 707,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbag_ts",
       "label": "savedBag.ts",
@@ -50560,7 +50638,7 @@
       "source_location": "L1"
     },
     {
-      "community": 707,
+      "community": 708,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
@@ -50569,21 +50647,12 @@
       "source_location": "L1"
     },
     {
-      "community": 708,
+      "community": 709,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontsession_ts",
       "label": "storeFrontSession.ts",
       "norm_label": "storefrontsession.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 709,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_storefrontuser_ts",
-      "label": "storeFrontUser.ts",
-      "norm_label": "storefrontuser.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontUser.ts",
       "source_location": "L1"
     },
     {
@@ -50643,6 +50712,15 @@
     {
       "community": 710,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_storefrontuser_ts",
+      "label": "storeFrontUser.ts",
+      "norm_label": "storefrontuser.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontUser.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 711,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontverificationcode_ts",
       "label": "storeFrontVerificationCode.ts",
       "norm_label": "storefrontverificationcode.ts",
@@ -50650,7 +50728,7 @@
       "source_location": "L1"
     },
     {
-      "community": 711,
+      "community": 712,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_supportticket_ts",
       "label": "supportTicket.ts",
@@ -50659,7 +50737,7 @@
       "source_location": "L1"
     },
     {
-      "community": 712,
+      "community": 713,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bag_ts",
       "label": "bag.ts",
@@ -50668,7 +50746,7 @@
       "source_location": "L1"
     },
     {
-      "community": 713,
+      "community": 714,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -50677,7 +50755,7 @@
       "source_location": "L1"
     },
     {
-      "community": 714,
+      "community": 715,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customer_ts",
       "label": "customer.ts",
@@ -50686,7 +50764,7 @@
       "source_location": "L1"
     },
     {
-      "community": 715,
+      "community": 716,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_guest_ts",
       "label": "guest.ts",
@@ -50695,7 +50773,7 @@
       "source_location": "L1"
     },
     {
-      "community": 716,
+      "community": 717,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorderutilfns_ts",
       "label": "onlineOrderUtilFns.ts",
@@ -50704,7 +50782,7 @@
       "source_location": "L1"
     },
     {
-      "community": 717,
+      "community": 718,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_payment_ts",
       "label": "payment.ts",
@@ -50713,21 +50791,12 @@
       "source_location": "L1"
     },
     {
-      "community": 718,
+      "community": 719,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_paystackactions_ts",
       "label": "paystackActions.ts",
       "norm_label": "paystackactions.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/paystackActions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 719,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_rewards_ts",
-      "label": "rewards.ts",
-      "norm_label": "rewards.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/rewards.ts",
       "source_location": "L1"
     },
     {
@@ -50787,6 +50856,15 @@
     {
       "community": 720,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_rewards_ts",
+      "label": "rewards.ts",
+      "norm_label": "rewards.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/rewards.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 721,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
       "norm_label": "savedbagitem.ts",
@@ -50794,7 +50872,7 @@
       "source_location": "L1"
     },
     {
-      "community": 721,
+      "community": 722,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_supportticket_ts",
       "label": "supportTicket.ts",
@@ -50803,7 +50881,7 @@
       "source_location": "L1"
     },
     {
-      "community": 722,
+      "community": 723,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_users_ts",
       "label": "users.ts",
@@ -50812,7 +50890,7 @@
       "source_location": "L1"
     },
     {
-      "community": 723,
+      "community": 724,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_types_payment_ts",
       "label": "payment.ts",
@@ -50821,7 +50899,7 @@
       "source_location": "L1"
     },
     {
-      "community": 724,
+      "community": 725,
       "file_type": "code",
       "id": "packages_athena_webapp_eslint_config_js",
       "label": "eslint.config.js",
@@ -50830,7 +50908,7 @@
       "source_location": "L1"
     },
     {
-      "community": 725,
+      "community": 726,
       "file_type": "code",
       "id": "packages_athena_webapp_index_ts",
       "label": "index.ts",
@@ -50839,7 +50917,7 @@
       "source_location": "L1"
     },
     {
-      "community": 726,
+      "community": 727,
       "file_type": "code",
       "id": "packages_athena_webapp_postcss_config_js",
       "label": "postcss.config.js",
@@ -50848,7 +50926,7 @@
       "source_location": "L1"
     },
     {
-      "community": 727,
+      "community": 728,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_genericcombobox_tsx",
       "label": "GenericComboBox.tsx",
@@ -50857,21 +50935,12 @@
       "source_location": "L1"
     },
     {
-      "community": 728,
+      "community": 729,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeaccordion_tsx",
       "label": "StoreAccordion.tsx",
       "norm_label": "storeaccordion.tsx",
       "source_file": "packages/athena-webapp/src/components/StoreAccordion.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 729,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_storesaccordion_tsx",
-      "label": "StoresAccordion.tsx",
-      "norm_label": "storesaccordion.tsx",
-      "source_file": "packages/athena-webapp/src/components/StoresAccordion.tsx",
       "source_location": "L1"
     },
     {
@@ -50931,6 +51000,15 @@
     {
       "community": 730,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_storesaccordion_tsx",
+      "label": "StoresAccordion.tsx",
+      "norm_label": "storesaccordion.tsx",
+      "source_file": "packages/athena-webapp/src/components/StoresAccordion.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 731,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_themetoggle_tsx",
       "label": "ThemeToggle.tsx",
       "norm_label": "themetoggle.tsx",
@@ -50938,7 +51016,7 @@
       "source_location": "L1"
     },
     {
-      "community": 731,
+      "community": 732,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_defaultattributestogglegroup_tsx",
       "label": "DefaultAttributesToggleGroup.tsx",
@@ -50947,7 +51025,7 @@
       "source_location": "L1"
     },
     {
-      "community": 732,
+      "community": 733,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributesview_tsx",
       "label": "ProductAttributesView.tsx",
@@ -50956,7 +51034,7 @@
       "source_location": "L1"
     },
     {
-      "community": 733,
+      "community": 734,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_constants_ts",
       "label": "constants.ts",
@@ -50965,7 +51043,7 @@
       "source_location": "L1"
     },
     {
-      "community": 734,
+      "community": 735,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -50974,7 +51052,7 @@
       "source_location": "L1"
     },
     {
-      "community": 735,
+      "community": 736,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -50983,7 +51061,7 @@
       "source_location": "L1"
     },
     {
-      "community": 736,
+      "community": 737,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -50992,7 +51070,7 @@
       "source_location": "L1"
     },
     {
-      "community": 737,
+      "community": 738,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_types_ts",
       "label": "types.ts",
@@ -51001,7 +51079,7 @@
       "source_location": "L1"
     },
     {
-      "community": 738,
+      "community": 739,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_conversionfunnelchart_tsx",
       "label": "ConversionFunnelChart.tsx",
@@ -51010,7 +51088,61 @@
       "source_location": "L1"
     },
     {
-      "community": 739,
+      "community": 74,
+      "file_type": "code",
+      "id": "image_uploader_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L100"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "image_uploader_ondrop",
+      "label": "onDrop()",
+      "norm_label": "ondrop()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "image_uploader_removeimage",
+      "label": "removeImage()",
+      "norm_label": "removeimage()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "image_uploader_unmarkfordeletion",
+      "label": "unmarkForDeletion()",
+      "norm_label": "unmarkfordeletion()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 74,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 740,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_revenuechart_tsx",
       "label": "RevenueChart.tsx",
@@ -51019,61 +51151,7 @@
       "source_location": "L1"
     },
     {
-      "community": 74,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
-      "label": "sidebar.tsx",
-      "norm_label": "sidebar.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "sidebar_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L147"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "sidebar_handlekeydown",
-      "label": "handleKeyDown()",
-      "norm_label": "handlekeydown()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "sidebar_handleonhover",
-      "label": "handleOnHover()",
-      "norm_label": "handleonhover()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L224"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "sidebar_handleonmouseleave",
-      "label": "handleOnMouseLeave()",
-      "norm_label": "handleonmouseleave()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L228"
-    },
-    {
-      "community": 74,
-      "file_type": "code",
-      "id": "sidebar_usesidebar",
-      "label": "useSidebar()",
-      "norm_label": "usesidebar()",
-      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
-      "source_location": "L45"
-    },
-    {
-      "community": 740,
+      "community": 741,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_analytics_columns_tsx",
       "label": "analytics-columns.tsx",
@@ -51082,7 +51160,7 @@
       "source_location": "L1"
     },
     {
-      "community": 741,
+      "community": 742,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -51091,7 +51169,7 @@
       "source_location": "L1"
     },
     {
-      "community": 742,
+      "community": 743,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -51100,7 +51178,7 @@
       "source_location": "L1"
     },
     {
-      "community": 743,
+      "community": 744,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -51109,7 +51187,7 @@
       "source_location": "L1"
     },
     {
-      "community": 744,
+      "community": 745,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -51118,7 +51196,7 @@
       "source_location": "L1"
     },
     {
-      "community": 745,
+      "community": 746,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -51127,7 +51205,7 @@
       "source_location": "L1"
     },
     {
-      "community": 746,
+      "community": 747,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -51136,7 +51214,7 @@
       "source_location": "L1"
     },
     {
-      "community": 747,
+      "community": 748,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -51145,7 +51223,7 @@
       "source_location": "L1"
     },
     {
-      "community": 748,
+      "community": 749,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -51154,7 +51232,61 @@
       "source_location": "L1"
     },
     {
-      "community": 749,
+      "community": 75,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
+      "label": "sidebar.tsx",
+      "norm_label": "sidebar.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "sidebar_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L147"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "sidebar_handlekeydown",
+      "label": "handleKeyDown()",
+      "norm_label": "handlekeydown()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L105"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "sidebar_handleonhover",
+      "label": "handleOnHover()",
+      "norm_label": "handleonhover()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L224"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "sidebar_handleonmouseleave",
+      "label": "handleOnMouseLeave()",
+      "norm_label": "handleonmouseleave()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L228"
+    },
+    {
+      "community": 75,
+      "file_type": "code",
+      "id": "sidebar_usesidebar",
+      "label": "useSidebar()",
+      "norm_label": "usesidebar()",
+      "source_file": "packages/athena-webapp/src/components/ui/sidebar.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 750,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -51163,61 +51295,7 @@
       "source_location": "L1"
     },
     {
-      "community": 75,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
-      "label": "useBulkOperations.ts",
-      "norm_label": "usebulkoperations.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "usebulkoperations_applyoperation",
-      "label": "applyOperation()",
-      "norm_label": "applyoperation()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L56"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "usebulkoperations_calculatepricewithfee",
-      "label": "calculatePriceWithFee()",
-      "norm_label": "calculatepricewithfee()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L87"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "usebulkoperations_computepreview",
-      "label": "computePreview()",
-      "norm_label": "computepreview()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "usebulkoperations_usebulkoperations",
-      "label": "useBulkOperations()",
-      "norm_label": "usebulkoperations()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L158"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "usebulkoperations_validateoperationvalue",
-      "label": "validateOperationValue()",
-      "norm_label": "validateoperationvalue()",
-      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
-      "source_location": "L139"
-    },
-    {
-      "community": 750,
+      "community": 751,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -51226,7 +51304,7 @@
       "source_location": "L1"
     },
     {
-      "community": 751,
+      "community": 752,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -51235,7 +51313,7 @@
       "source_location": "L1"
     },
     {
-      "community": 752,
+      "community": 753,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -51244,7 +51322,7 @@
       "source_location": "L1"
     },
     {
-      "community": 753,
+      "community": 754,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -51253,7 +51331,7 @@
       "source_location": "L1"
     },
     {
-      "community": 754,
+      "community": 755,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_chart_tsx",
       "label": "chart.tsx",
@@ -51262,7 +51340,7 @@
       "source_location": "L1"
     },
     {
-      "community": 755,
+      "community": 756,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -51271,7 +51349,7 @@
       "source_location": "L1"
     },
     {
-      "community": 756,
+      "community": 757,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -51280,7 +51358,7 @@
       "source_location": "L1"
     },
     {
-      "community": 757,
+      "community": 758,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -51289,7 +51367,7 @@
       "source_location": "L1"
     },
     {
-      "community": 758,
+      "community": 759,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_columns_tsx",
       "label": "columns.tsx",
@@ -51298,7 +51376,61 @@
       "source_location": "L1"
     },
     {
-      "community": 759,
+      "community": 76,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
+      "label": "useBulkOperations.ts",
+      "norm_label": "usebulkoperations.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "usebulkoperations_applyoperation",
+      "label": "applyOperation()",
+      "norm_label": "applyoperation()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L56"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "usebulkoperations_calculatepricewithfee",
+      "label": "calculatePriceWithFee()",
+      "norm_label": "calculatepricewithfee()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L87"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "usebulkoperations_computepreview",
+      "label": "computePreview()",
+      "norm_label": "computepreview()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "usebulkoperations_usebulkoperations",
+      "label": "useBulkOperations()",
+      "norm_label": "usebulkoperations()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L158"
+    },
+    {
+      "community": 76,
+      "file_type": "code",
+      "id": "usebulkoperations_validateoperationvalue",
+      "label": "validateOperationValue()",
+      "norm_label": "validateoperationvalue()",
+      "source_file": "packages/athena-webapp/src/hooks/useBulkOperations.ts",
+      "source_location": "L139"
+    },
+    {
+      "community": 760,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_constants_ts",
       "label": "constants.ts",
@@ -51307,61 +51439,7 @@
       "source_location": "L1"
     },
     {
-      "community": 76,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
-      "label": "useExpenseSessions.ts",
-      "norm_label": "useexpensesessions.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpenseactivesession",
-      "label": "useExpenseActiveSession()",
-      "norm_label": "useexpenseactivesession()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensesession",
-      "label": "useExpenseSession()",
-      "norm_label": "useexpensesession()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L23"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensesessioncreate",
-      "label": "useExpenseSessionCreate()",
-      "norm_label": "useexpensesessioncreate()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensesessionupdate",
-      "label": "useExpenseSessionUpdate()",
-      "norm_label": "useexpensesessionupdate()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 76,
-      "file_type": "code",
-      "id": "useexpensesessions_useexpensestoresessions",
-      "label": "useExpenseStoreSessions()",
-      "norm_label": "useexpensestoresessions()",
-      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 760,
+      "community": 761,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -51370,7 +51448,7 @@
       "source_location": "L1"
     },
     {
-      "community": 761,
+      "community": 762,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -51379,7 +51457,7 @@
       "source_location": "L1"
     },
     {
-      "community": 762,
+      "community": 763,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -51388,7 +51466,7 @@
       "source_location": "L1"
     },
     {
-      "community": 763,
+      "community": 764,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_ts",
       "label": "data.ts",
@@ -51397,7 +51475,7 @@
       "source_location": "L1"
     },
     {
-      "community": 764,
+      "community": 765,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
@@ -51406,7 +51484,7 @@
       "source_location": "L1"
     },
     {
-      "community": 765,
+      "community": 766,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -51415,7 +51493,7 @@
       "source_location": "L1"
     },
     {
-      "community": 766,
+      "community": 767,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -51424,7 +51502,7 @@
       "source_location": "L1"
     },
     {
-      "community": 767,
+      "community": 768,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_columns_tsx",
       "label": "columns.tsx",
@@ -51433,7 +51511,7 @@
       "source_location": "L1"
     },
     {
-      "community": 768,
+      "community": 769,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -51442,7 +51520,61 @@
       "source_location": "L1"
     },
     {
-      "community": 769,
+      "community": 77,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
+      "label": "useExpenseSessions.ts",
+      "norm_label": "useexpensesessions.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpenseactivesession",
+      "label": "useExpenseActiveSession()",
+      "norm_label": "useexpenseactivesession()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensesession",
+      "label": "useExpenseSession()",
+      "norm_label": "useexpensesession()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L23"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensesessioncreate",
+      "label": "useExpenseSessionCreate()",
+      "norm_label": "useexpensesessioncreate()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensesessionupdate",
+      "label": "useExpenseSessionUpdate()",
+      "norm_label": "useexpensesessionupdate()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 77,
+      "file_type": "code",
+      "id": "useexpensesessions_useexpensestoresessions",
+      "label": "useExpenseStoreSessions()",
+      "norm_label": "useexpensestoresessions()",
+      "source_file": "packages/athena-webapp/src/hooks/useExpenseSessions.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 770,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -51451,61 +51583,7 @@
       "source_location": "L1"
     },
     {
-      "community": 77,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useposcustomers_ts",
-      "label": "usePOSCustomers.ts",
-      "norm_label": "useposcustomers.ts",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "useposcustomers_useposcustomer",
-      "label": "usePOSCustomer()",
-      "norm_label": "useposcustomer()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "useposcustomers_useposcustomercreate",
-      "label": "usePOSCustomerCreate()",
-      "norm_label": "useposcustomercreate()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "useposcustomers_useposcustomersearch",
-      "label": "usePOSCustomerSearch()",
-      "norm_label": "useposcustomersearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "useposcustomers_useposcustomertransactions",
-      "label": "usePOSCustomerTransactions()",
-      "norm_label": "useposcustomertransactions()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
-      "source_location": "L90"
-    },
-    {
-      "community": 77,
-      "file_type": "code",
-      "id": "useposcustomers_useposcustomerupdate",
-      "label": "usePOSCustomerUpdate()",
-      "norm_label": "useposcustomerupdate()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 770,
+      "community": 771,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -51514,7 +51592,7 @@
       "source_location": "L1"
     },
     {
-      "community": 771,
+      "community": 772,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -51523,7 +51601,7 @@
       "source_location": "L1"
     },
     {
-      "community": 772,
+      "community": 773,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -51532,7 +51610,7 @@
       "source_location": "L1"
     },
     {
-      "community": 773,
+      "community": 774,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_sidebar_tsx",
       "label": "app-sidebar.tsx",
@@ -51541,7 +51619,7 @@
       "source_location": "L1"
     },
     {
-      "community": 774,
+      "community": 775,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_assetscolumns_tsx",
       "label": "assetsColumns.tsx",
@@ -51550,7 +51628,7 @@
       "source_location": "L1"
     },
     {
-      "community": 775,
+      "community": 776,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_constants_ts",
       "label": "constants.ts",
@@ -51559,7 +51637,7 @@
       "source_location": "L1"
     },
     {
-      "community": 776,
+      "community": 777,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -51568,7 +51646,7 @@
       "source_location": "L1"
     },
     {
-      "community": 777,
+      "community": 778,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -51577,7 +51655,7 @@
       "source_location": "L1"
     },
     {
-      "community": 778,
+      "community": 779,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -51586,7 +51664,61 @@
       "source_location": "L1"
     },
     {
-      "community": 779,
+      "community": 78,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useposcustomers_ts",
+      "label": "usePOSCustomers.ts",
+      "norm_label": "useposcustomers.ts",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "useposcustomers_useposcustomer",
+      "label": "usePOSCustomer()",
+      "norm_label": "useposcustomer()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "useposcustomers_useposcustomercreate",
+      "label": "usePOSCustomerCreate()",
+      "norm_label": "useposcustomercreate()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "useposcustomers_useposcustomersearch",
+      "label": "usePOSCustomerSearch()",
+      "norm_label": "useposcustomersearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "useposcustomers_useposcustomertransactions",
+      "label": "usePOSCustomerTransactions()",
+      "norm_label": "useposcustomertransactions()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
+      "source_location": "L90"
+    },
+    {
+      "community": 78,
+      "file_type": "code",
+      "id": "useposcustomers_useposcustomerupdate",
+      "label": "usePOSCustomerUpdate()",
+      "norm_label": "useposcustomerupdate()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSCustomers.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 780,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_assets_assets_table_data_ts",
       "label": "data.ts",
@@ -51595,61 +51727,7 @@
       "source_location": "L1"
     },
     {
-      "community": 78,
-      "file_type": "code",
-      "id": "behaviorutils_calculateengagementmetrics",
-      "label": "calculateEngagementMetrics()",
-      "norm_label": "calculateengagementmetrics()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L173"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "behaviorutils_calculateriskindicators",
-      "label": "calculateRiskIndicators()",
-      "norm_label": "calculateriskindicators()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "behaviorutils_getactivitypriority",
-      "label": "getActivityPriority()",
-      "norm_label": "getactivitypriority()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L251"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "behaviorutils_getcustomerjourneystage",
-      "label": "getCustomerJourneyStage()",
-      "norm_label": "getcustomerjourneystage()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "behaviorutils_getjourneystageinfo",
-      "label": "getJourneyStageInfo()",
-      "norm_label": "getjourneystageinfo()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L277"
-    },
-    {
-      "community": 78,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
-      "label": "behaviorUtils.ts",
-      "norm_label": "behaviorutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 780,
+      "community": 781,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
@@ -51658,7 +51736,7 @@
       "source_location": "L1"
     },
     {
-      "community": 781,
+      "community": 782,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_loginform_tsx",
       "label": "LoginForm.tsx",
@@ -51667,7 +51745,7 @@
       "source_location": "L1"
     },
     {
-      "community": 782,
+      "community": 783,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -51676,7 +51754,7 @@
       "source_location": "L1"
     },
     {
-      "community": 783,
+      "community": 784,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -51685,7 +51763,7 @@
       "source_location": "L1"
     },
     {
-      "community": 784,
+      "community": 785,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -51694,7 +51772,7 @@
       "source_location": "L1"
     },
     {
-      "community": 785,
+      "community": 786,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -51703,7 +51781,7 @@
       "source_location": "L1"
     },
     {
-      "community": 786,
+      "community": 787,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -51712,7 +51790,7 @@
       "source_location": "L1"
     },
     {
-      "community": 787,
+      "community": 788,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -51721,7 +51799,7 @@
       "source_location": "L1"
     },
     {
-      "community": 788,
+      "community": 789,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_columns_tsx",
       "label": "columns.tsx",
@@ -51730,7 +51808,61 @@
       "source_location": "L1"
     },
     {
-      "community": 789,
+      "community": 79,
+      "file_type": "code",
+      "id": "behaviorutils_calculateengagementmetrics",
+      "label": "calculateEngagementMetrics()",
+      "norm_label": "calculateengagementmetrics()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L173"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "behaviorutils_calculateriskindicators",
+      "label": "calculateRiskIndicators()",
+      "norm_label": "calculateriskindicators()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "behaviorutils_getactivitypriority",
+      "label": "getActivityPriority()",
+      "norm_label": "getactivitypriority()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L251"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "behaviorutils_getcustomerjourneystage",
+      "label": "getCustomerJourneyStage()",
+      "norm_label": "getcustomerjourneystage()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "behaviorutils_getjourneystageinfo",
+      "label": "getJourneyStageInfo()",
+      "norm_label": "getjourneystageinfo()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L277"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
+      "label": "behaviorUtils.ts",
+      "norm_label": "behaviorutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 790,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_constants_ts",
       "label": "constants.ts",
@@ -51739,61 +51871,7 @@
       "source_location": "L1"
     },
     {
-      "community": 79,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
-      "label": "toastService.ts",
-      "norm_label": "toastservice.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "toastservice_handleposoperation",
-      "label": "handlePOSOperation()",
-      "norm_label": "handleposoperation()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L171"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "toastservice_showinventoryerror",
-      "label": "showInventoryError()",
-      "norm_label": "showinventoryerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L302"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "toastservice_shownoactivesessionerror",
-      "label": "showNoActiveSessionError()",
-      "norm_label": "shownoactivesessionerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L319"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "toastservice_showsessionexpirederror",
-      "label": "showSessionExpiredError()",
-      "norm_label": "showsessionexpirederror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L312"
-    },
-    {
-      "community": 79,
-      "file_type": "code",
-      "id": "toastservice_showvalidationerror",
-      "label": "showValidationError()",
-      "norm_label": "showvalidationerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
-      "source_location": "L293"
-    },
-    {
-      "community": 790,
+      "community": 791,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -51802,7 +51880,7 @@
       "source_location": "L1"
     },
     {
-      "community": 791,
+      "community": 792,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -51811,7 +51889,7 @@
       "source_location": "L1"
     },
     {
-      "community": 792,
+      "community": 793,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -51820,7 +51898,7 @@
       "source_location": "L1"
     },
     {
-      "community": 793,
+      "community": 794,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspage_tsx",
       "label": "BulkOperationsPage.tsx",
@@ -51829,7 +51907,7 @@
       "source_location": "L1"
     },
     {
-      "community": 794,
+      "community": 795,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cashiers_index_tsx",
       "label": "index.tsx",
@@ -51838,7 +51916,7 @@
       "source_location": "L1"
     },
     {
-      "community": 795,
+      "community": 796,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_columns_tsx",
       "label": "columns.tsx",
@@ -51847,7 +51925,7 @@
       "source_location": "L1"
     },
     {
-      "community": 796,
+      "community": 797,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -51856,7 +51934,7 @@
       "source_location": "L1"
     },
     {
-      "community": 797,
+      "community": 798,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -51865,21 +51943,12 @@
       "source_location": "L1"
     },
     {
-      "community": 798,
+      "community": 799,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_metriccard_tsx",
       "label": "MetricCard.tsx",
       "norm_label": "metriccard.tsx",
       "source_file": "packages/athena-webapp/src/components/dashboard/MetricCard.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 799,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_expense_expensecompletion_tsx",
-      "label": "ExpenseCompletion.tsx",
-      "norm_label": "expensecompletion.tsx",
-      "source_file": "packages/athena-webapp/src/components/expense/ExpenseCompletion.tsx",
       "source_location": "L1"
     },
     {
@@ -52083,59 +52152,68 @@
     {
       "community": 80,
       "file_type": "code",
-      "id": "organizationsettingsview_handledeletestore",
-      "label": "handleDeleteStore()",
-      "norm_label": "handledeletestore()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L156"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "organizationsettingsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L198"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "organizationsettingsview_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "organizationsettingsview_organizationsettings",
-      "label": "OrganizationSettings()",
-      "norm_label": "organizationsettings()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L24"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "organizationsettingsview_savestorechanges",
-      "label": "saveStoreChanges()",
-      "norm_label": "savestorechanges()",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
-      "source_location": "L71"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
-      "label": "OrganizationSettingsView.tsx",
-      "norm_label": "organizationsettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
+      "label": "toastService.ts",
+      "norm_label": "toastservice.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L1"
     },
     {
+      "community": 80,
+      "file_type": "code",
+      "id": "toastservice_handleposoperation",
+      "label": "handlePOSOperation()",
+      "norm_label": "handleposoperation()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L171"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "toastservice_showinventoryerror",
+      "label": "showInventoryError()",
+      "norm_label": "showinventoryerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L302"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "toastservice_shownoactivesessionerror",
+      "label": "showNoActiveSessionError()",
+      "norm_label": "shownoactivesessionerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L319"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "toastservice_showsessionexpirederror",
+      "label": "showSessionExpiredError()",
+      "norm_label": "showsessionexpirederror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L312"
+    },
+    {
+      "community": 80,
+      "file_type": "code",
+      "id": "toastservice_showvalidationerror",
+      "label": "showValidationError()",
+      "norm_label": "showvalidationerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
+      "source_location": "L293"
+    },
+    {
       "community": 800,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_expense_expensecompletion_tsx",
+      "label": "ExpenseCompletion.tsx",
+      "norm_label": "expensecompletion.tsx",
+      "source_file": "packages/athena-webapp/src/components/expense/ExpenseCompletion.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 801,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderstatus_tsx",
       "label": "OrderStatus.tsx",
@@ -52144,7 +52222,7 @@
       "source_location": "L1"
     },
     {
-      "community": 801,
+      "community": 802,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -52153,7 +52231,7 @@
       "source_location": "L1"
     },
     {
-      "community": 802,
+      "community": 803,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_tsx",
       "label": "Orders.tsx",
@@ -52162,7 +52240,7 @@
       "source_location": "L1"
     },
     {
-      "community": 803,
+      "community": 804,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_constants_ts",
       "label": "constants.ts",
@@ -52171,7 +52249,7 @@
       "source_location": "L1"
     },
     {
-      "community": 804,
+      "community": 805,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -52180,7 +52258,7 @@
       "source_location": "L1"
     },
     {
-      "community": 805,
+      "community": 806,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -52189,7 +52267,7 @@
       "source_location": "L1"
     },
     {
-      "community": 806,
+      "community": 807,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -52198,7 +52276,7 @@
       "source_location": "L1"
     },
     {
-      "community": 807,
+      "community": 808,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_ts",
       "label": "data.ts",
@@ -52207,7 +52285,7 @@
       "source_location": "L1"
     },
     {
-      "community": 808,
+      "community": 809,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_constants_ts",
       "label": "constants.ts",
@@ -52216,7 +52294,61 @@
       "source_location": "L1"
     },
     {
-      "community": 809,
+      "community": 81,
+      "file_type": "code",
+      "id": "organizationsettingsview_handledeletestore",
+      "label": "handleDeleteStore()",
+      "norm_label": "handledeletestore()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L156"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "organizationsettingsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L198"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "organizationsettingsview_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L105"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "organizationsettingsview_organizationsettings",
+      "label": "OrganizationSettings()",
+      "norm_label": "organizationsettings()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L24"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "organizationsettingsview_savestorechanges",
+      "label": "saveStoreChanges()",
+      "norm_label": "savestorechanges()",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L71"
+    },
+    {
+      "community": 81,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
+      "label": "OrganizationSettingsView.tsx",
+      "norm_label": "organizationsettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/settings/organization/components/OrganizationSettingsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 810,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -52225,61 +52357,7 @@
       "source_location": "L1"
     },
     {
-      "community": 81,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
-      "label": "StoreSettingsView.tsx",
-      "norm_label": "storesettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "storesettingsview_handledeleteallproductsinstore",
-      "label": "handleDeleteAllProductsInStore()",
-      "norm_label": "handledeleteallproductsinstore()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L232"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "storesettingsview_handledeletestore",
-      "label": "handleDeleteStore()",
-      "norm_label": "handledeletestore()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L167"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "storesettingsview_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L116"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "storesettingsview_savestorechanges",
-      "label": "saveStoreChanges()",
-      "norm_label": "savestorechanges()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L82"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
-      "id": "storesettingsview_storesettings",
-      "label": "StoreSettings()",
-      "norm_label": "storesettings()",
-      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
-      "source_location": "L28"
-    },
-    {
-      "community": 810,
+      "community": 811,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -52288,7 +52366,7 @@
       "source_location": "L1"
     },
     {
-      "community": 811,
+      "community": 812,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -52297,7 +52375,7 @@
       "source_location": "L1"
     },
     {
-      "community": 812,
+      "community": 813,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -52306,7 +52384,7 @@
       "source_location": "L1"
     },
     {
-      "community": 813,
+      "community": 814,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_ts",
       "label": "data.ts",
@@ -52315,7 +52393,7 @@
       "source_location": "L1"
     },
     {
-      "community": 814,
+      "community": 815,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_invitecolumns_tsx",
       "label": "inviteColumns.tsx",
@@ -52324,7 +52402,7 @@
       "source_location": "L1"
     },
     {
-      "community": 815,
+      "community": 816,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_constants_ts",
       "label": "constants.ts",
@@ -52333,7 +52411,7 @@
       "source_location": "L1"
     },
     {
-      "community": 816,
+      "community": 817,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -52342,7 +52420,7 @@
       "source_location": "L1"
     },
     {
-      "community": 817,
+      "community": 818,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -52351,7 +52429,7 @@
       "source_location": "L1"
     },
     {
-      "community": 818,
+      "community": 819,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -52360,7 +52438,61 @@
       "source_location": "L1"
     },
     {
-      "community": 819,
+      "community": 82,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
+      "label": "StoreSettingsView.tsx",
+      "norm_label": "storesettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "storesettingsview_handledeleteallproductsinstore",
+      "label": "handleDeleteAllProductsInStore()",
+      "norm_label": "handledeleteallproductsinstore()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L232"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "storesettingsview_handledeletestore",
+      "label": "handleDeleteStore()",
+      "norm_label": "handledeletestore()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "storesettingsview_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L116"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "storesettingsview_savestorechanges",
+      "label": "saveStoreChanges()",
+      "norm_label": "savestorechanges()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L82"
+    },
+    {
+      "community": 82,
+      "file_type": "code",
+      "id": "storesettingsview_storesettings",
+      "label": "StoreSettings()",
+      "norm_label": "storesettings()",
+      "source_file": "packages/athena-webapp/src/settings/store/StoreSettingsView.tsx",
+      "source_location": "L28"
+    },
+    {
+      "community": 820,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -52369,61 +52501,7 @@
       "source_location": "L1"
     },
     {
-      "community": 82,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
-      "label": "storybook-shell.tsx",
-      "norm_label": "storybook-shell.tsx",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "storybook_shell_storybookcallout",
-      "label": "StorybookCallout()",
-      "norm_label": "storybookcallout()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L83"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "storybook_shell_storybooklist",
-      "label": "StorybookList()",
-      "norm_label": "storybooklist()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L62"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "storybook_shell_storybookpillrow",
-      "label": "StorybookPillRow()",
-      "norm_label": "storybookpillrow()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L95"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "storybook_shell_storybooksection",
-      "label": "StorybookSection()",
-      "norm_label": "storybooksection()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L41"
-    },
-    {
-      "community": 82,
-      "file_type": "code",
-      "id": "storybook_shell_storybookshell",
-      "label": "StorybookShell()",
-      "norm_label": "storybookshell()",
-      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 820,
+      "community": 821,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_ts",
       "label": "data.ts",
@@ -52432,7 +52510,7 @@
       "source_location": "L1"
     },
     {
-      "community": 821,
+      "community": 822,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_members_members_table_components_memberscolumns_tsx",
       "label": "membersColumns.tsx",
@@ -52441,7 +52519,7 @@
       "source_location": "L1"
     },
     {
-      "community": 822,
+      "community": 823,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cartitems_tsx",
       "label": "CartItems.tsx",
@@ -52450,7 +52528,7 @@
       "source_location": "L1"
     },
     {
-      "community": 823,
+      "community": 824,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_tsx",
       "label": "CashierAuthDialog.tsx",
@@ -52459,7 +52537,7 @@
       "source_location": "L1"
     },
     {
-      "community": 824,
+      "community": 825,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productlookup_tsx",
       "label": "ProductLookup.tsx",
@@ -52468,7 +52546,7 @@
       "source_location": "L1"
     },
     {
-      "community": 825,
+      "community": 826,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_registeractions_tsx",
       "label": "RegisterActions.tsx",
@@ -52477,7 +52555,7 @@
       "source_location": "L1"
     },
     {
-      "community": 826,
+      "community": 827,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_searchresultssection_tsx",
       "label": "SearchResultsSection.tsx",
@@ -52486,7 +52564,7 @@
       "source_location": "L1"
     },
     {
-      "community": 827,
+      "community": 828,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_totalsdisplay_test_tsx",
       "label": "TotalsDisplay.test.tsx",
@@ -52495,7 +52573,7 @@
       "source_location": "L1"
     },
     {
-      "community": 828,
+      "community": 829,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportview_tsx",
       "label": "ExpenseReportView.tsx",
@@ -52504,7 +52582,61 @@
       "source_location": "L1"
     },
     {
-      "community": 829,
+      "community": 83,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
+      "label": "storybook-shell.tsx",
+      "norm_label": "storybook-shell.tsx",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "storybook_shell_storybookcallout",
+      "label": "StorybookCallout()",
+      "norm_label": "storybookcallout()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L83"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "storybook_shell_storybooklist",
+      "label": "StorybookList()",
+      "norm_label": "storybooklist()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L62"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "storybook_shell_storybookpillrow",
+      "label": "StorybookPillRow()",
+      "norm_label": "storybookpillrow()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L95"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "storybook_shell_storybooksection",
+      "label": "StorybookSection()",
+      "norm_label": "storybooksection()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L41"
+    },
+    {
+      "community": 83,
+      "file_type": "code",
+      "id": "storybook_shell_storybookshell",
+      "label": "StorybookShell()",
+      "norm_label": "storybookshell()",
+      "source_file": "packages/athena-webapp/src/stories/storybook-shell.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 830,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportcolumns_tsx",
       "label": "expenseReportColumns.tsx",
@@ -52513,61 +52645,7 @@
       "source_location": "L1"
     },
     {
-      "community": 83,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_promocodes_ts",
-      "label": "promoCodes.ts",
-      "norm_label": "promocodes.ts",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "promocodes_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "promocodes_getpromocodeitems",
-      "label": "getPromoCodeItems()",
-      "norm_label": "getpromocodeitems()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "promocodes_getpromocodes",
-      "label": "getPromoCodes()",
-      "norm_label": "getpromocodes()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L34"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "promocodes_getredeemedpromocodes",
-      "label": "getRedeemedPromoCodes()",
-      "norm_label": "getredeemedpromocodes()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 83,
-      "file_type": "code",
-      "id": "promocodes_redeempromocode",
-      "label": "redeemPromoCode()",
-      "norm_label": "redeempromocode()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 830,
+      "community": 831,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
       "label": "TransactionView.tsx",
@@ -52576,7 +52654,7 @@
       "source_location": "L1"
     },
     {
-      "community": 831,
+      "community": 832,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_types_ts",
       "label": "types.ts",
@@ -52585,7 +52663,7 @@
       "source_location": "L1"
     },
     {
-      "community": 832,
+      "community": 833,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_analyticsinsights_tsx",
       "label": "AnalyticsInsights.tsx",
@@ -52594,7 +52672,7 @@
       "source_location": "L1"
     },
     {
-      "community": 833,
+      "community": 834,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_attributesview_tsx",
       "label": "AttributesView.tsx",
@@ -52603,7 +52681,7 @@
       "source_location": "L1"
     },
     {
-      "community": 834,
+      "community": 835,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_detailsview_tsx",
       "label": "DetailsView.tsx",
@@ -52612,7 +52690,7 @@
       "source_location": "L1"
     },
     {
-      "community": 835,
+      "community": 836,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productdetailview_tsx",
       "label": "ProductDetailView.tsx",
@@ -52621,7 +52699,7 @@
       "source_location": "L1"
     },
     {
-      "community": 836,
+      "community": 837,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstatus_tsx",
       "label": "ProductStatus.tsx",
@@ -52630,7 +52708,7 @@
       "source_location": "L1"
     },
     {
-      "community": 837,
+      "community": 838,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_categorylistview_tsx",
       "label": "CategoryListView.tsx",
@@ -52639,7 +52717,7 @@
       "source_location": "L1"
     },
     {
-      "community": 838,
+      "community": 839,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsubcategorytogglegroup_tsx",
       "label": "ProductSubcategoryToggleGroup.tsx",
@@ -52648,7 +52726,61 @@
       "source_location": "L1"
     },
     {
-      "community": 839,
+      "community": 84,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_promocodes_ts",
+      "label": "promoCodes.ts",
+      "norm_label": "promocodes.ts",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 84,
+      "file_type": "code",
+      "id": "promocodes_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 84,
+      "file_type": "code",
+      "id": "promocodes_getpromocodeitems",
+      "label": "getPromoCodeItems()",
+      "norm_label": "getpromocodeitems()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 84,
+      "file_type": "code",
+      "id": "promocodes_getpromocodes",
+      "label": "getPromoCodes()",
+      "norm_label": "getpromocodes()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L34"
+    },
+    {
+      "community": 84,
+      "file_type": "code",
+      "id": "promocodes_getredeemedpromocodes",
+      "label": "getRedeemedPromoCodes()",
+      "norm_label": "getredeemedpromocodes()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 84,
+      "file_type": "code",
+      "id": "promocodes_redeempromocode",
+      "label": "redeemPromoCode()",
+      "norm_label": "redeempromocode()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 840,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_tsx",
       "label": "Products.tsx",
@@ -52657,61 +52789,7 @@
       "source_location": "L1"
     },
     {
-      "community": 84,
-      "file_type": "code",
-      "id": "billingdetails_clearform",
-      "label": "clearForm()",
-      "norm_label": "clearform()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L173"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "billingdetails_enteredbillingaddressdetails",
-      "label": "EnteredBillingAddressDetails()",
-      "norm_label": "enteredbillingaddressdetails()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L102"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "billingdetails_handleusebillingaddressonfile",
-      "label": "handleUseBillingAddressOnFile()",
-      "norm_label": "handleusebillingaddressonfile()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L201"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "billingdetails_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L150"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "billingdetails_togglesameasdelivery",
-      "label": "toggleSameAsDelivery()",
-      "norm_label": "togglesameasdelivery()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L155"
-    },
-    {
-      "community": 84,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
-      "label": "BillingDetails.tsx",
-      "norm_label": "billingdetails.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 840,
+      "community": 841,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_storeproducts_tsx",
       "label": "StoreProducts.tsx",
@@ -52720,7 +52798,7 @@
       "source_location": "L1"
     },
     {
-      "community": 841,
+      "community": 842,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_unresolvedproducts_tsx",
       "label": "UnresolvedProducts.tsx",
@@ -52729,7 +52807,7 @@
       "source_location": "L1"
     },
     {
-      "community": 842,
+      "community": 843,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproducts_tsx",
       "label": "ComplimentaryProducts.tsx",
@@ -52738,7 +52816,7 @@
       "source_location": "L1"
     },
     {
-      "community": 843,
+      "community": 844,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductscolumn_tsx",
       "label": "complimentaryProductsColumn.tsx",
@@ -52747,7 +52825,7 @@
       "source_location": "L1"
     },
     {
-      "community": 844,
+      "community": 845,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -52756,7 +52834,7 @@
       "source_location": "L1"
     },
     {
-      "community": 845,
+      "community": 846,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -52765,7 +52843,7 @@
       "source_location": "L1"
     },
     {
-      "community": 846,
+      "community": 847,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -52774,7 +52852,7 @@
       "source_location": "L1"
     },
     {
-      "community": 847,
+      "community": 848,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -52783,7 +52861,7 @@
       "source_location": "L1"
     },
     {
-      "community": 848,
+      "community": 849,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_tsx",
       "label": "data-table.tsx",
@@ -52792,7 +52870,61 @@
       "source_location": "L1"
     },
     {
-      "community": 849,
+      "community": 85,
+      "file_type": "code",
+      "id": "billingdetails_clearform",
+      "label": "clearForm()",
+      "norm_label": "clearform()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L173"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "billingdetails_enteredbillingaddressdetails",
+      "label": "EnteredBillingAddressDetails()",
+      "norm_label": "enteredbillingaddressdetails()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L102"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "billingdetails_handleusebillingaddressonfile",
+      "label": "handleUseBillingAddressOnFile()",
+      "norm_label": "handleusebillingaddressonfile()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L201"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "billingdetails_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L150"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "billingdetails_togglesameasdelivery",
+      "label": "toggleSameAsDelivery()",
+      "norm_label": "togglesameasdelivery()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L155"
+    },
+    {
+      "community": 85,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
+      "label": "BillingDetails.tsx",
+      "norm_label": "billingdetails.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 850,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_ts",
       "label": "data.ts",
@@ -52801,61 +52933,7 @@
       "source_location": "L1"
     },
     {
-      "community": 85,
-      "file_type": "code",
-      "id": "checkoutexpired_checkoutexpired",
-      "label": "CheckoutExpired()",
-      "norm_label": "checkoutexpired()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "checkoutexpired_checkoutsessiongeneric",
-      "label": "CheckoutSessionGeneric()",
-      "norm_label": "checkoutsessiongeneric()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L73"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "checkoutexpired_checkoutsessionnotfound",
-      "label": "CheckoutSessionNotFound()",
-      "norm_label": "checkoutsessionnotfound()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L54"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "checkoutexpired_handlesendemail",
-      "label": "handleSendEmail()",
-      "norm_label": "handlesendemail()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L98"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "checkoutexpired_nocheckoutsession",
-      "label": "NoCheckoutSession()",
-      "norm_label": "nocheckoutsession()",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L33"
-    },
-    {
-      "community": 85,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
-      "label": "CheckoutExpired.tsx",
-      "norm_label": "checkoutexpired.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 850,
+      "community": 851,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_productcolumns_tsx",
       "label": "productColumns.tsx",
@@ -52864,7 +52942,7 @@
       "source_location": "L1"
     },
     {
-      "community": 851,
+      "community": 852,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodepreview_tsx",
       "label": "PromoCodePreview.tsx",
@@ -52873,7 +52951,7 @@
       "source_location": "L1"
     },
     {
-      "community": 852,
+      "community": 853,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodes_tsx",
       "label": "PromoCodes.tsx",
@@ -52882,7 +52960,7 @@
       "source_location": "L1"
     },
     {
-      "community": 853,
+      "community": 854,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_analytics_promocodeanalytics_tsx",
       "label": "PromoCodeAnalytics.tsx",
@@ -52891,7 +52969,7 @@
       "source_location": "L1"
     },
     {
-      "community": 854,
+      "community": 855,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_captured_emails_columns_tsx",
       "label": "captured-emails-columns.tsx",
@@ -52900,7 +52978,7 @@
       "source_location": "L1"
     },
     {
-      "community": 855,
+      "community": 856,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -52909,7 +52987,7 @@
       "source_location": "L1"
     },
     {
-      "community": 856,
+      "community": 857,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -52918,7 +52996,7 @@
       "source_location": "L1"
     },
     {
-      "community": 857,
+      "community": 858,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -52927,7 +53005,7 @@
       "source_location": "L1"
     },
     {
-      "community": 858,
+      "community": 859,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -52936,7 +53014,61 @@
       "source_location": "L1"
     },
     {
-      "community": 859,
+      "community": 86,
+      "file_type": "code",
+      "id": "checkoutexpired_checkoutexpired",
+      "label": "CheckoutExpired()",
+      "norm_label": "checkoutexpired()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "checkoutexpired_checkoutsessiongeneric",
+      "label": "CheckoutSessionGeneric()",
+      "norm_label": "checkoutsessiongeneric()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L73"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "checkoutexpired_checkoutsessionnotfound",
+      "label": "CheckoutSessionNotFound()",
+      "norm_label": "checkoutsessionnotfound()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L54"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "checkoutexpired_handlesendemail",
+      "label": "handleSendEmail()",
+      "norm_label": "handlesendemail()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L98"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "checkoutexpired_nocheckoutsession",
+      "label": "NoCheckoutSession()",
+      "norm_label": "nocheckoutsession()",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L33"
+    },
+    {
+      "community": 86,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
+      "label": "CheckoutExpired.tsx",
+      "norm_label": "checkoutexpired.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 860,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -52945,61 +53077,7 @@
       "source_location": "L1"
     },
     {
-      "community": 86,
-      "file_type": "code",
-      "id": "image_uploader_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L100"
-    },
-    {
-      "community": 86,
-      "file_type": "code",
-      "id": "image_uploader_ondrop",
-      "label": "onDrop()",
-      "norm_label": "ondrop()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 86,
-      "file_type": "code",
-      "id": "image_uploader_removeimage",
-      "label": "removeImage()",
-      "norm_label": "removeimage()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 86,
-      "file_type": "code",
-      "id": "image_uploader_unmarkfordeletion",
-      "label": "unmarkForDeletion()",
-      "norm_label": "unmarkfordeletion()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 86,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 86,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 860,
+      "community": 861,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -53008,7 +53086,7 @@
       "source_location": "L1"
     },
     {
-      "community": 861,
+      "community": 862,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_columns_tsx",
       "label": "columns.tsx",
@@ -53017,7 +53095,7 @@
       "source_location": "L1"
     },
     {
-      "community": 862,
+      "community": 863,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_constants_ts",
       "label": "constants.ts",
@@ -53026,7 +53104,7 @@
       "source_location": "L1"
     },
     {
-      "community": 863,
+      "community": 864,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -53035,7 +53113,7 @@
       "source_location": "L1"
     },
     {
-      "community": 864,
+      "community": 865,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -53044,7 +53122,7 @@
       "source_location": "L1"
     },
     {
-      "community": 865,
+      "community": 866,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -53053,7 +53131,7 @@
       "source_location": "L1"
     },
     {
-      "community": 866,
+      "community": 867,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_ts",
       "label": "data.ts",
@@ -53062,7 +53140,7 @@
       "source_location": "L1"
     },
     {
-      "community": 867,
+      "community": 868,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_types_ts",
       "label": "types.ts",
@@ -53071,21 +53149,12 @@
       "source_location": "L1"
     },
     {
-      "community": 868,
+      "community": 869,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_welcome_offer_card_tsx",
       "label": "welcome-offer-card.tsx",
       "norm_label": "welcome-offer-card.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/welcome-offer-card.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 869,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reviews_ratingstars_tsx",
-      "label": "RatingStars.tsx",
-      "norm_label": "ratingstars.tsx",
-      "source_file": "packages/athena-webapp/src/components/reviews/RatingStars.tsx",
       "source_location": "L1"
     },
     {
@@ -53145,6 +53214,15 @@
     {
       "community": 870,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_reviews_ratingstars_tsx",
+      "label": "RatingStars.tsx",
+      "norm_label": "ratingstars.tsx",
+      "source_file": "packages/athena-webapp/src/components/reviews/RatingStars.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 871,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewcard_tsx",
       "label": "ReviewCard.tsx",
       "norm_label": "reviewcard.tsx",
@@ -53152,7 +53230,7 @@
       "source_location": "L1"
     },
     {
-      "community": 871,
+      "community": 872,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewmetadata_tsx",
       "label": "ReviewMetadata.tsx",
@@ -53161,7 +53239,7 @@
       "source_location": "L1"
     },
     {
-      "community": 872,
+      "community": 873,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_test_tsx",
       "label": "MtnMomoView.test.tsx",
@@ -53170,7 +53248,7 @@
       "source_location": "L1"
     },
     {
-      "community": 873,
+      "community": 874,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_index_tsx",
       "label": "index.tsx",
@@ -53179,7 +53257,7 @@
       "source_location": "L1"
     },
     {
-      "community": 874,
+      "community": 875,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
@@ -53188,7 +53266,7 @@
       "source_location": "L1"
     },
     {
-      "community": 875,
+      "community": 876,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_test_tsx",
       "label": "button.test.tsx",
@@ -53197,7 +53275,7 @@
       "source_location": "L1"
     },
     {
-      "community": 876,
+      "community": 877,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
@@ -53206,7 +53284,7 @@
       "source_location": "L1"
     },
     {
-      "community": 877,
+      "community": 878,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_test_tsx",
       "label": "calendar.test.tsx",
@@ -53215,21 +53293,12 @@
       "source_location": "L1"
     },
     {
-      "community": 878,
+      "community": 879,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_tsx",
       "label": "calendar.tsx",
       "norm_label": "calendar.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/calendar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 879,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_card_tsx",
-      "label": "card.tsx",
-      "norm_label": "card.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/card.tsx",
       "source_location": "L1"
     },
     {
@@ -53289,6 +53358,15 @@
     {
       "community": 880,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_card_tsx",
+      "label": "card.tsx",
+      "norm_label": "card.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/card.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 881,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
       "norm_label": "checkbox.tsx",
@@ -53296,7 +53374,7 @@
       "source_location": "L1"
     },
     {
-      "community": 881,
+      "community": 882,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_collapsible_tsx",
       "label": "collapsible.tsx",
@@ -53305,7 +53383,7 @@
       "source_location": "L1"
     },
     {
-      "community": 882,
+      "community": 883,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
@@ -53314,7 +53392,7 @@
       "source_location": "L1"
     },
     {
-      "community": 883,
+      "community": 884,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
@@ -53323,7 +53401,7 @@
       "source_location": "L1"
     },
     {
-      "community": 884,
+      "community": 885,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
@@ -53332,7 +53410,7 @@
       "source_location": "L1"
     },
     {
-      "community": 885,
+      "community": 886,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
@@ -53341,7 +53419,7 @@
       "source_location": "L1"
     },
     {
-      "community": 886,
+      "community": 887,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
@@ -53350,7 +53428,7 @@
       "source_location": "L1"
     },
     {
-      "community": 887,
+      "community": 888,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
@@ -53359,21 +53437,12 @@
       "source_location": "L1"
     },
     {
-      "community": 888,
+      "community": 889,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
       "norm_label": "input-otp.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/input-otp.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 889,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_input_tsx",
-      "label": "input.tsx",
-      "norm_label": "input.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/input.tsx",
       "source_location": "L1"
     },
     {
@@ -53433,6 +53502,15 @@
     {
       "community": 890,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_input_tsx",
+      "label": "input.tsx",
+      "norm_label": "input.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/input.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 891,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
       "norm_label": "action-modal.tsx",
@@ -53440,7 +53518,7 @@
       "source_location": "L1"
     },
     {
-      "community": 891,
+      "community": 892,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -53449,7 +53527,7 @@
       "source_location": "L1"
     },
     {
-      "community": 892,
+      "community": 893,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
@@ -53458,7 +53536,7 @@
       "source_location": "L1"
     },
     {
-      "community": 893,
+      "community": 894,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
@@ -53467,7 +53545,7 @@
       "source_location": "L1"
     },
     {
-      "community": 894,
+      "community": 895,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
@@ -53476,7 +53554,7 @@
       "source_location": "L1"
     },
     {
-      "community": 895,
+      "community": 896,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
@@ -53485,7 +53563,7 @@
       "source_location": "L1"
     },
     {
-      "community": 896,
+      "community": 897,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
@@ -53494,7 +53572,7 @@
       "source_location": "L1"
     },
     {
-      "community": 897,
+      "community": 898,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_switch_tsx",
       "label": "switch.tsx",
@@ -53503,21 +53581,12 @@
       "source_location": "L1"
     },
     {
-      "community": 898,
+      "community": 899,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
       "norm_label": "table.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 899,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_tabs_tsx",
-      "label": "tabs.tsx",
-      "norm_label": "tabs.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/tabs.tsx",
       "source_location": "L1"
     },
     {
@@ -53766,6 +53835,15 @@
     {
       "community": 900,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_tabs_tsx",
+      "label": "tabs.tsx",
+      "norm_label": "tabs.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/tabs.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 901,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
       "norm_label": "textarea.tsx",
@@ -53773,7 +53851,7 @@
       "source_location": "L1"
     },
     {
-      "community": 901,
+      "community": 902,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
@@ -53782,7 +53860,7 @@
       "source_location": "L1"
     },
     {
-      "community": 902,
+      "community": 903,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
@@ -53791,7 +53869,7 @@
       "source_location": "L1"
     },
     {
-      "community": 903,
+      "community": 904,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
@@ -53800,7 +53878,7 @@
       "source_location": "L1"
     },
     {
-      "community": 904,
+      "community": 905,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_upload_button_tsx",
       "label": "upload-button.tsx",
@@ -53809,7 +53887,7 @@
       "source_location": "L1"
     },
     {
-      "community": 905,
+      "community": 906,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagview_tsx",
       "label": "BagView.tsx",
@@ -53818,7 +53896,7 @@
       "source_location": "L1"
     },
     {
-      "community": 906,
+      "community": 907,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_columns_tsx",
       "label": "columns.tsx",
@@ -53827,7 +53905,7 @@
       "source_location": "L1"
     },
     {
-      "community": 907,
+      "community": 908,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
       "label": "constants.ts",
@@ -53836,21 +53914,12 @@
       "source_location": "L1"
     },
     {
-      "community": 908,
+      "community": 909,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
       "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 909,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -53901,6 +53970,15 @@
     {
       "community": 910,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 911,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -53908,7 +53986,7 @@
       "source_location": "L1"
     },
     {
-      "community": 911,
+      "community": 912,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_ts",
       "label": "data.ts",
@@ -53917,7 +53995,7 @@
       "source_location": "L1"
     },
     {
-      "community": 912,
+      "community": 913,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bag_columns_tsx",
       "label": "bag-columns.tsx",
@@ -53926,7 +54004,7 @@
       "source_location": "L1"
     },
     {
-      "community": 913,
+      "community": 914,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
       "label": "bags-table.tsx",
@@ -53935,7 +54013,7 @@
       "source_location": "L1"
     },
     {
-      "community": 914,
+      "community": 915,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_columns_tsx",
       "label": "columns.tsx",
@@ -53944,7 +54022,7 @@
       "source_location": "L1"
     },
     {
-      "community": 915,
+      "community": 916,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -53953,7 +54031,7 @@
       "source_location": "L1"
     },
     {
-      "community": 916,
+      "community": 917,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -53962,7 +54040,7 @@
       "source_location": "L1"
     },
     {
-      "community": 917,
+      "community": 918,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -53971,21 +54049,12 @@
       "source_location": "L1"
     },
     {
-      "community": 918,
+      "community": 919,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
       "norm_label": "data-table-toolbar.tsx",
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 919,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -54036,6 +54105,15 @@
     {
       "community": 920,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 921,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_linkedaccounts_tsx",
       "label": "LinkedAccounts.tsx",
       "norm_label": "linkedaccounts.tsx",
@@ -54043,7 +54121,7 @@
       "source_location": "L1"
     },
     {
-      "community": 921,
+      "community": 922,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_test_tsx",
       "label": "TimelineEventCard.test.tsx",
@@ -54052,7 +54130,7 @@
       "source_location": "L1"
     },
     {
-      "community": 922,
+      "community": 923,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_usercheckoutsession_tsx",
       "label": "UserCheckoutSession.tsx",
@@ -54061,7 +54139,7 @@
       "source_location": "L1"
     },
     {
-      "community": 923,
+      "community": 924,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userinsightssection_tsx",
       "label": "UserInsightsSection.tsx",
@@ -54070,7 +54148,7 @@
       "source_location": "L1"
     },
     {
-      "community": 924,
+      "community": 925,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_userbehaviorinsights_tsx",
       "label": "UserBehaviorInsights.tsx",
@@ -54079,7 +54157,7 @@
       "source_location": "L1"
     },
     {
-      "community": 925,
+      "community": 926,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_index_ts",
       "label": "index.ts",
@@ -54088,7 +54166,7 @@
       "source_location": "L1"
     },
     {
-      "community": 926,
+      "community": 927,
       "file_type": "code",
       "id": "packages_athena_webapp_src_config_ts",
       "label": "config.ts",
@@ -54097,7 +54175,7 @@
       "source_location": "L1"
     },
     {
-      "community": 927,
+      "community": 928,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_themecontext_tsx",
       "label": "ThemeContext.tsx",
@@ -54106,21 +54184,12 @@
       "source_location": "L1"
     },
     {
-      "community": 928,
+      "community": 929,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
       "norm_label": "use-store-modal.tsx",
       "source_file": "packages/athena-webapp/src/hooks/use-store-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 929,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
-      "label": "useOrganizationModal.tsx",
-      "norm_label": "useorganizationmodal.tsx",
-      "source_file": "packages/athena-webapp/src/hooks/useOrganizationModal.tsx",
       "source_location": "L1"
     },
     {
@@ -54171,6 +54240,15 @@
     {
       "community": 930,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
+      "label": "useOrganizationModal.tsx",
+      "norm_label": "useorganizationmodal.tsx",
+      "source_file": "packages/athena-webapp/src/hooks/useOrganizationModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 931,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_aws_ts",
       "label": "aws.ts",
       "norm_label": "aws.ts",
@@ -54178,7 +54256,7 @@
       "source_location": "L1"
     },
     {
-      "community": 931,
+      "community": 932,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_constants_ts",
       "label": "constants.ts",
@@ -54187,7 +54265,7 @@
       "source_location": "L1"
     },
     {
-      "community": 932,
+      "community": 933,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_countries_ts",
       "label": "countries.ts",
@@ -54196,7 +54274,7 @@
       "source_location": "L1"
     },
     {
-      "community": 933,
+      "community": 934,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -54205,7 +54283,7 @@
       "source_location": "L1"
     },
     {
-      "community": 934,
+      "community": 935,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
@@ -54214,7 +54292,7 @@
       "source_location": "L1"
     },
     {
-      "community": 935,
+      "community": 936,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_constants_ts",
       "label": "constants.ts",
@@ -54223,7 +54301,7 @@
       "source_location": "L1"
     },
     {
-      "community": 936,
+      "community": 937,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_test_ts",
       "label": "displayAmounts.test.ts",
@@ -54232,7 +54310,7 @@
       "source_location": "L1"
     },
     {
-      "community": 937,
+      "community": 938,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_productutils_test_ts",
       "label": "productUtils.test.ts",
@@ -54241,21 +54319,12 @@
       "source_location": "L1"
     },
     {
-      "community": 938,
+      "community": 939,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
       "norm_label": "category.ts",
       "source_file": "packages/athena-webapp/src/lib/schemas/category.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 939,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_schemas_product_ts",
-      "label": "product.ts",
-      "norm_label": "product.ts",
-      "source_file": "packages/athena-webapp/src/lib/schemas/product.ts",
       "source_location": "L1"
     },
     {
@@ -54306,6 +54375,15 @@
     {
       "community": 940,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_schemas_product_ts",
+      "label": "product.ts",
+      "norm_label": "product.ts",
+      "source_file": "packages/athena-webapp/src/lib/schemas/product.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 941,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
       "norm_label": "store.ts",
@@ -54313,7 +54391,7 @@
       "source_location": "L1"
     },
     {
-      "community": 941,
+      "community": 942,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
@@ -54322,7 +54400,7 @@
       "source_location": "L1"
     },
     {
-      "community": 942,
+      "community": 943,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
@@ -54331,7 +54409,7 @@
       "source_location": "L1"
     },
     {
-      "community": 943,
+      "community": 944,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
@@ -54340,7 +54418,7 @@
       "source_location": "L1"
     },
     {
-      "community": 944,
+      "community": 945,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
@@ -54349,7 +54427,7 @@
       "source_location": "L1"
     },
     {
-      "community": 945,
+      "community": 946,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
@@ -54358,7 +54436,7 @@
       "source_location": "L1"
     },
     {
-      "community": 946,
+      "community": 947,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -54367,7 +54445,7 @@
       "source_location": "L1"
     },
     {
-      "community": 947,
+      "community": 948,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_index_tsx",
       "label": "index.tsx",
@@ -54376,21 +54454,12 @@
       "source_location": "L1"
     },
     {
-      "community": 948,
+      "community": 949,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 949,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/organization/index.tsx",
       "source_location": "L1"
     },
     {
@@ -54441,6 +54510,15 @@
     {
       "community": 950,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/organization/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 951,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_stores_storeurlslug_tsx",
       "label": "$storeUrlSlug.tsx",
       "norm_label": "$storeurlslug.tsx",
@@ -54448,7 +54526,7 @@
       "source_location": "L1"
     },
     {
-      "community": 951,
+      "community": 952,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_analytics_tsx",
       "label": "analytics.tsx",
@@ -54457,7 +54535,7 @@
       "source_location": "L1"
     },
     {
-      "community": 952,
+      "community": 953,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_assets_index_tsx",
       "label": "assets.index.tsx",
@@ -54466,7 +54544,7 @@
       "source_location": "L1"
     },
     {
-      "community": 953,
+      "community": 954,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_bagid_tsx",
       "label": "bags.$bagId.tsx",
@@ -54475,7 +54553,7 @@
       "source_location": "L1"
     },
     {
-      "community": 954,
+      "community": 955,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_index_tsx",
       "label": "bags.index.tsx",
@@ -54484,7 +54562,7 @@
       "source_location": "L1"
     },
     {
-      "community": 955,
+      "community": 956,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bulk_operations_index_tsx",
       "label": "index.tsx",
@@ -54493,7 +54571,7 @@
       "source_location": "L1"
     },
     {
-      "community": 956,
+      "community": 957,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_checkout_sessions_index_tsx",
       "label": "checkout-sessions.index.tsx",
@@ -54502,7 +54580,7 @@
       "source_location": "L1"
     },
     {
-      "community": 957,
+      "community": 958,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_configuration_index_tsx",
       "label": "configuration.index.tsx",
@@ -54511,21 +54589,12 @@
       "source_location": "L1"
     },
     {
-      "community": 958,
+      "community": 959,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
       "label": "dashboard.index.tsx",
       "norm_label": "dashboard.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/dashboard.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 959,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
-      "label": "home.tsx",
-      "norm_label": "home.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/home.tsx",
       "source_location": "L1"
     },
     {
@@ -54576,6 +54645,15 @@
     {
       "community": 960,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
+      "label": "home.tsx",
+      "norm_label": "home.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/home.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 961,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_logid_tsx",
       "label": "logs.$logId.tsx",
       "norm_label": "logs.$logid.tsx",
@@ -54583,7 +54661,7 @@
       "source_location": "L1"
     },
     {
-      "community": 961,
+      "community": 962,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_index_tsx",
       "label": "logs.index.tsx",
@@ -54592,7 +54670,7 @@
       "source_location": "L1"
     },
     {
-      "community": 962,
+      "community": 963,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_members_index_tsx",
       "label": "members.index.tsx",
@@ -54601,7 +54679,7 @@
       "source_location": "L1"
     },
     {
-      "community": 963,
+      "community": 964,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_orderslug_index_tsx",
       "label": "index.tsx",
@@ -54610,7 +54688,7 @@
       "source_location": "L1"
     },
     {
-      "community": 964,
+      "community": 965,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_all_index_tsx",
       "label": "all.index.tsx",
@@ -54619,7 +54697,7 @@
       "source_location": "L1"
     },
     {
-      "community": 965,
+      "community": 966,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_cancelled_index_tsx",
       "label": "cancelled.index.tsx",
@@ -54628,7 +54706,7 @@
       "source_location": "L1"
     },
     {
-      "community": 966,
+      "community": 967,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
       "label": "completed.index.tsx",
@@ -54637,7 +54715,7 @@
       "source_location": "L1"
     },
     {
-      "community": 967,
+      "community": 968,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_index_tsx",
       "label": "index.tsx",
@@ -54646,21 +54724,12 @@
       "source_location": "L1"
     },
     {
-      "community": 968,
+      "community": 969,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
       "label": "open.index.tsx",
       "norm_label": "open.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/open.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 969,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_out_for_delivery_index_tsx",
-      "label": "out-for-delivery.index.tsx",
-      "norm_label": "out-for-delivery.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/out-for-delivery.index.tsx",
       "source_location": "L1"
     },
     {
@@ -54711,6 +54780,15 @@
     {
       "community": 970,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_out_for_delivery_index_tsx",
+      "label": "out-for-delivery.index.tsx",
+      "norm_label": "out-for-delivery.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/out-for-delivery.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 971,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
       "label": "ready.index.tsx",
       "norm_label": "ready.index.tsx",
@@ -54718,7 +54796,7 @@
       "source_location": "L1"
     },
     {
-      "community": 971,
+      "community": 972,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
       "label": "refunded.index.tsx",
@@ -54727,7 +54805,7 @@
       "source_location": "L1"
     },
     {
-      "community": 972,
+      "community": 973,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
       "label": "$reportId.tsx",
@@ -54736,7 +54814,7 @@
       "source_location": "L1"
     },
     {
-      "community": 973,
+      "community": 974,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
       "label": "expense-reports.index.tsx",
@@ -54745,7 +54823,7 @@
       "source_location": "L1"
     },
     {
-      "community": 974,
+      "community": 975,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_index_tsx",
       "label": "expense.index.tsx",
@@ -54754,7 +54832,7 @@
       "source_location": "L1"
     },
     {
-      "community": 975,
+      "community": 976,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_index_tsx",
       "label": "index.tsx",
@@ -54763,7 +54841,7 @@
       "source_location": "L1"
     },
     {
-      "community": 976,
+      "community": 977,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
       "label": "register.index.tsx",
@@ -54772,7 +54850,7 @@
       "source_location": "L1"
     },
     {
-      "community": 977,
+      "community": 978,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_settings_index_tsx",
       "label": "settings.index.tsx",
@@ -54781,21 +54859,12 @@
       "source_location": "L1"
     },
     {
-      "community": 978,
+      "community": 979,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
       "label": "$transactionId.tsx",
       "norm_label": "$transactionid.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 979,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
-      "label": "transactions.index.tsx",
-      "norm_label": "transactions.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions.index.tsx",
       "source_location": "L1"
     },
     {
@@ -54846,6 +54915,15 @@
     {
       "community": 980,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
+      "label": "transactions.index.tsx",
+      "norm_label": "transactions.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 981,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_edit_tsx",
       "label": "edit.tsx",
       "norm_label": "edit.tsx",
@@ -54853,7 +54931,7 @@
       "source_location": "L1"
     },
     {
-      "community": 981,
+      "community": 982,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_index_tsx",
       "label": "index.tsx",
@@ -54862,7 +54940,7 @@
       "source_location": "L1"
     },
     {
-      "community": 982,
+      "community": 983,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_index_tsx",
       "label": "index.tsx",
@@ -54871,7 +54949,7 @@
       "source_location": "L1"
     },
     {
-      "community": 983,
+      "community": 984,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_new_tsx",
       "label": "new.tsx",
@@ -54880,7 +54958,7 @@
       "source_location": "L1"
     },
     {
-      "community": 984,
+      "community": 985,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_index_tsx",
       "label": "index.tsx",
@@ -54889,7 +54967,7 @@
       "source_location": "L1"
     },
     {
-      "community": 985,
+      "community": 986,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_new_tsx",
       "label": "new.tsx",
@@ -54898,7 +54976,7 @@
       "source_location": "L1"
     },
     {
-      "community": 986,
+      "community": 987,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_unresolved_tsx",
       "label": "unresolved.tsx",
@@ -54907,7 +54985,7 @@
       "source_location": "L1"
     },
     {
-      "community": 987,
+      "community": 988,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
       "label": "$promoCodeSlug.tsx",
@@ -54916,21 +54994,12 @@
       "source_location": "L1"
     },
     {
-      "community": 988,
+      "community": 989,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 989,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
-      "label": "new.tsx",
-      "norm_label": "new.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/new.tsx",
       "source_location": "L1"
     },
     {
@@ -54981,6 +55050,15 @@
     {
       "community": 990,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
+      "label": "new.tsx",
+      "norm_label": "new.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/new.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 991,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
@@ -54988,7 +55066,7 @@
       "source_location": "L1"
     },
     {
-      "community": 991,
+      "community": 992,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_new_index_tsx",
       "label": "new.index.tsx",
@@ -54997,7 +55075,7 @@
       "source_location": "L1"
     },
     {
-      "community": 992,
+      "community": 993,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_users_userid_tsx",
       "label": "users.$userId.tsx",
@@ -55006,7 +55084,7 @@
       "source_location": "L1"
     },
     {
-      "community": 993,
+      "community": 994,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_index_tsx",
       "label": "index.tsx",
@@ -55015,7 +55093,7 @@
       "source_location": "L1"
     },
     {
-      "community": 994,
+      "community": 995,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_join_team_index_tsx",
       "label": "join-team.index.tsx",
@@ -55024,7 +55102,7 @@
       "source_location": "L1"
     },
     {
-      "community": 995,
+      "community": 996,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_test_tsx",
       "label": "_layout.index.test.tsx",
@@ -55033,7 +55111,7 @@
       "source_location": "L1"
     },
     {
-      "community": 996,
+      "community": 997,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storessettingsaccordion_tsx",
       "label": "StoresSettingsAccordion.tsx",
@@ -55042,7 +55120,7 @@
       "source_location": "L1"
     },
     {
-      "community": 997,
+      "community": 998,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stores_expensestore_ts",
       "label": "expenseStore.ts",
@@ -55051,21 +55129,12 @@
       "source_location": "L1"
     },
     {
-      "community": 998,
+      "community": 999,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stores_posstore_ts",
       "label": "posStore.ts",
       "norm_label": "posstore.ts",
       "source_file": "packages/athena-webapp/src/stores/posStore.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 999,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_foundations_overview_stories_tsx",
-      "label": "Overview.stories.tsx",
-      "norm_label": "overview.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/Overview.stories.tsx",
       "source_location": "L1"
     }
   ]

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1227
-- Graph nodes: 2882
-- Graph edges: 2427
-- Communities: 1142
+- Code files discovered: 1230
+- Graph nodes: 2887
+- Graph edges: 2429
+- Communities: 1145
 
 ## Graph Hotspots
 - `harness-inferential-review.ts` (46 edges, Community 0) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -49,6 +49,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`src/lib/utils.test.ts`](../../src/lib/utils.test.ts)
 - [`src/routes/login/_layout.index.test.tsx`](../../src/routes/login/_layout.index.test.tsx)
 - [`src/stories/Foundations/foundations-content.test.tsx`](../../src/stories/Foundations/foundations-content.test.tsx)
+- [`src/stories/Patterns/admin-shell-patterns.test.tsx`](../../src/stories/Patterns/admin-shell-patterns.test.tsx)
 - [`src/tests/pos/backend.test.ts`](../../src/tests/pos/backend.test.ts)
 - [`src/tests/pos/inventoryValidationLogic.test.ts`](../../src/tests/pos/inventoryValidationLogic.test.ts)
 - [`src/tests/pos/simple.test.ts`](../../src/tests/pos/simple.test.ts)

--- a/packages/athena-webapp/src/stories/Patterns/AdminShell.stories.tsx
+++ b/packages/athena-webapp/src/stories/Patterns/AdminShell.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import {
+  AthenaAdminShellPatterns,
+  AthenaLoadingPattern,
+  AthenaMetricPattern,
+  AthenaPageHeaderPattern,
+  AthenaSidebarPattern,
+} from "./admin-shell-patterns";
+
+const meta = {
+  title: "Patterns/Athena Admin Shell",
+  component: AthenaAdminShellPatterns,
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          "Athena-authored shell scenes that pair the sidebar, page header, metrics, and loading surfaces without router, auth, or Convex dependencies.",
+      },
+    },
+  },
+} satisfies Meta<typeof AthenaAdminShellPatterns>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const ShellComposition: Story = {};
+
+export const SidebarFocus: Story = {
+  render: () => <AthenaSidebarPattern />,
+};
+
+export const PageHeaderFocus: Story = {
+  render: () => <AthenaPageHeaderPattern />,
+};
+
+export const MetricSurfaceFocus: Story = {
+  render: () => <AthenaMetricPattern />,
+};
+
+export const LoadingSurfaceFocus: Story = {
+  render: () => <AthenaLoadingPattern />,
+};

--- a/packages/athena-webapp/src/stories/Patterns/Overview.stories.tsx
+++ b/packages/athena-webapp/src/stories/Patterns/Overview.stories.tsx
@@ -10,14 +10,14 @@ function PatternsOverview() {
       description="Patterns are where the system starts to feel like Athena: navigation, page headers, metric surfaces, filters, and shared app states."
     >
       <StorybookSection
-        title="Planned shell stories"
-        description="Pattern stories will avoid live app state and use stable fixtures instead."
+        title="Shell stories"
+        description="These stories are authored scenes, not primitive showcases. They use stable fixtures so the admin shell reads like Athena without live app dependencies."
       >
         <StorybookList
           items={[
-            "Sidebar navigation and shell rhythm.",
-            "Page headers, toolbar rows, and metric surfaces.",
-            "Empty, loading, error, and confirmation patterns.",
+            "Athena admin shell composition with sidebar, header, metrics, and loading surfaces.",
+            "Focused sidebar, page header, and metric surface stories for design review.",
+            "Static loading states that keep the shell rhythm intact while data resolves.",
           ]}
         />
       </StorybookSection>

--- a/packages/athena-webapp/src/stories/Patterns/admin-shell-patterns.test.tsx
+++ b/packages/athena-webapp/src/stories/Patterns/admin-shell-patterns.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  AthenaAdminShellPatterns,
+  AthenaSidebarPattern,
+} from "./admin-shell-patterns";
+
+describe("Athena admin shell patterns", () => {
+  it("renders a shell composition that reads like Athena's admin workspace", () => {
+    render(<AthenaAdminShellPatterns />);
+
+    expect(
+      screen.getByRole("heading", {
+        name: /athena admin shell patterns/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /^northwind atelier$/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/^store$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^analytics$/i)).toBeInTheDocument();
+    expect(screen.getByText(/bulk operations/i)).toBeInTheDocument();
+    expect(screen.getByText(/open orders/i)).toBeInTheDocument();
+    expect(screen.getByText(/pending reviews/i)).toBeInTheDocument();
+    expect(screen.getByText(/loading surfaces/i)).toBeInTheDocument();
+  });
+
+  it("renders the sidebar preview without live app providers", () => {
+    render(<AthenaSidebarPattern />);
+
+    expect(screen.getByText(/^store$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^analytics$/i)).toBeInTheDocument();
+    expect(screen.getByText(/bulk operations/i)).toBeInTheDocument();
+    expect(screen.getByText(/reviews/i)).toBeInTheDocument();
+  });
+});

--- a/packages/athena-webapp/src/stories/Patterns/admin-shell-patterns.tsx
+++ b/packages/athena-webapp/src/stories/Patterns/admin-shell-patterns.tsx
@@ -1,0 +1,459 @@
+import type { ComponentType, ReactNode } from "react";
+
+import {
+  AlertOctagon,
+  ArrowLeftIcon,
+  BarChart3,
+  BadgePercent,
+  Bell,
+  ClipboardList,
+  Clock3,
+  PackageSearch,
+  Search,
+  Sparkles,
+  Store,
+  Truck,
+  Users,
+  CheckCircle2,
+  Layers3,
+} from "lucide-react";
+
+import MetricCard from "@/components/dashboard/MetricCard";
+import DashboardSkeleton from "@/components/states/loading/dashboard-skeleton";
+import TableSkeleton from "@/components/states/loading/table-skeleton";
+import TransactionsSkeleton from "@/components/states/loading/transactions-skeleton";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+type NavItem = {
+  label: string;
+  meta?: string;
+  icon: ComponentType<{ className?: string }>;
+  active?: boolean;
+};
+
+type NavGroup = {
+  label: string;
+  items: NavItem[];
+};
+
+const NAV_GROUPS: NavGroup[] = [
+  {
+    label: "Store",
+    items: [
+      { label: "Dashboard", icon: Layers3, active: true },
+      { label: "Analytics", icon: BarChart3, meta: "14 insights" },
+      { label: "Point of sale", icon: Store, meta: "Live" },
+      { label: "Orders", icon: ClipboardList, meta: "12 open" },
+      { label: "Products", icon: PackageSearch, meta: "8 unresolved" },
+    ],
+  },
+  {
+    label: "Operations",
+    items: [
+      { label: "Fulfillment", icon: Truck, meta: "3 in transit" },
+      { label: "Reviews", icon: Sparkles, meta: "4 waiting" },
+      { label: "Bulk operations", icon: Layers3, meta: "1 lane" },
+      { label: "Promo codes", icon: BadgePercent },
+    ],
+  },
+  {
+    label: "Customers",
+    items: [
+      { label: "Segments", icon: Users },
+      { label: "Activity", icon: Clock3, meta: "Today" },
+      { label: "Issues", icon: AlertOctagon, meta: "2 alerts" },
+    ],
+  },
+];
+
+const METRICS = [
+  {
+    label: "Open orders",
+    value: "42",
+    change: 12.4,
+    changeLabel: "vs yesterday",
+  },
+  {
+    label: "Pending reviews",
+    value: "8",
+    change: -18.2,
+    changeLabel: "last 24h",
+  },
+  {
+    label: "Unresolved images",
+    value: "6",
+    change: -5.5,
+    changeLabel: "after import pass",
+  },
+  {
+    label: "Revenue today",
+    value: "GHS 18.4k",
+    change: 7.9,
+    changeLabel: "morning trade",
+  },
+] as const;
+
+const STATUS_CHIPS = [
+  "Northwind Atelier",
+  "Accra | OS 3",
+  "Shift open",
+  "Fresh sync 2m ago",
+] as const;
+
+function PatternShell({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className="min-h-screen bg-[radial-gradient(circle_at_top_left,_hsl(var(--signal)/0.16),_transparent_34%),radial-gradient(circle_at_top_right,_hsl(var(--primary)/0.12),_transparent_28%),linear-gradient(180deg,_hsl(var(--background)),_hsl(var(--background))_45%,_hsl(var(--muted)/0.18))] p-4 text-foreground md:p-8">
+      <div
+        className={cn(
+          "mx-auto flex min-h-[calc(100vh-2rem)] w-full max-w-7xl overflow-hidden rounded-[2rem] border border-border bg-background/96 shadow-[0_24px_80px_-24px_hsl(var(--foreground)/0.22)] md:min-h-[calc(100vh-4rem)]",
+          className,
+        )}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function PatternCard({
+  eyebrow,
+  title,
+  description,
+  children,
+  className,
+}: {
+  eyebrow: string;
+  title: string;
+  description: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <section
+      className={cn(
+        "rounded-[1.75rem] border border-border bg-surface-raised/95 p-5 shadow-surface md:p-6",
+        className,
+      )}
+    >
+      <div className="space-y-2 border-b border-border/70 pb-4">
+        <p className="text-[0.7rem] font-semibold uppercase tracking-[0.3em] text-muted-foreground">
+          {eyebrow}
+        </p>
+        <h2 className="font-display text-2xl tracking-[-0.04em] text-foreground">
+          {title}
+        </h2>
+        <p className="max-w-3xl text-sm leading-6 text-muted-foreground">
+          {description}
+        </p>
+      </div>
+      <div className="pt-4">{children}</div>
+    </section>
+  );
+}
+
+function PatternSidebarItem({
+  icon: Icon,
+  label,
+  meta,
+  active,
+}: NavItem) {
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-between rounded-2xl px-3 py-2.5 transition-colors",
+        active
+          ? "bg-[hsl(var(--signal)/0.16)] text-shell-foreground"
+          : "text-shell-foreground/78 hover:bg-white/6 hover:text-shell-foreground",
+      )}
+    >
+      <div className="flex items-center gap-3">
+        <span
+          className={cn(
+            "flex h-9 w-9 items-center justify-center rounded-xl border border-white/8",
+            active ? "bg-[hsl(var(--signal))] text-[hsl(var(--signal-foreground))]" : "bg-white/5 text-shell-foreground/80",
+          )}
+        >
+          <Icon className="h-4 w-4" />
+        </span>
+        <span className="text-sm font-medium">{label}</span>
+      </div>
+      {meta ? (
+        <span className="text-[0.7rem] font-semibold uppercase tracking-[0.22em] text-shell-foreground/55">
+          {meta}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+function PatternSidebarGroup({ group }: { group: NavGroup }) {
+  return (
+    <div className="space-y-3">
+      <p className="px-3 text-[0.7rem] font-semibold uppercase tracking-[0.28em] text-shell-foreground/52">
+        {group.label}
+      </p>
+      <div className="space-y-1.5">
+        {group.items.map((item) => (
+          <PatternSidebarItem key={item.label} {...item} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function PatternSidebar() {
+  return (
+    <aside className="flex h-full w-full flex-col bg-shell text-shell-foreground shadow-overlay">
+      <div className="border-b border-white/8 p-5">
+        <div className="flex items-center gap-3">
+          <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-[hsl(var(--signal))] text-[hsl(var(--signal-foreground))] shadow-[0_12px_24px_-10px_hsl(var(--signal)/0.65)]">
+            <Sparkles className="h-5 w-5" />
+          </div>
+          <div className="space-y-0.5">
+            <p className="text-[0.72rem] font-semibold uppercase tracking-[0.28em] text-shell-foreground/56">
+              Athena Admin
+            </p>
+            <h3 className="font-display text-xl tracking-[-0.03em]">
+              Northwind Atelier
+            </h3>
+          </div>
+        </div>
+
+        <div className="mt-4 grid gap-3 rounded-[1.5rem] border border-white/8 bg-black/12 p-3">
+          <div className="flex items-center justify-between">
+            <span className="text-xs uppercase tracking-[0.24em] text-shell-foreground/52">
+              Active store
+            </span>
+            <Badge variant="outline" className="border-white/10 text-xs text-shell-foreground">
+              Open
+            </Badge>
+          </div>
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-white/8 text-shell-foreground">
+              <Store className="h-4 w-4" />
+            </div>
+            <div>
+              <p className="text-sm font-semibold">Kente House Goods</p>
+              <p className="text-xs text-shell-foreground/60">Accra, Ghana</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex-1 space-y-5 overflow-auto p-4">
+        {NAV_GROUPS.map((group) => (
+          <PatternSidebarGroup key={group.label} group={group} />
+        ))}
+      </div>
+
+      <div className="border-t border-white/8 p-4">
+        <div className="flex items-center justify-between rounded-[1.35rem] border border-white/8 bg-white/5 px-3 py-3">
+          <div>
+            <p className="text-sm font-semibold">Grace Mensah</p>
+            <p className="text-xs text-shell-foreground/60">Operations lead</p>
+          </div>
+          <Button
+            size="sm"
+            variant="outline"
+            className="border-white/10 bg-transparent text-shell-foreground hover:bg-white/8 hover:text-shell-foreground"
+          >
+            Profile
+          </Button>
+        </div>
+      </div>
+    </aside>
+  );
+}
+
+function PatternHeader() {
+  return (
+    <PatternCard
+      eyebrow="Page header"
+      title="Today’s admin pulse"
+      description="A focused header that carries store context, navigation affordances, and a clear action rail without collapsing into a generic toolbar."
+    >
+      <div className="flex flex-col gap-5">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="space-y-4">
+            <div className="flex flex-wrap items-center gap-2">
+              <Button variant="ghost" size="icon" className="h-9 w-9 rounded-full border border-border/60 bg-background/50">
+                <ArrowLeftIcon className="h-4 w-4" />
+              </Button>
+              {STATUS_CHIPS.map((chip) => (
+                <Badge
+                  key={chip}
+                  variant="outline"
+                  className="rounded-full border-border/70 bg-background/60 px-3 py-1 text-[0.68rem] uppercase tracking-[0.22em] text-muted-foreground"
+                >
+                  {chip}
+                </Badge>
+              ))}
+            </div>
+            <div className="space-y-2">
+              <h3 className="font-display text-[clamp(2.4rem,3.8vw,3.4rem)] leading-none tracking-[-0.05em] text-foreground">
+                A calm command surface for the store team.
+              </h3>
+              <p className="max-w-3xl text-sm leading-6 text-muted-foreground md:text-base">
+                Keep the workspace anchored with store identity, search, and key
+                actions at the top of the page. The shell should feel purposeful,
+                not like a placeholder scaffold.
+              </p>
+            </div>
+          </div>
+
+          <div className="flex min-w-[280px] flex-1 flex-col gap-3 sm:flex-none">
+            <div className="relative">
+              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                value="Search products, orders, reviews"
+                readOnly
+                className="h-11 rounded-full border-border/70 pl-10 text-sm shadow-none"
+              />
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Button variant="outline" className="rounded-full">
+                <Bell className="h-4 w-4" />
+                Alerts
+              </Button>
+              <Button className="rounded-full">
+                <CheckCircle2 className="h-4 w-4" />
+                Publish updates
+              </Button>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-2 border-t border-border/70 pt-4">
+          <Badge className="rounded-full bg-[hsl(var(--signal)/0.15)] text-[hsl(var(--signal))] hover:bg-[hsl(var(--signal)/0.15)]">
+            Shift open
+          </Badge>
+          <Badge variant="outline" className="rounded-full">
+            4 urgent tasks
+          </Badge>
+          <Badge variant="outline" className="rounded-full">
+            2 approvals pending
+          </Badge>
+        </div>
+      </div>
+    </PatternCard>
+  );
+}
+
+function PatternMetrics() {
+  return (
+    <PatternCard
+      eyebrow="Metric surface"
+      title="A quick read on the store"
+      description="Small, deliberate metric cards should feel like operator tools. They need enough hierarchy to answer the first question fast and enough warmth to feel authored."
+    >
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        {METRICS.map((metric) => (
+          <MetricCard key={metric.label} {...metric} />
+        ))}
+      </div>
+    </PatternCard>
+  );
+}
+
+function PatternLoading() {
+  return (
+    <PatternCard
+      eyebrow="Loading surfaces"
+      title="Stable shells while data arrives"
+      description="Loading states should preserve the overall admin rhythm instead of collapsing into a wall of generic gray bars."
+      className="overflow-hidden"
+    >
+      <div className="grid gap-4 xl:grid-cols-[1.2fr_0.8fr]">
+        <div className="rounded-[1.5rem] border border-border/70 bg-background/70 p-4">
+          <DashboardSkeleton />
+        </div>
+        <div className="grid gap-4">
+          <div className="rounded-[1.5rem] border border-border/70 bg-background/70 p-4">
+            <TableSkeleton />
+          </div>
+          <div className="rounded-[1.5rem] border border-border/70 bg-background/70 p-4">
+            <TransactionsSkeleton />
+          </div>
+        </div>
+      </div>
+    </PatternCard>
+  );
+}
+
+export function AthenaSidebarPattern() {
+  return <PatternShell className="bg-background/94"><div className="grid min-h-[760px] w-full lg:grid-cols-[320px_1fr]"><PatternSidebar /><div className="hidden lg:block bg-[linear-gradient(180deg,_hsl(var(--surface-raised)),_hsl(var(--background)))] p-6"><PatternHeader /></div></div></PatternShell>;
+}
+
+export function AthenaPageHeaderPattern() {
+  return (
+    <PatternShell>
+      <div className="flex w-full items-center justify-center p-4 md:p-8">
+        <div className="w-full max-w-6xl">
+          <PatternHeader />
+        </div>
+      </div>
+    </PatternShell>
+  );
+}
+
+export function AthenaMetricPattern() {
+  return (
+    <PatternShell>
+      <div className="w-full p-4 md:p-8">
+        <div className="mx-auto max-w-6xl space-y-6">
+          <PatternHeader />
+          <PatternMetrics />
+        </div>
+      </div>
+    </PatternShell>
+  );
+}
+
+export function AthenaLoadingPattern() {
+  return (
+    <PatternShell>
+      <div className="w-full p-4 md:p-8">
+        <div className="mx-auto max-w-6xl">
+          <PatternLoading />
+        </div>
+      </div>
+    </PatternShell>
+  );
+}
+
+export function AthenaAdminShellPatterns() {
+  return (
+    <PatternShell>
+      <div className="grid min-h-[860px] w-full lg:grid-cols-[320px_1fr]">
+        <PatternSidebar />
+        <main className="flex min-w-0 flex-col gap-6 overflow-hidden bg-[linear-gradient(180deg,_hsl(var(--surface-raised)),_hsl(var(--background))_35%)] p-4 md:p-6">
+          <div className="rounded-[1.75rem] border border-border/70 bg-background/75 p-5 shadow-surface">
+            <p className="text-[0.72rem] font-semibold uppercase tracking-[0.28em] text-muted-foreground">
+              Patterns
+            </p>
+            <h1 className="mt-2 font-display text-[clamp(2.5rem,4vw,3.75rem)] leading-[0.95] tracking-[-0.05em] text-foreground">
+              Athena admin shell patterns
+            </h1>
+            <p className="mt-3 max-w-3xl text-sm leading-6 text-muted-foreground md:text-base">
+              A full workspace composition for reviewing the sidebar, page
+              header, metric surfaces, and loading states that define Athena’s
+              admin experience.
+            </p>
+          </div>
+          <PatternHeader />
+          <PatternMetrics />
+          <PatternLoading />
+        </main>
+      </div>
+    </PatternShell>
+  );
+}


### PR DESCRIPTION
## Summary
- add Athena-authored admin shell pattern stories for the sidebar, page header, metric surfaces, loading states, and a full shell composition
- keep the patterns fully static so they render without router, auth, or Convex providers while still reading like Athena's real admin experience
- refresh generated harness/graph artifacts for the new Storybook pattern surfaces

## Validation
- bun run pr:athena
- bun run --filter '@athena/webapp' test -- src/stories/Patterns/admin-shell-patterns.test.tsx

## Linear
- https://linear.app/v26-labs/issue/V26-267/build-athena-admin-shell-patterns-in-storybook