### PR TITLE
[codex] Fix graphify hook staging gap

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,3 @@
+#!/bin/sh
+cd "$(git rev-parse --show-toplevel)" || exit 1
+bun run pre-commit:generated-artifacts

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Key repo-level commands:
 It targets repo-root `scripts/*.test.ts` files only (excluding cloned worktree trees).
 Use `bun run harness:test -- --dry-run` to print the selected files without executing tests.
 
-`pre-push:review` automatically runs `bun run graphify:rebuild` before the local validation suite, so stale tracked graphify artifacts get repaired before freshness-sensitive checks execute.
+`pre-commit:generated-artifacts` automatically runs `bun run graphify:rebuild` and stages the tracked graphify outputs before the commit is finalized, so the pushed ref includes the refreshed graph artifacts.
+`pre-push:review` uses `bun run graphify:check` as a non-mutating freshness gate before the rest of the local validation suite.
 If `harness:self-review` or `harness:review` gets blocked by stale generated harness docs, the hook runs `bun run harness:generate` once and retries the blocked step.
 
 List runtime behavior scenarios with `bun run harness:behavior --list`.
@@ -104,7 +105,7 @@ Use [the packages agent router](./packages/AGENTS.md) plus each package's `AGENT
 
 Use `bun run graphify:check` as the non-mutating freshness gate for tracked graphify artifacts.
 
-Use `bun run graphify:rebuild` as the repair path when the check reports stale artifacts. The rebuild command uses the interpreter recorded in `.graphify_python` (default `python3` in this repo). Local `pre-push:review` runs this repair step automatically before its validation suite.
+Use `bun run graphify:rebuild` as the repair path when the check reports stale artifacts. The rebuild command uses the interpreter recorded in `.graphify_python` (default `python3` in this repo). Local `pre-commit:generated-artifacts` runs this repair step and stages the tracked graphify outputs before the commit is finalized, while `pre-push:review` re-checks freshness without mutating the tree.
 
 If you need to repair the local graphify setup, install the repo-pinned runtime with `python3 -m pip install -r .graphify-requirements.txt`.
 

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1246 files · ~0 words
+- 1248 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 2918 nodes · 2445 edges · 1161 communities detected
+- 2924 nodes · 2450 edges · 1163 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1171,6 +1171,8 @@
 - [[_COMMUNITY_Community 1158|Community 1158]]
 - [[_COMMUNITY_Community 1159|Community 1159]]
 - [[_COMMUNITY_Community 1160|Community 1160]]
+- [[_COMMUNITY_Community 1161|Community 1161]]
+- [[_COMMUNITY_Community 1162|Community 1162]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -1499,16 +1501,16 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 75 - "Community 75"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
-
-### Community 76 - "Community 76"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 77 - "Community 77"
+### Community 76 - "Community 76"
 Cohesion: 0.4
 Nodes (2): useBulkOperations(), validateOperationValue()
+
+### Community 77 - "Community 77"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 78 - "Community 78"
 Cohesion: 0.33
@@ -1523,32 +1525,32 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 81 - "Community 81"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 82 - "Community 82"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 83 - "Community 83"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 84 - "Community 84"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 85 - "Community 85"
+### Community 84 - "Community 84"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 85 - "Community 85"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 86 - "Community 86"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 87 - "Community 87"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 88 - "Community 88"
 Cohesion: 0.53
@@ -1612,19 +1614,19 @@ Nodes (0):
 
 ### Community 103 - "Community 103"
 Cohesion: 0.4
-Nodes (1): Header()
+Nodes (0):
 
 ### Community 104 - "Community 104"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 105 - "Community 105"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 106 - "Community 106"
 Cohesion: 0.5
 Nodes (2): handleFileSelect(), validateFile()
+
+### Community 106 - "Community 106"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 107 - "Community 107"
 Cohesion: 0.4
@@ -1636,7 +1638,7 @@ Nodes (0):
 
 ### Community 109 - "Community 109"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): Header()
 
 ### Community 110 - "Community 110"
 Cohesion: 0.4
@@ -1727,20 +1729,20 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 132 - "Community 132"
-Cohesion: 0.67
-Nodes (2): toDisplayAmount(), toPesewas()
-
-### Community 133 - "Community 133"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 134 - "Community 134"
+### Community 133 - "Community 133"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 135 - "Community 135"
+### Community 134 - "Community 134"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
+
+### Community 135 - "Community 135"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 136 - "Community 136"
 Cohesion: 0.5
@@ -1759,12 +1761,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 140 - "Community 140"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 141 - "Community 141"
 Cohesion: 0.67
 Nodes (2): countGroupedAnalytics(), groupAnalytics()
+
+### Community 141 - "Community 141"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 142 - "Community 142"
 Cohesion: 0.5
@@ -1791,32 +1793,32 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 148 - "Community 148"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 149 - "Community 149"
 Cohesion: 0.67
 Nodes (2): getRiskStyles(), RiskIndicators()
+
+### Community 149 - "Community 149"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 150 - "Community 150"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 151 - "Community 151"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 152 - "Community 152"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 153 - "Community 153"
+### Community 152 - "Community 152"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 154 - "Community 154"
+### Community 153 - "Community 153"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+
+### Community 154 - "Community 154"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 155 - "Community 155"
 Cohesion: 0.5
@@ -1839,8 +1841,8 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 160 - "Community 160"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): toDisplayAmount(), toPesewas()
 
 ### Community 161 - "Community 161"
 Cohesion: 0.67
@@ -2323,12 +2325,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 281 - "Community 281"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0):
 
 ### Community 282 - "Community 282"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): runPreCommitGeneratedArtifacts(), stageTrackedGraphifyArtifacts()
 
 ### Community 283 - "Community 283"
 Cohesion: 1.0
@@ -5842,1766 +5844,1774 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1161 - "Community 1161"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1162 - "Community 1162"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
-- **Thin community `Community 281`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 283`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 282`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 284`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 283`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 285`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 284`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 286`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 285`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 287`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 286`** (2 nodes): `authenticateHandler()`, `cashier.ts`
+- **Thin community `Community 288`** (2 nodes): `authenticateHandler()`, `cashier.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 287`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 289`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 288`** (2 nodes): `sessionQueryIndexes.test.ts`, `readProjectFile()`
+- **Thin community `Community 290`** (2 nodes): `sessionQueryIndexes.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 289`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 291`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 290`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 292`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 291`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 293`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 292`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 294`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 293`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 295`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 294`** (2 nodes): `VerificationCodeEmail.tsx`, `VerificationCodeEmail()`
+- **Thin community `Community 296`** (2 nodes): `VerificationCodeEmail.tsx`, `VerificationCodeEmail()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 295`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 297`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 296`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 298`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 297`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 299`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 298`** (2 nodes): `listOrderItems()`, `onlineOrder.ts`
+- **Thin community `Community 300`** (2 nodes): `listOrderItems()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 299`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 301`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 300`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 302`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 301`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 303`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 302`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 304`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 303`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 305`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 304`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 306`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 305`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 307`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 306`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 308`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 307`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 309`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 308`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 310`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 309`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 311`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 310`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 312`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 311`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 313`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 312`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 314`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 313`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 315`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 314`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 316`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 315`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 317`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 316`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 318`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 317`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 319`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 318`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
+- **Thin community `Community 320`** (2 nodes): `ProductAttributes.tsx`, `isAllowedAttribute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 319`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 321`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 320`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 322`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 321`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 323`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 322`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 324`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 323`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 325`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 324`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 326`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 325`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 327`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 326`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 328`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 327`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 329`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 328`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 330`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 329`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 331`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 330`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 332`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 331`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 333`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 332`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 334`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 333`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 335`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 334`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 336`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 335`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 337`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 336`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 338`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 337`** (2 nodes): `Login()`, `index.tsx`
+- **Thin community `Community 339`** (2 nodes): `Login()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 338`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 340`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 339`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 341`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 340`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 342`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 341`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 343`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 342`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 344`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 343`** (2 nodes): `PageHeader.tsx`, `PageHeader()`
+- **Thin community `Community 345`** (2 nodes): `PageHeader.tsx`, `PageHeader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 344`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 346`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 345`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 347`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 346`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 348`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 347`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 349`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 348`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 350`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 349`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 351`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 350`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 352`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 351`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 353`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 352`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 354`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 353`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 355`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 354`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 356`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 355`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 357`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 356`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 358`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 357`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 359`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 358`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 360`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 359`** (2 nodes): `handleSignOut()`, `CashierView.tsx`
+- **Thin community `Community 361`** (2 nodes): `handleSignOut()`, `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 360`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 362`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 361`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 363`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 362`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 364`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 363`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
+- **Thin community `Community 365`** (2 nodes): `PointOfSaleView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 364`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 366`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 365`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
+- **Thin community `Community 367`** (2 nodes): `ProductCard.tsx`, `ProductCard()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 366`** (2 nodes): `ProductEntry.tsx`, `handleClearSearch()`
+- **Thin community `Community 368`** (2 nodes): `ProductEntry.tsx`, `handleClearSearch()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 367`** (2 nodes): `QuickActionsBar.tsx`, `QuickActionsBar()`
+- **Thin community `Community 369`** (2 nodes): `QuickActionsBar.tsx`, `QuickActionsBar()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 368`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 370`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 369`** (2 nodes): `TotalsDisplay.tsx`, `TotalsDisplay()`
+- **Thin community `Community 371`** (2 nodes): `TotalsDisplay.tsx`, `TotalsDisplay()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 370`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
+- **Thin community `Community 372`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 371`** (2 nodes): `usePOSCashier()`, `hooks.ts`
+- **Thin community `Community 373`** (2 nodes): `usePOSCashier()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 372`** (2 nodes): `HoldSessionDialog()`, `HoldSessionDialog.tsx`
+- **Thin community `Community 374`** (2 nodes): `HoldSessionDialog()`, `HoldSessionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 373`** (2 nodes): `VoidSessionDialog.tsx`, `VoidSessionDialog()`
+- **Thin community `Community 375`** (2 nodes): `VoidSessionDialog.tsx`, `VoidSessionDialog()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 374`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 376`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 375`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 377`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 376`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 378`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 377`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 379`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 378`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 380`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 379`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
+- **Thin community `Community 381`** (2 nodes): `product-actions.tsx`, `useDeleteProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 380`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 382`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 381`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 383`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 382`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 384`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 383`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 385`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 384`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 386`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 385`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 387`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 386`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 388`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 387`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 389`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 388`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 390`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 389`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 391`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 390`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 392`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 391`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 393`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 392`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 394`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 393`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 395`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 394`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 396`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 395`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 397`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 396`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 398`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 397`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 399`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 398`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 400`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 399`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 401`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 400`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 402`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 401`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 403`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 402`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 404`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 403`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 405`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 404`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 406`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 405`** (2 nodes): `DateTimePicker()`, `date-time-picker.tsx`
+- **Thin community `Community 407`** (2 nodes): `DateTimePicker()`, `date-time-picker.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 406`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 408`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 407`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 409`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 408`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 410`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 409`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 411`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 410`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 412`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 411`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 413`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 412`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 414`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 413`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 415`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 414`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 416`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 415`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 417`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 416`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 418`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 417`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 419`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 418`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 420`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 419`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 421`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 420`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 422`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 421`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 423`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 422`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 424`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 423`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 425`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 424`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 426`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 425`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 427`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 426`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 428`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 427`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 429`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 428`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 430`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 429`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 431`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 430`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 432`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 431`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 433`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 432`** (2 nodes): `useCartOperations.ts`, `useCartOperations()`
+- **Thin community `Community 434`** (2 nodes): `useCartOperations.ts`, `useCartOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 433`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 435`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 434`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 436`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 435`** (2 nodes): `useCustomerOperations.ts`, `useCustomerOperations()`
+- **Thin community `Community 437`** (2 nodes): `useCustomerOperations.ts`, `useCustomerOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 436`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 438`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 437`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
+- **Thin community `Community 439`** (2 nodes): `useExpenseOperations.ts`, `useExpenseOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 438`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 440`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 439`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 441`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 440`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 442`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 441`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 443`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 442`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 444`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 443`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 445`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 444`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 446`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 445`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 447`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 446`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 448`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 447`** (2 nodes): `usePrint.ts`, `usePrint()`
+- **Thin community `Community 449`** (2 nodes): `usePrint.ts`, `usePrint()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 448`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 450`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 449`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 451`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 450`** (2 nodes): `useSessionManagement.ts`, `useSessionManagement()`
+- **Thin community `Community 452`** (2 nodes): `useSessionManagement.ts`, `useSessionManagement()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 451`** (2 nodes): `useSessionManagementExpense.ts`, `useSessionManagementExpense()`
+- **Thin community `Community 453`** (2 nodes): `useSessionManagementExpense.ts`, `useSessionManagementExpense()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 452`** (2 nodes): `useSessionManagerOperations.ts`, `useSessionManagerOperations()`
+- **Thin community `Community 454`** (2 nodes): `useSessionManagerOperations.ts`, `useSessionManagerOperations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 453`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 455`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 454`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 456`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 455`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 457`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 456`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 458`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 457`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 459`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 458`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 460`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 459`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 461`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 460`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 462`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 461`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 463`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 462`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 464`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 463`** (2 nodes): `LoginLayout()`, `_layout.tsx`
+- **Thin community `Community 465`** (2 nodes): `LoginLayout()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 464`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 466`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 465`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 467`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 466`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 468`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 467`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 469`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 468`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 470`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 469`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 471`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 470`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 472`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 471`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 473`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 472`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 474`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 473`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 475`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 474`** (2 nodes): `storybook-theme-decorator.tsx`, `withAthenaTheme()`
+- **Thin community `Community 476`** (2 nodes): `storybook-theme-decorator.tsx`, `withAthenaTheme()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 475`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 477`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 476`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 478`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 477`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 479`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 478`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 480`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 479`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 481`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 480`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 482`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 481`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 483`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 482`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 484`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 483`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 485`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 484`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 486`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 485`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 487`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 486`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
+- **Thin community `Community 488`** (2 nodes): `PickupOptions.tsx`, `isWithinRestrictionTime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 487`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 489`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 488`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 490`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 489`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 491`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 490`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 492`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 491`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 493`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 492`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 494`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 493`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 495`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 494`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 496`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 495`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 497`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 496`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 498`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 497`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 499`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 498`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 500`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 499`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 501`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 500`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 502`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 501`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 503`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 502`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 504`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 503`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 505`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 504`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 506`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 505`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 507`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 506`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 508`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 507`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 509`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 508`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 510`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 509`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 511`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 510`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 512`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 511`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 513`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 512`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 514`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 513`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 515`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 514`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 516`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 515`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 517`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 516`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 518`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 517`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 519`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 518`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 520`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 519`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 521`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 520`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 522`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 521`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 523`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 522`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 524`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 523`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 525`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 524`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 526`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 525`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 527`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 526`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 528`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 527`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 529`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 528`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 530`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 529`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 531`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 530`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 532`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 531`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 533`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 532`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 534`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 533`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 535`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 534`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 536`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 535`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 537`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 536`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 538`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 537`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 539`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 538`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 540`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 539`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 541`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 540`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 542`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 541`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 543`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 542`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 544`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 543`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 545`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 544`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 546`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 545`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 547`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 546`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 548`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 547`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 549`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 548`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 550`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 551`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 552`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 553`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 554`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 555`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 556`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 557`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 558`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 559`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 560`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 561`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 562`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 563`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 564`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 565`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 566`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 567`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 568`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 569`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 570`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 571`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 572`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 573`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 574`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 575`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 576`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 577`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 578`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 579`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 580`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 581`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 582`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 583`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 584`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 585`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 586`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 587`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 588`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 589`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 590`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 591`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 592`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 593`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 594`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (1 nodes): `api.d.ts`
+- **Thin community `Community 595`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (1 nodes): `api.js`
+- **Thin community `Community 596`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 597`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (1 nodes): `server.d.ts`
+- **Thin community `Community 598`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (1 nodes): `server.js`
+- **Thin community `Community 599`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (1 nodes): `app.ts`
+- **Thin community `Community 600`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (1 nodes): `auth.config.js`
+- **Thin community `Community 601`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (1 nodes): `auth.ts`
+- **Thin community `Community 602`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (1 nodes): `countries.ts`
+- **Thin community `Community 603`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (1 nodes): `email.ts`
+- **Thin community `Community 604`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (1 nodes): `ghana.ts`
+- **Thin community `Community 605`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (1 nodes): `payment.ts`
+- **Thin community `Community 606`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (1 nodes): `crons.ts`
+- **Thin community `Community 607`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 608`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 609`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 610`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 611`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (1 nodes): `env.ts`
+- **Thin community `Community 612`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (1 nodes): `analytics.ts`
+- **Thin community `Community 613`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (1 nodes): `auth.ts`
+- **Thin community `Community 614`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 615`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (1 nodes): `categories.ts`
+- **Thin community `Community 616`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (1 nodes): `colors.ts`
+- **Thin community `Community 617`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (1 nodes): `index.ts`
+- **Thin community `Community 618`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (1 nodes): `organizations.ts`
+- **Thin community `Community 619`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (1 nodes): `products.ts`
+- **Thin community `Community 620`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (1 nodes): `stores.ts`
+- **Thin community `Community 621`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 622`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (1 nodes): `index.ts`
+- **Thin community `Community 623`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (1 nodes): `bag.ts`
+- **Thin community `Community 624`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (1 nodes): `guest.ts`
+- **Thin community `Community 625`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (1 nodes): `index.ts`
+- **Thin community `Community 626`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (1 nodes): `me.ts`
+- **Thin community `Community 627`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (1 nodes): `offers.ts`
+- **Thin community `Community 628`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 629`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (1 nodes): `paystack.ts`
+- **Thin community `Community 630`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (1 nodes): `reviews.ts`
+- **Thin community `Community 631`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (1 nodes): `rewards.ts`
+- **Thin community `Community 632`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 633`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (1 nodes): `security.test.ts`
+- **Thin community `Community 634`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (1 nodes): `storefront.ts`
+- **Thin community `Community 635`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (1 nodes): `upsells.ts`
+- **Thin community `Community 636`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (1 nodes): `user.ts`
+- **Thin community `Community 637`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 638`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (1 nodes): `health.test.ts`
+- **Thin community `Community 639`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (1 nodes): `http.ts`
+- **Thin community `Community 640`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 641`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (1 nodes): `auth.ts`
+- **Thin community `Community 642`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 643`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 644`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (1 nodes): `categories.ts`
+- **Thin community `Community 645`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (1 nodes): `colors.ts`
+- **Thin community `Community 646`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 647`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (1 nodes): `expenseSessionItems.ts`
+- **Thin community `Community 648`** (1 nodes): `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (1 nodes): `expenseTransactions.ts`
+- **Thin community `Community 649`** (1 nodes): `expenseTransactions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 650`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 651`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 652`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (1 nodes): `organizations.ts`
+- **Thin community `Community 653`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 654`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (1 nodes): `posSessionItems.ts`
+- **Thin community `Community 655`** (1 nodes): `posSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 656`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (1 nodes): `productSku.ts`
+- **Thin community `Community 657`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (1 nodes): `productUtil.ts`
+- **Thin community `Community 658`** (1 nodes): `productUtil.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 659`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 660`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 661`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 662`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 663`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 664`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 665`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 666`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (1 nodes): `client.test.ts`
+- **Thin community `Community 667`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (1 nodes): `config.test.ts`
+- **Thin community `Community 668`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 669`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (1 nodes): `types.ts`
+- **Thin community `Community 670`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (1 nodes): `ResendOTP.ts`
+- **Thin community `Community 671`** (1 nodes): `ResendOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (1 nodes): `schema.ts`
+- **Thin community `Community 672`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 673`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 674`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 675`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 676`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (1 nodes): `cashier.ts`
+- **Thin community `Community 677`** (1 nodes): `cashier.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (1 nodes): `category.ts`
+- **Thin community `Community 678`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (1 nodes): `color.ts`
+- **Thin community `Community 679`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 680`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 681`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (1 nodes): `index.ts`
+- **Thin community `Community 682`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 683`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (1 nodes): `organization.ts`
+- **Thin community `Community 684`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 685`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (1 nodes): `product.ts`
+- **Thin community `Community 686`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 687`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 688`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (1 nodes): `store.ts`
+- **Thin community `Community 689`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 690`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 691`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (1 nodes): `customer.ts`
+- **Thin community `Community 692`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 693`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 694`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 695`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 696`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (1 nodes): `index.ts`
+- **Thin community `Community 697`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (1 nodes): `posSession.ts`
+- **Thin community `Community 698`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 699`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 700`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 701`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 702`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (1 nodes): `analytics.ts`
+- **Thin community `Community 703`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (1 nodes): `bag.ts`
+- **Thin community `Community 704`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 705`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 706`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 707`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (1 nodes): `customer.ts`
+- **Thin community `Community 708`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (1 nodes): `guest.ts`
+- **Thin community `Community 709`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (1 nodes): `index.ts`
+- **Thin community `Community 710`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (1 nodes): `offer.ts`
+- **Thin community `Community 711`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 712`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 713`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (1 nodes): `review.ts`
+- **Thin community `Community 714`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (1 nodes): `rewards.ts`
+- **Thin community `Community 715`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 716`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 717`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 718`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 719`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 720`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 721`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (1 nodes): `bag.ts`
+- **Thin community `Community 722`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 723`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (1 nodes): `customer.ts`
+- **Thin community `Community 724`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (1 nodes): `guest.ts`
+- **Thin community `Community 725`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 726`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (1 nodes): `payment.ts`
+- **Thin community `Community 727`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 728`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (1 nodes): `rewards.ts`
+- **Thin community `Community 729`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 730`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 731`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (1 nodes): `users.ts`
+- **Thin community `Community 732`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (1 nodes): `payment.ts`
+- **Thin community `Community 733`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 734`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (1 nodes): `index.ts`
+- **Thin community `Community 735`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 736`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 737`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 738`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 739`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 740`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 741`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 742`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (1 nodes): `constants.ts`
+- **Thin community `Community 743`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 744`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 745`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 746`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (1 nodes): `types.ts`
+- **Thin community `Community 747`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 748`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 749`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 750`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 751`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 752`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 753`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 754`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 755`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (1 nodes): `columns.tsx`
+- **Thin community `Community 756`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 757`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 758`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 759`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 760`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (1 nodes): `columns.tsx`
+- **Thin community `Community 761`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 762`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 763`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (1 nodes): `chart.tsx`
+- **Thin community `Community 764`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (1 nodes): `columns.tsx`
+- **Thin community `Community 765`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 766`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 767`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (1 nodes): `columns.tsx`
+- **Thin community `Community 768`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (1 nodes): `constants.ts`
+- **Thin community `Community 769`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 770`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 771`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 772`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (1 nodes): `data.ts`
+- **Thin community `Community 773`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (1 nodes): `columns.tsx`
+- **Thin community `Community 774`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 775`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 776`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (1 nodes): `columns.tsx`
+- **Thin community `Community 777`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 778`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 779`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 780`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 781`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 782`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (1 nodes): `app-sidebar.tsx`
+- **Thin community `Community 783`** (1 nodes): `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 784`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (1 nodes): `constants.ts`
+- **Thin community `Community 785`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 786`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 787`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 788`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (1 nodes): `data.ts`
+- **Thin community `Community 789`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 790`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 791`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (1 nodes): `columns.tsx`
+- **Thin community `Community 792`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 793`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 794`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 795`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 796`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 797`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (1 nodes): `columns.tsx`
+- **Thin community `Community 798`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (1 nodes): `constants.ts`
+- **Thin community `Community 799`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 800`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 801`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 802`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 803`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (1 nodes): `index.tsx`
+- **Thin community `Community 804`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (1 nodes): `columns.tsx`
+- **Thin community `Community 805`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 806`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 807`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 808`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (1 nodes): `ExpenseCompletion.tsx`
+- **Thin community `Community 809`** (1 nodes): `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 810`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 811`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 812`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 813`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (1 nodes): `constants.ts`
+- **Thin community `Community 814`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 815`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 816`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 817`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (1 nodes): `data.ts`
+- **Thin community `Community 818`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (1 nodes): `constants.ts`
+- **Thin community `Community 819`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 820`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 821`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 822`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 823`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (1 nodes): `data.ts`
+- **Thin community `Community 824`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 825`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (1 nodes): `constants.ts`
+- **Thin community `Community 826`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 827`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 828`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 829`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 830`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (1 nodes): `data.ts`
+- **Thin community `Community 831`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 832`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (1 nodes): `CartItems.tsx`
+- **Thin community `Community 833`** (1 nodes): `CartItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (1 nodes): `CashierAuthDialog.tsx`
+- **Thin community `Community 834`** (1 nodes): `CashierAuthDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 835`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 836`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (1 nodes): `SearchResultsSection.tsx`
+- **Thin community `Community 837`** (1 nodes): `SearchResultsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 838`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (1 nodes): `ExpenseReportView.tsx`
+- **Thin community `Community 839`** (1 nodes): `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 840`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (1 nodes): `TransactionView.tsx`
+- **Thin community `Community 841`** (1 nodes): `TransactionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (1 nodes): `types.ts`
+- **Thin community `Community 842`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 843`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 844`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 845`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (1 nodes): `ProductDetailView.tsx`
+- **Thin community `Community 846`** (1 nodes): `ProductDetailView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (1 nodes): `ProductStatus.tsx`
+- **Thin community `Community 847`** (1 nodes): `ProductStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (1 nodes): `CategoryListView.tsx`
+- **Thin community `Community 848`** (1 nodes): `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 849`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (1 nodes): `Products.tsx`
+- **Thin community `Community 850`** (1 nodes): `Products.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 851`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 852`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 853`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 854`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 855`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 856`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 857`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 858`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 859`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (1 nodes): `data.ts`
+- **Thin community `Community 860`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 861`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (1 nodes): `PromoCodePreview.tsx`
+- **Thin community `Community 862`** (1 nodes): `PromoCodePreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 863`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 864`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 865`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (1 nodes): `columns.tsx`
+- **Thin community `Community 866`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 867`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 868`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 869`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 870`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 871`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (1 nodes): `columns.tsx`
+- **Thin community `Community 872`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (1 nodes): `constants.ts`
+- **Thin community `Community 873`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 874`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 875`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 876`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (1 nodes): `data.ts`
+- **Thin community `Community 877`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (1 nodes): `types.ts`
+- **Thin community `Community 878`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 879`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 880`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 881`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 882`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 883`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (1 nodes): `index.tsx`
+- **Thin community `Community 884`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 885`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 886`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (1 nodes): `button.tsx`
+- **Thin community `Community 887`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 888`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (1 nodes): `calendar.tsx`
+- **Thin community `Community 889`** (1 nodes): `calendar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (1 nodes): `card.tsx`
+- **Thin community `Community 890`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 891`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 892`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (1 nodes): `command.tsx`
+- **Thin community `Community 893`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 894`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 895`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 896`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (1 nodes): `form.tsx`
+- **Thin community `Community 897`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (1 nodes): `icons.tsx`
+- **Thin community `Community 898`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 899`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (1 nodes): `input.tsx`
+- **Thin community `Community 900`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 901`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (1 nodes): `popover.tsx`
+- **Thin community `Community 902`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 903`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 904`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 905`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (1 nodes): `select.tsx`
+- **Thin community `Community 906`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (1 nodes): `separator.tsx`
+- **Thin community `Community 907`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 908`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (1 nodes): `switch.tsx`
+- **Thin community `Community 909`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (1 nodes): `table.tsx`
+- **Thin community `Community 910`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 911`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 912`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 913`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 914`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 915`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 916`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 917`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (1 nodes): `columns.tsx`
+- **Thin community `Community 918`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (1 nodes): `constants.ts`
+- **Thin community `Community 919`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 920`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 921`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 922`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (1 nodes): `data.ts`
+- **Thin community `Community 923`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 924`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 925`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (1 nodes): `columns.tsx`
+- **Thin community `Community 926`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (1 nodes): `data-table-column-header.tsx`
+- **Thin community `Community 927`** (1 nodes): `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 928`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 929`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 930`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 931`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 932`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 933`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 934`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 935`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (1 nodes): `UserBehaviorInsights.tsx`
+- **Thin community `Community 936`** (1 nodes): `UserBehaviorInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `index.ts`
+- **Thin community `Community 937`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `config.ts`
+- **Thin community `Community 938`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 939`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 940`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 941`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `aws.ts`
+- **Thin community `Community 942`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `constants.ts`
+- **Thin community `Community 943`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `countries.ts`
+- **Thin community `Community 944`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `ghana.ts`
+- **Thin community `Community 945`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 946`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `constants.ts`
+- **Thin community `Community 947`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 948`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 949`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `category.ts`
+- **Thin community `Community 950`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `product.ts`
+- **Thin community `Community 951`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `store.ts`
+- **Thin community `Community 952`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 953`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `user.ts`
+- **Thin community `Community 954`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 955`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 956`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 957`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `__root.tsx`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `index.tsx`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `index.tsx`
+- **Thin community `Community 958`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 959`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 960`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 961`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 962`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 963`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 964`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `index.tsx`
+- **Thin community `Community 965`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 966`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 967`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 968`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `home.tsx`
+- **Thin community `Community 969`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 970`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 971`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 972`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `index.tsx`
+- **Thin community `Community 973`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 974`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 975`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 976`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `index.tsx`
+- **Thin community `Community 977`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 978`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 979`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 980`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 981`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 982`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 983`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `expense.index.tsx`
+- **Thin community `Community 984`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `index.tsx`
+- **Thin community `Community 985`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 986`** (1 nodes): `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 987`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 988`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 989`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (1 nodes): `edit.tsx`
+- **Thin community `Community 990`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `index.tsx`
+- **Thin community `Community 991`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `index.tsx`
+- **Thin community `Community 992`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `new.tsx`
+- **Thin community `Community 993`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 994`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 995`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 996`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 997`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `index.tsx`
+- **Thin community `Community 998`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `new.tsx`
+- **Thin community `Community 999`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1000`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1001`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1002`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `index.tsx`
+- **Thin community `Community 1003`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1004`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1005`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1006`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1007`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `posStore.ts`
+- **Thin community `Community 1008`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1009`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1010`** (1 nodes): `posStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1011`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1012`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1013`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1014`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1015`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1016`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1017`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1018`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1019`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1020`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `setup.ts`
+- **Thin community `Community 1021`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `usePrint.test.ts`
+- **Thin community `Community 1022`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1023`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `types.ts`
+- **Thin community `Community 1024`** (1 nodes): `usePrint.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1025`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1026`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1027`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1028`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1029`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1030`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `types.ts`
+- **Thin community `Community 1031`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1032`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `client.tsx`
+- **Thin community `Community 1033`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1034`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1035`** (1 nodes): `client.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1036`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1037`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1038`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1039`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1040`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1041`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `schema.ts`
+- **Thin community `Community 1042`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1043`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1044`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1045`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1046`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1047`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1048`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1049`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1050`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1051`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `types.ts`
+- **Thin community `Community 1052`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1053`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1054`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1055`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1056`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1057`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1058`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1059`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `constants.ts`
+- **Thin community `Community 1060`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1061`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `About.tsx`
+- **Thin community `Community 1062`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1063`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1064`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1065`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1066`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1067`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1068`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1069`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1070`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1071`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `types.ts`
+- **Thin community `Community 1072`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1073`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1074`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1075`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1076`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1077`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1078`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1079`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1080`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1081`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1082`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `button.tsx`
+- **Thin community `Community 1083`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `card.tsx`
+- **Thin community `Community 1084`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1085`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `command.tsx`
+- **Thin community `Community 1086`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1087`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1088`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1089`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `form.tsx`
+- **Thin community `Community 1090`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1091`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1092`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1093`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1094`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `input.tsx`
+- **Thin community `Community 1095`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `label.tsx`
+- **Thin community `Community 1096`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1097`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1098`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1099`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `index.ts`
+- **Thin community `Community 1100`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `types.ts`
+- **Thin community `Community 1101`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1102`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1103`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1104`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1105`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `select.tsx`
+- **Thin community `Community 1106`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1107`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1108`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `table.tsx`
+- **Thin community `Community 1109`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1110`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1111`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1112`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1113`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1114`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `config.ts`
+- **Thin community `Community 1115`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1116`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1117`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1118`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `constants.ts`
+- **Thin community `Community 1119`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `countries.ts`
+- **Thin community `Community 1120`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1121`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1122`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1123`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1124`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `index.ts`
+- **Thin community `Community 1125`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `store.ts`
+- **Thin community `Community 1126`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `bag.ts`
+- **Thin community `Community 1127`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1128`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `category.ts`
+- **Thin community `Community 1129`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `organization.ts`
+- **Thin community `Community 1130`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `product.ts`
+- **Thin community `Community 1131`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `store.ts`
+- **Thin community `Community 1132`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1133`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `user.ts`
+- **Thin community `Community 1134`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `states.ts`
+- **Thin community `Community 1135`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1136`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1137`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1138`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1139`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1140`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1141`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1142`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `index.tsx`
+- **Thin community `Community 1143`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1144`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1145`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1146`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1147`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1148`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1149`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1150`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `index.tsx`
+- **Thin community `Community 1151`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1152`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `ssr.tsx`
+- **Thin community `Community 1153`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1154`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1155`** (1 nodes): `ssr.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1156`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `index.js`
+- **Thin community `Community 1157`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1158`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1159`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1160`** (1 nodes): `harness-app-registry.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1161`** (1 nodes): `valkey-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1162`** (1 nodes): `harness-behavior-scenarios.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -22624,6 +22624,18 @@
       "weight": 1
     },
     {
+      "_src": "pre_commit_generated_artifacts_runprecommitgeneratedartifacts",
+      "_tgt": "pre_commit_generated_artifacts_stagetrackedgraphifyartifacts",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "pre_commit_generated_artifacts_stagetrackedgraphifyartifacts",
+      "source_file": "scripts/pre-commit-generated-artifacts.ts",
+      "source_location": "L60",
+      "target": "pre_commit_generated_artifacts_runprecommitgeneratedartifacts",
+      "weight": 1
+    },
+    {
       "_src": "pre_push_review_runprepushreview",
       "_tgt": "pre_push_review_formatblockerlist",
       "confidence": "EXTRACTED",
@@ -22631,7 +22643,7 @@
       "relation": "calls",
       "source": "pre_push_review_formatblockerlist",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L257",
+      "source_location": "L258",
       "target": "pre_push_review_runprepushreview",
       "weight": 1
     },
@@ -22643,7 +22655,7 @@
       "relation": "calls",
       "source": "pre_push_review_shouldrunharnessimplementationtests",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L266",
+      "source_location": "L267",
       "target": "pre_push_review_runprepushreview",
       "weight": 1
     },
@@ -27328,6 +27340,54 @@
       "weight": 1
     },
     {
+      "_src": "scripts_pre_commit_generated_artifacts_test_ts",
+      "_tgt": "pre_commit_generated_artifacts_test_log",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_pre_commit_generated_artifacts_test_ts",
+      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
+      "source_location": "L69",
+      "target": "pre_commit_generated_artifacts_test_log",
+      "weight": 1
+    },
+    {
+      "_src": "scripts_pre_commit_generated_artifacts_test_ts",
+      "_tgt": "pre_commit_generated_artifacts_test_spawn",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_pre_commit_generated_artifacts_test_ts",
+      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
+      "source_location": "L62",
+      "target": "pre_commit_generated_artifacts_test_spawn",
+      "weight": 1
+    },
+    {
+      "_src": "scripts_pre_commit_generated_artifacts_ts",
+      "_tgt": "pre_commit_generated_artifacts_runprecommitgeneratedartifacts",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_pre_commit_generated_artifacts_ts",
+      "source_file": "scripts/pre-commit-generated-artifacts.ts",
+      "source_location": "L45",
+      "target": "pre_commit_generated_artifacts_runprecommitgeneratedartifacts",
+      "weight": 1
+    },
+    {
+      "_src": "scripts_pre_commit_generated_artifacts_ts",
+      "_tgt": "pre_commit_generated_artifacts_stagetrackedgraphifyartifacts",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_pre_commit_generated_artifacts_ts",
+      "source_file": "scripts/pre-commit-generated-artifacts.ts",
+      "source_location": "L20",
+      "target": "pre_commit_generated_artifacts_stagetrackedgraphifyartifacts",
+      "weight": 1
+    },
+    {
       "_src": "scripts_pre_push_review_test_ts",
       "_tgt": "pre_push_review_test_error",
       "confidence": "EXTRACTED",
@@ -27371,7 +27431,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_ts",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L151",
+      "source_location": "L152",
       "target": "pre_push_review_collectrepairableharnessdocerrors",
       "weight": 1
     },
@@ -27383,7 +27443,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_ts",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L183",
+      "source_location": "L184",
       "target": "pre_push_review_formatblockerlist",
       "weight": 1
     },
@@ -27395,7 +27455,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_ts",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L58",
+      "source_location": "L59",
       "target": "pre_push_review_getchangedfilesvsoriginmain",
       "weight": 1
     },
@@ -27407,7 +27467,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_ts",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L99",
+      "source_location": "L100",
       "target": "pre_push_review_runarchitecturecheck",
       "weight": 1
     },
@@ -27419,7 +27479,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_ts",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L117",
+      "source_location": "L118",
       "target": "pre_push_review_runharnessgenerate",
       "weight": 1
     },
@@ -27431,7 +27491,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_ts",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L121",
+      "source_location": "L122",
       "target": "pre_push_review_runharnessimplementationtests",
       "weight": 1
     },
@@ -27443,7 +27503,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_ts",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L133",
+      "source_location": "L134",
       "target": "pre_push_review_runharnessinferentialreview",
       "weight": 1
     },
@@ -27455,7 +27515,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_ts",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L111",
+      "source_location": "L112",
       "target": "pre_push_review_runharnessselfreview",
       "weight": 1
     },
@@ -27467,7 +27527,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_ts",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L187",
+      "source_location": "L188",
       "target": "pre_push_review_runprepushreview",
       "weight": 1
     },
@@ -27479,7 +27539,7 @@
       "relation": "contains",
       "source": "scripts_pre_push_review_ts",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L145",
+      "source_location": "L146",
       "target": "pre_push_review_shouldrunharnessimplementationtests",
       "weight": 1
     },
@@ -30411,6 +30471,24 @@
     {
       "community": 1000,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1001,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
+      "label": "new.tsx",
+      "norm_label": "new.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/new.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1002,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
@@ -30418,7 +30496,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1001,
+      "community": 1003,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_new_index_tsx",
       "label": "new.index.tsx",
@@ -30427,7 +30505,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1002,
+      "community": 1004,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_users_userid_tsx",
       "label": "users.$userId.tsx",
@@ -30436,7 +30514,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1003,
+      "community": 1005,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_index_tsx",
       "label": "index.tsx",
@@ -30445,7 +30523,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1004,
+      "community": 1006,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_join_team_index_tsx",
       "label": "join-team.index.tsx",
@@ -30454,7 +30532,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1005,
+      "community": 1007,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_test_tsx",
       "label": "_layout.index.test.tsx",
@@ -30463,7 +30541,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1006,
+      "community": 1008,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storessettingsaccordion_tsx",
       "label": "StoresSettingsAccordion.tsx",
@@ -30472,30 +30550,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1007,
+      "community": 1009,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stores_expensestore_ts",
       "label": "expenseStore.ts",
       "norm_label": "expensestore.ts",
       "source_file": "packages/athena-webapp/src/stores/expenseStore.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1008,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stores_posstore_ts",
-      "label": "posStore.ts",
-      "norm_label": "posstore.ts",
-      "source_file": "packages/athena-webapp/src/stores/posStore.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1009,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_foundations_overview_stories_tsx",
-      "label": "Overview.stories.tsx",
-      "norm_label": "overview.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/Overview.stories.tsx",
       "source_location": "L1"
     },
     {
@@ -30546,6 +30606,24 @@
     {
       "community": 1010,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_stores_posstore_ts",
+      "label": "posStore.ts",
+      "norm_label": "posstore.ts",
+      "source_file": "packages/athena-webapp/src/stores/posStore.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1011,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_foundations_overview_stories_tsx",
+      "label": "Overview.stories.tsx",
+      "norm_label": "overview.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/Overview.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1012,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_foundations_content_test_tsx",
       "label": "foundations-content.test.tsx",
       "norm_label": "foundations-content.test.tsx",
@@ -30553,7 +30631,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1011,
+      "community": 1013,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_stories_tsx",
       "label": "Introduction.stories.tsx",
@@ -30562,7 +30640,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1012,
+      "community": 1014,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_content_test_tsx",
       "label": "introduction-content.test.tsx",
@@ -30571,7 +30649,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1013,
+      "community": 1015,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_content_tsx",
       "label": "introduction-content.tsx",
@@ -30580,7 +30658,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1014,
+      "community": 1016,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_adminshell_stories_tsx",
       "label": "AdminShell.stories.tsx",
@@ -30589,7 +30667,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1015,
+      "community": 1017,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_test_tsx",
       "label": "admin-shell-patterns.test.tsx",
@@ -30598,7 +30676,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1016,
+      "community": 1018,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_surfaces_stories_tsx",
       "label": "Surfaces.stories.tsx",
@@ -30607,30 +30685,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1017,
+      "community": 1019,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_dashboardworkspace_stories_tsx",
       "label": "DashboardWorkspace.stories.tsx",
       "norm_label": "dashboardworkspace.stories.tsx",
       "source_file": "packages/athena-webapp/src/stories/Templates/DashboardWorkspace.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1018,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_dataworkspace_stories_tsx",
-      "label": "DataWorkspace.stories.tsx",
-      "norm_label": "dataworkspace.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/DataWorkspace.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1019,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_templates_settingsworkspace_stories_tsx",
-      "label": "SettingsWorkspace.stories.tsx",
-      "norm_label": "settingsworkspace.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Templates/SettingsWorkspace.stories.tsx",
       "source_location": "L1"
     },
     {
@@ -30681,6 +30741,24 @@
     {
       "community": 1020,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_templates_dataworkspace_stories_tsx",
+      "label": "DataWorkspace.stories.tsx",
+      "norm_label": "dataworkspace.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/DataWorkspace.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1021,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_templates_settingsworkspace_stories_tsx",
+      "label": "SettingsWorkspace.stories.tsx",
+      "norm_label": "settingsworkspace.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Templates/SettingsWorkspace.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1022,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_test_tsx",
       "label": "reference-fixtures.test.tsx",
       "norm_label": "reference-fixtures.test.tsx",
@@ -30688,7 +30766,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1021,
+      "community": 1023,
       "file_type": "code",
       "id": "packages_athena_webapp_src_test_setup_ts",
       "label": "setup.ts",
@@ -30697,7 +30775,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1022,
+      "community": 1024,
       "file_type": "code",
       "id": "packages_athena_webapp_src_tests_pos_useprint_test_ts",
       "label": "usePrint.test.ts",
@@ -30706,7 +30784,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1023,
+      "community": 1025,
       "file_type": "code",
       "id": "packages_athena_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
@@ -30715,7 +30793,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1024,
+      "community": 1026,
       "file_type": "code",
       "id": "packages_athena_webapp_types_ts",
       "label": "types.ts",
@@ -30724,7 +30802,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1025,
+      "community": 1027,
       "file_type": "code",
       "id": "packages_athena_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
@@ -30733,7 +30811,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1026,
+      "community": 1028,
       "file_type": "code",
       "id": "packages_athena_webapp_vitest_setup_ts",
       "label": "vitest.setup.ts",
@@ -30742,7 +30820,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1027,
+      "community": 1029,
       "file_type": "code",
       "id": "packages_storefront_webapp_eslint_config_js",
       "label": "eslint.config.js",
@@ -30751,160 +30829,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1028,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_global_d_ts",
-      "label": "global.d.ts",
-      "norm_label": "global.d.ts",
-      "source_file": "packages/storefront-webapp/global.d.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1029,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_playwright_config_ts",
-      "label": "playwright.config.ts",
-      "norm_label": "playwright.config.ts",
-      "source_file": "packages/storefront-webapp/playwright.config.ts",
-      "source_location": "L1"
-    },
-    {
       "community": 103,
-      "file_type": "code",
-      "id": "index_feesview",
-      "label": "FeesView()",
-      "norm_label": "feesview()",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
-      "source_location": "L29"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "index_header",
-      "label": "Header()",
-      "norm_label": "header()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L42"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "index_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L105"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 103,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1030,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_analytics_test_ts",
-      "label": "analytics.test.ts",
-      "norm_label": "analytics.test.ts",
-      "source_file": "packages/storefront-webapp/src/api/analytics.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1031,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/storefront-webapp/src/api/types.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1032,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_assets_icons_hearticonfilled_tsx",
-      "label": "HeartIconFilled.tsx",
-      "norm_label": "hearticonfilled.tsx",
-      "source_file": "packages/storefront-webapp/src/assets/icons/HeartIconFilled.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1033,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_client_tsx",
-      "label": "client.tsx",
-      "norm_label": "client.tsx",
-      "source_file": "packages/storefront-webapp/src/client.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1034,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_defaultcatchboundary_tsx",
-      "label": "DefaultCatchBoundary.tsx",
-      "norm_label": "defaultcatchboundary.tsx",
-      "source_file": "packages/storefront-webapp/src/components/DefaultCatchBoundary.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1035,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_homepage_test_tsx",
-      "label": "HomePage.test.tsx",
-      "norm_label": "homepage.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/HomePage.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1036,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_productcard_test_tsx",
-      "label": "ProductCard.test.tsx",
-      "norm_label": "productcard.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ProductCard.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1037,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_productcard_tsx",
-      "label": "ProductCard.tsx",
-      "norm_label": "productcard.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ProductCard.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1038,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_upsell_tsx",
-      "label": "Upsell.tsx",
-      "norm_label": "upsell.tsx",
-      "source_file": "packages/storefront-webapp/src/components/Upsell.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1039,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_checkout_test_tsx",
-      "label": "Checkout.test.tsx",
-      "norm_label": "checkout.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/Checkout.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 104,
       "file_type": "code",
       "id": "dashboard_getperiodrange",
       "label": "getPeriodRange()",
@@ -30913,7 +30838,7 @@
       "source_location": "L20"
     },
     {
-      "community": 104,
+      "community": 103,
       "file_type": "code",
       "id": "dashboard_loadingsection",
       "label": "LoadingSection()",
@@ -30922,7 +30847,7 @@
       "source_location": "L50"
     },
     {
-      "community": 104,
+      "community": 103,
       "file_type": "code",
       "id": "dashboard_renderproductssection",
       "label": "renderProductsSection()",
@@ -30931,7 +30856,7 @@
       "source_location": "L342"
     },
     {
-      "community": 104,
+      "community": 103,
       "file_type": "code",
       "id": "dashboard_rendersalessection",
       "label": "renderSalesSection()",
@@ -30940,7 +30865,7 @@
       "source_location": "L322"
     },
     {
-      "community": 104,
+      "community": 103,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
       "label": "Dashboard.tsx",
@@ -30949,97 +30874,97 @@
       "source_location": "L1"
     },
     {
-      "community": 1040,
+      "community": 1030,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_checkout_tsx",
-      "label": "Checkout.tsx",
-      "norm_label": "checkout.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/Checkout.tsx",
+      "id": "packages_storefront_webapp_global_d_ts",
+      "label": "global.d.ts",
+      "norm_label": "global.d.ts",
+      "source_file": "packages/storefront-webapp/global.d.ts",
       "source_location": "L1"
     },
     {
-      "community": 1041,
+      "community": 1031,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_customerinfosection_tsx",
-      "label": "CustomerInfoSection.tsx",
-      "norm_label": "customerinfosection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/CustomerInfoSection.tsx",
+      "id": "packages_storefront_webapp_playwright_config_ts",
+      "label": "playwright.config.ts",
+      "norm_label": "playwright.config.ts",
+      "source_file": "packages/storefront-webapp/playwright.config.ts",
       "source_location": "L1"
     },
     {
-      "community": 1042,
+      "community": 1032,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_schema_ts",
-      "label": "schema.ts",
-      "norm_label": "schema.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/schema.ts",
+      "id": "packages_storefront_webapp_src_api_analytics_test_ts",
+      "label": "analytics.test.ts",
+      "norm_label": "analytics.test.ts",
+      "source_file": "packages/storefront-webapp/src/api/analytics.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1043,
+      "community": 1033,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_deliverydetailssection_tsx",
-      "label": "DeliveryDetailsSection.tsx",
-      "norm_label": "deliverydetailssection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetailsSection.tsx",
+      "id": "packages_storefront_webapp_src_api_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/storefront-webapp/src/api/types.ts",
       "source_location": "L1"
     },
     {
-      "community": 1044,
+      "community": 1034,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_test_ts",
-      "label": "checkoutStorage.test.ts",
-      "norm_label": "checkoutstorage.test.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.test.ts",
+      "id": "packages_storefront_webapp_src_assets_icons_hearticonfilled_tsx",
+      "label": "HeartIconFilled.tsx",
+      "norm_label": "hearticonfilled.tsx",
+      "source_file": "packages/storefront-webapp/src/assets/icons/HeartIconFilled.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1045,
+      "community": 1035,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_test_ts",
-      "label": "deliveryFees.test.ts",
-      "norm_label": "deliveryfees.test.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.test.ts",
+      "id": "packages_storefront_webapp_src_client_tsx",
+      "label": "client.tsx",
+      "norm_label": "client.tsx",
+      "source_file": "packages/storefront-webapp/src/client.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1046,
+      "community": 1036,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_test_ts",
-      "label": "deriveCheckoutState.test.ts",
-      "norm_label": "derivecheckoutstate.test.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.test.ts",
+      "id": "packages_storefront_webapp_src_components_defaultcatchboundary_tsx",
+      "label": "DefaultCatchBoundary.tsx",
+      "norm_label": "defaultcatchboundary.tsx",
+      "source_file": "packages/storefront-webapp/src/components/DefaultCatchBoundary.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1047,
+      "community": 1037,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_billingdetailsschema_ts",
-      "label": "billingDetailsSchema.ts",
-      "norm_label": "billingdetailsschema.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/billingDetailsSchema.ts",
+      "id": "packages_storefront_webapp_src_components_homepage_test_tsx",
+      "label": "HomePage.test.tsx",
+      "norm_label": "homepage.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/HomePage.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1048,
+      "community": 1038,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutformschema_ts",
-      "label": "checkoutFormSchema.ts",
-      "norm_label": "checkoutformschema.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutFormSchema.ts",
+      "id": "packages_storefront_webapp_src_components_productcard_test_tsx",
+      "label": "ProductCard.test.tsx",
+      "norm_label": "productcard.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ProductCard.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1049,
+      "community": 1039,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_customerdetailsschema_ts",
-      "label": "customerDetailsSchema.ts",
-      "norm_label": "customerdetailsschema.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/customerDetailsSchema.ts",
+      "id": "packages_storefront_webapp_src_components_productcard_tsx",
+      "label": "ProductCard.tsx",
+      "norm_label": "productcard.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ProductCard.tsx",
       "source_location": "L1"
     },
     {
-      "community": 105,
+      "community": 104,
       "file_type": "code",
       "id": "herosectiontabs_handledisplaytypechange",
       "label": "handleDisplayTypeChange()",
@@ -31048,7 +30973,7 @@
       "source_location": "L61"
     },
     {
-      "community": 105,
+      "community": 104,
       "file_type": "code",
       "id": "herosectiontabs_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -31057,7 +30982,7 @@
       "source_location": "L57"
     },
     {
-      "community": 105,
+      "community": 104,
       "file_type": "code",
       "id": "herosectiontabs_handleoverlaytoggle",
       "label": "handleOverlayToggle()",
@@ -31066,7 +30991,7 @@
       "source_location": "L98"
     },
     {
-      "community": 105,
+      "community": 104,
       "file_type": "code",
       "id": "herosectiontabs_handletexttoggle",
       "label": "handleTextToggle()",
@@ -31075,7 +31000,7 @@
       "source_location": "L134"
     },
     {
-      "community": 105,
+      "community": 104,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
       "label": "HeroSectionTabs.tsx",
@@ -31084,97 +31009,97 @@
       "source_location": "L1"
     },
     {
-      "community": 1050,
+      "community": 1040,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_deliverydetailsschema_ts",
-      "label": "deliveryDetailsSchema.ts",
-      "norm_label": "deliverydetailsschema.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/deliveryDetailsSchema.ts",
+      "id": "packages_storefront_webapp_src_components_upsell_tsx",
+      "label": "Upsell.tsx",
+      "norm_label": "upsell.tsx",
+      "source_file": "packages/storefront-webapp/src/components/Upsell.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1051,
+      "community": 1041,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_ts",
-      "label": "webOrderSchema.ts",
-      "norm_label": "weborderschema.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.ts",
+      "id": "packages_storefront_webapp_src_components_checkout_checkout_test_tsx",
+      "label": "Checkout.test.tsx",
+      "norm_label": "checkout.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/Checkout.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1052,
+      "community": 1042,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/types.ts",
+      "id": "packages_storefront_webapp_src_components_checkout_checkout_tsx",
+      "label": "Checkout.tsx",
+      "norm_label": "checkout.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/Checkout.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1053,
+      "community": 1043,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_utils_test_ts",
-      "label": "utils.test.ts",
-      "norm_label": "utils.test.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.test.ts",
+      "id": "packages_storefront_webapp_src_components_checkout_customerinfosection_tsx",
+      "label": "CustomerInfoSection.tsx",
+      "norm_label": "customerinfosection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/CustomerInfoSection.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1054,
+      "community": 1044,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_filter_productfilterbar_tsx",
-      "label": "ProductFilterBar.tsx",
-      "norm_label": "productfilterbar.tsx",
-      "source_file": "packages/storefront-webapp/src/components/filter/ProductFilterBar.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_schema_ts",
+      "label": "schema.ts",
+      "norm_label": "schema.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/schema.ts",
       "source_location": "L1"
     },
     {
-      "community": 1055,
+      "community": 1045,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_bestsellerssection_test_tsx",
-      "label": "BestSellersSection.test.tsx",
-      "norm_label": "bestsellerssection.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.test.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_deliverydetailssection_tsx",
+      "label": "DeliveryDetailsSection.tsx",
+      "norm_label": "deliverydetailssection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetailsSection.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1056,
+      "community": 1046,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_homehero_tsx",
-      "label": "HomeHero.tsx",
-      "norm_label": "homehero.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/HomeHero.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_test_ts",
+      "label": "checkoutStorage.test.ts",
+      "norm_label": "checkoutstorage.test.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/checkoutStorage.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1057,
+      "community": 1047,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_homeherosection_tsx",
-      "label": "HomeHeroSection.tsx",
-      "norm_label": "homeherosection.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/HomeHeroSection.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_test_ts",
+      "label": "deliveryFees.test.ts",
+      "norm_label": "deliveryfees.test.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1058,
+      "community": 1048,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_homepagecontent_test_ts",
-      "label": "homePageContent.test.ts",
-      "norm_label": "homepagecontent.test.ts",
-      "source_file": "packages/storefront-webapp/src/components/home/homePageContent.test.ts",
+      "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_test_ts",
+      "label": "deriveCheckoutState.test.ts",
+      "norm_label": "derivecheckoutstate.test.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1059,
+      "community": 1049,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_mobilemenu_tsx",
-      "label": "MobileMenu.tsx",
-      "norm_label": "mobilemenu.tsx",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileMenu.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_billingdetailsschema_ts",
+      "label": "billingDetailsSchema.ts",
+      "norm_label": "billingdetailsschema.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/billingDetailsSchema.ts",
       "source_location": "L1"
     },
     {
-      "community": 106,
+      "community": 105,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
       "label": "ReelUploader.tsx",
@@ -31183,7 +31108,7 @@
       "source_location": "L1"
     },
     {
-      "community": 106,
+      "community": 105,
       "file_type": "code",
       "id": "reeluploader_formatfilesize",
       "label": "formatFileSize()",
@@ -31192,7 +31117,7 @@
       "source_location": "L38"
     },
     {
-      "community": 106,
+      "community": 105,
       "file_type": "code",
       "id": "reeluploader_handlefileselect",
       "label": "handleFileSelect()",
@@ -31201,7 +31126,7 @@
       "source_location": "L64"
     },
     {
-      "community": 106,
+      "community": 105,
       "file_type": "code",
       "id": "reeluploader_handleupload",
       "label": "handleUpload()",
@@ -31210,7 +31135,7 @@
       "source_location": "L135"
     },
     {
-      "community": 106,
+      "community": 105,
       "file_type": "code",
       "id": "reeluploader_validatefile",
       "label": "validateFile()",
@@ -31219,97 +31144,97 @@
       "source_location": "L43"
     },
     {
-      "community": 1060,
+      "community": 1050,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/constants.ts",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutformschema_ts",
+      "label": "checkoutFormSchema.ts",
+      "norm_label": "checkoutformschema.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/checkoutFormSchema.ts",
       "source_location": "L1"
     },
     {
-      "community": 1061,
+      "community": 1051,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_navbarconstants_ts",
-      "label": "navBarConstants.ts",
-      "norm_label": "navbarconstants.ts",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarConstants.ts",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_customerdetailsschema_ts",
+      "label": "customerDetailsSchema.ts",
+      "norm_label": "customerdetailsschema.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/customerDetailsSchema.ts",
       "source_location": "L1"
     },
     {
-      "community": 1062,
+      "community": 1052,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_about_tsx",
-      "label": "About.tsx",
-      "norm_label": "about.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/About.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_deliverydetailsschema_ts",
+      "label": "deliveryDetailsSchema.ts",
+      "norm_label": "deliverydetailsschema.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/deliveryDetailsSchema.ts",
       "source_location": "L1"
     },
     {
-      "community": 1063,
+      "community": 1053,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_aboutproduct_tsx",
-      "label": "AboutProduct.tsx",
-      "norm_label": "aboutproduct.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/AboutProduct.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_ts",
+      "label": "webOrderSchema.ts",
+      "norm_label": "weborderschema.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/webOrderSchema.ts",
       "source_location": "L1"
     },
     {
-      "community": 1064,
+      "community": 1054,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productactions_test_tsx",
-      "label": "ProductActions.test.tsx",
-      "norm_label": "productactions.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.test.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/types.ts",
       "source_location": "L1"
     },
     {
-      "community": 1065,
+      "community": 1055,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productinfo_tsx",
-      "label": "ProductInfo.tsx",
-      "norm_label": "productinfo.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductInfo.tsx",
+      "id": "packages_storefront_webapp_src_components_checkout_utils_test_ts",
+      "label": "utils.test.ts",
+      "norm_label": "utils.test.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1066,
+      "community": 1056,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productreviews_tsx",
-      "label": "ProductReviews.tsx",
-      "norm_label": "productreviews.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductReviews.tsx",
+      "id": "packages_storefront_webapp_src_components_filter_productfilterbar_tsx",
+      "label": "ProductFilterBar.tsx",
+      "norm_label": "productfilterbar.tsx",
+      "source_file": "packages/storefront-webapp/src/components/filter/ProductFilterBar.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1067,
+      "community": 1057,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productsnavigationbar_tsx",
-      "label": "ProductsNavigationBar.tsx",
-      "norm_label": "productsnavigationbar.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductsNavigationBar.tsx",
+      "id": "packages_storefront_webapp_src_components_home_bestsellerssection_test_tsx",
+      "label": "BestSellersSection.test.tsx",
+      "norm_label": "bestsellerssection.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1068,
+      "community": 1058,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_errormessage_tsx",
-      "label": "ErrorMessage.tsx",
-      "norm_label": "errormessage.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/ErrorMessage.tsx",
+      "id": "packages_storefront_webapp_src_components_home_homehero_tsx",
+      "label": "HomeHero.tsx",
+      "norm_label": "homehero.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/HomeHero.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1069,
+      "community": 1059,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_existingreviewmessage_tsx",
-      "label": "ExistingReviewMessage.tsx",
-      "norm_label": "existingreviewmessage.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/ExistingReviewMessage.tsx",
+      "id": "packages_storefront_webapp_src_components_home_homeherosection_tsx",
+      "label": "HomeHeroSection.tsx",
+      "norm_label": "homeherosection.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/HomeHeroSection.tsx",
       "source_location": "L1"
     },
     {
-      "community": 107,
+      "community": 106,
       "file_type": "code",
       "id": "activityview_iscreatedaction",
       "label": "isCreatedAction()",
@@ -31318,7 +31243,7 @@
       "source_location": "L58"
     },
     {
-      "community": 107,
+      "community": 106,
       "file_type": "code",
       "id": "activityview_isfeedbackrequestaction",
       "label": "isFeedbackRequestAction()",
@@ -31327,7 +31252,7 @@
       "source_location": "L63"
     },
     {
-      "community": 107,
+      "community": 106,
       "file_type": "code",
       "id": "activityview_isrefundaction",
       "label": "isRefundAction()",
@@ -31336,7 +31261,7 @@
       "source_location": "L50"
     },
     {
-      "community": 107,
+      "community": 106,
       "file_type": "code",
       "id": "activityview_istransitionaction",
       "label": "isTransitionAction()",
@@ -31345,7 +31270,7 @@
       "source_location": "L53"
     },
     {
-      "community": 107,
+      "community": 106,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
       "label": "ActivityView.tsx",
@@ -31354,97 +31279,97 @@
       "source_location": "L1"
     },
     {
-      "community": 1070,
+      "community": 1060,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_reviewform_tsx",
-      "label": "ReviewForm.tsx",
-      "norm_label": "reviewform.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewForm.tsx",
+      "id": "packages_storefront_webapp_src_components_home_homepagecontent_test_ts",
+      "label": "homePageContent.test.ts",
+      "norm_label": "homepagecontent.test.ts",
+      "source_file": "packages/storefront-webapp/src/components/home/homePageContent.test.ts",
       "source_location": "L1"
     },
     {
-      "community": 1071,
+      "community": 1061,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_successmessage_tsx",
-      "label": "SuccessMessage.tsx",
-      "norm_label": "successmessage.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/SuccessMessage.tsx",
+      "id": "packages_storefront_webapp_src_components_navigation_bar_mobilemenu_tsx",
+      "label": "MobileMenu.tsx",
+      "norm_label": "mobilemenu.tsx",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/MobileMenu.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1072,
+      "community": 1062,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/types.ts",
+      "id": "packages_storefront_webapp_src_components_navigation_bar_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/constants.ts",
       "source_location": "L1"
     },
     {
-      "community": 1073,
+      "community": 1063,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_saved_items_savedbag_tsx",
-      "label": "SavedBag.tsx",
-      "norm_label": "savedbag.tsx",
-      "source_file": "packages/storefront-webapp/src/components/saved-items/SavedBag.tsx",
+      "id": "packages_storefront_webapp_src_components_navigation_bar_navbarconstants_ts",
+      "label": "navBarConstants.ts",
+      "norm_label": "navbarconstants.ts",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarConstants.ts",
       "source_location": "L1"
     },
     {
-      "community": 1074,
+      "community": 1064,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_saved_items_savedicon_tsx",
-      "label": "SavedIcon.tsx",
-      "norm_label": "savedicon.tsx",
-      "source_file": "packages/storefront-webapp/src/components/saved-items/SavedIcon.tsx",
+      "id": "packages_storefront_webapp_src_components_product_page_about_tsx",
+      "label": "About.tsx",
+      "norm_label": "about.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/About.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1075,
+      "community": 1065,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_shopping_bag_carticon_tsx",
-      "label": "CartIcon.tsx",
-      "norm_label": "carticon.tsx",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/CartIcon.tsx",
+      "id": "packages_storefront_webapp_src_components_product_page_aboutproduct_tsx",
+      "label": "AboutProduct.tsx",
+      "norm_label": "aboutproduct.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/AboutProduct.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1076,
+      "community": 1066,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_test_tsx",
-      "label": "ShoppingBag.test.tsx",
-      "norm_label": "shoppingbag.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.test.tsx",
+      "id": "packages_storefront_webapp_src_components_product_page_productactions_test_tsx",
+      "label": "ProductActions.test.tsx",
+      "norm_label": "productactions.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductActions.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1077,
+      "community": 1067,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_empty_empty_state_tsx",
-      "label": "empty-state.tsx",
-      "norm_label": "empty-state.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/empty/empty-state.tsx",
+      "id": "packages_storefront_webapp_src_components_product_page_productinfo_tsx",
+      "label": "ProductInfo.tsx",
+      "norm_label": "productinfo.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductInfo.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1078,
+      "community": 1068,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_tsx",
-      "label": "Maintenance.tsx",
-      "norm_label": "maintenance.tsx",
-      "source_file": "packages/storefront-webapp/src/components/states/maintenance/Maintenance.tsx",
+      "id": "packages_storefront_webapp_src_components_product_page_productreviews_tsx",
+      "label": "ProductReviews.tsx",
+      "norm_label": "productreviews.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductReviews.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1079,
+      "community": 1069,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_animatedcard_tsx",
-      "label": "AnimatedCard.tsx",
-      "norm_label": "animatedcard.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/AnimatedCard.tsx",
+      "id": "packages_storefront_webapp_src_components_product_page_productsnavigationbar_tsx",
+      "label": "ProductsNavigationBar.tsx",
+      "norm_label": "productsnavigationbar.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductsNavigationBar.tsx",
       "source_location": "L1"
     },
     {
-      "community": 108,
+      "community": 107,
       "file_type": "code",
       "id": "orderdetailsview_fetchtransactions",
       "label": "fetchTransactions()",
@@ -31453,7 +31378,7 @@
       "source_location": "L138"
     },
     {
-      "community": 108,
+      "community": 107,
       "file_type": "code",
       "id": "orderdetailsview_handlemarkasverified",
       "label": "handleMarkAsVerified()",
@@ -31462,7 +31387,7 @@
       "source_location": "L175"
     },
     {
-      "community": 108,
+      "community": 107,
       "file_type": "code",
       "id": "orderdetailsview_handlemarkpaymentcollected",
       "label": "handleMarkPaymentCollected()",
@@ -31471,7 +31396,7 @@
       "source_location": "L189"
     },
     {
-      "community": 108,
+      "community": 107,
       "file_type": "code",
       "id": "orderdetailsview_verifiedbadge",
       "label": "VerifiedBadge()",
@@ -31480,7 +31405,7 @@
       "source_location": "L43"
     },
     {
-      "community": 108,
+      "community": 107,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderdetailsview_tsx",
       "label": "OrderDetailsView.tsx",
@@ -31489,97 +31414,97 @@
       "source_location": "L1"
     },
     {
-      "community": 1080,
+      "community": 1070,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_accordion_tsx",
-      "label": "accordion.tsx",
-      "norm_label": "accordion.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/accordion.tsx",
+      "id": "packages_storefront_webapp_src_components_product_reviews_errormessage_tsx",
+      "label": "ErrorMessage.tsx",
+      "norm_label": "errormessage.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/ErrorMessage.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1081,
+      "community": 1071,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_alert_tsx",
-      "label": "alert.tsx",
-      "norm_label": "alert.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/alert.tsx",
+      "id": "packages_storefront_webapp_src_components_product_reviews_existingreviewmessage_tsx",
+      "label": "ExistingReviewMessage.tsx",
+      "norm_label": "existingreviewmessage.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/ExistingReviewMessage.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1082,
+      "community": 1072,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_breadcrumb_tsx",
-      "label": "breadcrumb.tsx",
-      "norm_label": "breadcrumb.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/breadcrumb.tsx",
+      "id": "packages_storefront_webapp_src_components_product_reviews_reviewform_tsx",
+      "label": "ReviewForm.tsx",
+      "norm_label": "reviewform.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewForm.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1083,
+      "community": 1073,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_button_tsx",
-      "label": "button.tsx",
-      "norm_label": "button.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/button.tsx",
+      "id": "packages_storefront_webapp_src_components_product_reviews_successmessage_tsx",
+      "label": "SuccessMessage.tsx",
+      "norm_label": "successmessage.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/SuccessMessage.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1084,
+      "community": 1074,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_card_tsx",
-      "label": "card.tsx",
-      "norm_label": "card.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/card.tsx",
+      "id": "packages_storefront_webapp_src_components_product_reviews_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/types.ts",
       "source_location": "L1"
     },
     {
-      "community": 1085,
+      "community": 1075,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_checkbox_tsx",
-      "label": "checkbox.tsx",
-      "norm_label": "checkbox.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/checkbox.tsx",
+      "id": "packages_storefront_webapp_src_components_saved_items_savedbag_tsx",
+      "label": "SavedBag.tsx",
+      "norm_label": "savedbag.tsx",
+      "source_file": "packages/storefront-webapp/src/components/saved-items/SavedBag.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1086,
+      "community": 1076,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_command_tsx",
-      "label": "command.tsx",
-      "norm_label": "command.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/command.tsx",
+      "id": "packages_storefront_webapp_src_components_saved_items_savedicon_tsx",
+      "label": "SavedIcon.tsx",
+      "norm_label": "savedicon.tsx",
+      "source_file": "packages/storefront-webapp/src/components/saved-items/SavedIcon.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1087,
+      "community": 1077,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_context_menu_tsx",
-      "label": "context-menu.tsx",
-      "norm_label": "context-menu.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/context-menu.tsx",
+      "id": "packages_storefront_webapp_src_components_shopping_bag_carticon_tsx",
+      "label": "CartIcon.tsx",
+      "norm_label": "carticon.tsx",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/CartIcon.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1088,
+      "community": 1078,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_dialog_tsx",
-      "label": "dialog.tsx",
-      "norm_label": "dialog.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/dialog.tsx",
+      "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_test_tsx",
+      "label": "ShoppingBag.test.tsx",
+      "norm_label": "shoppingbag.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/ShoppingBag.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 1089,
+      "community": 1079,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_dropdown_menu_tsx",
-      "label": "dropdown-menu.tsx",
-      "norm_label": "dropdown-menu.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/dropdown-menu.tsx",
+      "id": "packages_storefront_webapp_src_components_states_empty_empty_state_tsx",
+      "label": "empty-state.tsx",
+      "norm_label": "empty-state.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/empty/empty-state.tsx",
       "source_location": "L1"
     },
     {
-      "community": 109,
+      "community": 108,
       "file_type": "code",
       "id": "orderitemsview_handlerequestfeedback",
       "label": "handleRequestFeedback()",
@@ -31588,7 +31513,7 @@
       "source_location": "L77"
     },
     {
-      "community": 109,
+      "community": 108,
       "file_type": "code",
       "id": "orderitemsview_handlerestockall",
       "label": "handleRestockAll()",
@@ -31597,7 +31522,7 @@
       "source_location": "L295"
     },
     {
-      "community": 109,
+      "community": 108,
       "file_type": "code",
       "id": "orderitemsview_handlereturnitemtostock",
       "label": "handleReturnItemToStock()",
@@ -31606,7 +31531,7 @@
       "source_location": "L61"
     },
     {
-      "community": 109,
+      "community": 108,
       "file_type": "code",
       "id": "orderitemsview_handleupdateorderitem",
       "label": "handleUpdateOrderItem()",
@@ -31615,7 +31540,7 @@
       "source_location": "L47"
     },
     {
-      "community": 109,
+      "community": 108,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
       "label": "OrderItemsView.tsx",
@@ -31624,7 +31549,160 @@
       "source_location": "L1"
     },
     {
+      "community": 1080,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_tsx",
+      "label": "Maintenance.tsx",
+      "norm_label": "maintenance.tsx",
+      "source_file": "packages/storefront-webapp/src/components/states/maintenance/Maintenance.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1081,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_animatedcard_tsx",
+      "label": "AnimatedCard.tsx",
+      "norm_label": "animatedcard.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/AnimatedCard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1082,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_accordion_tsx",
+      "label": "accordion.tsx",
+      "norm_label": "accordion.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/accordion.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1083,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_alert_tsx",
+      "label": "alert.tsx",
+      "norm_label": "alert.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/alert.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1084,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_breadcrumb_tsx",
+      "label": "breadcrumb.tsx",
+      "norm_label": "breadcrumb.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/breadcrumb.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1085,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_button_tsx",
+      "label": "button.tsx",
+      "norm_label": "button.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/button.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1086,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_card_tsx",
+      "label": "card.tsx",
+      "norm_label": "card.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/card.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1087,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_checkbox_tsx",
+      "label": "checkbox.tsx",
+      "norm_label": "checkbox.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/checkbox.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1088,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_command_tsx",
+      "label": "command.tsx",
+      "norm_label": "command.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/command.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1089,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_context_menu_tsx",
+      "label": "context-menu.tsx",
+      "norm_label": "context-menu.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/context-menu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "index_feesview",
+      "label": "FeesView()",
+      "norm_label": "feesview()",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "source_location": "L29"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "index_header",
+      "label": "Header()",
+      "norm_label": "header()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L42"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "index_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L105"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 109,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/index.tsx",
+      "source_location": "L1"
+    },
+    {
       "community": 1090,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_dialog_tsx",
+      "label": "dialog.tsx",
+      "norm_label": "dialog.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/dialog.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1091,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_dropdown_menu_tsx",
+      "label": "dropdown-menu.tsx",
+      "norm_label": "dropdown-menu.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/dropdown-menu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1092,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
@@ -31633,7 +31711,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1091,
+      "community": 1093,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
@@ -31642,7 +31720,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1092,
+      "community": 1094,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_image_with_fallback_tsx",
       "label": "image-with-fallback.tsx",
@@ -31651,7 +31729,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1093,
+      "community": 1095,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
@@ -31660,7 +31738,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1094,
+      "community": 1096,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_with_end_button_tsx",
       "label": "input-with-end-button.tsx",
@@ -31669,7 +31747,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1095,
+      "community": 1097,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
@@ -31678,7 +31756,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1096,
+      "community": 1098,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
@@ -31687,30 +31765,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1097,
+      "community": 1099,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodalform_tsx",
       "label": "LeaveAReviewModalForm.tsx",
       "norm_label": "leaveareviewmodalform.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/modals/LeaveAReviewModalForm.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1098,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_action_modal_tsx",
-      "label": "action-modal.tsx",
-      "norm_label": "action-modal.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/action-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1099,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_animations_welcomebackmodalanimations_ts",
-      "label": "welcomeBackModalAnimations.ts",
-      "norm_label": "welcomebackmodalanimations.ts",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/animations/welcomeBackModalAnimations.ts",
       "source_location": "L1"
     },
     {
@@ -31941,6 +32001,24 @@
     {
       "community": 1100,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_action_modal_tsx",
+      "label": "action-modal.tsx",
+      "norm_label": "action-modal.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/action-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1101,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_animations_welcomebackmodalanimations_ts",
+      "label": "welcomeBackModalAnimations.ts",
+      "norm_label": "welcomebackmodalanimations.ts",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/animations/welcomeBackModalAnimations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1102,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
@@ -31948,7 +32026,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1101,
+      "community": 1103,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_types_ts",
       "label": "types.ts",
@@ -31957,7 +32035,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1102,
+      "community": 1104,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_navigation_menu_tsx",
       "label": "navigation-menu.tsx",
@@ -31966,7 +32044,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1103,
+      "community": 1105,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -31975,7 +32053,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1104,
+      "community": 1106,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
@@ -31984,7 +32062,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1105,
+      "community": 1107,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
@@ -31993,7 +32071,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1106,
+      "community": 1108,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
@@ -32002,30 +32080,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1107,
+      "community": 1109,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
       "norm_label": "separator.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/separator.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1108,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_sheet_tsx",
-      "label": "sheet.tsx",
-      "norm_label": "sheet.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/sheet.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1109,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_table_tsx",
-      "label": "table.tsx",
-      "norm_label": "table.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/table.tsx",
       "source_location": "L1"
     },
     {
@@ -32076,6 +32136,24 @@
     {
       "community": 1110,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_sheet_tsx",
+      "label": "sheet.tsx",
+      "norm_label": "sheet.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/sheet.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1111,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_table_tsx",
+      "label": "table.tsx",
+      "norm_label": "table.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1112,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
       "norm_label": "tabs.tsx",
@@ -32083,7 +32161,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1111,
+      "community": 1113,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
@@ -32092,7 +32170,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1112,
+      "community": 1114,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
@@ -32101,7 +32179,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1113,
+      "community": 1115,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
@@ -32110,7 +32188,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1114,
+      "community": 1116,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
@@ -32119,7 +32197,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1115,
+      "community": 1117,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_config_ts",
       "label": "config.ts",
@@ -32128,7 +32206,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1116,
+      "community": 1118,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
@@ -32137,30 +32215,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1117,
+      "community": 1119,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useorganizationmodal_tsx",
       "label": "useOrganizationModal.tsx",
       "norm_label": "useorganizationmodal.tsx",
       "source_file": "packages/storefront-webapp/src/hooks/useOrganizationModal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1118,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usestorefrontobservability_ts",
-      "label": "useStorefrontObservability.ts",
-      "norm_label": "usestorefrontobservability.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useStorefrontObservability.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1119,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/storefront-webapp/src/lib/constants.ts",
       "source_location": "L1"
     },
     {
@@ -32211,6 +32271,24 @@
     {
       "community": 1120,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usestorefrontobservability_ts",
+      "label": "useStorefrontObservability.ts",
+      "norm_label": "usestorefrontobservability.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useStorefrontObservability.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1121,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/storefront-webapp/src/lib/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1122,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_countries_ts",
       "label": "countries.ts",
       "norm_label": "countries.ts",
@@ -32218,7 +32296,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1121,
+      "community": 1123,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_feeutils_test_ts",
       "label": "feeUtils.test.ts",
@@ -32227,7 +32305,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1122,
+      "community": 1124,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -32236,7 +32314,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1123,
+      "community": 1125,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
@@ -32245,7 +32323,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1124,
+      "community": 1126,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_test_ts",
       "label": "maintenanceUtils.test.ts",
@@ -32254,7 +32332,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1125,
+      "community": 1127,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_index_ts",
       "label": "index.ts",
@@ -32263,7 +32341,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1126,
+      "community": 1128,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_store_ts",
       "label": "store.ts",
@@ -32272,30 +32350,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1127,
+      "community": 1129,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bag_ts",
       "label": "bag.ts",
       "norm_label": "bag.ts",
       "source_file": "packages/storefront-webapp/src/lib/schemas/bag.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1128,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_bagitem_ts",
-      "label": "bagItem.ts",
-      "norm_label": "bagitem.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/bagItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1129,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_schemas_category_ts",
-      "label": "category.ts",
-      "norm_label": "category.ts",
-      "source_file": "packages/storefront-webapp/src/lib/schemas/category.ts",
       "source_location": "L1"
     },
     {
@@ -32346,6 +32406,24 @@
     {
       "community": 1130,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_bagitem_ts",
+      "label": "bagItem.ts",
+      "norm_label": "bagitem.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/bagItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1131,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_schemas_category_ts",
+      "label": "category.ts",
+      "norm_label": "category.ts",
+      "source_file": "packages/storefront-webapp/src/lib/schemas/category.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1132,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_organization_ts",
       "label": "organization.ts",
       "norm_label": "organization.ts",
@@ -32353,7 +32431,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1131,
+      "community": 1133,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
@@ -32362,7 +32440,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1132,
+      "community": 1134,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -32371,7 +32449,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1133,
+      "community": 1135,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
@@ -32380,7 +32458,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1134,
+      "community": 1136,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
@@ -32389,7 +32467,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1135,
+      "community": 1137,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_states_ts",
       "label": "states.ts",
@@ -32398,7 +32476,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1136,
+      "community": 1138,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_test_ts",
       "label": "storefrontFailureObservability.test.ts",
@@ -32407,30 +32485,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1137,
+      "community": 1139,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontjourneyevents_test_ts",
       "label": "storefrontJourneyEvents.test.ts",
       "norm_label": "storefrontjourneyevents.test.ts",
       "source_file": "packages/storefront-webapp/src/lib/storefrontJourneyEvents.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1138,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_utils_test_ts",
-      "label": "utils.test.ts",
-      "norm_label": "utils.test.ts",
-      "source_file": "packages/storefront-webapp/src/lib/utils.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1139,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routetree_gen_ts",
-      "label": "routeTree.gen.ts",
-      "norm_label": "routetree.gen.ts",
-      "source_file": "packages/storefront-webapp/src/routeTree.gen.ts",
       "source_location": "L1"
     },
     {
@@ -32481,6 +32541,24 @@
     {
       "community": 1140,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_utils_test_ts",
+      "label": "utils.test.ts",
+      "norm_label": "utils.test.ts",
+      "source_file": "packages/storefront-webapp/src/lib/utils.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1141,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routetree_gen_ts",
+      "label": "routeTree.gen.ts",
+      "norm_label": "routetree.gen.ts",
+      "source_file": "packages/storefront-webapp/src/routeTree.gen.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1142,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_test_ts",
       "label": "-homePageLoader.test.ts",
       "norm_label": "-homepageloader.test.ts",
@@ -32488,7 +32566,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1141,
+      "community": 1143,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -32497,7 +32575,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1142,
+      "community": 1144,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_orderitemid_review_tsx",
       "label": "$orderItemId.review.tsx",
@@ -32506,7 +32584,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1143,
+      "community": 1145,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_index_tsx",
       "label": "index.tsx",
@@ -32515,7 +32593,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1144,
+      "community": 1146,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_subcategoryslug_tsx",
       "label": "$subcategorySlug.tsx",
@@ -32524,7 +32602,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1145,
+      "community": 1147,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_index_tsx",
       "label": "index.tsx",
@@ -32533,7 +32611,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1146,
+      "community": 1148,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_rewards_index_tsx",
       "label": "rewards.index.tsx",
@@ -32542,30 +32620,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1147,
+      "community": 1149,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_saved_index_tsx",
       "label": "shop.saved.index.tsx",
       "norm_label": "shop.saved.index.tsx",
       "source_file": "packages/storefront-webapp/src/routes/_layout/shop.saved.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1148,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_bag_index_tsx",
-      "label": "bag.index.tsx",
-      "norm_label": "bag.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/bag.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1149,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_complete_tsx",
-      "label": "complete.tsx",
-      "norm_label": "complete.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/complete.tsx",
       "source_location": "L1"
     },
     {
@@ -32616,6 +32676,24 @@
     {
       "community": 1150,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_bag_index_tsx",
+      "label": "bag.index.tsx",
+      "norm_label": "bag.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/bag.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1151,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_complete_tsx",
+      "label": "complete.tsx",
+      "norm_label": "complete.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/shop/checkout/$sessionIdSlug/complete.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1152,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_incomplete_tsx",
       "label": "incomplete.tsx",
       "norm_label": "incomplete.tsx",
@@ -32623,7 +32701,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1151,
+      "community": 1153,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_index_tsx",
       "label": "index.tsx",
@@ -32632,7 +32710,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1152,
+      "community": 1154,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pending_tsx",
       "label": "pending.tsx",
@@ -32641,7 +32719,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1153,
+      "community": 1155,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_ssr_tsx",
       "label": "ssr.tsx",
@@ -32650,7 +32728,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1154,
+      "community": 1156,
       "file_type": "code",
       "id": "packages_storefront_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
@@ -32659,7 +32737,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1155,
+      "community": 1157,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
@@ -32668,7 +32746,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1156,
+      "community": 1158,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_setup_ts",
       "label": "vitest.setup.ts",
@@ -32677,30 +32755,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1157,
+      "community": 1159,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_index_js",
       "label": "index.js",
       "norm_label": "index.js",
       "source_file": "packages/valkey-proxy-server/index.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 1158,
-      "file_type": "code",
-      "id": "scripts_harness_app_registry_test_ts",
-      "label": "harness-app-registry.test.ts",
-      "norm_label": "harness-app-registry.test.ts",
-      "source_file": "scripts/harness-app-registry.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1159,
-      "file_type": "code",
-      "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_test_ts",
-      "label": "valkey-runtime-app.test.ts",
-      "norm_label": "valkey-runtime-app.test.ts",
-      "source_file": "scripts/harness-behavior-fixtures/valkey-runtime-app.test.ts",
       "source_location": "L1"
     },
     {
@@ -32750,6 +32810,24 @@
     },
     {
       "community": 1160,
+      "file_type": "code",
+      "id": "scripts_harness_app_registry_test_ts",
+      "label": "harness-app-registry.test.ts",
+      "norm_label": "harness-app-registry.test.ts",
+      "source_file": "scripts/harness-app-registry.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1161,
+      "file_type": "code",
+      "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_test_ts",
+      "label": "valkey-runtime-app.test.ts",
+      "norm_label": "valkey-runtime-app.test.ts",
+      "source_file": "scripts/harness-behavior-fixtures/valkey-runtime-app.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1162,
       "file_type": "code",
       "id": "scripts_harness_behavior_scenarios_test_ts",
       "label": "harness-behavior-scenarios.test.ts",
@@ -33723,42 +33801,6 @@
     {
       "community": 132,
       "file_type": "code",
-      "id": "currency_todisplayamount",
-      "label": "toDisplayAmount()",
-      "norm_label": "todisplayamount()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 132,
-      "file_type": "code",
-      "id": "currency_topesewas",
-      "label": "toPesewas()",
-      "norm_label": "topesewas()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 132,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_lib_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/athena-webapp/convex/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 132,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
       "id": "collections_getcachedtokenrecord",
       "label": "getCachedTokenRecord()",
       "norm_label": "getcachedtokenrecord()",
@@ -33766,7 +33808,7 @@
       "source_location": "L26"
     },
     {
-      "community": 133,
+      "community": 132,
       "file_type": "code",
       "id": "collections_resolveaccesstokenforstore",
       "label": "resolveAccessTokenForStore()",
@@ -33775,7 +33817,7 @@
       "source_location": "L79"
     },
     {
-      "community": 133,
+      "community": 132,
       "file_type": "code",
       "id": "collections_resolveconfigforstore",
       "label": "resolveConfigForStore()",
@@ -33784,7 +33826,7 @@
       "source_location": "L33"
     },
     {
-      "community": 133,
+      "community": 132,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_collections_ts",
       "label": "collections.ts",
@@ -33793,7 +33835,7 @@
       "source_location": "L1"
     },
     {
-      "community": 134,
+      "community": 133,
       "file_type": "code",
       "id": "normalize_maskmtnpartyid",
       "label": "maskMtnPartyId()",
@@ -33802,7 +33844,7 @@
       "source_location": "L10"
     },
     {
-      "community": 134,
+      "community": 133,
       "file_type": "code",
       "id": "normalize_normalizecollectionstransaction",
       "label": "normalizeCollectionsTransaction()",
@@ -33811,7 +33853,7 @@
       "source_location": "L18"
     },
     {
-      "community": 134,
+      "community": 133,
       "file_type": "code",
       "id": "normalize_parsecollectionsnotificationrequest",
       "label": "parseCollectionsNotificationRequest()",
@@ -33820,7 +33862,7 @@
       "source_location": "L52"
     },
     {
-      "community": 134,
+      "community": 133,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_ts",
       "label": "normalize.ts",
@@ -33829,7 +33871,7 @@
       "source_location": "L1"
     },
     {
-      "community": 135,
+      "community": 134,
       "file_type": "code",
       "id": "commercequeryindexes_test_expectindex",
       "label": "expectIndex()",
@@ -33838,7 +33880,7 @@
       "source_location": "L19"
     },
     {
-      "community": 135,
+      "community": 134,
       "file_type": "code",
       "id": "commercequeryindexes_test_getsource",
       "label": "getSource()",
@@ -33847,7 +33889,7 @@
       "source_location": "L26"
     },
     {
-      "community": 135,
+      "community": 134,
       "file_type": "code",
       "id": "commercequeryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -33856,7 +33898,7 @@
       "source_location": "L12"
     },
     {
-      "community": 135,
+      "community": 134,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_commercequeryindexes_test_ts",
       "label": "commerceQueryIndexes.test.ts",
@@ -33865,7 +33907,7 @@
       "source_location": "L1"
     },
     {
-      "community": 136,
+      "community": 135,
       "file_type": "code",
       "id": "attributesmanager_attributesmanager",
       "label": "AttributesManager()",
@@ -33874,7 +33916,7 @@
       "source_location": "L228"
     },
     {
-      "community": 136,
+      "community": 135,
       "file_type": "code",
       "id": "attributesmanager_colormanager",
       "label": "ColorManager()",
@@ -33883,7 +33925,7 @@
       "source_location": "L45"
     },
     {
-      "community": 136,
+      "community": 135,
       "file_type": "code",
       "id": "attributesmanager_sidebar",
       "label": "Sidebar()",
@@ -33892,7 +33934,7 @@
       "source_location": "L26"
     },
     {
-      "community": 136,
+      "community": 135,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributesmanager_tsx",
       "label": "AttributesManager.tsx",
@@ -33901,7 +33943,7 @@
       "source_location": "L1"
     },
     {
-      "community": 137,
+      "community": 136,
       "file_type": "code",
       "id": "attributestable_getproductattribute",
       "label": "getProductAttribute()",
@@ -33910,7 +33952,7 @@
       "source_location": "L55"
     },
     {
-      "community": 137,
+      "community": 136,
       "file_type": "code",
       "id": "attributestable_handlechange",
       "label": "handleChange()",
@@ -33919,7 +33961,7 @@
       "source_location": "L32"
     },
     {
-      "community": 137,
+      "community": 136,
       "file_type": "code",
       "id": "attributestable_onsubmit",
       "label": "onSubmit()",
@@ -33928,7 +33970,7 @@
       "source_location": "L210"
     },
     {
-      "community": 137,
+      "community": 136,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributestable_tsx",
       "label": "AttributesTable.tsx",
@@ -33937,7 +33979,7 @@
       "source_location": "L1"
     },
     {
-      "community": 138,
+      "community": 137,
       "file_type": "code",
       "id": "categorysubcategorymanager_categorymanager",
       "label": "CategoryManager()",
@@ -33946,7 +33988,7 @@
       "source_location": "L51"
     },
     {
-      "community": 138,
+      "community": 137,
       "file_type": "code",
       "id": "categorysubcategorymanager_sidebar",
       "label": "Sidebar()",
@@ -33955,7 +33997,7 @@
       "source_location": "L26"
     },
     {
-      "community": 138,
+      "community": 137,
       "file_type": "code",
       "id": "categorysubcategorymanager_subcategorymanager",
       "label": "SubcategoryManager()",
@@ -33964,7 +34006,7 @@
       "source_location": "L290"
     },
     {
-      "community": 138,
+      "community": 137,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_categorysubcategorymanager_tsx",
       "label": "CategorySubcategoryManager.tsx",
@@ -33973,7 +34015,7 @@
       "source_location": "L1"
     },
     {
-      "community": 139,
+      "community": 138,
       "file_type": "code",
       "id": "analyticsview_activecheckoutsessions",
       "label": "ActiveCheckoutSessions()",
@@ -33982,7 +34024,7 @@
       "source_location": "L48"
     },
     {
-      "community": 139,
+      "community": 138,
       "file_type": "code",
       "id": "analyticsview_analyticsview",
       "label": "AnalyticsView()",
@@ -33991,7 +34033,7 @@
       "source_location": "L88"
     },
     {
-      "community": 139,
+      "community": 138,
       "file_type": "code",
       "id": "analyticsview_storevisitors",
       "label": "StoreVisitors()",
@@ -34000,13 +34042,49 @@
       "source_location": "L14"
     },
     {
-      "community": 139,
+      "community": 138,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsview_tsx",
       "label": "AnalyticsView.tsx",
       "norm_label": "analyticsview.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsView.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_storefrontobservabilitypanel_tsx",
+      "label": "StorefrontObservabilityPanel.tsx",
+      "norm_label": "storefrontobservabilitypanel.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "storefrontobservabilitypanel_formatlabel",
+      "label": "formatLabel()",
+      "norm_label": "formatlabel()",
+      "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "storefrontobservabilitypanel_gettrafficsourcebadge",
+      "label": "getTrafficSourceBadge()",
+      "norm_label": "gettrafficsourcebadge()",
+      "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
+      "source_location": "L28"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "storefrontobservabilitypanel_summarycard",
+      "label": "SummaryCard()",
+      "norm_label": "summarycard()",
+      "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
+      "source_location": "L19"
     },
     {
       "community": 14,
@@ -34164,42 +34242,6 @@
     {
       "community": 140,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_storefrontobservabilitypanel_tsx",
-      "label": "StorefrontObservabilityPanel.tsx",
-      "norm_label": "storefrontobservabilitypanel.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "storefrontobservabilitypanel_formatlabel",
-      "label": "formatLabel()",
-      "norm_label": "formatlabel()",
-      "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
-      "source_location": "L15"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "storefrontobservabilitypanel_gettrafficsourcebadge",
-      "label": "getTrafficSourceBadge()",
-      "norm_label": "gettrafficsourcebadge()",
-      "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
-      "source_location": "L28"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "storefrontobservabilitypanel_summarycard",
-      "label": "SummaryCard()",
-      "norm_label": "summarycard()",
-      "source_file": "packages/athena-webapp/src/components/analytics/StorefrontObservabilityPanel.tsx",
-      "source_location": "L19"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_utils_ts",
       "label": "utils.ts",
       "norm_label": "utils.ts",
@@ -34207,7 +34249,7 @@
       "source_location": "L1"
     },
     {
-      "community": 141,
+      "community": 140,
       "file_type": "code",
       "id": "utils_countgroupedanalytics",
       "label": "countGroupedAnalytics()",
@@ -34216,7 +34258,7 @@
       "source_location": "L52"
     },
     {
-      "community": 141,
+      "community": 140,
       "file_type": "code",
       "id": "utils_groupanalytics",
       "label": "groupAnalytics()",
@@ -34225,7 +34267,7 @@
       "source_location": "L3"
     },
     {
-      "community": 141,
+      "community": 140,
       "file_type": "code",
       "id": "utils_groupproductviewsbyday",
       "label": "groupProductViewsByDay()",
@@ -34234,7 +34276,7 @@
       "source_location": "L90"
     },
     {
-      "community": 142,
+      "community": 141,
       "file_type": "code",
       "id": "maintenancemessageeditor_getcountdownstatus",
       "label": "getCountdownStatus()",
@@ -34243,7 +34285,7 @@
       "source_location": "L86"
     },
     {
-      "community": 142,
+      "community": 141,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlecountdownchange",
       "label": "handleCountdownChange()",
@@ -34252,7 +34294,7 @@
       "source_location": "L76"
     },
     {
-      "community": 142,
+      "community": 141,
       "file_type": "code",
       "id": "maintenancemessageeditor_handlesave",
       "label": "handleSave()",
@@ -34261,7 +34303,7 @@
       "source_location": "L52"
     },
     {
-      "community": 142,
+      "community": 141,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_maintenancemessageeditor_tsx",
       "label": "MaintenanceMessageEditor.tsx",
@@ -34270,7 +34312,7 @@
       "source_location": "L1"
     },
     {
-      "community": 143,
+      "community": 142,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplook_tsx",
       "label": "ShopLook.tsx",
@@ -34279,7 +34321,7 @@
       "source_location": "L1"
     },
     {
-      "community": 143,
+      "community": 142,
       "file_type": "code",
       "id": "shoplook_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -34288,7 +34330,7 @@
       "source_location": "L67"
     },
     {
-      "community": 143,
+      "community": 142,
       "file_type": "code",
       "id": "shoplook_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -34297,7 +34339,7 @@
       "source_location": "L90"
     },
     {
-      "community": 143,
+      "community": 142,
       "file_type": "code",
       "id": "shoplook_ondragend",
       "label": "onDragEnd()",
@@ -34306,7 +34348,7 @@
       "source_location": "L73"
     },
     {
-      "community": 144,
+      "community": 143,
       "file_type": "code",
       "id": "newtransactionview_handlequickstart",
       "label": "handleQuickStart()",
@@ -34315,7 +34357,7 @@
       "source_location": "L91"
     },
     {
-      "community": 144,
+      "community": 143,
       "file_type": "code",
       "id": "newtransactionview_handlestarttransaction",
       "label": "handleStartTransaction()",
@@ -34324,7 +34366,7 @@
       "source_location": "L68"
     },
     {
-      "community": 144,
+      "community": 143,
       "file_type": "code",
       "id": "newtransactionview_navigation",
       "label": "Navigation()",
@@ -34333,7 +34375,7 @@
       "source_location": "L22"
     },
     {
-      "community": 144,
+      "community": 143,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
       "label": "NewTransactionView.tsx",
@@ -34342,7 +34384,7 @@
       "source_location": "L1"
     },
     {
-      "community": 145,
+      "community": 144,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_tsx",
       "label": "POSSettingsView.tsx",
@@ -34351,7 +34393,7 @@
       "source_location": "L1"
     },
     {
-      "community": 145,
+      "community": 144,
       "file_type": "code",
       "id": "possettingsview_handleregisterterminal",
       "label": "handleRegisterTerminal()",
@@ -34360,7 +34402,7 @@
       "source_location": "L247"
     },
     {
-      "community": 145,
+      "community": 144,
       "file_type": "code",
       "id": "possettingsview_handleupdateexistingterminal",
       "label": "handleUpdateExistingTerminal()",
@@ -34369,7 +34411,7 @@
       "source_location": "L284"
     },
     {
-      "community": 145,
+      "community": 144,
       "file_type": "code",
       "id": "possettingsview_loadfingerprint",
       "label": "loadFingerprint()",
@@ -34378,7 +34420,7 @@
       "source_location": "L166"
     },
     {
-      "community": 146,
+      "community": 145,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstock_tsx",
       "label": "ProductStock.tsx",
@@ -34387,7 +34429,7 @@
       "source_location": "L1"
     },
     {
-      "community": 146,
+      "community": 145,
       "file_type": "code",
       "id": "productstock_lowstockstatus",
       "label": "LowStockStatus()",
@@ -34396,7 +34438,7 @@
       "source_location": "L63"
     },
     {
-      "community": 146,
+      "community": 145,
       "file_type": "code",
       "id": "productstock_outofstockstatus",
       "label": "OutOfStockStatus()",
@@ -34405,7 +34447,7 @@
       "source_location": "L54"
     },
     {
-      "community": 146,
+      "community": 145,
       "file_type": "code",
       "id": "productstock_productstockstatus",
       "label": "ProductStockStatus()",
@@ -34414,7 +34456,7 @@
       "source_location": "L11"
     },
     {
-      "community": 147,
+      "community": 146,
       "file_type": "code",
       "id": "complimentaryproductsview_body",
       "label": "Body()",
@@ -34423,7 +34465,7 @@
       "source_location": "L16"
     },
     {
-      "community": 147,
+      "community": 146,
       "file_type": "code",
       "id": "complimentaryproductsview_complimentaryproductsview",
       "label": "ComplimentaryProductsView()",
@@ -34432,7 +34474,7 @@
       "source_location": "L35"
     },
     {
-      "community": 147,
+      "community": 146,
       "file_type": "code",
       "id": "complimentaryproductsview_navigation",
       "label": "Navigation()",
@@ -34441,7 +34483,7 @@
       "source_location": "L6"
     },
     {
-      "community": 147,
+      "community": 146,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
       "label": "ComplimentaryProductsView.tsx",
@@ -34450,7 +34492,7 @@
       "source_location": "L1"
     },
     {
-      "community": 148,
+      "community": 147,
       "file_type": "code",
       "id": "engagementmetrics_formatlastactivity",
       "label": "formatLastActivity()",
@@ -34459,7 +34501,7 @@
       "source_location": "L75"
     },
     {
-      "community": 148,
+      "community": 147,
       "file_type": "code",
       "id": "engagementmetrics_getdeviceicon",
       "label": "getDeviceIcon()",
@@ -34468,7 +34510,7 @@
       "source_location": "L82"
     },
     {
-      "community": 148,
+      "community": 147,
       "file_type": "code",
       "id": "engagementmetrics_getdevicelabel",
       "label": "getDeviceLabel()",
@@ -34477,7 +34519,7 @@
       "source_location": "L93"
     },
     {
-      "community": 148,
+      "community": 147,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_engagementmetrics_tsx",
       "label": "EngagementMetrics.tsx",
@@ -34486,7 +34528,7 @@
       "source_location": "L1"
     },
     {
-      "community": 149,
+      "community": 148,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_riskindicators_tsx",
       "label": "RiskIndicators.tsx",
@@ -34495,7 +34537,7 @@
       "source_location": "L1"
     },
     {
-      "community": 149,
+      "community": 148,
       "file_type": "code",
       "id": "riskindicators_getriskicon",
       "label": "getRiskIcon()",
@@ -34504,7 +34546,7 @@
       "source_location": "L15"
     },
     {
-      "community": 149,
+      "community": 148,
       "file_type": "code",
       "id": "riskindicators_getriskstyles",
       "label": "getRiskStyles()",
@@ -34513,13 +34555,49 @@
       "source_location": "L28"
     },
     {
-      "community": 149,
+      "community": 148,
       "file_type": "code",
       "id": "riskindicators_riskindicators",
       "label": "RiskIndicators()",
       "norm_label": "riskindicators()",
       "source_file": "packages/athena-webapp/src/components/users/behavioral-insights/RiskIndicators.tsx",
       "source_location": "L54"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "customerobservabilitytimeline_formatobservabilitylabel",
+      "label": "formatObservabilityLabel()",
+      "norm_label": "formatobservabilitylabel()",
+      "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "customerobservabilitytimeline_getdeviceicon",
+      "label": "getDeviceIcon()",
+      "norm_label": "getdeviceicon()",
+      "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
+      "source_location": "L114"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
+      "label": "getObservabilityStatusStyles()",
+      "norm_label": "getobservabilitystatusstyles()",
+      "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_customerobservabilitytimeline_ts",
+      "label": "customerObservabilityTimeline.ts",
+      "norm_label": "customerobservabilitytimeline.ts",
+      "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
+      "source_location": "L1"
     },
     {
       "community": 15,
@@ -34677,42 +34755,6 @@
     {
       "community": 150,
       "file_type": "code",
-      "id": "customerobservabilitytimeline_formatobservabilitylabel",
-      "label": "formatObservabilityLabel()",
-      "norm_label": "formatobservabilitylabel()",
-      "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 150,
-      "file_type": "code",
-      "id": "customerobservabilitytimeline_getdeviceicon",
-      "label": "getDeviceIcon()",
-      "norm_label": "getdeviceicon()",
-      "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
-      "source_location": "L114"
-    },
-    {
-      "community": 150,
-      "file_type": "code",
-      "id": "customerobservabilitytimeline_getobservabilitystatusstyles",
-      "label": "getObservabilityStatusStyles()",
-      "norm_label": "getobservabilitystatusstyles()",
-      "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 150,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_customerobservabilitytimeline_ts",
-      "label": "customerObservabilityTimeline.ts",
-      "norm_label": "customerobservabilitytimeline.ts",
-      "source_file": "packages/athena-webapp/src/lib/customerObservabilityTimeline.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 151,
-      "file_type": "code",
       "id": "barcodeutils_extractbarcodefrominput",
       "label": "extractBarcodeFromInput()",
       "norm_label": "extractbarcodefrominput()",
@@ -34720,7 +34762,7 @@
       "source_location": "L51"
     },
     {
-      "community": 151,
+      "community": 150,
       "file_type": "code",
       "id": "barcodeutils_isurlorbarcode",
       "label": "isUrlOrBarcode()",
@@ -34729,7 +34771,7 @@
       "source_location": "L92"
     },
     {
-      "community": 151,
+      "community": 150,
       "file_type": "code",
       "id": "barcodeutils_isvalidconvexid",
       "label": "isValidConvexId()",
@@ -34738,7 +34780,7 @@
       "source_location": "L16"
     },
     {
-      "community": 151,
+      "community": 150,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_barcodeutils_ts",
       "label": "barcodeUtils.ts",
@@ -34747,7 +34789,7 @@
       "source_location": "L1"
     },
     {
-      "community": 152,
+      "community": 151,
       "file_type": "code",
       "id": "offers_getbaseurl",
       "label": "getBaseUrl()",
@@ -34756,7 +34798,7 @@
       "source_location": "L13"
     },
     {
-      "community": 152,
+      "community": 151,
       "file_type": "code",
       "id": "offers_getuserredeemedoffers",
       "label": "getUserRedeemedOffers()",
@@ -34765,7 +34807,7 @@
       "source_location": "L46"
     },
     {
-      "community": 152,
+      "community": 151,
       "file_type": "code",
       "id": "offers_submitoffer",
       "label": "submitOffer()",
@@ -34774,7 +34816,7 @@
       "source_location": "L21"
     },
     {
-      "community": 152,
+      "community": 151,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_offers_ts",
       "label": "offers.ts",
@@ -34783,7 +34825,7 @@
       "source_location": "L1"
     },
     {
-      "community": 153,
+      "community": 152,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_stores_ts",
       "label": "stores.ts",
@@ -34792,7 +34834,7 @@
       "source_location": "L1"
     },
     {
-      "community": 153,
+      "community": 152,
       "file_type": "code",
       "id": "stores_getallstores",
       "label": "getAllStores()",
@@ -34801,7 +34843,7 @@
       "source_location": "L8"
     },
     {
-      "community": 153,
+      "community": 152,
       "file_type": "code",
       "id": "stores_getbaseurl",
       "label": "getBaseUrl()",
@@ -34810,7 +34852,7 @@
       "source_location": "L5"
     },
     {
-      "community": 153,
+      "community": 152,
       "file_type": "code",
       "id": "stores_getstore",
       "label": "getStore()",
@@ -34819,7 +34861,7 @@
       "source_location": "L20"
     },
     {
-      "community": 154,
+      "community": 153,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_subcategory_ts",
       "label": "subcategory.ts",
@@ -34828,7 +34870,7 @@
       "source_location": "L1"
     },
     {
-      "community": 154,
+      "community": 153,
       "file_type": "code",
       "id": "subcategory_getallsubcategories",
       "label": "getAllSubcategories()",
@@ -34837,7 +34879,7 @@
       "source_location": "L11"
     },
     {
-      "community": 154,
+      "community": 153,
       "file_type": "code",
       "id": "subcategory_getbaseurl",
       "label": "getBaseUrl()",
@@ -34846,7 +34888,7 @@
       "source_location": "L9"
     },
     {
-      "community": 154,
+      "community": 153,
       "file_type": "code",
       "id": "subcategory_getsubategory",
       "label": "getSubategory()",
@@ -34855,7 +34897,7 @@
       "source_location": "L25"
     },
     {
-      "community": 155,
+      "community": 154,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productactionbar_tsx",
       "label": "ProductActionBar.tsx",
@@ -34864,7 +34906,7 @@
       "source_location": "L1"
     },
     {
-      "community": 155,
+      "community": 154,
       "file_type": "code",
       "id": "productactionbar_checkscroll",
       "label": "checkScroll()",
@@ -34873,7 +34915,7 @@
       "source_location": "L50"
     },
     {
-      "community": 155,
+      "community": 154,
       "file_type": "code",
       "id": "productactionbar_handleaction",
       "label": "handleAction()",
@@ -34882,7 +34924,7 @@
       "source_location": "L92"
     },
     {
-      "community": 155,
+      "community": 154,
       "file_type": "code",
       "id": "productactionbar_handledismiss",
       "label": "handleDismiss()",
@@ -34891,7 +34933,7 @@
       "source_location": "L74"
     },
     {
-      "community": 156,
+      "community": 155,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productreminderbar_tsx",
       "label": "ProductReminderBar.tsx",
@@ -34900,7 +34942,7 @@
       "source_location": "L1"
     },
     {
-      "community": 156,
+      "community": 155,
       "file_type": "code",
       "id": "productreminderbar_checkscroll",
       "label": "checkScroll()",
@@ -34909,7 +34951,7 @@
       "source_location": "L62"
     },
     {
-      "community": 156,
+      "community": 155,
       "file_type": "code",
       "id": "productreminderbar_handleaddtobag",
       "label": "handleAddToBag()",
@@ -34918,7 +34960,7 @@
       "source_location": "L109"
     },
     {
-      "community": 156,
+      "community": 155,
       "file_type": "code",
       "id": "productreminderbar_handledismiss",
       "label": "handleDismiss()",
@@ -34927,7 +34969,7 @@
       "source_location": "L177"
     },
     {
-      "community": 157,
+      "community": 156,
       "file_type": "code",
       "id": "billingdetailssection_clearform",
       "label": "clearForm()",
@@ -34936,7 +34978,7 @@
       "source_location": "L18"
     },
     {
-      "community": 157,
+      "community": 156,
       "file_type": "code",
       "id": "billingdetailssection_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -34945,7 +34987,7 @@
       "source_location": "L52"
     },
     {
-      "community": 157,
+      "community": 156,
       "file_type": "code",
       "id": "billingdetailssection_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -34954,7 +34996,7 @@
       "source_location": "L68"
     },
     {
-      "community": 157,
+      "community": 156,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetailssection_tsx",
       "label": "BillingDetailsSection.tsx",
@@ -34963,7 +35005,7 @@
       "source_location": "L1"
     },
     {
-      "community": 158,
+      "community": 157,
       "file_type": "code",
       "id": "hooks_usegetshopsearchparams",
       "label": "useGetShopSearchParams()",
@@ -34972,7 +35014,7 @@
       "source_location": "L68"
     },
     {
-      "community": 158,
+      "community": 157,
       "file_type": "code",
       "id": "hooks_usegetstorecategories",
       "label": "useGetStoreCategories()",
@@ -34981,7 +35023,7 @@
       "source_location": "L26"
     },
     {
-      "community": 158,
+      "community": 157,
       "file_type": "code",
       "id": "hooks_usegetstoresubcategories",
       "label": "useGetStoreSubcategories()",
@@ -34990,7 +35032,7 @@
       "source_location": "L7"
     },
     {
-      "community": 158,
+      "community": 157,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_hooks_ts",
       "label": "hooks.ts",
@@ -34999,7 +35041,7 @@
       "source_location": "L1"
     },
     {
-      "community": 159,
+      "community": 158,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -35008,7 +35050,7 @@
       "source_location": "L1"
     },
     {
-      "community": 159,
+      "community": 158,
       "file_type": "code",
       "id": "productdetails_bagproduct",
       "label": "BagProduct()",
@@ -35017,7 +35059,7 @@
       "source_location": "L43"
     },
     {
-      "community": 159,
+      "community": 158,
       "file_type": "code",
       "id": "productdetails_pickupdetails",
       "label": "PickupDetails()",
@@ -35026,13 +35068,49 @@
       "source_location": "L13"
     },
     {
-      "community": 159,
+      "community": 158,
       "file_type": "code",
       "id": "productdetails_shippingpolicy",
       "label": "ShippingPolicy()",
       "norm_label": "shippingpolicy()",
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductDetails.tsx",
       "source_location": "L88"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
+      "label": "UpsellModal.tsx",
+      "norm_label": "upsellmodal.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "upsellmodal_handleclose",
+      "label": "handleClose()",
+      "norm_label": "handleclose()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
+      "source_location": "L111"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "upsellmodal_handlescroll",
+      "label": "handleScroll()",
+      "norm_label": "handlescroll()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
+      "source_location": "L66"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "upsellmodal_handlesuccess",
+      "label": "handleSuccess()",
+      "norm_label": "handlesuccess()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
+      "source_location": "L127"
     },
     {
       "community": 16,
@@ -35190,38 +35268,38 @@
     {
       "community": 160,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodal_tsx",
-      "label": "UpsellModal.tsx",
-      "norm_label": "upsellmodal.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
+      "id": "currency_todisplayamount",
+      "label": "toDisplayAmount()",
+      "norm_label": "todisplayamount()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 160,
+      "file_type": "code",
+      "id": "currency_topesewas",
+      "label": "toPesewas()",
+      "norm_label": "topesewas()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
       "source_location": "L1"
     },
     {
       "community": 160,
       "file_type": "code",
-      "id": "upsellmodal_handleclose",
-      "label": "handleClose()",
-      "norm_label": "handleclose()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
-      "source_location": "L111"
+      "id": "packages_athena_webapp_convex_lib_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/athena-webapp/convex/lib/currency.ts",
+      "source_location": "L1"
     },
     {
       "community": 160,
       "file_type": "code",
-      "id": "upsellmodal_handlescroll",
-      "label": "handleScroll()",
-      "norm_label": "handlescroll()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
-      "source_location": "L66"
-    },
-    {
-      "community": 160,
-      "file_type": "code",
-      "id": "upsellmodal_handlesuccess",
-      "label": "handleSuccess()",
-      "norm_label": "handlesuccess()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/UpsellModal.tsx",
-      "source_location": "L127"
+      "id": "packages_storefront_webapp_src_lib_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L1"
     },
     {
       "community": 161,
@@ -40117,7 +40195,7 @@
       "label": "collectRepairableHarnessDocErrors()",
       "norm_label": "collectrepairableharnessdocerrors()",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L151"
+      "source_location": "L152"
     },
     {
       "community": 28,
@@ -40126,7 +40204,7 @@
       "label": "formatBlockerList()",
       "norm_label": "formatblockerlist()",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L183"
+      "source_location": "L184"
     },
     {
       "community": 28,
@@ -40135,7 +40213,7 @@
       "label": "getChangedFilesVsOriginMain()",
       "norm_label": "getchangedfilesvsoriginmain()",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L58"
+      "source_location": "L59"
     },
     {
       "community": 28,
@@ -40144,7 +40222,7 @@
       "label": "runArchitectureCheck()",
       "norm_label": "runarchitecturecheck()",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L99"
+      "source_location": "L100"
     },
     {
       "community": 28,
@@ -40153,7 +40231,7 @@
       "label": "runHarnessGenerate()",
       "norm_label": "runharnessgenerate()",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L117"
+      "source_location": "L118"
     },
     {
       "community": 28,
@@ -40162,7 +40240,7 @@
       "label": "runHarnessImplementationTests()",
       "norm_label": "runharnessimplementationtests()",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L121"
+      "source_location": "L122"
     },
     {
       "community": 28,
@@ -40171,7 +40249,7 @@
       "label": "runHarnessInferentialReview()",
       "norm_label": "runharnessinferentialreview()",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L133"
+      "source_location": "L134"
     },
     {
       "community": 28,
@@ -40180,7 +40258,7 @@
       "label": "runHarnessSelfReview()",
       "norm_label": "runharnessselfreview()",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L111"
+      "source_location": "L112"
     },
     {
       "community": 28,
@@ -40189,7 +40267,7 @@
       "label": "runPrePushReview()",
       "norm_label": "runprepushreview()",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L187"
+      "source_location": "L188"
     },
     {
       "community": 28,
@@ -40198,7 +40276,7 @@
       "label": "shouldRunHarnessImplementationTests()",
       "norm_label": "shouldrunharnessimplementationtests()",
       "source_file": "scripts/pre-push-review.ts",
-      "source_location": "L145"
+      "source_location": "L146"
     },
     {
       "community": 28,
@@ -40239,6 +40317,60 @@
     {
       "community": 281,
       "file_type": "code",
+      "id": "pre_commit_generated_artifacts_test_log",
+      "label": "log()",
+      "norm_label": "log()",
+      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
+      "id": "pre_commit_generated_artifacts_test_spawn",
+      "label": "spawn()",
+      "norm_label": "spawn()",
+      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
+      "id": "scripts_pre_commit_generated_artifacts_test_ts",
+      "label": "pre-commit-generated-artifacts.test.ts",
+      "norm_label": "pre-commit-generated-artifacts.test.ts",
+      "source_file": "scripts/pre-commit-generated-artifacts.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 282,
+      "file_type": "code",
+      "id": "pre_commit_generated_artifacts_runprecommitgeneratedartifacts",
+      "label": "runPreCommitGeneratedArtifacts()",
+      "norm_label": "runprecommitgeneratedartifacts()",
+      "source_file": "scripts/pre-commit-generated-artifacts.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 282,
+      "file_type": "code",
+      "id": "pre_commit_generated_artifacts_stagetrackedgraphifyartifacts",
+      "label": "stageTrackedGraphifyArtifacts()",
+      "norm_label": "stagetrackedgraphifyartifacts()",
+      "source_file": "scripts/pre-commit-generated-artifacts.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 282,
+      "file_type": "code",
+      "id": "scripts_pre_commit_generated_artifacts_ts",
+      "label": "pre-commit-generated-artifacts.ts",
+      "norm_label": "pre-commit-generated-artifacts.ts",
+      "source_file": "scripts/pre-commit-generated-artifacts.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 283,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_cloudflare_stream_ts",
       "label": "stream.ts",
       "norm_label": "stream.ts",
@@ -40246,7 +40378,7 @@
       "source_location": "L1"
     },
     {
-      "community": 281,
+      "community": 283,
       "file_type": "code",
       "id": "stream_getcloudflareconfig",
       "label": "getCloudflareConfig()",
@@ -40255,7 +40387,7 @@
       "source_location": "L8"
     },
     {
-      "community": 282,
+      "community": 284,
       "file_type": "code",
       "id": "convexauditscript_test_createcommandshimbin",
       "label": "createCommandShimBin()",
@@ -40264,7 +40396,7 @@
       "source_location": "L10"
     },
     {
-      "community": 282,
+      "community": 284,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_convexauditscript_test_ts",
       "label": "convexAuditScript.test.ts",
@@ -40273,7 +40405,7 @@
       "source_location": "L1"
     },
     {
-      "community": 283,
+      "community": 285,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_verificationcode_tsx",
       "label": "VerificationCode.tsx",
@@ -40282,7 +40414,7 @@
       "source_location": "L1"
     },
     {
-      "community": 283,
+      "community": 285,
       "file_type": "code",
       "id": "verificationcode_verificationcode",
       "label": "VerificationCode()",
@@ -40291,7 +40423,7 @@
       "source_location": "L18"
     },
     {
-      "community": 284,
+      "community": 286,
       "file_type": "code",
       "id": "mtnmomo_handlecollectionnotification",
       "label": "handleCollectionNotification()",
@@ -40300,7 +40432,7 @@
       "source_location": "L10"
     },
     {
-      "community": 284,
+      "community": 286,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_payments_routes_mtnmomo_ts",
       "label": "mtnMomo.ts",
@@ -40309,7 +40441,7 @@
       "source_location": "L1"
     },
     {
-      "community": 285,
+      "community": 287,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_routercomposition_test_ts",
       "label": "routerComposition.test.ts",
@@ -40318,7 +40450,7 @@
       "source_location": "L1"
     },
     {
-      "community": 285,
+      "community": 287,
       "file_type": "code",
       "id": "routercomposition_test_readprojectfile",
       "label": "readProjectFile()",
@@ -40327,7 +40459,7 @@
       "source_location": "L6"
     },
     {
-      "community": 286,
+      "community": 288,
       "file_type": "code",
       "id": "cashier_authenticatehandler",
       "label": "authenticateHandler()",
@@ -40336,7 +40468,7 @@
       "source_location": "L239"
     },
     {
-      "community": 286,
+      "community": 288,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_cashier_ts",
       "label": "cashier.ts",
@@ -40345,7 +40477,7 @@
       "source_location": "L1"
     },
     {
-      "community": 287,
+      "community": 289,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posquerycleanup_test_ts",
       "label": "posQueryCleanup.test.ts",
@@ -40354,49 +40486,13 @@
       "source_location": "L1"
     },
     {
-      "community": 287,
+      "community": 289,
       "file_type": "code",
       "id": "posquerycleanup_test_readprojectfile",
       "label": "readProjectFile()",
       "norm_label": "readprojectfile()",
       "source_file": "packages/athena-webapp/convex/inventory/posQueryCleanup.test.ts",
       "source_location": "L8"
-    },
-    {
-      "community": 288,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_sessionqueryindexes_test_ts",
-      "label": "sessionQueryIndexes.test.ts",
-      "norm_label": "sessionqueryindexes.test.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/sessionQueryIndexes.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 288,
-      "file_type": "code",
-      "id": "sessionqueryindexes_test_readprojectfile",
-      "label": "readProjectFile()",
-      "norm_label": "readprojectfile()",
-      "source_file": "packages/athena-webapp/convex/inventory/sessionQueryIndexes.test.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_stores_ts",
-      "label": "stores.ts",
-      "norm_label": "stores.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/stores.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "stores_tov2onlyconfig",
-      "label": "toV2OnlyConfig()",
-      "norm_label": "tov2onlyconfig()",
-      "source_file": "packages/athena-webapp/convex/inventory/stores.ts",
-      "source_location": "L27"
     },
     {
       "community": 29,
@@ -40491,6 +40587,42 @@
     {
       "community": 290,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_sessionqueryindexes_test_ts",
+      "label": "sessionQueryIndexes.test.ts",
+      "norm_label": "sessionqueryindexes.test.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/sessionQueryIndexes.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "sessionqueryindexes_test_readprojectfile",
+      "label": "readProjectFile()",
+      "norm_label": "readprojectfile()",
+      "source_file": "packages/athena-webapp/convex/inventory/sessionQueryIndexes.test.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 291,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_stores_ts",
+      "label": "stores.ts",
+      "norm_label": "stores.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/stores.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 291,
+      "file_type": "code",
+      "id": "stores_tov2onlyconfig",
+      "label": "toV2OnlyConfig()",
+      "norm_label": "tov2onlyconfig()",
+      "source_file": "packages/athena-webapp/convex/inventory/stores.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 292,
+      "file_type": "code",
       "id": "callllmprovider_callllmprovider",
       "label": "callLlmProvider()",
       "norm_label": "callllmprovider()",
@@ -40498,7 +40630,7 @@
       "source_location": "L4"
     },
     {
-      "community": 290,
+      "community": 292,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_callllmprovider_ts",
       "label": "callLlmProvider.ts",
@@ -40507,7 +40639,7 @@
       "source_location": "L1"
     },
     {
-      "community": 291,
+      "community": 293,
       "file_type": "code",
       "id": "anthropic_callanthropic",
       "label": "callAnthropic()",
@@ -40516,7 +40648,7 @@
       "source_location": "L3"
     },
     {
-      "community": 291,
+      "community": 293,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_anthropic_ts",
       "label": "anthropic.ts",
@@ -40525,7 +40657,7 @@
       "source_location": "L1"
     },
     {
-      "community": 292,
+      "community": 294,
       "file_type": "code",
       "id": "openai_callopenai",
       "label": "callOpenAi()",
@@ -40534,7 +40666,7 @@
       "source_location": "L3"
     },
     {
-      "community": 292,
+      "community": 294,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_openai_ts",
       "label": "openai.ts",
@@ -40543,7 +40675,7 @@
       "source_location": "L1"
     },
     {
-      "community": 293,
+      "community": 295,
       "file_type": "code",
       "id": "foundation_test_readprojectfile",
       "label": "readProjectFile()",
@@ -40552,7 +40684,7 @@
       "source_location": "L6"
     },
     {
-      "community": 293,
+      "community": 295,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_foundation_test_ts",
       "label": "foundation.test.ts",
@@ -40561,7 +40693,7 @@
       "source_location": "L1"
     },
     {
-      "community": 294,
+      "community": 296,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_verificationcodeemail_tsx",
       "label": "VerificationCodeEmail.tsx",
@@ -40570,7 +40702,7 @@
       "source_location": "L1"
     },
     {
-      "community": 294,
+      "community": 296,
       "file_type": "code",
       "id": "verificationcodeemail_verificationcodeemail",
       "label": "VerificationCodeEmail()",
@@ -40579,7 +40711,7 @@
       "source_location": "L11"
     },
     {
-      "community": 295,
+      "community": 297,
       "file_type": "code",
       "id": "auth_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -40588,7 +40720,7 @@
       "source_location": "L15"
     },
     {
-      "community": 295,
+      "community": 297,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_auth_ts",
       "label": "auth.ts",
@@ -40597,7 +40729,7 @@
       "source_location": "L1"
     },
     {
-      "community": 296,
+      "community": 298,
       "file_type": "code",
       "id": "customerobservabilitytimeline_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -40606,7 +40738,7 @@
       "source_location": "L17"
     },
     {
-      "community": 296,
+      "community": 298,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerobservabilitytimeline_test_ts",
       "label": "customerObservabilityTimeline.test.ts",
@@ -40615,7 +40747,7 @@
       "source_location": "L1"
     },
     {
-      "community": 297,
+      "community": 299,
       "file_type": "code",
       "id": "helperorchestration_test_readprojectfile",
       "label": "readProjectFile()",
@@ -40624,48 +40756,12 @@
       "source_location": "L6"
     },
     {
-      "community": 297,
+      "community": 299,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helperorchestration_test_ts",
       "label": "helperOrchestration.test.ts",
       "norm_label": "helperorchestration.test.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/helperOrchestration.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 298,
-      "file_type": "code",
-      "id": "onlineorder_listorderitems",
-      "label": "listOrderItems()",
-      "norm_label": "listorderitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 298,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_onlineorder_ts",
-      "label": "onlineOrder.ts",
-      "norm_label": "onlineorder.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "onlineorderitem_updateonlineorderitem",
-      "label": "updateOnlineOrderItem()",
-      "norm_label": "updateonlineorderitem()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderItem.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_onlineorderitem_ts",
-      "label": "onlineOrderItem.ts",
-      "norm_label": "onlineorderitem.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderItem.ts",
       "source_location": "L1"
     },
     {
@@ -41040,6 +41136,42 @@
     {
       "community": 300,
       "file_type": "code",
+      "id": "onlineorder_listorderitems",
+      "label": "listOrderItems()",
+      "norm_label": "listorderitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_onlineorder_ts",
+      "label": "onlineOrder.ts",
+      "norm_label": "onlineorder.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "onlineorderitem_updateonlineorderitem",
+      "label": "updateOnlineOrderItem()",
+      "norm_label": "updateonlineorderitem()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderItem.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_onlineorderitem_ts",
+      "label": "onlineOrderItem.ts",
+      "norm_label": "onlineorderitem.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 302,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_reviews_ts",
       "label": "reviews.ts",
       "norm_label": "reviews.ts",
@@ -41047,7 +41179,7 @@
       "source_location": "L1"
     },
     {
-      "community": 300,
+      "community": 302,
       "file_type": "code",
       "id": "reviews_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -41056,7 +41188,7 @@
       "source_location": "L17"
     },
     {
-      "community": 301,
+      "community": 303,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbag_ts",
       "label": "savedBag.ts",
@@ -41065,7 +41197,7 @@
       "source_location": "L1"
     },
     {
-      "community": 301,
+      "community": 303,
       "file_type": "code",
       "id": "savedbag_listsavedbagitems",
       "label": "listSavedBagItems()",
@@ -41074,7 +41206,7 @@
       "source_location": "L14"
     },
     {
-      "community": 302,
+      "community": 304,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_test_ts",
       "label": "storefrontObservabilityReport.test.ts",
@@ -41083,7 +41215,7 @@
       "source_location": "L1"
     },
     {
-      "community": 302,
+      "community": 304,
       "file_type": "code",
       "id": "storefrontobservabilityreport_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -41092,7 +41224,7 @@
       "source_location": "L8"
     },
     {
-      "community": 303,
+      "community": 305,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_syntheticmonitor_ts",
       "label": "syntheticMonitor.ts",
@@ -41101,7 +41233,7 @@
       "source_location": "L1"
     },
     {
-      "community": 303,
+      "community": 305,
       "file_type": "code",
       "id": "syntheticmonitor_issyntheticmonitororigin",
       "label": "isSyntheticMonitorOrigin()",
@@ -41110,7 +41242,7 @@
       "source_location": "L3"
     },
     {
-      "community": 304,
+      "community": 306,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_timequeryrefactors_test_ts",
       "label": "timeQueryRefactors.test.ts",
@@ -41119,7 +41251,7 @@
       "source_location": "L1"
     },
     {
-      "community": 304,
+      "community": 306,
       "file_type": "code",
       "id": "timequeryrefactors_test_readsource",
       "label": "readSource()",
@@ -41128,7 +41260,7 @@
       "source_location": "L5"
     },
     {
-      "community": 305,
+      "community": 307,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_user_ts",
       "label": "user.ts",
@@ -41137,7 +41269,7 @@
       "source_location": "L1"
     },
     {
-      "community": 305,
+      "community": 307,
       "file_type": "code",
       "id": "user_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -41146,7 +41278,7 @@
       "source_location": "L16"
     },
     {
-      "community": 306,
+      "community": 308,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_useroffers_ts",
       "label": "userOffers.ts",
@@ -41155,7 +41287,7 @@
       "source_location": "L1"
     },
     {
-      "community": 306,
+      "community": 308,
       "file_type": "code",
       "id": "useroffers_determineoffereligibility",
       "label": "determineOfferEligibility()",
@@ -41164,7 +41296,7 @@
       "source_location": "L30"
     },
     {
-      "community": 307,
+      "community": 309,
       "file_type": "code",
       "id": "organizationview_navigation",
       "label": "Navigation()",
@@ -41173,49 +41305,13 @@
       "source_location": "L7"
     },
     {
-      "community": 307,
+      "community": 309,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationview_tsx",
       "label": "OrganizationView.tsx",
       "norm_label": "organizationview.tsx",
       "source_file": "packages/athena-webapp/src/components/OrganizationView.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 308,
-      "file_type": "code",
-      "id": "organizationsview_navigation",
-      "label": "Navigation()",
-      "norm_label": "navigation()",
-      "source_file": "packages/athena-webapp/src/components/OrganizationsView.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 308,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organizationsview_tsx",
-      "label": "OrganizationsView.tsx",
-      "norm_label": "organizationsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/OrganizationsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_permissiongate_tsx",
-      "label": "PermissionGate.tsx",
-      "norm_label": "permissiongate.tsx",
-      "source_file": "packages/athena-webapp/src/components/PermissionGate.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "permissiongate_permissiongate",
-      "label": "PermissionGate()",
-      "norm_label": "permissiongate()",
-      "source_file": "packages/athena-webapp/src/components/PermissionGate.tsx",
-      "source_location": "L11"
     },
     {
       "community": 31,
@@ -41310,6 +41406,42 @@
     {
       "community": 310,
       "file_type": "code",
+      "id": "organizationsview_navigation",
+      "label": "Navigation()",
+      "norm_label": "navigation()",
+      "source_file": "packages/athena-webapp/src/components/OrganizationsView.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 310,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organizationsview_tsx",
+      "label": "OrganizationsView.tsx",
+      "norm_label": "organizationsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/OrganizationsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_permissiongate_tsx",
+      "label": "PermissionGate.tsx",
+      "norm_label": "permissiongate.tsx",
+      "source_file": "packages/athena-webapp/src/components/PermissionGate.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 311,
+      "file_type": "code",
+      "id": "permissiongate_permissiongate",
+      "label": "PermissionGate()",
+      "norm_label": "permissiongate()",
+      "source_file": "packages/athena-webapp/src/components/PermissionGate.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 312,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_protectedroute_tsx",
       "label": "ProtectedRoute.tsx",
       "norm_label": "protectedroute.tsx",
@@ -41317,7 +41449,7 @@
       "source_location": "L1"
     },
     {
-      "community": 310,
+      "community": 312,
       "file_type": "code",
       "id": "protectedroute_protectedroute",
       "label": "ProtectedRoute()",
@@ -41326,7 +41458,7 @@
       "source_location": "L11"
     },
     {
-      "community": 311,
+      "community": 313,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_settingsview_tsx",
       "label": "SettingsView.tsx",
@@ -41335,7 +41467,7 @@
       "source_location": "L1"
     },
     {
-      "community": 311,
+      "community": 313,
       "file_type": "code",
       "id": "settingsview_settingsview",
       "label": "SettingsView()",
@@ -41344,7 +41476,7 @@
       "source_location": "L3"
     },
     {
-      "community": 312,
+      "community": 314,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeactions_tsx",
       "label": "StoreActions.tsx",
@@ -41353,7 +41485,7 @@
       "source_location": "L1"
     },
     {
-      "community": 312,
+      "community": 314,
       "file_type": "code",
       "id": "storeactions_storeactions",
       "label": "StoreActions()",
@@ -41362,7 +41494,7 @@
       "source_location": "L12"
     },
     {
-      "community": 313,
+      "community": 315,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storedropdown_tsx",
       "label": "StoreDropdown.tsx",
@@ -41371,7 +41503,7 @@
       "source_location": "L1"
     },
     {
-      "community": 313,
+      "community": 315,
       "file_type": "code",
       "id": "storedropdown_storedropdown",
       "label": "StoreDropdown()",
@@ -41380,7 +41512,7 @@
       "source_location": "L42"
     },
     {
-      "community": 314,
+      "community": 316,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeview_tsx",
       "label": "StoreView.tsx",
@@ -41389,7 +41521,7 @@
       "source_location": "L1"
     },
     {
-      "community": 314,
+      "community": 316,
       "file_type": "code",
       "id": "storeview_navigation",
       "label": "Navigation()",
@@ -41398,7 +41530,7 @@
       "source_location": "L13"
     },
     {
-      "community": 315,
+      "community": 317,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesdropdown_tsx",
       "label": "StoresDropdown.tsx",
@@ -41407,7 +41539,7 @@
       "source_location": "L1"
     },
     {
-      "community": 315,
+      "community": 317,
       "file_type": "code",
       "id": "storesdropdown_storesdropdown",
       "label": "StoresDropdown()",
@@ -41416,7 +41548,7 @@
       "source_location": "L42"
     },
     {
-      "community": 316,
+      "community": 318,
       "file_type": "code",
       "id": "barcodeqrviewer_handleprint",
       "label": "handlePrint()",
@@ -41425,7 +41557,7 @@
       "source_location": "L31"
     },
     {
-      "community": 316,
+      "community": 318,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_barcodeqrviewer_tsx",
       "label": "BarcodeQRViewer.tsx",
@@ -41434,7 +41566,7 @@
       "source_location": "L1"
     },
     {
-      "community": 317,
+      "community": 319,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_processingfees_tsx",
       "label": "ProcessingFees.tsx",
@@ -41443,49 +41575,13 @@
       "source_location": "L1"
     },
     {
-      "community": 317,
+      "community": 319,
       "file_type": "code",
       "id": "processingfees_processingfeesview",
       "label": "ProcessingFeesView()",
       "norm_label": "processingfeesview()",
       "source_file": "packages/athena-webapp/src/components/add-product/ProcessingFees.tsx",
       "source_location": "L10"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productattributes_tsx",
-      "label": "ProductAttributes.tsx",
-      "norm_label": "productattributes.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductAttributes.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "productattributes_isallowedattribute",
-      "label": "isAllowedAttribute()",
-      "norm_label": "isallowedattribute()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductAttributes.tsx",
-      "source_location": "L14"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productavailabilitytogglegroup_tsx",
-      "label": "ProductAvailabilityToggleGroup.tsx",
-      "norm_label": "productavailabilitytogglegroup.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailabilityToggleGroup.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 319,
-      "file_type": "code",
-      "id": "productavailabilitytogglegroup_productavailabilitytogglegroup",
-      "label": "ProductAvailabilityToggleGroup()",
-      "norm_label": "productavailabilitytogglegroup()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailabilityToggleGroup.tsx",
-      "source_location": "L5"
     },
     {
       "community": 32,
@@ -41580,6 +41676,42 @@
     {
       "community": 320,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_productattributes_tsx",
+      "label": "ProductAttributes.tsx",
+      "norm_label": "productattributes.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductAttributes.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 320,
+      "file_type": "code",
+      "id": "productattributes_isallowedattribute",
+      "label": "isAllowedAttribute()",
+      "norm_label": "isallowedattribute()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductAttributes.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_productavailabilitytogglegroup_tsx",
+      "label": "ProductAvailabilityToggleGroup.tsx",
+      "norm_label": "productavailabilitytogglegroup.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailabilityToggleGroup.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "productavailabilitytogglegroup_productavailabilitytogglegroup",
+      "label": "ProductAvailabilityToggleGroup()",
+      "norm_label": "productavailabilitytogglegroup()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailabilityToggleGroup.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 322,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productdetails_tsx",
       "label": "ProductDetails.tsx",
       "norm_label": "productdetails.tsx",
@@ -41587,7 +41719,7 @@
       "source_location": "L1"
     },
     {
-      "community": 320,
+      "community": 322,
       "file_type": "code",
       "id": "productdetails_handlenamechange",
       "label": "handleNameChange()",
@@ -41596,7 +41728,7 @@
       "source_location": "L10"
     },
     {
-      "community": 321,
+      "community": 323,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productimages_tsx",
       "label": "ProductImages.tsx",
@@ -41605,7 +41737,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 323,
       "file_type": "code",
       "id": "productimages_header",
       "label": "Header()",
@@ -41614,7 +41746,7 @@
       "source_location": "L15"
     },
     {
-      "community": 322,
+      "community": 324,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productpage_tsx",
       "label": "ProductPage.tsx",
@@ -41623,7 +41755,7 @@
       "source_location": "L1"
     },
     {
-      "community": 322,
+      "community": 324,
       "file_type": "code",
       "id": "productpage_productpage",
       "label": "ProductPage()",
@@ -41632,7 +41764,7 @@
       "source_location": "L13"
     },
     {
-      "community": 323,
+      "community": 325,
       "file_type": "code",
       "id": "copyimagesview_setisupdatingsku",
       "label": "setIsUpdatingSku()",
@@ -41641,7 +41773,7 @@
       "source_location": "L116"
     },
     {
-      "community": 323,
+      "community": 325,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesview_tsx",
       "label": "CopyImagesView.tsx",
@@ -41650,7 +41782,7 @@
       "source_location": "L1"
     },
     {
-      "community": 324,
+      "community": 326,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_product_variant_columns_tsx",
       "label": "product-variant-columns.tsx",
@@ -41659,7 +41791,7 @@
       "source_location": "L1"
     },
     {
-      "community": 324,
+      "community": 326,
       "file_type": "code",
       "id": "product_variant_columns_setsourcevariant",
       "label": "setSourceVariant()",
@@ -41668,7 +41800,7 @@
       "source_location": "L47"
     },
     {
-      "community": 325,
+      "community": 327,
       "file_type": "code",
       "id": "activitytimeline_capitalizefirstletter",
       "label": "capitalizeFirstLetter()",
@@ -41677,7 +41809,7 @@
       "source_location": "L151"
     },
     {
-      "community": 325,
+      "community": 327,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_activitytimeline_tsx",
       "label": "ActivityTimeline.tsx",
@@ -41686,7 +41818,7 @@
       "source_location": "L1"
     },
     {
-      "community": 326,
+      "community": 328,
       "file_type": "code",
       "id": "analyticsitems_analyticsitems",
       "label": "AnalyticsItems()",
@@ -41695,7 +41827,7 @@
       "source_location": "L6"
     },
     {
-      "community": 326,
+      "community": 328,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsitems_tsx",
       "label": "AnalyticsItems.tsx",
@@ -41704,7 +41836,7 @@
       "source_location": "L1"
     },
     {
-      "community": 327,
+      "community": 329,
       "file_type": "code",
       "id": "analyticsproducts_analyticsproducts",
       "label": "AnalyticsProducts()",
@@ -41713,48 +41845,12 @@
       "source_location": "L19"
     },
     {
-      "community": 327,
+      "community": 329,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsproducts_tsx",
       "label": "AnalyticsProducts.tsx",
       "norm_label": "analyticsproducts.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsProducts.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 328,
-      "file_type": "code",
-      "id": "analyticsusers_analyticsusers",
-      "label": "AnalyticsUsers()",
-      "norm_label": "analyticsusers()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsUsers.tsx",
-      "source_location": "L7"
-    },
-    {
-      "community": 328,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analyticsusers_tsx",
-      "label": "AnalyticsUsers.tsx",
-      "norm_label": "analyticsusers.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsUsers.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "enhancedanalyticsview_getdaterangemilliseconds",
-      "label": "getDateRangeMilliseconds()",
-      "norm_label": "getdaterangemilliseconds()",
-      "source_file": "packages/athena-webapp/src/components/analytics/EnhancedAnalyticsView.tsx",
-      "source_location": "L42"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_enhancedanalyticsview_tsx",
-      "label": "EnhancedAnalyticsView.tsx",
-      "norm_label": "enhancedanalyticsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/EnhancedAnalyticsView.tsx",
       "source_location": "L1"
     },
     {
@@ -41850,6 +41946,42 @@
     {
       "community": 330,
       "file_type": "code",
+      "id": "analyticsusers_analyticsusers",
+      "label": "AnalyticsUsers()",
+      "norm_label": "analyticsusers()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsUsers.tsx",
+      "source_location": "L7"
+    },
+    {
+      "community": 330,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analyticsusers_tsx",
+      "label": "AnalyticsUsers.tsx",
+      "norm_label": "analyticsusers.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsUsers.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
+      "id": "enhancedanalyticsview_getdaterangemilliseconds",
+      "label": "getDateRangeMilliseconds()",
+      "norm_label": "getdaterangemilliseconds()",
+      "source_file": "packages/athena-webapp/src/components/analytics/EnhancedAnalyticsView.tsx",
+      "source_location": "L42"
+    },
+    {
+      "community": 331,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_enhancedanalyticsview_tsx",
+      "label": "EnhancedAnalyticsView.tsx",
+      "norm_label": "enhancedanalyticsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/EnhancedAnalyticsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 332,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storeinsights_tsx",
       "label": "StoreInsights.tsx",
       "norm_label": "storeinsights.tsx",
@@ -41857,7 +41989,7 @@
       "source_location": "L1"
     },
     {
-      "community": 330,
+      "community": 332,
       "file_type": "code",
       "id": "storeinsights_gettrendicon",
       "label": "getTrendIcon()",
@@ -41866,7 +41998,7 @@
       "source_location": "L66"
     },
     {
-      "community": 331,
+      "community": 333,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_visitorchart_tsx",
       "label": "VisitorChart.tsx",
@@ -41875,7 +42007,7 @@
       "source_location": "L1"
     },
     {
-      "community": 331,
+      "community": 333,
       "file_type": "code",
       "id": "visitorchart_formathour",
       "label": "formatHour()",
@@ -41884,7 +42016,7 @@
       "source_location": "L18"
     },
     {
-      "community": 332,
+      "community": 334,
       "file_type": "code",
       "id": "logitems_logitems",
       "label": "LogItems()",
@@ -41893,7 +42025,7 @@
       "source_location": "L6"
     },
     {
-      "community": 332,
+      "community": 334,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logitems_tsx",
       "label": "LogItems.tsx",
@@ -41902,7 +42034,7 @@
       "source_location": "L1"
     },
     {
-      "community": 333,
+      "community": 335,
       "file_type": "code",
       "id": "logview_header",
       "label": "Header()",
@@ -41911,7 +42043,7 @@
       "source_location": "L10"
     },
     {
-      "community": 333,
+      "community": 335,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logview_tsx",
       "label": "LogView.tsx",
@@ -41920,7 +42052,7 @@
       "source_location": "L1"
     },
     {
-      "community": 334,
+      "community": 336,
       "file_type": "code",
       "id": "logsview_navigation",
       "label": "Navigation()",
@@ -41929,7 +42061,7 @@
       "source_location": "L27"
     },
     {
-      "community": 334,
+      "community": 336,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logsview_tsx",
       "label": "LogsView.tsx",
@@ -41938,7 +42070,7 @@
       "source_location": "L1"
     },
     {
-      "community": 335,
+      "community": 337,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_hooks_useloadlogitems_ts",
       "label": "useLoadLogItems.ts",
@@ -41947,7 +42079,7 @@
       "source_location": "L1"
     },
     {
-      "community": 335,
+      "community": 337,
       "file_type": "code",
       "id": "useloadlogitems_useloadlogitems",
       "label": "useLoadLogItems()",
@@ -41956,7 +42088,7 @@
       "source_location": "L12"
     },
     {
-      "community": 336,
+      "community": 338,
       "file_type": "code",
       "id": "auth_auth",
       "label": "Auth()",
@@ -41965,7 +42097,7 @@
       "source_location": "L3"
     },
     {
-      "community": 336,
+      "community": 338,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -41974,7 +42106,7 @@
       "source_location": "L1"
     },
     {
-      "community": 337,
+      "community": 339,
       "file_type": "code",
       "id": "index_login",
       "label": "Login()",
@@ -41983,48 +42115,12 @@
       "source_location": "L5"
     },
     {
-      "community": 337,
+      "community": 339,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/components/auth/Login/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 338,
-      "file_type": "code",
-      "id": "bulkoperationsfilters_handleloadproducts",
-      "label": "handleLoadProducts()",
-      "norm_label": "handleloadproducts()",
-      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsFilters.tsx",
-      "source_location": "L49"
-    },
-    {
-      "community": 338,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationsfilters_tsx",
-      "label": "BulkOperationsFilters.tsx",
-      "norm_label": "bulkoperationsfilters.tsx",
-      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsFilters.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "bulkoperationspreview_test_makerow",
-      "label": "makeRow()",
-      "norm_label": "makerow()",
-      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.test.tsx",
-      "source_location": "L23"
-    },
-    {
-      "community": 339,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_test_tsx",
-      "label": "BulkOperationsPreview.test.tsx",
-      "norm_label": "bulkoperationspreview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.test.tsx",
       "source_location": "L1"
     },
     {
@@ -42120,6 +42216,42 @@
     {
       "community": 340,
       "file_type": "code",
+      "id": "bulkoperationsfilters_handleloadproducts",
+      "label": "handleLoadProducts()",
+      "norm_label": "handleloadproducts()",
+      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsFilters.tsx",
+      "source_location": "L49"
+    },
+    {
+      "community": 340,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationsfilters_tsx",
+      "label": "BulkOperationsFilters.tsx",
+      "norm_label": "bulkoperationsfilters.tsx",
+      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsFilters.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
+      "id": "bulkoperationspreview_test_makerow",
+      "label": "makeRow()",
+      "norm_label": "makerow()",
+      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.test.tsx",
+      "source_location": "L23"
+    },
+    {
+      "community": 341,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_test_tsx",
+      "label": "BulkOperationsPreview.test.tsx",
+      "norm_label": "bulkoperationspreview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPreview.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 342,
+      "file_type": "code",
       "id": "bulkoperationspreview_formatprice",
       "label": "formatPrice()",
       "norm_label": "formatprice()",
@@ -42127,7 +42259,7 @@
       "source_location": "L50"
     },
     {
-      "community": 340,
+      "community": 342,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_tsx",
       "label": "BulkOperationsPreview.tsx",
@@ -42136,7 +42268,7 @@
       "source_location": "L1"
     },
     {
-      "community": 341,
+      "community": 343,
       "file_type": "code",
       "id": "checkoutsessionstable_checkoutsessionstable",
       "label": "CheckoutSessionsTable()",
@@ -42145,7 +42277,7 @@
       "source_location": "L13"
     },
     {
-      "community": 341,
+      "community": 343,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsessionstable_tsx",
       "label": "CheckoutSessionsTable.tsx",
@@ -42154,7 +42286,7 @@
       "source_location": "L1"
     },
     {
-      "community": 342,
+      "community": 344,
       "file_type": "code",
       "id": "checkoutsesssionsview_navigation",
       "label": "Navigation()",
@@ -42163,7 +42295,7 @@
       "source_location": "L11"
     },
     {
-      "community": 342,
+      "community": 344,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsesssionsview_tsx",
       "label": "CheckoutSesssionsView.tsx",
@@ -42172,7 +42304,7 @@
       "source_location": "L1"
     },
     {
-      "community": 343,
+      "community": 345,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_pageheader_tsx",
       "label": "PageHeader.tsx",
@@ -42181,7 +42313,7 @@
       "source_location": "L1"
     },
     {
-      "community": 343,
+      "community": 345,
       "file_type": "code",
       "id": "pageheader_pageheader",
       "label": "PageHeader()",
@@ -42190,7 +42322,7 @@
       "source_location": "L7"
     },
     {
-      "community": 344,
+      "community": 346,
       "file_type": "code",
       "id": "bestsellersdialog_handleaddbestseller",
       "label": "handleAddBestSeller()",
@@ -42199,7 +42331,7 @@
       "source_location": "L29"
     },
     {
-      "community": 344,
+      "community": 346,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellersdialog_tsx",
       "label": "BestSellersDialog.tsx",
@@ -42208,7 +42340,7 @@
       "source_location": "L1"
     },
     {
-      "community": 345,
+      "community": 347,
       "file_type": "code",
       "id": "featuredsectiondialog_handleaddfeatureditem",
       "label": "handleAddFeaturedItem()",
@@ -42217,7 +42349,7 @@
       "source_location": "L37"
     },
     {
-      "community": 345,
+      "community": 347,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsectiondialog_tsx",
       "label": "FeaturedSectionDialog.tsx",
@@ -42226,7 +42358,7 @@
       "source_location": "L1"
     },
     {
-      "community": 346,
+      "community": 348,
       "file_type": "code",
       "id": "home_navigation",
       "label": "Navigation()",
@@ -42235,7 +42367,7 @@
       "source_location": "L25"
     },
     {
-      "community": 346,
+      "community": 348,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_home_tsx",
       "label": "Home.tsx",
@@ -42244,7 +42376,7 @@
       "source_location": "L1"
     },
     {
-      "community": 347,
+      "community": 349,
       "file_type": "code",
       "id": "landingpagereelversion_handleupdateconfig",
       "label": "handleUpdateConfig()",
@@ -42253,49 +42385,13 @@
       "source_location": "L83"
     },
     {
-      "community": 347,
+      "community": 349,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_landingpagereelversion_tsx",
       "label": "LandingPageReelVersion.tsx",
       "norm_label": "landingpagereelversion.tsx",
       "source_file": "packages/athena-webapp/src/components/homepage/LandingPageReelVersion.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 348,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_shoplookdialog_tsx",
-      "label": "ShopLookDialog.tsx",
-      "norm_label": "shoplookdialog.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookDialog.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 348,
-      "file_type": "code",
-      "id": "shoplookdialog_handleaddfeatureditem",
-      "label": "handleAddFeaturedItem()",
-      "norm_label": "handleaddfeatureditem()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookDialog.tsx",
-      "source_location": "L35"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_shoplookimageuploader_tsx",
-      "label": "ShopLookImageUploader.tsx",
-      "norm_label": "shoplookimageuploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 349,
-      "file_type": "code",
-      "id": "shoplookimageuploader_shoplookimageuploader",
-      "label": "ShopLookImageUploader()",
-      "norm_label": "shoplookimageuploader()",
-      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
-      "source_location": "L28"
     },
     {
       "community": 35,
@@ -42390,6 +42486,42 @@
     {
       "community": 350,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_shoplookdialog_tsx",
+      "label": "ShopLookDialog.tsx",
+      "norm_label": "shoplookdialog.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookDialog.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 350,
+      "file_type": "code",
+      "id": "shoplookdialog_handleaddfeatureditem",
+      "label": "handleAddFeaturedItem()",
+      "norm_label": "handleaddfeatureditem()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookDialog.tsx",
+      "source_location": "L35"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_shoplookimageuploader_tsx",
+      "label": "ShopLookImageUploader.tsx",
+      "norm_label": "shoplookimageuploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 351,
+      "file_type": "code",
+      "id": "shoplookimageuploader_shoplookimageuploader",
+      "label": "ShopLookImageUploader()",
+      "norm_label": "shoplookimageuploader()",
+      "source_file": "packages/athena-webapp/src/components/homepage/ShopLookImageUploader.tsx",
+      "source_location": "L28"
+    },
+    {
+      "community": 352,
+      "file_type": "code",
       "id": "index_jointeam",
       "label": "JoinTeam()",
       "norm_label": "jointeam()",
@@ -42397,7 +42529,7 @@
       "source_location": "L11"
     },
     {
-      "community": 350,
+      "community": 352,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_join_team_index_tsx",
       "label": "index.tsx",
@@ -42406,7 +42538,7 @@
       "source_location": "L1"
     },
     {
-      "community": 351,
+      "community": 353,
       "file_type": "code",
       "id": "customerdetailsview_customerdetailsview",
       "label": "CustomerDetailsView()",
@@ -42415,7 +42547,7 @@
       "source_location": "L13"
     },
     {
-      "community": 351,
+      "community": 353,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_customerdetailsview_tsx",
       "label": "CustomerDetailsView.tsx",
@@ -42424,7 +42556,7 @@
       "source_location": "L1"
     },
     {
-      "community": 352,
+      "community": 354,
       "file_type": "code",
       "id": "emailstatusview_handlesendorderemail",
       "label": "handleSendOrderEmail()",
@@ -42433,7 +42565,7 @@
       "source_location": "L41"
     },
     {
-      "community": 352,
+      "community": 354,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_emailstatusview_tsx",
       "label": "EmailStatusView.tsx",
@@ -42442,7 +42574,7 @@
       "source_location": "L1"
     },
     {
-      "community": 353,
+      "community": 355,
       "file_type": "code",
       "id": "ordermetricspanel_handletimerangechange",
       "label": "handleTimeRangeChange()",
@@ -42451,7 +42583,7 @@
       "source_location": "L33"
     },
     {
-      "community": 353,
+      "community": 355,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordermetricspanel_tsx",
       "label": "OrderMetricsPanel.tsx",
@@ -42460,7 +42592,7 @@
       "source_location": "L1"
     },
     {
-      "community": 354,
+      "community": 356,
       "file_type": "code",
       "id": "ordersview_gettimefilter",
       "label": "getTimeFilter()",
@@ -42469,7 +42601,7 @@
       "source_location": "L35"
     },
     {
-      "community": 354,
+      "community": 356,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersview_tsx",
       "label": "OrdersView.tsx",
@@ -42478,7 +42610,7 @@
       "source_location": "L1"
     },
     {
-      "community": 355,
+      "community": 357,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_refundsview_tsx",
       "label": "RefundsView.tsx",
@@ -42487,7 +42619,7 @@
       "source_location": "L1"
     },
     {
-      "community": 355,
+      "community": 357,
       "file_type": "code",
       "id": "refundsview_handlerefundorder",
       "label": "handleRefundOrder()",
@@ -42496,7 +42628,7 @@
       "source_location": "L79"
     },
     {
-      "community": 356,
+      "community": 358,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_hooks_usegetactiveonlineorder_ts",
       "label": "useGetActiveOnlineOrder.ts",
@@ -42505,7 +42637,7 @@
       "source_location": "L1"
     },
     {
-      "community": 356,
+      "community": 358,
       "file_type": "code",
       "id": "usegetactiveonlineorder_usegetactiveonlineorder",
       "label": "useGetActiveOnlineOrder()",
@@ -42514,7 +42646,7 @@
       "source_location": "L6"
     },
     {
-      "community": 357,
+      "community": 359,
       "file_type": "code",
       "id": "data_table_toolbar_handleclearfilters",
       "label": "handleClearFilters()",
@@ -42523,48 +42655,12 @@
       "source_location": "L34"
     },
     {
-      "community": 357,
+      "community": 359,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
       "norm_label": "data-table-toolbar.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 358,
-      "file_type": "code",
-      "id": "ordercolumns_if",
-      "label": "if()",
-      "norm_label": "if()",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/orderColumns.tsx",
-      "source_location": "L89"
-    },
-    {
-      "community": 358,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_ordercolumns_tsx",
-      "label": "orderColumns.tsx",
-      "norm_label": "ordercolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/orderColumns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "cashierview_handlesignout",
-      "label": "handleSignOut()",
-      "norm_label": "handlesignout()",
-      "source_file": "packages/athena-webapp/src/components/pos/CashierView.tsx",
-      "source_location": "L63"
-    },
-    {
-      "community": 359,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_cashierview_tsx",
-      "label": "CashierView.tsx",
-      "norm_label": "cashierview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/CashierView.tsx",
       "source_location": "L1"
     },
     {
@@ -42651,6 +42747,42 @@
     {
       "community": 360,
       "file_type": "code",
+      "id": "ordercolumns_if",
+      "label": "if()",
+      "norm_label": "if()",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/orderColumns.tsx",
+      "source_location": "L89"
+    },
+    {
+      "community": 360,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_ordercolumns_tsx",
+      "label": "orderColumns.tsx",
+      "norm_label": "ordercolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/orderColumns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
+      "id": "cashierview_handlesignout",
+      "label": "handleSignOut()",
+      "norm_label": "handlesignout()",
+      "source_file": "packages/athena-webapp/src/components/pos/CashierView.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 361,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_cashierview_tsx",
+      "label": "CashierView.tsx",
+      "norm_label": "cashierview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/CashierView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 362,
+      "file_type": "code",
       "id": "debugproducts_debugproducts",
       "label": "DebugProducts()",
       "norm_label": "debugproducts()",
@@ -42658,7 +42790,7 @@
       "source_location": "L5"
     },
     {
-      "community": 360,
+      "community": 362,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_debugproducts_tsx",
       "label": "DebugProducts.tsx",
@@ -42667,7 +42799,7 @@
       "source_location": "L1"
     },
     {
-      "community": 361,
+      "community": 363,
       "file_type": "code",
       "id": "noresultsmessage_noresultsmessage",
       "label": "NoResultsMessage()",
@@ -42676,7 +42808,7 @@
       "source_location": "L7"
     },
     {
-      "community": 361,
+      "community": 363,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_noresultsmessage_tsx",
       "label": "NoResultsMessage.tsx",
@@ -42685,7 +42817,7 @@
       "source_location": "L1"
     },
     {
-      "community": 362,
+      "community": 364,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pininput_tsx",
       "label": "PinInput.tsx",
@@ -42694,7 +42826,7 @@
       "source_location": "L1"
     },
     {
-      "community": 362,
+      "community": 364,
       "file_type": "code",
       "id": "pininput_pininput",
       "label": "PinInput()",
@@ -42703,7 +42835,7 @@
       "source_location": "L13"
     },
     {
-      "community": 363,
+      "community": 365,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
       "label": "PointOfSaleView.tsx",
@@ -42712,7 +42844,7 @@
       "source_location": "L1"
     },
     {
-      "community": 363,
+      "community": 365,
       "file_type": "code",
       "id": "pointofsaleview_navigation",
       "label": "Navigation()",
@@ -42721,7 +42853,7 @@
       "source_location": "L35"
     },
     {
-      "community": 364,
+      "community": 366,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_printinstructions_tsx",
       "label": "PrintInstructions.tsx",
@@ -42730,7 +42862,7 @@
       "source_location": "L1"
     },
     {
-      "community": 364,
+      "community": 366,
       "file_type": "code",
       "id": "printinstructions_printinstructions",
       "label": "PrintInstructions()",
@@ -42739,7 +42871,7 @@
       "source_location": "L3"
     },
     {
-      "community": 365,
+      "community": 367,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productcard_tsx",
       "label": "ProductCard.tsx",
@@ -42748,7 +42880,7 @@
       "source_location": "L1"
     },
     {
-      "community": 365,
+      "community": 367,
       "file_type": "code",
       "id": "productcard_productcard",
       "label": "ProductCard()",
@@ -42757,7 +42889,7 @@
       "source_location": "L14"
     },
     {
-      "community": 366,
+      "community": 368,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productentry_tsx",
       "label": "ProductEntry.tsx",
@@ -42766,7 +42898,7 @@
       "source_location": "L1"
     },
     {
-      "community": 366,
+      "community": 368,
       "file_type": "code",
       "id": "productentry_handleclearsearch",
       "label": "handleClearSearch()",
@@ -42775,7 +42907,7 @@
       "source_location": "L86"
     },
     {
-      "community": 367,
+      "community": 369,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_quickactionsbar_tsx",
       "label": "QuickActionsBar.tsx",
@@ -42784,49 +42916,13 @@
       "source_location": "L1"
     },
     {
-      "community": 367,
+      "community": 369,
       "file_type": "code",
       "id": "quickactionsbar_quickactionsbar",
       "label": "QuickActionsBar()",
       "norm_label": "quickactionsbar()",
       "source_file": "packages/athena-webapp/src/components/pos/QuickActionsBar.tsx",
       "source_location": "L11"
-    },
-    {
-      "community": 368,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_sessiondemo_tsx",
-      "label": "SessionDemo.tsx",
-      "norm_label": "sessiondemo.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/SessionDemo.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 368,
-      "file_type": "code",
-      "id": "sessiondemo_sessiondemo",
-      "label": "SessionDemo()",
-      "norm_label": "sessiondemo()",
-      "source_file": "packages/athena-webapp/src/components/pos/SessionDemo.tsx",
-      "source_location": "L15"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_totalsdisplay_tsx",
-      "label": "TotalsDisplay.tsx",
-      "norm_label": "totalsdisplay.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 369,
-      "file_type": "code",
-      "id": "totalsdisplay_totalsdisplay",
-      "label": "TotalsDisplay()",
-      "norm_label": "totalsdisplay()",
-      "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.tsx",
-      "source_location": "L14"
     },
     {
       "community": 37,
@@ -42912,6 +43008,42 @@
     {
       "community": 370,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_sessiondemo_tsx",
+      "label": "SessionDemo.tsx",
+      "norm_label": "sessiondemo.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/SessionDemo.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 370,
+      "file_type": "code",
+      "id": "sessiondemo_sessiondemo",
+      "label": "SessionDemo()",
+      "norm_label": "sessiondemo()",
+      "source_file": "packages/athena-webapp/src/components/pos/SessionDemo.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 371,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_totalsdisplay_tsx",
+      "label": "TotalsDisplay.tsx",
+      "norm_label": "totalsdisplay.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 371,
+      "file_type": "code",
+      "id": "totalsdisplay_totalsdisplay",
+      "label": "TotalsDisplay()",
+      "norm_label": "totalsdisplay()",
+      "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 372,
+      "file_type": "code",
       "id": "expensereportsview_istoday",
       "label": "isToday()",
       "norm_label": "istoday()",
@@ -42919,7 +43051,7 @@
       "source_location": "L18"
     },
     {
-      "community": 370,
+      "community": 372,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_tsx",
       "label": "ExpenseReportsView.tsx",
@@ -42928,7 +43060,7 @@
       "source_location": "L1"
     },
     {
-      "community": 371,
+      "community": 373,
       "file_type": "code",
       "id": "hooks_useposcashier",
       "label": "usePOSCashier()",
@@ -42937,7 +43069,7 @@
       "source_location": "L5"
     },
     {
-      "community": 371,
+      "community": 373,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_hooks_ts",
       "label": "hooks.ts",
@@ -42946,7 +43078,7 @@
       "source_location": "L1"
     },
     {
-      "community": 372,
+      "community": 374,
       "file_type": "code",
       "id": "holdsessiondialog_holdsessiondialog",
       "label": "HoldSessionDialog()",
@@ -42955,7 +43087,7 @@
       "source_location": "L19"
     },
     {
-      "community": 372,
+      "community": 374,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_holdsessiondialog_tsx",
       "label": "HoldSessionDialog.tsx",
@@ -42964,7 +43096,7 @@
       "source_location": "L1"
     },
     {
-      "community": 373,
+      "community": 375,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_session_voidsessiondialog_tsx",
       "label": "VoidSessionDialog.tsx",
@@ -42973,7 +43105,7 @@
       "source_location": "L1"
     },
     {
-      "community": 373,
+      "community": 375,
       "file_type": "code",
       "id": "voidsessiondialog_voidsessiondialog",
       "label": "VoidSessionDialog()",
@@ -42982,7 +43114,7 @@
       "source_location": "L19"
     },
     {
-      "community": 374,
+      "community": 376,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_tsx",
       "label": "transactionColumns.tsx",
@@ -42991,7 +43123,7 @@
       "source_location": "L1"
     },
     {
-      "community": 374,
+      "community": 376,
       "file_type": "code",
       "id": "transactioncolumns_getpaymentmethodicon",
       "label": "getPaymentMethodIcon()",
@@ -43000,7 +43132,7 @@
       "source_location": "L22"
     },
     {
-      "community": 375,
+      "community": 377,
       "file_type": "code",
       "id": "barcodeview_barcodeview",
       "label": "BarcodeView()",
@@ -43009,7 +43141,7 @@
       "source_location": "L14"
     },
     {
-      "community": 375,
+      "community": 377,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_barcodeview_tsx",
       "label": "BarcodeView.tsx",
@@ -43018,7 +43150,7 @@
       "source_location": "L1"
     },
     {
-      "community": 376,
+      "community": 378,
       "file_type": "code",
       "id": "categorizationview_categorizationview",
       "label": "CategorizationView()",
@@ -43027,7 +43159,7 @@
       "source_location": "L6"
     },
     {
-      "community": 376,
+      "community": 378,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_categorizationview_tsx",
       "label": "CategorizationView.tsx",
@@ -43036,7 +43168,7 @@
       "source_location": "L1"
     },
     {
-      "community": 377,
+      "community": 379,
       "file_type": "code",
       "id": "imagesview_handlekeydown",
       "label": "handleKeyDown()",
@@ -43045,49 +43177,13 @@
       "source_location": "L38"
     },
     {
-      "community": 377,
+      "community": 379,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_imagesview_tsx",
       "label": "ImagesView.tsx",
       "norm_label": "imagesview.tsx",
       "source_file": "packages/athena-webapp/src/components/product/ImagesView.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 378,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_skuselector_tsx",
-      "label": "SKUSelector.tsx",
-      "norm_label": "skuselector.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/SKUSelector.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 378,
-      "file_type": "code",
-      "id": "skuselector_skuselector",
-      "label": "SKUSelector()",
-      "norm_label": "skuselector()",
-      "source_file": "packages/athena-webapp/src/components/product/SKUSelector.tsx",
-      "source_location": "L10"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_actions_tsx",
-      "label": "product-actions.tsx",
-      "norm_label": "product-actions.tsx",
-      "source_file": "packages/athena-webapp/src/components/product-actions.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 379,
-      "file_type": "code",
-      "id": "product_actions_usedeleteproduct",
-      "label": "useDeleteProduct()",
-      "norm_label": "usedeleteproduct()",
-      "source_file": "packages/athena-webapp/src/components/product-actions.tsx",
-      "source_location": "L6"
     },
     {
       "community": 38,
@@ -43173,6 +43269,42 @@
     {
       "community": 380,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_skuselector_tsx",
+      "label": "SKUSelector.tsx",
+      "norm_label": "skuselector.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/SKUSelector.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 380,
+      "file_type": "code",
+      "id": "skuselector_skuselector",
+      "label": "SKUSelector()",
+      "norm_label": "skuselector()",
+      "source_file": "packages/athena-webapp/src/components/product/SKUSelector.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 381,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_actions_tsx",
+      "label": "product-actions.tsx",
+      "norm_label": "product-actions.tsx",
+      "source_file": "packages/athena-webapp/src/components/product-actions.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 381,
+      "file_type": "code",
+      "id": "product_actions_usedeleteproduct",
+      "label": "useDeleteProduct()",
+      "norm_label": "usedeleteproduct()",
+      "source_file": "packages/athena-webapp/src/components/product-actions.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 382,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsview_tsx",
       "label": "ProductsView.tsx",
       "norm_label": "productsview.tsx",
@@ -43180,7 +43312,7 @@
       "source_location": "L1"
     },
     {
-      "community": 380,
+      "community": 382,
       "file_type": "code",
       "id": "productsview_productsview",
       "label": "ProductsView()",
@@ -43189,7 +43321,7 @@
       "source_location": "L5"
     },
     {
-      "community": 381,
+      "community": 383,
       "file_type": "code",
       "id": "add_product_command_addproductcommand",
       "label": "AddProductCommand()",
@@ -43198,7 +43330,7 @@
       "source_location": "L17"
     },
     {
-      "community": 381,
+      "community": 383,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_add_product_command_tsx",
       "label": "add-product-command.tsx",
@@ -43207,7 +43339,7 @@
       "source_location": "L1"
     },
     {
-      "community": 382,
+      "community": 384,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_products_tsx",
       "label": "Products.tsx",
@@ -43216,7 +43348,7 @@
       "source_location": "L1"
     },
     {
-      "community": 382,
+      "community": 384,
       "file_type": "code",
       "id": "products_products",
       "label": "Products()",
@@ -43225,7 +43357,7 @@
       "source_location": "L4"
     },
     {
-      "community": 383,
+      "community": 385,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeform_tsx",
       "label": "PromoCodeForm.tsx",
@@ -43234,7 +43366,7 @@
       "source_location": "L1"
     },
     {
-      "community": 383,
+      "community": 385,
       "file_type": "code",
       "id": "promocodeform_togglediscounttype",
       "label": "toggleDiscountType()",
@@ -43243,7 +43375,7 @@
       "source_location": "L84"
     },
     {
-      "community": 384,
+      "community": 386,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_tsx",
       "label": "PromoCodeHeader.tsx",
@@ -43252,7 +43384,7 @@
       "source_location": "L1"
     },
     {
-      "community": 384,
+      "community": 386,
       "file_type": "code",
       "id": "promocodeheader_handledeletepromocode",
       "label": "handleDeletePromoCode()",
@@ -43261,7 +43393,7 @@
       "source_location": "L22"
     },
     {
-      "community": 385,
+      "community": 387,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodesview_tsx",
       "label": "PromoCodesView.tsx",
@@ -43270,7 +43402,7 @@
       "source_location": "L1"
     },
     {
-      "community": 385,
+      "community": 387,
       "file_type": "code",
       "id": "promocodesview_promocodesview",
       "label": "PromoCodesView()",
@@ -43279,7 +43411,7 @@
       "source_location": "L9"
     },
     {
-      "community": 386,
+      "community": 388,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectablecategories_tsx",
       "label": "SelectableCategories.tsx",
@@ -43288,7 +43420,7 @@
       "source_location": "L1"
     },
     {
-      "community": 386,
+      "community": 388,
       "file_type": "code",
       "id": "selectablecategories_toggle",
       "label": "toggle()",
@@ -43297,7 +43429,7 @@
       "source_location": "L23"
     },
     {
-      "community": 387,
+      "community": 389,
       "file_type": "code",
       "id": "discounttypetogglegroup_discounttypetogglegroup",
       "label": "DiscountTypeToggleGroup()",
@@ -43306,48 +43438,12 @@
       "source_location": "L5"
     },
     {
-      "community": 387,
+      "community": 389,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_discounttypetogglegroup_tsx",
       "label": "DiscountTypeToggleGroup.tsx",
       "norm_label": "discounttypetogglegroup.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/DiscountTypeToggleGroup.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 388,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_promocodespantogglegroup_tsx",
-      "label": "PromoCodeSpanToggleGroup.tsx",
-      "norm_label": "promocodespantogglegroup.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/PromoCodeSpanToggleGroup.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 388,
-      "file_type": "code",
-      "id": "promocodespantogglegroup_promocodespantogglegroup",
-      "label": "PromoCodeSpanToggleGroup()",
-      "norm_label": "promocodespantogglegroup()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/PromoCodeSpanToggleGroup.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "capturedemails_capturedemails",
-      "label": "CapturedEmails()",
-      "norm_label": "capturedemails()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/captured/CapturedEmails.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 389,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_captured_capturedemails_tsx",
-      "label": "CapturedEmails.tsx",
-      "norm_label": "capturedemails.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/captured/CapturedEmails.tsx",
       "source_location": "L1"
     },
     {
@@ -43434,6 +43530,42 @@
     {
       "community": 390,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_promocodespantogglegroup_tsx",
+      "label": "PromoCodeSpanToggleGroup.tsx",
+      "norm_label": "promocodespantogglegroup.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/PromoCodeSpanToggleGroup.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 390,
+      "file_type": "code",
+      "id": "promocodespantogglegroup_promocodespantogglegroup",
+      "label": "PromoCodeSpanToggleGroup()",
+      "norm_label": "promocodespantogglegroup()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/PromoCodeSpanToggleGroup.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 391,
+      "file_type": "code",
+      "id": "capturedemails_capturedemails",
+      "label": "CapturedEmails()",
+      "norm_label": "capturedemails()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/captured/CapturedEmails.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 391,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_captured_capturedemails_tsx",
+      "label": "CapturedEmails.tsx",
+      "norm_label": "capturedemails.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/captured/CapturedEmails.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 392,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_promo_code_modal_tsx",
       "label": "promo-code-modal.tsx",
       "norm_label": "promo-code-modal.tsx",
@@ -43441,7 +43573,7 @@
       "source_location": "L1"
     },
     {
-      "community": 390,
+      "community": 392,
       "file_type": "code",
       "id": "promo_code_modal_promocodemodal",
       "label": "PromoCodeModal()",
@@ -43450,7 +43582,7 @@
       "source_location": "L29"
     },
     {
-      "community": 391,
+      "community": 393,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewactions_tsx",
       "label": "ReviewActions.tsx",
@@ -43459,7 +43591,7 @@
       "source_location": "L1"
     },
     {
-      "community": 391,
+      "community": 393,
       "file_type": "code",
       "id": "reviewactions_reviewactions",
       "label": "ReviewActions()",
@@ -43468,7 +43600,7 @@
       "source_location": "L20"
     },
     {
-      "community": 392,
+      "community": 394,
       "file_type": "code",
       "id": "empty_state_onclick",
       "label": "onClick()",
@@ -43477,7 +43609,7 @@
       "source_location": "L29"
     },
     {
-      "community": 392,
+      "community": 394,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
@@ -43486,7 +43618,7 @@
       "source_location": "L1"
     },
     {
-      "community": 393,
+      "community": 395,
       "file_type": "code",
       "id": "nopermission_nopermission",
       "label": "NoPermission()",
@@ -43495,7 +43627,7 @@
       "source_location": "L3"
     },
     {
-      "community": 393,
+      "community": 395,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermission_tsx",
       "label": "NoPermission.tsx",
@@ -43504,7 +43636,7 @@
       "source_location": "L1"
     },
     {
-      "community": 394,
+      "community": 396,
       "file_type": "code",
       "id": "nopermissionview_nopermissionview",
       "label": "NoPermissionView()",
@@ -43513,7 +43645,7 @@
       "source_location": "L4"
     },
     {
-      "community": 394,
+      "community": 396,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermissionview_tsx",
       "label": "NoPermissionView.tsx",
@@ -43522,7 +43654,7 @@
       "source_location": "L1"
     },
     {
-      "community": 395,
+      "community": 397,
       "file_type": "code",
       "id": "notfoundview_notfoundview",
       "label": "NotFoundView()",
@@ -43531,7 +43663,7 @@
       "source_location": "L4"
     },
     {
-      "community": 395,
+      "community": 397,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfoundview_tsx",
       "label": "NotFoundView.tsx",
@@ -43540,7 +43672,7 @@
       "source_location": "L1"
     },
     {
-      "community": 396,
+      "community": 398,
       "file_type": "code",
       "id": "contactview_contactview",
       "label": "ContactView()",
@@ -43549,7 +43681,7 @@
       "source_location": "L9"
     },
     {
-      "community": 396,
+      "community": 398,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_contactview_tsx",
       "label": "ContactView.tsx",
@@ -43558,7 +43690,7 @@
       "source_location": "L1"
     },
     {
-      "community": 397,
+      "community": 399,
       "file_type": "code",
       "id": "header_header",
       "label": "Header()",
@@ -43567,49 +43699,13 @@
       "source_location": "L1"
     },
     {
-      "community": 397,
+      "community": 399,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_header_tsx",
       "label": "Header.tsx",
       "norm_label": "header.tsx",
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 398,
-      "file_type": "code",
-      "id": "maintenanceview_maintenanceview",
-      "label": "MaintenanceView()",
-      "norm_label": "maintenanceview()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 398,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_tsx",
-      "label": "MaintenanceView.tsx",
-      "norm_label": "maintenanceview.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_taxview_tsx",
-      "label": "TaxView.tsx",
-      "norm_label": "taxview.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/TaxView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 399,
-      "file_type": "code",
-      "id": "taxview_handleupdatetaxsettings",
-      "label": "handleUpdateTaxSettings()",
-      "norm_label": "handleupdatetaxsettings()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/TaxView.tsx",
-      "source_location": "L25"
     },
     {
       "community": 4,
@@ -43947,6 +44043,42 @@
     {
       "community": 400,
       "file_type": "code",
+      "id": "maintenanceview_maintenanceview",
+      "label": "MaintenanceView()",
+      "norm_label": "maintenanceview()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 400,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_tsx",
+      "label": "MaintenanceView.tsx",
+      "norm_label": "maintenanceview.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 401,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_taxview_tsx",
+      "label": "TaxView.tsx",
+      "norm_label": "taxview.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/TaxView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 401,
+      "file_type": "code",
+      "id": "taxview_handleupdatetaxsettings",
+      "label": "handleUpdateTaxSettings()",
+      "norm_label": "handleupdatetaxsettings()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/TaxView.tsx",
+      "source_location": "L25"
+    },
+    {
+      "community": 402,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_ts",
       "label": "useStoreConfigUpdate.ts",
       "norm_label": "usestoreconfigupdate.ts",
@@ -43954,7 +44086,7 @@
       "source_location": "L1"
     },
     {
-      "community": 400,
+      "community": 402,
       "file_type": "code",
       "id": "usestoreconfigupdate_usestoreconfigupdate",
       "label": "useStoreConfigUpdate()",
@@ -43963,7 +44095,7 @@
       "source_location": "L19"
     },
     {
-      "community": 401,
+      "community": 403,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_switcher_tsx",
       "label": "store-switcher.tsx",
@@ -43972,7 +44104,7 @@
       "source_location": "L1"
     },
     {
-      "community": 401,
+      "community": 403,
       "file_type": "code",
       "id": "store_switcher_onstoreselect",
       "label": "onStoreSelect()",
@@ -43981,7 +44113,7 @@
       "source_location": "L63"
     },
     {
-      "community": 402,
+      "community": 404,
       "file_type": "code",
       "id": "chart_usechart",
       "label": "useChart()",
@@ -43990,7 +44122,7 @@
       "source_location": "L25"
     },
     {
-      "community": 402,
+      "community": 404,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_chart_tsx",
       "label": "chart.tsx",
@@ -43999,7 +44131,7 @@
       "source_location": "L1"
     },
     {
-      "community": 403,
+      "community": 405,
       "file_type": "code",
       "id": "copy_button_handlecopy",
       "label": "handleCopy()",
@@ -44008,7 +44140,7 @@
       "source_location": "L15"
     },
     {
-      "community": 403,
+      "community": 405,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_copy_button_tsx",
       "label": "copy-button.tsx",
@@ -44017,7 +44149,7 @@
       "source_location": "L1"
     },
     {
-      "community": 404,
+      "community": 406,
       "file_type": "code",
       "id": "copy_wrapper_handlecopy",
       "label": "handleCopy()",
@@ -44026,7 +44158,7 @@
       "source_location": "L21"
     },
     {
-      "community": 404,
+      "community": 406,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_copy_wrapper_tsx",
       "label": "copy-wrapper.tsx",
@@ -44035,7 +44167,7 @@
       "source_location": "L1"
     },
     {
-      "community": 405,
+      "community": 407,
       "file_type": "code",
       "id": "date_time_picker_datetimepicker",
       "label": "DateTimePicker()",
@@ -44044,7 +44176,7 @@
       "source_location": "L21"
     },
     {
-      "community": 405,
+      "community": 407,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
       "label": "date-time-picker.tsx",
@@ -44053,7 +44185,7 @@
       "source_location": "L1"
     },
     {
-      "community": 406,
+      "community": 408,
       "file_type": "code",
       "id": "label_label",
       "label": "Label()",
@@ -44062,7 +44194,7 @@
       "source_location": "L6"
     },
     {
-      "community": 406,
+      "community": 408,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
@@ -44071,7 +44203,7 @@
       "source_location": "L1"
     },
     {
-      "community": 407,
+      "community": 409,
       "file_type": "code",
       "id": "custom_modal_custommodal",
       "label": "CustomModal()",
@@ -44080,49 +44212,13 @@
       "source_location": "L25"
     },
     {
-      "community": 407,
+      "community": 409,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_tsx",
       "label": "custom-modal.tsx",
       "norm_label": "custom-modal.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/modals/custom-modal.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 408,
-      "file_type": "code",
-      "id": "organization_modal_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/organization-modal.tsx",
-      "source_location": "L49"
-    },
-    {
-      "community": 408,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_modals_organization_modal_tsx",
-      "label": "organization-modal.tsx",
-      "norm_label": "organization-modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/organization-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_modals_store_modal_tsx",
-      "label": "store-modal.tsx",
-      "norm_label": "store-modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/store-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 409,
-      "file_type": "code",
-      "id": "store_modal_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/store-modal.tsx",
-      "source_location": "L63"
     },
     {
       "community": 41,
@@ -44208,6 +44304,42 @@
     {
       "community": 410,
       "file_type": "code",
+      "id": "organization_modal_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/organization-modal.tsx",
+      "source_location": "L49"
+    },
+    {
+      "community": 410,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_modals_organization_modal_tsx",
+      "label": "organization-modal.tsx",
+      "norm_label": "organization-modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/organization-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 411,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_modals_store_modal_tsx",
+      "label": "store-modal.tsx",
+      "norm_label": "store-modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/store-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 411,
+      "file_type": "code",
+      "id": "store_modal_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/store-modal.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 412,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_example_tsx",
       "label": "welcome-back-modal-example.tsx",
       "norm_label": "welcome-back-modal-example.tsx",
@@ -44215,7 +44347,7 @@
       "source_location": "L1"
     },
     {
-      "community": 410,
+      "community": 412,
       "file_type": "code",
       "id": "welcome_back_modal_example_welcomebackmodalexample",
       "label": "WelcomeBackModalExample()",
@@ -44224,7 +44356,7 @@
       "source_location": "L5"
     },
     {
-      "community": 411,
+      "community": 413,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_tsx",
       "label": "welcome-back-modal.tsx",
@@ -44233,7 +44365,7 @@
       "source_location": "L1"
     },
     {
-      "community": 411,
+      "community": 413,
       "file_type": "code",
       "id": "welcome_back_modal_welcomebackmodal",
       "label": "WelcomeBackModal()",
@@ -44242,7 +44374,7 @@
       "source_location": "L12"
     },
     {
-      "community": 412,
+      "community": 414,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_native_tsx",
       "label": "select-native.tsx",
@@ -44251,7 +44383,7 @@
       "source_location": "L1"
     },
     {
-      "community": 412,
+      "community": 414,
       "file_type": "code",
       "id": "select_native_cn",
       "label": "cn()",
@@ -44260,7 +44392,7 @@
       "source_location": "L15"
     },
     {
-      "community": 413,
+      "community": 415,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_timeline_item_tsx",
       "label": "timeline-item.tsx",
@@ -44269,7 +44401,7 @@
       "source_location": "L1"
     },
     {
-      "community": 413,
+      "community": 415,
       "file_type": "code",
       "id": "timeline_item_timelineitem",
       "label": "TimelineItem()",
@@ -44278,7 +44410,7 @@
       "source_location": "L3"
     },
     {
-      "community": 414,
+      "community": 416,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_webp_image_tsx",
       "label": "webp-image.tsx",
@@ -44287,7 +44419,7 @@
       "source_location": "L1"
     },
     {
-      "community": 414,
+      "community": 416,
       "file_type": "code",
       "id": "webp_image_webpimage",
       "label": "WebpImage()",
@@ -44296,7 +44428,7 @@
       "source_location": "L1"
     },
     {
-      "community": 415,
+      "community": 417,
       "file_type": "code",
       "id": "bagitems_bagitems",
       "label": "BagItems()",
@@ -44305,7 +44437,7 @@
       "source_location": "L5"
     },
     {
-      "community": 415,
+      "community": 417,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagitems_tsx",
       "label": "BagItems.tsx",
@@ -44314,7 +44446,7 @@
       "source_location": "L1"
     },
     {
-      "community": 416,
+      "community": 418,
       "file_type": "code",
       "id": "bagitemsview_bagitemsview",
       "label": "BagItemsView()",
@@ -44323,7 +44455,7 @@
       "source_location": "L11"
     },
     {
-      "community": 416,
+      "community": 418,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagitemsview_tsx",
       "label": "BagItemsView.tsx",
@@ -44332,7 +44464,7 @@
       "source_location": "L1"
     },
     {
-      "community": 417,
+      "community": 419,
       "file_type": "code",
       "id": "bags_bags",
       "label": "Bags()",
@@ -44341,49 +44473,13 @@
       "source_location": "L4"
     },
     {
-      "community": 417,
+      "community": 419,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bags_tsx",
       "label": "Bags.tsx",
       "norm_label": "bags.tsx",
       "source_file": "packages/athena-webapp/src/components/user-bags/Bags.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 418,
-      "file_type": "code",
-      "id": "customerbehaviortimeline_string",
-      "label": "String()",
-      "norm_label": "string()",
-      "source_file": "packages/athena-webapp/src/components/users/CustomerBehaviorTimeline.tsx",
-      "source_location": "L110"
-    },
-    {
-      "community": 418,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_customerbehaviortimeline_tsx",
-      "label": "CustomerBehaviorTimeline.tsx",
-      "norm_label": "customerbehaviortimeline.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/CustomerBehaviorTimeline.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_useranalyticsname_tsx",
-      "label": "UserAnalyticsName.tsx",
-      "norm_label": "useranalyticsname.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/UserAnalyticsName.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 419,
-      "file_type": "code",
-      "id": "useranalyticsname_useranalyticsname",
-      "label": "UserAnalyticsName()",
-      "norm_label": "useranalyticsname()",
-      "source_file": "packages/athena-webapp/src/components/users/UserAnalyticsName.tsx",
-      "source_location": "L13"
     },
     {
       "community": 42,
@@ -44460,6 +44556,42 @@
     {
       "community": 420,
       "file_type": "code",
+      "id": "customerbehaviortimeline_string",
+      "label": "String()",
+      "norm_label": "string()",
+      "source_file": "packages/athena-webapp/src/components/users/CustomerBehaviorTimeline.tsx",
+      "source_location": "L110"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_customerbehaviortimeline_tsx",
+      "label": "CustomerBehaviorTimeline.tsx",
+      "norm_label": "customerbehaviortimeline.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/CustomerBehaviorTimeline.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 421,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_useranalyticsname_tsx",
+      "label": "UserAnalyticsName.tsx",
+      "norm_label": "useranalyticsname.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/UserAnalyticsName.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 421,
+      "file_type": "code",
+      "id": "useranalyticsname_useranalyticsname",
+      "label": "UserAnalyticsName()",
+      "norm_label": "useranalyticsname()",
+      "source_file": "packages/athena-webapp/src/components/users/UserAnalyticsName.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 422,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userbag_tsx",
       "label": "UserBag.tsx",
       "norm_label": "userbag.tsx",
@@ -44467,7 +44599,7 @@
       "source_location": "L1"
     },
     {
-      "community": 420,
+      "community": 422,
       "file_type": "code",
       "id": "userbag_userbag",
       "label": "UserBag()",
@@ -44476,7 +44608,7 @@
       "source_location": "L7"
     },
     {
-      "community": 421,
+      "community": 423,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useronlineorders_tsx",
       "label": "UserOnlineOrders.tsx",
@@ -44485,7 +44617,7 @@
       "source_location": "L1"
     },
     {
-      "community": 421,
+      "community": 423,
       "file_type": "code",
       "id": "useronlineorders_useronlineorders",
       "label": "UserOnlineOrders()",
@@ -44494,7 +44626,7 @@
       "source_location": "L11"
     },
     {
-      "community": 422,
+      "community": 424,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userstatus_tsx",
       "label": "UserStatus.tsx",
@@ -44503,7 +44635,7 @@
       "source_location": "L1"
     },
     {
-      "community": 422,
+      "community": 424,
       "file_type": "code",
       "id": "userstatus_userstatus",
       "label": "UserStatus()",
@@ -44512,7 +44644,7 @@
       "source_location": "L7"
     },
     {
-      "community": 423,
+      "community": 425,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userview_tsx",
       "label": "UserView.tsx",
@@ -44521,7 +44653,7 @@
       "source_location": "L1"
     },
     {
-      "community": 423,
+      "community": 425,
       "file_type": "code",
       "id": "userview_useractions",
       "label": "UserActions()",
@@ -44530,7 +44662,7 @@
       "source_location": "L45"
     },
     {
-      "community": 424,
+      "community": 426,
       "file_type": "code",
       "id": "customerjourneystage_customerjourneystagecard",
       "label": "CustomerJourneyStageCard()",
@@ -44539,7 +44671,7 @@
       "source_location": "L13"
     },
     {
-      "community": 424,
+      "community": 426,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_customerjourneystage_tsx",
       "label": "CustomerJourneyStage.tsx",
@@ -44548,7 +44680,7 @@
       "source_location": "L1"
     },
     {
-      "community": 425,
+      "community": 427,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_image_upload_ts",
       "label": "use-image-upload.ts",
@@ -44557,7 +44689,7 @@
       "source_location": "L1"
     },
     {
-      "community": 425,
+      "community": 427,
       "file_type": "code",
       "id": "use_image_upload_useimageupload",
       "label": "useImageUpload()",
@@ -44566,7 +44698,7 @@
       "source_location": "L7"
     },
     {
-      "community": 426,
+      "community": 428,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_mobile_tsx",
       "label": "use-mobile.tsx",
@@ -44575,7 +44707,7 @@
       "source_location": "L1"
     },
     {
-      "community": 426,
+      "community": 428,
       "file_type": "code",
       "id": "use_mobile_useismobile",
       "label": "useIsMobile()",
@@ -44584,7 +44716,7 @@
       "source_location": "L5"
     },
     {
-      "community": 427,
+      "community": 429,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_navigate_back_ts",
       "label": "use-navigate-back.ts",
@@ -44593,49 +44725,13 @@
       "source_location": "L1"
     },
     {
-      "community": 427,
+      "community": 429,
       "file_type": "code",
       "id": "use_navigate_back_usenavigateback",
       "label": "useNavigateBack()",
       "norm_label": "usenavigateback()",
       "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
       "source_location": "L5"
-    },
-    {
-      "community": 428,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_use_navigation_keyboard_shortcuts_ts",
-      "label": "use-navigation-keyboard-shortcuts.ts",
-      "norm_label": "use-navigation-keyboard-shortcuts.ts",
-      "source_file": "packages/athena-webapp/src/hooks/use-navigation-keyboard-shortcuts.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 428,
-      "file_type": "code",
-      "id": "use_navigation_keyboard_shortcuts_usenavigationkeyboardshortcuts",
-      "label": "useNavigationKeyboardShortcuts()",
-      "norm_label": "usenavigationkeyboardshortcuts()",
-      "source_file": "packages/athena-webapp/src/hooks/use-navigation-keyboard-shortcuts.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_use_pagination_persistence_ts",
-      "label": "use-pagination-persistence.ts",
-      "norm_label": "use-pagination-persistence.ts",
-      "source_file": "packages/athena-webapp/src/hooks/use-pagination-persistence.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "use_pagination_persistence_usepaginationpersistence",
-      "label": "usePaginationPersistence()",
-      "norm_label": "usepaginationpersistence()",
-      "source_file": "packages/athena-webapp/src/hooks/use-pagination-persistence.ts",
-      "source_location": "L9"
     },
     {
       "community": 43,
@@ -44712,6 +44808,42 @@
     {
       "community": 430,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_use_navigation_keyboard_shortcuts_ts",
+      "label": "use-navigation-keyboard-shortcuts.ts",
+      "norm_label": "use-navigation-keyboard-shortcuts.ts",
+      "source_file": "packages/athena-webapp/src/hooks/use-navigation-keyboard-shortcuts.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "use_navigation_keyboard_shortcuts_usenavigationkeyboardshortcuts",
+      "label": "useNavigationKeyboardShortcuts()",
+      "norm_label": "usenavigationkeyboardshortcuts()",
+      "source_file": "packages/athena-webapp/src/hooks/use-navigation-keyboard-shortcuts.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 431,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_use_pagination_persistence_ts",
+      "label": "use-pagination-persistence.ts",
+      "norm_label": "use-pagination-persistence.ts",
+      "source_file": "packages/athena-webapp/src/hooks/use-pagination-persistence.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 431,
+      "file_type": "code",
+      "id": "use_pagination_persistence_usepaginationpersistence",
+      "label": "usePaginationPersistence()",
+      "norm_label": "usepaginationpersistence()",
+      "source_file": "packages/athena-webapp/src/hooks/use-pagination-persistence.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 432,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_table_keyboard_pagination_ts",
       "label": "use-table-keyboard-pagination.ts",
       "norm_label": "use-table-keyboard-pagination.ts",
@@ -44719,7 +44851,7 @@
       "source_location": "L1"
     },
     {
-      "community": 430,
+      "community": 432,
       "file_type": "code",
       "id": "use_table_keyboard_pagination_usetablekeyboardpagination",
       "label": "useTableKeyboardPagination()",
@@ -44728,7 +44860,7 @@
       "source_location": "L6"
     },
     {
-      "community": 431,
+      "community": 433,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usebulkoperations_test_ts",
       "label": "useBulkOperations.test.ts",
@@ -44737,7 +44869,7 @@
       "source_location": "L1"
     },
     {
-      "community": 431,
+      "community": 433,
       "file_type": "code",
       "id": "usebulkoperations_test_makesku",
       "label": "makeSku()",
@@ -44746,7 +44878,7 @@
       "source_location": "L168"
     },
     {
-      "community": 432,
+      "community": 434,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecartoperations_ts",
       "label": "useCartOperations.ts",
@@ -44755,7 +44887,7 @@
       "source_location": "L1"
     },
     {
-      "community": 432,
+      "community": 434,
       "file_type": "code",
       "id": "usecartoperations_usecartoperations",
       "label": "useCartOperations()",
@@ -44764,7 +44896,7 @@
       "source_location": "L23"
     },
     {
-      "community": 433,
+      "community": 435,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecopytext_ts",
       "label": "useCopyText.ts",
@@ -44773,7 +44905,7 @@
       "source_location": "L1"
     },
     {
-      "community": 433,
+      "community": 435,
       "file_type": "code",
       "id": "usecopytext_usecopytext",
       "label": "useCopyText()",
@@ -44782,7 +44914,7 @@
       "source_location": "L1"
     },
     {
-      "community": 434,
+      "community": 436,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecreatecomplimentaryproduct_ts",
       "label": "useCreateComplimentaryProduct.ts",
@@ -44791,7 +44923,7 @@
       "source_location": "L1"
     },
     {
-      "community": 434,
+      "community": 436,
       "file_type": "code",
       "id": "usecreatecomplimentaryproduct_usecreatecomplimentaryproduct",
       "label": "useCreateComplimentaryProduct()",
@@ -44800,7 +44932,7 @@
       "source_location": "L6"
     },
     {
-      "community": 435,
+      "community": 437,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecustomeroperations_ts",
       "label": "useCustomerOperations.ts",
@@ -44809,7 +44941,7 @@
       "source_location": "L1"
     },
     {
-      "community": 435,
+      "community": 437,
       "file_type": "code",
       "id": "usecustomeroperations_usecustomeroperations",
       "label": "useCustomerOperations()",
@@ -44818,7 +44950,7 @@
       "source_location": "L21"
     },
     {
-      "community": 436,
+      "community": 438,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usedebounce_ts",
       "label": "useDebounce.ts",
@@ -44827,7 +44959,7 @@
       "source_location": "L1"
     },
     {
-      "community": 436,
+      "community": 438,
       "file_type": "code",
       "id": "usedebounce_usedebounce",
       "label": "useDebounce()",
@@ -44836,7 +44968,7 @@
       "source_location": "L12"
     },
     {
-      "community": 437,
+      "community": 439,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpenseoperations_ts",
       "label": "useExpenseOperations.ts",
@@ -44845,49 +44977,13 @@
       "source_location": "L1"
     },
     {
-      "community": 437,
+      "community": 439,
       "file_type": "code",
       "id": "useexpenseoperations_useexpenseoperations",
       "label": "useExpenseOperations()",
       "norm_label": "useexpenseoperations()",
       "source_file": "packages/athena-webapp/src/hooks/useExpenseOperations.ts",
       "source_location": "L23"
-    },
-    {
-      "community": 438,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usegetactiveproduct_ts",
-      "label": "useGetActiveProduct.ts",
-      "norm_label": "usegetactiveproduct.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 438,
-      "file_type": "code",
-      "id": "usegetactiveproduct_usegetactiveproduct",
-      "label": "useGetActiveProduct()",
-      "norm_label": "usegetactiveproduct()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usegetautheduser_ts",
-      "label": "useGetAuthedUser.ts",
-      "norm_label": "usegetautheduser.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useGetAuthedUser.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "usegetautheduser_usegetautheduser",
-      "label": "useGetAuthedUser()",
-      "norm_label": "usegetautheduser()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetAuthedUser.ts",
-      "source_location": "L4"
     },
     {
       "community": 44,
@@ -44964,6 +45060,42 @@
     {
       "community": 440,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usegetactiveproduct_ts",
+      "label": "useGetActiveProduct.ts",
+      "norm_label": "usegetactiveproduct.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "usegetactiveproduct_usegetactiveproduct",
+      "label": "useGetActiveProduct()",
+      "norm_label": "usegetactiveproduct()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 441,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usegetautheduser_ts",
+      "label": "useGetAuthedUser.ts",
+      "norm_label": "usegetautheduser.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useGetAuthedUser.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 441,
+      "file_type": "code",
+      "id": "usegetautheduser_usegetautheduser",
+      "label": "useGetAuthedUser()",
+      "norm_label": "usegetautheduser()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetAuthedUser.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 442,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcategories_ts",
       "label": "useGetCategories.ts",
       "norm_label": "usegetcategories.ts",
@@ -44971,7 +45103,7 @@
       "source_location": "L1"
     },
     {
-      "community": 440,
+      "community": 442,
       "file_type": "code",
       "id": "usegetcategories_usegetcategories",
       "label": "useGetCategories()",
@@ -44980,7 +45112,7 @@
       "source_location": "L5"
     },
     {
-      "community": 441,
+      "community": 443,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcomplimentaryproducts_ts",
       "label": "useGetComplimentaryProducts.ts",
@@ -44989,7 +45121,7 @@
       "source_location": "L1"
     },
     {
-      "community": 441,
+      "community": 443,
       "file_type": "code",
       "id": "usegetcomplimentaryproducts_usegetcomplimentaryproducts",
       "label": "useGetComplimentaryProducts()",
@@ -44998,7 +45130,7 @@
       "source_location": "L5"
     },
     {
-      "community": 442,
+      "community": 444,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcurrencyformatter_ts",
       "label": "useGetCurrencyFormatter.ts",
@@ -45007,7 +45139,7 @@
       "source_location": "L1"
     },
     {
-      "community": 442,
+      "community": 444,
       "file_type": "code",
       "id": "usegetcurrencyformatter_usegetcurrencyformatter",
       "label": "useGetCurrencyFormatter()",
@@ -45016,7 +45148,7 @@
       "source_location": "L4"
     },
     {
-      "community": 443,
+      "community": 445,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetsubcategories_ts",
       "label": "useGetSubcategories.ts",
@@ -45025,7 +45157,7 @@
       "source_location": "L1"
     },
     {
-      "community": 443,
+      "community": 445,
       "file_type": "code",
       "id": "usegetsubcategories_usegetsubcategories",
       "label": "useGetSubcategories()",
@@ -45034,7 +45166,7 @@
       "source_location": "L5"
     },
     {
-      "community": 444,
+      "community": 446,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetterminal_ts",
       "label": "useGetTerminal.ts",
@@ -45043,7 +45175,7 @@
       "source_location": "L1"
     },
     {
-      "community": 444,
+      "community": 446,
       "file_type": "code",
       "id": "usegetterminal_usegetterminal",
       "label": "useGetTerminal()",
@@ -45052,7 +45184,7 @@
       "source_location": "L6"
     },
     {
-      "community": 445,
+      "community": 447,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usenewordernotification_ts",
       "label": "useNewOrderNotification.ts",
@@ -45061,7 +45193,7 @@
       "source_location": "L1"
     },
     {
-      "community": 445,
+      "community": 447,
       "file_type": "code",
       "id": "usenewordernotification_usenewordernotification",
       "label": "useNewOrderNotification()",
@@ -45070,7 +45202,7 @@
       "source_location": "L8"
     },
     {
-      "community": 446,
+      "community": 448,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usepermissions_ts",
       "label": "usePermissions.ts",
@@ -45079,7 +45211,7 @@
       "source_location": "L1"
     },
     {
-      "community": 446,
+      "community": 448,
       "file_type": "code",
       "id": "usepermissions_usepermissions",
       "label": "usePermissions()",
@@ -45088,7 +45220,7 @@
       "source_location": "L12"
     },
     {
-      "community": 447,
+      "community": 449,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useprint_ts",
       "label": "usePrint.ts",
@@ -45097,49 +45229,13 @@
       "source_location": "L1"
     },
     {
-      "community": 447,
+      "community": 449,
       "file_type": "code",
       "id": "useprint_useprint",
       "label": "usePrint()",
       "norm_label": "useprint()",
       "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
       "source_location": "L3"
-    },
-    {
-      "community": 448,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useproductsearchresults_ts",
-      "label": "useProductSearchResults.ts",
-      "norm_label": "useproductsearchresults.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 448,
-      "file_type": "code",
-      "id": "useproductsearchresults_useproductsearchresults",
-      "label": "useProductSearchResults()",
-      "norm_label": "useproductsearchresults()",
-      "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useproductwithnoimagesnotification_tsx",
-      "label": "useProductWithNoImagesNotification.tsx",
-      "norm_label": "useproductwithnoimagesnotification.tsx",
-      "source_file": "packages/athena-webapp/src/hooks/useProductWithNoImagesNotification.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "useproductwithnoimagesnotification_useproductwithnoimagesnotification",
-      "label": "useProductWithNoImagesNotification()",
-      "norm_label": "useproductwithnoimagesnotification()",
-      "source_file": "packages/athena-webapp/src/hooks/useProductWithNoImagesNotification.tsx",
-      "source_location": "L7"
     },
     {
       "community": 45,
@@ -45216,6 +45312,42 @@
     {
       "community": 450,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useproductsearchresults_ts",
+      "label": "useProductSearchResults.ts",
+      "norm_label": "useproductsearchresults.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "useproductsearchresults_useproductsearchresults",
+      "label": "useProductSearchResults()",
+      "norm_label": "useproductsearchresults()",
+      "source_file": "packages/athena-webapp/src/hooks/useProductSearchResults.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 451,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useproductwithnoimagesnotification_tsx",
+      "label": "useProductWithNoImagesNotification.tsx",
+      "norm_label": "useproductwithnoimagesnotification.tsx",
+      "source_file": "packages/athena-webapp/src/hooks/useProductWithNoImagesNotification.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 451,
+      "file_type": "code",
+      "id": "useproductwithnoimagesnotification_useproductwithnoimagesnotification",
+      "label": "useProductWithNoImagesNotification()",
+      "norm_label": "useproductwithnoimagesnotification()",
+      "source_file": "packages/athena-webapp/src/hooks/useProductWithNoImagesNotification.tsx",
+      "source_location": "L7"
+    },
+    {
+      "community": 452,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usesessionmanagement_ts",
       "label": "useSessionManagement.ts",
       "norm_label": "usesessionmanagement.ts",
@@ -45223,7 +45355,7 @@
       "source_location": "L1"
     },
     {
-      "community": 450,
+      "community": 452,
       "file_type": "code",
       "id": "usesessionmanagement_usesessionmanagement",
       "label": "useSessionManagement()",
@@ -45232,7 +45364,7 @@
       "source_location": "L17"
     },
     {
-      "community": 451,
+      "community": 453,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usesessionmanagementexpense_ts",
       "label": "useSessionManagementExpense.ts",
@@ -45241,7 +45373,7 @@
       "source_location": "L1"
     },
     {
-      "community": 451,
+      "community": 453,
       "file_type": "code",
       "id": "usesessionmanagementexpense_usesessionmanagementexpense",
       "label": "useSessionManagementExpense()",
@@ -45250,7 +45382,7 @@
       "source_location": "L17"
     },
     {
-      "community": 452,
+      "community": 454,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usesessionmanageroperations_ts",
       "label": "useSessionManagerOperations.ts",
@@ -45259,7 +45391,7 @@
       "source_location": "L1"
     },
     {
-      "community": 452,
+      "community": 454,
       "file_type": "code",
       "id": "usesessionmanageroperations_usesessionmanageroperations",
       "label": "useSessionManagerOperations()",
@@ -45268,7 +45400,7 @@
       "source_location": "L16"
     },
     {
-      "community": 453,
+      "community": 455,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedincheckout_ts",
       "label": "useSkusReservedInCheckout.ts",
@@ -45277,7 +45409,7 @@
       "source_location": "L1"
     },
     {
-      "community": 453,
+      "community": 455,
       "file_type": "code",
       "id": "useskusreservedincheckout_useskusreservedincheckout",
       "label": "useSkusReservedInCheckout()",
@@ -45286,7 +45418,7 @@
       "source_location": "L12"
     },
     {
-      "community": 454,
+      "community": 456,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedinpossession_ts",
       "label": "useSkusReservedInPosSession.ts",
@@ -45295,7 +45427,7 @@
       "source_location": "L1"
     },
     {
-      "community": 454,
+      "community": 456,
       "file_type": "code",
       "id": "useskusreservedinpossession_useskusreservedinpossession",
       "label": "useSkusReservedInPosSession()",
@@ -45304,7 +45436,7 @@
       "source_location": "L12"
     },
     {
-      "community": 455,
+      "community": 457,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usetogglecomplimentaryproductactive_ts",
       "label": "useToggleComplimentaryProductActive.ts",
@@ -45313,7 +45445,7 @@
       "source_location": "L1"
     },
     {
-      "community": 455,
+      "community": 457,
       "file_type": "code",
       "id": "usetogglecomplimentaryproductactive_usetogglecomplimentaryproductactive",
       "label": "useToggleComplimentaryProductActive()",
@@ -45322,7 +45454,7 @@
       "source_location": "L5"
     },
     {
-      "community": 456,
+      "community": 458,
       "file_type": "code",
       "id": "navigationutils_getorigin",
       "label": "getOrigin()",
@@ -45331,7 +45463,7 @@
       "source_location": "L1"
     },
     {
-      "community": 456,
+      "community": 458,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_navigationutils_ts",
       "label": "navigationUtils.ts",
@@ -45340,7 +45472,7 @@
       "source_location": "L1"
     },
     {
-      "community": 457,
+      "community": 459,
       "file_type": "code",
       "id": "calculations_calculatecarttotals",
       "label": "calculateCartTotals()",
@@ -45349,48 +45481,12 @@
       "source_location": "L10"
     },
     {
-      "community": 457,
+      "community": 459,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_calculations_ts",
       "label": "calculations.ts",
       "norm_label": "calculations.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/calculations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 458,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_security_pinhash_ts",
-      "label": "pinHash.ts",
-      "norm_label": "pinhash.ts",
-      "source_file": "packages/athena-webapp/src/lib/security/pinHash.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 458,
-      "file_type": "code",
-      "id": "pinhash_hashpin",
-      "label": "hashPin()",
-      "norm_label": "hashpin()",
-      "source_file": "packages/athena-webapp/src/lib/security/pinHash.ts",
-      "source_location": "L12"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "index_storerootredirect",
-      "label": "StoreRootRedirect()",
-      "norm_label": "storerootredirect()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/index.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/index.tsx",
       "source_location": "L1"
     },
     {
@@ -45468,6 +45564,42 @@
     {
       "community": 460,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_security_pinhash_ts",
+      "label": "pinHash.ts",
+      "norm_label": "pinhash.ts",
+      "source_file": "packages/athena-webapp/src/lib/security/pinHash.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "pinhash_hashpin",
+      "label": "hashPin()",
+      "norm_label": "hashpin()",
+      "source_file": "packages/athena-webapp/src/lib/security/pinHash.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
+      "id": "index_storerootredirect",
+      "label": "StoreRootRedirect()",
+      "norm_label": "storerootredirect()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/index.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 462,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_published_index_tsx",
       "label": "published.index.tsx",
       "norm_label": "published.index.tsx",
@@ -45475,7 +45607,7 @@
       "source_location": "L1"
     },
     {
-      "community": 460,
+      "community": 462,
       "file_type": "code",
       "id": "published_index_routecomponent",
       "label": "RouteComponent()",
@@ -45484,7 +45616,7 @@
       "source_location": "L9"
     },
     {
-      "community": 461,
+      "community": 463,
       "file_type": "code",
       "id": "index_index",
       "label": "Index()",
@@ -45493,7 +45625,7 @@
       "source_location": "L13"
     },
     {
-      "community": 461,
+      "community": 463,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -45502,7 +45634,7 @@
       "source_location": "L1"
     },
     {
-      "community": 462,
+      "community": 464,
       "file_type": "code",
       "id": "layout_index_athenaloginreadyview",
       "label": "AthenaLoginReadyView()",
@@ -45511,7 +45643,7 @@
       "source_location": "L4"
     },
     {
-      "community": 462,
+      "community": 464,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_tsx",
       "label": "_layout.index.tsx",
@@ -45520,7 +45652,7 @@
       "source_location": "L1"
     },
     {
-      "community": 463,
+      "community": 465,
       "file_type": "code",
       "id": "layout_loginlayout",
       "label": "LoginLayout()",
@@ -45529,7 +45661,7 @@
       "source_location": "L36"
     },
     {
-      "community": 463,
+      "community": 465,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_tsx",
       "label": "_layout.tsx",
@@ -45538,7 +45670,7 @@
       "source_location": "L1"
     },
     {
-      "community": 464,
+      "community": 466,
       "file_type": "code",
       "id": "organizationssettingsaccordion_organizationsettingsaccordion",
       "label": "OrganizationSettingsAccordion()",
@@ -45547,7 +45679,7 @@
       "source_location": "L13"
     },
     {
-      "community": 464,
+      "community": 466,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationssettingsaccordion_tsx",
       "label": "OrganizationsSettingsAccordion.tsx",
@@ -45556,7 +45688,7 @@
       "source_location": "L1"
     },
     {
-      "community": 465,
+      "community": 467,
       "file_type": "code",
       "id": "overview_stories_patternsoverview",
       "label": "PatternsOverview()",
@@ -45565,7 +45697,7 @@
       "source_location": "L5"
     },
     {
-      "community": 465,
+      "community": 467,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -45574,7 +45706,7 @@
       "source_location": "L1"
     },
     {
-      "community": 466,
+      "community": 468,
       "file_type": "code",
       "id": "controls_stories_controlsshowcase",
       "label": "ControlsShowcase()",
@@ -45583,7 +45715,7 @@
       "source_location": "L17"
     },
     {
-      "community": 466,
+      "community": 468,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_controls_stories_tsx",
       "label": "Controls.stories.tsx",
@@ -45592,7 +45724,7 @@
       "source_location": "L1"
     },
     {
-      "community": 467,
+      "community": 469,
       "file_type": "code",
       "id": "dialog_stories_dialogshowcase",
       "label": "DialogShowcase()",
@@ -45601,48 +45733,12 @@
       "source_location": "L15"
     },
     {
-      "community": 467,
+      "community": 469,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_dialog_stories_tsx",
       "label": "Dialog.stories.tsx",
       "norm_label": "dialog.stories.tsx",
       "source_file": "packages/athena-webapp/src/stories/Primitives/Dialog.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 468,
-      "file_type": "code",
-      "id": "feedback_stories_feedbackshowcase",
-      "label": "FeedbackShowcase()",
-      "norm_label": "feedbackshowcase()",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Feedback.stories.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 468,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_feedback_stories_tsx",
-      "label": "Feedback.stories.tsx",
-      "norm_label": "feedback.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Feedback.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "overview_stories_primitivesoverview",
-      "label": "PrimitivesOverview()",
-      "norm_label": "primitivesoverview()",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Overview.stories.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_overview_stories_tsx",
-      "label": "Overview.stories.tsx",
-      "norm_label": "overview.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Overview.stories.tsx",
       "source_location": "L1"
     },
     {
@@ -45720,6 +45816,42 @@
     {
       "community": 470,
       "file_type": "code",
+      "id": "feedback_stories_feedbackshowcase",
+      "label": "FeedbackShowcase()",
+      "norm_label": "feedbackshowcase()",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Feedback.stories.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_primitives_feedback_stories_tsx",
+      "label": "Feedback.stories.tsx",
+      "norm_label": "feedback.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Feedback.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
+      "id": "overview_stories_primitivesoverview",
+      "label": "PrimitivesOverview()",
+      "norm_label": "primitivesoverview()",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Overview.stories.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_primitives_overview_stories_tsx",
+      "label": "Overview.stories.tsx",
+      "norm_label": "overview.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Overview.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 472,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_popover_stories_tsx",
       "label": "Popover.stories.tsx",
       "norm_label": "popover.stories.tsx",
@@ -45727,7 +45859,7 @@
       "source_location": "L1"
     },
     {
-      "community": 470,
+      "community": 472,
       "file_type": "code",
       "id": "popover_stories_popovershowcase",
       "label": "PopoverShowcase()",
@@ -45736,7 +45868,7 @@
       "source_location": "L13"
     },
     {
-      "community": 471,
+      "community": 473,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_sheet_stories_tsx",
       "label": "Sheet.stories.tsx",
@@ -45745,7 +45877,7 @@
       "source_location": "L1"
     },
     {
-      "community": 471,
+      "community": 473,
       "file_type": "code",
       "id": "sheet_stories_sheetshowcase",
       "label": "SheetShowcase()",
@@ -45754,7 +45886,7 @@
       "source_location": "L14"
     },
     {
-      "community": 472,
+      "community": 474,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_tooltip_stories_tsx",
       "label": "Tooltip.stories.tsx",
@@ -45763,7 +45895,7 @@
       "source_location": "L1"
     },
     {
-      "community": 472,
+      "community": 474,
       "file_type": "code",
       "id": "tooltip_stories_tooltipshowcase",
       "label": "TooltipShowcase()",
@@ -45772,7 +45904,7 @@
       "source_location": "L13"
     },
     {
-      "community": 473,
+      "community": 475,
       "file_type": "code",
       "id": "overview_stories_templatesoverview",
       "label": "TemplatesOverview()",
@@ -45781,7 +45913,7 @@
       "source_location": "L5"
     },
     {
-      "community": 473,
+      "community": 475,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -45790,7 +45922,7 @@
       "source_location": "L1"
     },
     {
-      "community": 474,
+      "community": 476,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_tsx",
       "label": "storybook-theme-decorator.tsx",
@@ -45799,7 +45931,7 @@
       "source_location": "L1"
     },
     {
-      "community": 474,
+      "community": 476,
       "file_type": "code",
       "id": "storybook_theme_decorator_withathenatheme",
       "label": "withAthenaTheme()",
@@ -45808,7 +45940,7 @@
       "source_location": "L17"
     },
     {
-      "community": 475,
+      "community": 477,
       "file_type": "code",
       "id": "formatnumber_formatnumber",
       "label": "formatNumber()",
@@ -45817,7 +45949,7 @@
       "source_location": "L1"
     },
     {
-      "community": 475,
+      "community": 477,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_formatnumber_ts",
       "label": "formatNumber.ts",
@@ -45826,7 +45958,7 @@
       "source_location": "L1"
     },
     {
-      "community": 476,
+      "community": 478,
       "file_type": "code",
       "id": "bannermessage_getbannermessage",
       "label": "getBannerMessage()",
@@ -45835,7 +45967,7 @@
       "source_location": "L4"
     },
     {
-      "community": 476,
+      "community": 478,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -45844,7 +45976,7 @@
       "source_location": "L1"
     },
     {
-      "community": 477,
+      "community": 479,
       "file_type": "code",
       "id": "checkoutsession_test_jsonresponse",
       "label": "jsonResponse()",
@@ -45853,49 +45985,13 @@
       "source_location": "L27"
     },
     {
-      "community": 477,
+      "community": 479,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_checkoutsession_test_ts",
       "label": "checkoutSession.test.ts",
       "norm_label": "checkoutsession.test.ts",
       "source_file": "packages/storefront-webapp/src/api/checkoutSession.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 478,
-      "file_type": "code",
-      "id": "guest_updateguest",
-      "label": "updateGuest()",
-      "norm_label": "updateguest()",
-      "source_file": "packages/storefront-webapp/src/api/guest.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 478,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_guest_ts",
-      "label": "guest.ts",
-      "norm_label": "guest.ts",
-      "source_file": "packages/storefront-webapp/src/api/guest.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_storefront_ts",
-      "label": "storefront.ts",
-      "norm_label": "storefront.ts",
-      "source_file": "packages/storefront-webapp/src/api/storefront.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "storefront_getstore",
-      "label": "getStore()",
-      "norm_label": "getstore()",
-      "source_file": "packages/storefront-webapp/src/api/storefront.ts",
-      "source_location": "L5"
     },
     {
       "community": 48,
@@ -45972,6 +46068,42 @@
     {
       "community": 480,
       "file_type": "code",
+      "id": "guest_updateguest",
+      "label": "updateGuest()",
+      "norm_label": "updateguest()",
+      "source_file": "packages/storefront-webapp/src/api/guest.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_guest_ts",
+      "label": "guest.ts",
+      "norm_label": "guest.ts",
+      "source_file": "packages/storefront-webapp/src/api/guest.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_storefront_ts",
+      "label": "storefront.ts",
+      "norm_label": "storefront.ts",
+      "source_file": "packages/storefront-webapp/src/api/storefront.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
+      "id": "storefront_getstore",
+      "label": "getStore()",
+      "norm_label": "getstore()",
+      "source_file": "packages/storefront-webapp/src/api/storefront.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 482,
+      "file_type": "code",
       "id": "entitypage_entitypage",
       "label": "EntityPage()",
       "norm_label": "entitypage()",
@@ -45979,7 +46111,7 @@
       "source_location": "L10"
     },
     {
-      "community": 480,
+      "community": 482,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_entitypage_tsx",
       "label": "EntityPage.tsx",
@@ -45988,7 +46120,7 @@
       "source_location": "L1"
     },
     {
-      "community": 481,
+      "community": 483,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productspage_tsx",
       "label": "ProductsPage.tsx",
@@ -45997,7 +46129,7 @@
       "source_location": "L1"
     },
     {
-      "community": 481,
+      "community": 483,
       "file_type": "code",
       "id": "productspage_productcardloadingskeleton",
       "label": "ProductCardLoadingSkeleton()",
@@ -46006,7 +46138,7 @@
       "source_location": "L10"
     },
     {
-      "community": 482,
+      "community": 484,
       "file_type": "code",
       "id": "auth_authcomponent",
       "label": "AuthComponent()",
@@ -46015,7 +46147,7 @@
       "source_location": "L4"
     },
     {
-      "community": 482,
+      "community": 484,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -46024,7 +46156,7 @@
       "source_location": "L1"
     },
     {
-      "community": 483,
+      "community": 485,
       "file_type": "code",
       "id": "bagsummary_tobagsummaryitems",
       "label": "toBagSummaryItems()",
@@ -46033,7 +46165,7 @@
       "source_location": "L39"
     },
     {
-      "community": 483,
+      "community": 485,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_bagsummary_tsx",
       "label": "BagSummary.tsx",
@@ -46042,7 +46174,7 @@
       "source_location": "L1"
     },
     {
-      "community": 484,
+      "community": 486,
       "file_type": "code",
       "id": "checkoutform_checkoutform",
       "label": "CheckoutForm()",
@@ -46051,7 +46183,7 @@
       "source_location": "L18"
     },
     {
-      "community": 484,
+      "community": 486,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutform_tsx",
       "label": "CheckoutForm.tsx",
@@ -46060,7 +46192,7 @@
       "source_location": "L1"
     },
     {
-      "community": 485,
+      "community": 487,
       "file_type": "code",
       "id": "checkoutprovider_checkoutprovider",
       "label": "CheckoutProvider()",
@@ -46069,7 +46201,7 @@
       "source_location": "L71"
     },
     {
-      "community": 485,
+      "community": 487,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutprovider_tsx",
       "label": "CheckoutProvider.tsx",
@@ -46078,7 +46210,7 @@
       "source_location": "L1"
     },
     {
-      "community": 486,
+      "community": 488,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_pickupoptions_tsx",
       "label": "PickupOptions.tsx",
@@ -46087,7 +46219,7 @@
       "source_location": "L1"
     },
     {
-      "community": 486,
+      "community": 488,
       "file_type": "code",
       "id": "pickupoptions_iswithinrestrictiontime",
       "label": "isWithinRestrictionTime()",
@@ -46096,7 +46228,7 @@
       "source_location": "L12"
     },
     {
-      "community": 487,
+      "community": 489,
       "file_type": "code",
       "id": "enteredbillingaddressdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -46105,48 +46237,12 @@
       "source_location": "L6"
     },
     {
-      "community": 487,
+      "community": 489,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_enteredbillingaddressdetails_tsx",
       "label": "EnteredBillingAddressDetails.tsx",
       "norm_label": "enteredbillingaddressdetails.tsx",
       "source_file": "packages/storefront-webapp/src/components/checkout/EnteredBillingAddressDetails.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 488,
-      "file_type": "code",
-      "id": "ordersummary_ordersummary",
-      "label": "OrderSummary()",
-      "norm_label": "ordersummary()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/OrderSummary.tsx",
-      "source_location": "L18"
-    },
-    {
-      "community": 488,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_orderdetails_ordersummary_tsx",
-      "label": "OrderSummary.tsx",
-      "norm_label": "ordersummary.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/OrderSummary.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "index_pickupdetails",
-      "label": "PickupDetails()",
-      "norm_label": "pickupdetails()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/index.tsx",
-      "source_location": "L10"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_orderdetails_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/index.tsx",
       "source_location": "L1"
     },
     {
@@ -46224,6 +46320,42 @@
     {
       "community": 490,
       "file_type": "code",
+      "id": "ordersummary_ordersummary",
+      "label": "OrderSummary()",
+      "norm_label": "ordersummary()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/OrderSummary.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_orderdetails_ordersummary_tsx",
+      "label": "OrderSummary.tsx",
+      "norm_label": "ordersummary.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/OrderSummary.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
+      "id": "index_pickupdetails",
+      "label": "PickupDetails()",
+      "norm_label": "pickupdetails()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/index.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_orderdetails_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/OrderDetails/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 492,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_paymentmethodsection_tsx",
       "label": "PaymentMethodSection.tsx",
       "norm_label": "paymentmethodsection.tsx",
@@ -46231,7 +46363,7 @@
       "source_location": "L1"
     },
     {
-      "community": 490,
+      "community": 492,
       "file_type": "code",
       "id": "paymentmethodsection_paymentmethodsection",
       "label": "PaymentMethodSection()",
@@ -46240,7 +46372,7 @@
       "source_location": "L8"
     },
     {
-      "community": 491,
+      "community": 493,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_paymentsection_tsx",
       "label": "PaymentSection.tsx",
@@ -46249,7 +46381,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 493,
       "file_type": "code",
       "id": "paymentsection_paymentsection",
       "label": "PaymentSection()",
@@ -46258,7 +46390,7 @@
       "source_location": "L27"
     },
     {
-      "community": 492,
+      "community": 494,
       "file_type": "code",
       "id": "deliveryfees_calculatedeliveryfee",
       "label": "calculateDeliveryFee()",
@@ -46267,7 +46399,7 @@
       "source_location": "L40"
     },
     {
-      "community": 492,
+      "community": 494,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_ts",
       "label": "deliveryFees.ts",
@@ -46276,7 +46408,7 @@
       "source_location": "L1"
     },
     {
-      "community": 493,
+      "community": 495,
       "file_type": "code",
       "id": "derivecheckoutstate_derivecheckoutstate",
       "label": "deriveCheckoutState()",
@@ -46285,7 +46417,7 @@
       "source_location": "L3"
     },
     {
-      "community": 493,
+      "community": 495,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_ts",
       "label": "deriveCheckoutState.ts",
@@ -46294,7 +46426,7 @@
       "source_location": "L1"
     },
     {
-      "community": 494,
+      "community": 496,
       "file_type": "code",
       "id": "checkoutschemas_test_getissuemap",
       "label": "getIssueMap()",
@@ -46303,7 +46435,7 @@
       "source_location": "L8"
     },
     {
-      "community": 494,
+      "community": 496,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutschemas_test_ts",
       "label": "checkoutSchemas.test.ts",
@@ -46312,7 +46444,7 @@
       "source_location": "L1"
     },
     {
-      "community": 495,
+      "community": 497,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_test_ts",
       "label": "webOrderSchema.test.ts",
@@ -46321,7 +46453,7 @@
       "source_location": "L1"
     },
     {
-      "community": 495,
+      "community": 497,
       "file_type": "code",
       "id": "weborderschema_test_getissuemap",
       "label": "getIssueMap()",
@@ -46330,7 +46462,7 @@
       "source_location": "L12"
     },
     {
-      "community": 496,
+      "community": 498,
       "file_type": "code",
       "id": "customerdetailsform_onsubmit",
       "label": "onSubmit()",
@@ -46339,7 +46471,7 @@
       "source_location": "L77"
     },
     {
-      "community": 496,
+      "community": 498,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_forms_customerdetailsform_tsx",
       "label": "CustomerDetailsForm.tsx",
@@ -46348,7 +46480,7 @@
       "source_location": "L1"
     },
     {
-      "community": 497,
+      "community": 499,
       "file_type": "code",
       "id": "deliverydetailsform_onsubmit",
       "label": "onSubmit()",
@@ -46357,49 +46489,13 @@
       "source_location": "L161"
     },
     {
-      "community": 497,
+      "community": 499,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_forms_deliverydetailsform_tsx",
       "label": "DeliveryDetailsForm.tsx",
       "norm_label": "deliverydetailsform.tsx",
       "source_file": "packages/storefront-webapp/src/components/common/forms/DeliveryDetailsForm.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 498,
-      "file_type": "code",
-      "id": "hooks_usecountdown",
-      "label": "useCountdown()",
-      "norm_label": "usecountdown()",
-      "source_file": "packages/storefront-webapp/src/components/common/hooks.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 498,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_common_hooks_ts",
-      "label": "hooks.ts",
-      "norm_label": "hooks.ts",
-      "source_file": "packages/storefront-webapp/src/components/common/hooks.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_communication_trustsignals_tsx",
-      "label": "TrustSignals.tsx",
-      "norm_label": "trustsignals.tsx",
-      "source_file": "packages/storefront-webapp/src/components/communication/TrustSignals.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "trustsignals_trustsignals",
-      "label": "TrustSignals()",
-      "norm_label": "trustsignals()",
-      "source_file": "packages/storefront-webapp/src/components/communication/TrustSignals.tsx",
-      "source_location": "L4"
     },
     {
       "community": 5,
@@ -46728,6 +46824,42 @@
     {
       "community": 500,
       "file_type": "code",
+      "id": "hooks_usecountdown",
+      "label": "useCountdown()",
+      "norm_label": "usecountdown()",
+      "source_file": "packages/storefront-webapp/src/components/common/hooks.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_common_hooks_ts",
+      "label": "hooks.ts",
+      "norm_label": "hooks.ts",
+      "source_file": "packages/storefront-webapp/src/components/common/hooks.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_communication_trustsignals_tsx",
+      "label": "TrustSignals.tsx",
+      "norm_label": "trustsignals.tsx",
+      "source_file": "packages/storefront-webapp/src/components/communication/TrustSignals.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
+      "id": "trustsignals_trustsignals",
+      "label": "TrustSignals()",
+      "norm_label": "trustsignals()",
+      "source_file": "packages/storefront-webapp/src/components/communication/TrustSignals.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 502,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilter_tsx",
       "label": "ProductFilter.tsx",
       "norm_label": "productfilter.tsx",
@@ -46735,7 +46867,7 @@
       "source_location": "L1"
     },
     {
-      "community": 500,
+      "community": 502,
       "file_type": "code",
       "id": "productfilter_productfilter",
       "label": "ProductFilter()",
@@ -46744,7 +46876,7 @@
       "source_location": "L14"
     },
     {
-      "community": 501,
+      "community": 503,
       "file_type": "code",
       "id": "filter_handlecheckboxchange",
       "label": "handleCheckboxChange()",
@@ -46753,7 +46885,7 @@
       "source_location": "L27"
     },
     {
-      "community": 501,
+      "community": 503,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_footer_filter_tsx",
       "label": "Filter.tsx",
@@ -46762,7 +46894,7 @@
       "source_location": "L1"
     },
     {
-      "community": 502,
+      "community": 504,
       "file_type": "code",
       "id": "bestsellerssection_bestsellerssection",
       "label": "BestSellersSection()",
@@ -46771,7 +46903,7 @@
       "source_location": "L17"
     },
     {
-      "community": 502,
+      "community": 504,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_tsx",
       "label": "BestSellersSection.tsx",
@@ -46780,7 +46912,7 @@
       "source_location": "L1"
     },
     {
-      "community": 503,
+      "community": 505,
       "file_type": "code",
       "id": "homepagecontent_resolvehomepagecontent",
       "label": "resolveHomepageContent()",
@@ -46789,7 +46921,7 @@
       "source_location": "L13"
     },
     {
-      "community": 503,
+      "community": 505,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_ts",
       "label": "homePageContent.ts",
@@ -46798,7 +46930,7 @@
       "source_location": "L1"
     },
     {
-      "community": 504,
+      "community": 506,
       "file_type": "code",
       "id": "bagmenu_handleonlinkclick",
       "label": "handleOnLinkClick()",
@@ -46807,7 +46939,7 @@
       "source_location": "L47"
     },
     {
-      "community": 504,
+      "community": 506,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_bagmenu_tsx",
       "label": "BagMenu.tsx",
@@ -46816,7 +46948,7 @@
       "source_location": "L1"
     },
     {
-      "community": 505,
+      "community": 507,
       "file_type": "code",
       "id": "mobilebagmenu_mobilebagmenu",
       "label": "MobileBagMenu()",
@@ -46825,7 +46957,7 @@
       "source_location": "L7"
     },
     {
-      "community": 505,
+      "community": 507,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilebagmenu_tsx",
       "label": "MobileBagMenu.tsx",
@@ -46834,7 +46966,7 @@
       "source_location": "L1"
     },
     {
-      "community": 506,
+      "community": 508,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_sitebanner_tsx",
       "label": "SiteBanner.tsx",
@@ -46843,7 +46975,7 @@
       "source_location": "L1"
     },
     {
-      "community": 506,
+      "community": 508,
       "file_type": "code",
       "id": "sitebanner_sitebanner",
       "label": "SiteBanner()",
@@ -46852,7 +46984,7 @@
       "source_location": "L17"
     },
     {
-      "community": 507,
+      "community": 509,
       "file_type": "code",
       "id": "notificationpill_notificationpill",
       "label": "NotificationPill()",
@@ -46861,48 +46993,12 @@
       "source_location": "L1"
     },
     {
-      "community": 507,
+      "community": 509,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_notification_notificationpill_tsx",
       "label": "NotificationPill.tsx",
       "norm_label": "notificationpill.tsx",
       "source_file": "packages/storefront-webapp/src/components/notification/NotificationPill.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 508,
-      "file_type": "code",
-      "id": "dimensionbar_mapvaluetolabelindex",
-      "label": "mapValueToLabelIndex()",
-      "norm_label": "mapvaluetolabelindex()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 508,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_dimensionbar_tsx",
-      "label": "DimensionBar.tsx",
-      "norm_label": "dimensionbar.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "discountbadge_discountbadge",
-      "label": "DiscountBadge()",
-      "norm_label": "discountbadge()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/DiscountBadge.tsx",
-      "source_location": "L7"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_discountbadge_tsx",
-      "label": "DiscountBadge.tsx",
-      "norm_label": "discountbadge.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/DiscountBadge.tsx",
       "source_location": "L1"
     },
     {
@@ -46980,6 +47076,42 @@
     {
       "community": 510,
       "file_type": "code",
+      "id": "dimensionbar_mapvaluetolabelindex",
+      "label": "mapValueToLabelIndex()",
+      "norm_label": "mapvaluetolabelindex()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_dimensionbar_tsx",
+      "label": "DimensionBar.tsx",
+      "norm_label": "dimensionbar.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/DimensionBar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
+      "id": "discountbadge_discountbadge",
+      "label": "DiscountBadge()",
+      "norm_label": "discountbadge()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/DiscountBadge.tsx",
+      "source_location": "L7"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_discountbadge_tsx",
+      "label": "DiscountBadge.tsx",
+      "norm_label": "discountbadge.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/DiscountBadge.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 512,
+      "file_type": "code",
       "id": "galleryviewer_handleclickonpreview",
       "label": "handleClickOnPreview()",
       "norm_label": "handleclickonpreview()",
@@ -46987,7 +47119,7 @@
       "source_location": "L45"
     },
     {
-      "community": 510,
+      "community": 512,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_galleryviewer_tsx",
       "label": "GalleryViewer.tsx",
@@ -46996,7 +47128,7 @@
       "source_location": "L1"
     },
     {
-      "community": 511,
+      "community": 513,
       "file_type": "code",
       "id": "onsaleproduct_onsaleproduct",
       "label": "OnsaleProduct()",
@@ -47005,7 +47137,7 @@
       "source_location": "L5"
     },
     {
-      "community": 511,
+      "community": 513,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_onsaleproduct_tsx",
       "label": "OnSaleProduct.tsx",
@@ -47014,7 +47146,7 @@
       "source_location": "L1"
     },
     {
-      "community": 512,
+      "community": 514,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_tsx",
       "label": "ProductActions.tsx",
@@ -47023,7 +47155,7 @@
       "source_location": "L1"
     },
     {
-      "community": 512,
+      "community": 514,
       "file_type": "code",
       "id": "productactions_productactions",
       "label": "ProductActions()",
@@ -47032,7 +47164,7 @@
       "source_location": "L17"
     },
     {
-      "community": 513,
+      "community": 515,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattributes_tsx",
       "label": "ProductAttributes.tsx",
@@ -47041,7 +47173,7 @@
       "source_location": "L1"
     },
     {
-      "community": 513,
+      "community": 515,
       "file_type": "code",
       "id": "productattributes_productattributes",
       "label": "ProductAttributes()",
@@ -47050,7 +47182,7 @@
       "source_location": "L3"
     },
     {
-      "community": 514,
+      "community": 516,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productpage_tsx",
       "label": "ProductPage.tsx",
@@ -47059,7 +47191,7 @@
       "source_location": "L1"
     },
     {
-      "community": 514,
+      "community": 516,
       "file_type": "code",
       "id": "productpage_showshippingpolicy",
       "label": "showShippingPolicy()",
@@ -47068,7 +47200,7 @@
       "source_location": "L78"
     },
     {
-      "community": 515,
+      "community": 517,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreview_tsx",
       "label": "ProductReview.tsx",
@@ -47077,7 +47209,7 @@
       "source_location": "L1"
     },
     {
-      "community": 515,
+      "community": 517,
       "file_type": "code",
       "id": "productreview_handlehelpful",
       "label": "handleHelpful()",
@@ -47086,7 +47218,7 @@
       "source_location": "L87"
     },
     {
-      "community": 516,
+      "community": 518,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_reviewsummary_tsx",
       "label": "ReviewSummary.tsx",
@@ -47095,7 +47227,7 @@
       "source_location": "L1"
     },
     {
-      "community": 516,
+      "community": 518,
       "file_type": "code",
       "id": "reviewsummary_reviewsummary",
       "label": "ReviewSummary()",
@@ -47104,7 +47236,7 @@
       "source_location": "L8"
     },
     {
-      "community": 517,
+      "community": 519,
       "file_type": "code",
       "id": "orderitem_orderitem",
       "label": "OrderItem()",
@@ -47113,48 +47245,12 @@
       "source_location": "L12"
     },
     {
-      "community": 517,
+      "community": 519,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_tsx",
       "label": "OrderItem.tsx",
       "norm_label": "orderitem.tsx",
       "source_file": "packages/storefront-webapp/src/components/product-reviews/OrderItem.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 518,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_ratingselector_tsx",
-      "label": "RatingSelector.tsx",
-      "norm_label": "ratingselector.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/RatingSelector.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 518,
-      "file_type": "code",
-      "id": "ratingselector_ratingselector",
-      "label": "RatingSelector()",
-      "norm_label": "ratingselector()",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/RatingSelector.tsx",
-      "source_location": "L18"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "guestrewardsprompt_guestrewardsprompt",
-      "label": "GuestRewardsPrompt()",
-      "norm_label": "guestrewardsprompt()",
-      "source_file": "packages/storefront-webapp/src/components/rewards/GuestRewardsPrompt.tsx",
-      "source_location": "L10"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_rewards_guestrewardsprompt_tsx",
-      "label": "GuestRewardsPrompt.tsx",
-      "norm_label": "guestrewardsprompt.tsx",
-      "source_file": "packages/storefront-webapp/src/components/rewards/GuestRewardsPrompt.tsx",
       "source_location": "L1"
     },
     {
@@ -47223,6 +47319,42 @@
     {
       "community": 520,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_reviews_ratingselector_tsx",
+      "label": "RatingSelector.tsx",
+      "norm_label": "ratingselector.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/RatingSelector.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "ratingselector_ratingselector",
+      "label": "RatingSelector()",
+      "norm_label": "ratingselector()",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/RatingSelector.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
+      "id": "guestrewardsprompt_guestrewardsprompt",
+      "label": "GuestRewardsPrompt()",
+      "norm_label": "guestrewardsprompt()",
+      "source_file": "packages/storefront-webapp/src/components/rewards/GuestRewardsPrompt.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_rewards_guestrewardsprompt_tsx",
+      "label": "GuestRewardsPrompt.tsx",
+      "norm_label": "guestrewardsprompt.tsx",
+      "source_file": "packages/storefront-webapp/src/components/rewards/GuestRewardsPrompt.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 522,
+      "file_type": "code",
       "id": "orderpointsdisplay_orderpointsdisplay",
       "label": "OrderPointsDisplay()",
       "norm_label": "orderpointsdisplay()",
@@ -47230,7 +47362,7 @@
       "source_location": "L11"
     },
     {
-      "community": 520,
+      "community": 522,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_orderpointsdisplay_tsx",
       "label": "OrderPointsDisplay.tsx",
@@ -47239,7 +47371,7 @@
       "source_location": "L1"
     },
     {
-      "community": 521,
+      "community": 523,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_pastordersrewards_tsx",
       "label": "PastOrdersRewards.tsx",
@@ -47248,7 +47380,7 @@
       "source_location": "L1"
     },
     {
-      "community": 521,
+      "community": 523,
       "file_type": "code",
       "id": "pastordersrewards_handleclaimpoints",
       "label": "handleClaimPoints()",
@@ -47257,7 +47389,7 @@
       "source_location": "L59"
     },
     {
-      "community": 522,
+      "community": 524,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_rewardspanel_tsx",
       "label": "RewardsPanel.tsx",
@@ -47266,7 +47398,7 @@
       "source_location": "L1"
     },
     {
-      "community": 522,
+      "community": 524,
       "file_type": "code",
       "id": "rewardspanel_handleredeemreward",
       "label": "handleRedeemReward()",
@@ -47275,7 +47407,7 @@
       "source_location": "L33"
     },
     {
-      "community": 523,
+      "community": 525,
       "file_type": "code",
       "id": "bagitem_bagitem",
       "label": "BagItem()",
@@ -47284,7 +47416,7 @@
       "source_location": "L19"
     },
     {
-      "community": 523,
+      "community": 525,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_bagitem_tsx",
       "label": "BagItem.tsx",
@@ -47293,7 +47425,7 @@
       "source_location": "L1"
     },
     {
-      "community": 524,
+      "community": 526,
       "file_type": "code",
       "id": "checkoutunavailable_checkoutunavailable",
       "label": "CheckoutUnavailable()",
@@ -47302,7 +47434,7 @@
       "source_location": "L4"
     },
     {
-      "community": 524,
+      "community": 526,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_unavailable_checkoutunavailable_tsx",
       "label": "CheckoutUnavailable.tsx",
@@ -47311,7 +47443,7 @@
       "source_location": "L1"
     },
     {
-      "community": 525,
+      "community": 527,
       "file_type": "code",
       "id": "errorboundary_errorboundary",
       "label": "ErrorBoundary()",
@@ -47320,7 +47452,7 @@
       "source_location": "L22"
     },
     {
-      "community": 525,
+      "community": 527,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_errorboundary_tsx",
       "label": "ErrorBoundary.tsx",
@@ -47329,7 +47461,7 @@
       "source_location": "L1"
     },
     {
-      "community": 526,
+      "community": 528,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scrolldownbutton_tsx",
       "label": "ScrollDownButton.tsx",
@@ -47338,7 +47470,7 @@
       "source_location": "L1"
     },
     {
-      "community": 526,
+      "community": 528,
       "file_type": "code",
       "id": "scrolldownbutton_scrolldownbutton",
       "label": "ScrollDownButton()",
@@ -47347,7 +47479,7 @@
       "source_location": "L11"
     },
     {
-      "community": 527,
+      "community": 529,
       "file_type": "code",
       "id": "country_select_countryselect",
       "label": "CountrySelect()",
@@ -47356,48 +47488,12 @@
       "source_location": "L3"
     },
     {
-      "community": 527,
+      "community": 529,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_country_select_tsx",
       "label": "country-select.tsx",
       "norm_label": "country-select.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/country-select.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 528,
-      "file_type": "code",
-      "id": "ghana_region_select_ghanaregionselect",
-      "label": "GhanaRegionSelect()",
-      "norm_label": "ghanaregionselect()",
-      "source_file": "packages/storefront-webapp/src/components/ui/ghana-region-select.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 528,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_ghana_region_select_tsx",
-      "label": "ghana-region-select.tsx",
-      "norm_label": "ghana-region-select.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/ghana-region-select.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "ghost_button_ghostbutton",
-      "label": "GhostButton()",
-      "norm_label": "ghostbutton()",
-      "source_file": "packages/storefront-webapp/src/components/ui/ghost-button.tsx",
-      "source_location": "L9"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_ghost_button_tsx",
-      "label": "ghost-button.tsx",
-      "norm_label": "ghost-button.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/ghost-button.tsx",
       "source_location": "L1"
     },
     {
@@ -47466,6 +47562,42 @@
     {
       "community": 530,
       "file_type": "code",
+      "id": "ghana_region_select_ghanaregionselect",
+      "label": "GhanaRegionSelect()",
+      "norm_label": "ghanaregionselect()",
+      "source_file": "packages/storefront-webapp/src/components/ui/ghana-region-select.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_ghana_region_select_tsx",
+      "label": "ghana-region-select.tsx",
+      "norm_label": "ghana-region-select.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/ghana-region-select.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
+      "id": "ghost_button_ghostbutton",
+      "label": "GhostButton()",
+      "norm_label": "ghostbutton()",
+      "source_file": "packages/storefront-webapp/src/components/ui/ghost-button.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_ghost_button_tsx",
+      "label": "ghost-button.tsx",
+      "norm_label": "ghost-button.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/ghost-button.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 532,
+      "file_type": "code",
       "id": "leaveareviewmodal_handleclose",
       "label": "handleClose()",
       "norm_label": "handleclose()",
@@ -47473,7 +47605,7 @@
       "source_location": "L66"
     },
     {
-      "community": 530,
+      "community": 532,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodal_tsx",
       "label": "LeaveAReviewModal.tsx",
@@ -47482,7 +47614,7 @@
       "source_location": "L1"
     },
     {
-      "community": 531,
+      "community": 533,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalsuccess_tsx",
       "label": "UpsellModalSuccess.tsx",
@@ -47491,7 +47623,7 @@
       "source_location": "L1"
     },
     {
-      "community": 531,
+      "community": 533,
       "file_type": "code",
       "id": "upsellmodalsuccess_upsellmodalsuccess",
       "label": "UpsellModalSuccess()",
@@ -47500,7 +47632,7 @@
       "source_location": "L19"
     },
     {
-      "community": 532,
+      "community": 534,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalsuccess_tsx",
       "label": "WelcomeBackModalSuccess.tsx",
@@ -47509,7 +47641,7 @@
       "source_location": "L1"
     },
     {
-      "community": 532,
+      "community": 534,
       "file_type": "code",
       "id": "welcomebackmodalsuccess_welcomebackmodalsuccess",
       "label": "WelcomeBackModalSuccess()",
@@ -47518,7 +47650,7 @@
       "source_location": "L13"
     },
     {
-      "community": 533,
+      "community": 535,
       "file_type": "code",
       "id": "leavereviewmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -47527,7 +47659,7 @@
       "source_location": "L46"
     },
     {
-      "community": 533,
+      "community": 535,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_leavereviewmodalconfig_tsx",
       "label": "leaveReviewModalConfig.tsx",
@@ -47536,7 +47668,7 @@
       "source_location": "L1"
     },
     {
-      "community": 534,
+      "community": 536,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_welcomebackmodalconfig_tsx",
       "label": "welcomeBackModalConfig.tsx",
@@ -47545,7 +47677,7 @@
       "source_location": "L1"
     },
     {
-      "community": 534,
+      "community": 536,
       "file_type": "code",
       "id": "welcomebackmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -47554,7 +47686,7 @@
       "source_location": "L46"
     },
     {
-      "community": 535,
+      "community": 537,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_webp_jpg_tsx",
       "label": "webp-jpg.tsx",
@@ -47563,7 +47695,7 @@
       "source_location": "L1"
     },
     {
-      "community": 535,
+      "community": 537,
       "file_type": "code",
       "id": "webp_jpg_webpimage",
       "label": "WebpImage()",
@@ -47572,7 +47704,7 @@
       "source_location": "L1"
     },
     {
-      "community": 536,
+      "community": 538,
       "file_type": "code",
       "id": "formsubmissionprovider_useformsubmission",
       "label": "useFormSubmission()",
@@ -47581,7 +47713,7 @@
       "source_location": "L15"
     },
     {
-      "community": 536,
+      "community": 538,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_formsubmissionprovider_tsx",
       "label": "FormSubmissionProvider.tsx",
@@ -47590,7 +47722,7 @@
       "source_location": "L1"
     },
     {
-      "community": 537,
+      "community": 539,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usecheckout_ts",
       "label": "useCheckout.ts",
@@ -47599,49 +47731,13 @@
       "source_location": "L1"
     },
     {
-      "community": 537,
+      "community": 539,
       "file_type": "code",
       "id": "usecheckout_usecheckout",
       "label": "useCheckout()",
       "norm_label": "usecheckout()",
       "source_file": "packages/storefront-webapp/src/hooks/useCheckout.ts",
       "source_location": "L5"
-    },
-    {
-      "community": 538,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usediscountcodealert_tsx",
-      "label": "useDiscountCodeAlert.tsx",
-      "norm_label": "usediscountcodealert.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useDiscountCodeAlert.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 538,
-      "file_type": "code",
-      "id": "usediscountcodealert_usediscountcodealert",
-      "label": "useDiscountCodeAlert()",
-      "norm_label": "usediscountcodealert()",
-      "source_file": "packages/storefront-webapp/src/hooks/useDiscountCodeAlert.tsx",
-      "source_location": "L14"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useenhancedtracking_ts",
-      "label": "useEnhancedTracking.ts",
-      "norm_label": "useenhancedtracking.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useEnhancedTracking.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "useenhancedtracking_useenhancedtracking",
-      "label": "useEnhancedTracking()",
-      "norm_label": "useenhancedtracking()",
-      "source_file": "packages/storefront-webapp/src/hooks/useEnhancedTracking.ts",
-      "source_location": "L29"
     },
     {
       "community": 54,
@@ -47709,6 +47805,42 @@
     {
       "community": 540,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usediscountcodealert_tsx",
+      "label": "useDiscountCodeAlert.tsx",
+      "norm_label": "usediscountcodealert.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useDiscountCodeAlert.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "usediscountcodealert_usediscountcodealert",
+      "label": "useDiscountCodeAlert()",
+      "norm_label": "usediscountcodealert()",
+      "source_file": "packages/storefront-webapp/src/hooks/useDiscountCodeAlert.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useenhancedtracking_ts",
+      "label": "useEnhancedTracking.ts",
+      "norm_label": "useenhancedtracking.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useEnhancedTracking.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
+      "id": "useenhancedtracking_useenhancedtracking",
+      "label": "useEnhancedTracking()",
+      "norm_label": "useenhancedtracking()",
+      "source_file": "packages/storefront-webapp/src/hooks/useEnhancedTracking.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 542,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetactivecheckoutsession_tsx",
       "label": "useGetActiveCheckoutSession.tsx",
       "norm_label": "usegetactivecheckoutsession.tsx",
@@ -47716,7 +47848,7 @@
       "source_location": "L1"
     },
     {
-      "community": 540,
+      "community": 542,
       "file_type": "code",
       "id": "usegetactivecheckoutsession_usegetactivecheckoutsession",
       "label": "useGetActiveCheckoutSession()",
@@ -47725,7 +47857,7 @@
       "source_location": "L5"
     },
     {
-      "community": 541,
+      "community": 543,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproduct_tsx",
       "label": "useGetProduct.tsx",
@@ -47734,7 +47866,7 @@
       "source_location": "L1"
     },
     {
-      "community": 541,
+      "community": 543,
       "file_type": "code",
       "id": "usegetproduct_usegetproductquery",
       "label": "useGetProductQuery()",
@@ -47743,7 +47875,7 @@
       "source_location": "L5"
     },
     {
-      "community": 542,
+      "community": 544,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductfilters_ts",
       "label": "useGetProductFilters.ts",
@@ -47752,7 +47884,7 @@
       "source_location": "L1"
     },
     {
-      "community": 542,
+      "community": 544,
       "file_type": "code",
       "id": "usegetproductfilters_usegetproductfilters",
       "label": "useGetProductFilters()",
@@ -47761,7 +47893,7 @@
       "source_location": "L3"
     },
     {
-      "community": 543,
+      "community": 545,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductreviews_ts",
       "label": "useGetProductReviews.ts",
@@ -47770,7 +47902,7 @@
       "source_location": "L1"
     },
     {
-      "community": 543,
+      "community": 545,
       "file_type": "code",
       "id": "usegetproductreviews_usegetproductreviewsquery",
       "label": "useGetProductReviewsQuery()",
@@ -47779,7 +47911,7 @@
       "source_location": "L4"
     },
     {
-      "community": 544,
+      "community": 546,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetstore_ts",
       "label": "useGetStore.ts",
@@ -47788,7 +47920,7 @@
       "source_location": "L1"
     },
     {
-      "community": 544,
+      "community": 546,
       "file_type": "code",
       "id": "usegetstore_usegetstore",
       "label": "useGetStore()",
@@ -47797,7 +47929,7 @@
       "source_location": "L4"
     },
     {
-      "community": 545,
+      "community": 547,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useinventorystatus_ts",
       "label": "useInventoryStatus.ts",
@@ -47806,7 +47938,7 @@
       "source_location": "L1"
     },
     {
-      "community": 545,
+      "community": 547,
       "file_type": "code",
       "id": "useinventorystatus_useinventorystatus",
       "label": "useInventoryStatus()",
@@ -47815,7 +47947,7 @@
       "source_location": "L9"
     },
     {
-      "community": 546,
+      "community": 548,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useleaveareviewmodal_tsx",
       "label": "useLeaveAReviewModal.tsx",
@@ -47824,7 +47956,7 @@
       "source_location": "L1"
     },
     {
-      "community": 546,
+      "community": 548,
       "file_type": "code",
       "id": "useleaveareviewmodal_useleaveareviewmodal",
       "label": "useLeaveAReviewModal()",
@@ -47833,7 +47965,7 @@
       "source_location": "L17"
     },
     {
-      "community": 547,
+      "community": 549,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_uselogout_ts",
       "label": "useLogout.ts",
@@ -47842,49 +47974,13 @@
       "source_location": "L1"
     },
     {
-      "community": 547,
+      "community": 549,
       "file_type": "code",
       "id": "uselogout_uselogout",
       "label": "useLogout()",
       "norm_label": "uselogout()",
       "source_file": "packages/storefront-webapp/src/hooks/useLogout.ts",
       "source_location": "L5"
-    },
-    {
-      "community": 548,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usemodalstate_tsx",
-      "label": "useModalState.tsx",
-      "norm_label": "usemodalstate.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useModalState.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 548,
-      "file_type": "code",
-      "id": "usemodalstate_usemodalstate",
-      "label": "useModalState()",
-      "norm_label": "usemodalstate()",
-      "source_file": "packages/storefront-webapp/src/hooks/useModalState.tsx",
-      "source_location": "L15"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_useproductpagelogic_ts",
-      "label": "useProductPageLogic.ts",
-      "norm_label": "useproductpagelogic.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductPageLogic.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "useproductpagelogic_useproductpagelogic",
-      "label": "useProductPageLogic()",
-      "norm_label": "useproductpagelogic()",
-      "source_file": "packages/storefront-webapp/src/hooks/useProductPageLogic.ts",
-      "source_location": "L18"
     },
     {
       "community": 55,
@@ -47952,6 +48048,42 @@
     {
       "community": 550,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usemodalstate_tsx",
+      "label": "useModalState.tsx",
+      "norm_label": "usemodalstate.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useModalState.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 550,
+      "file_type": "code",
+      "id": "usemodalstate_usemodalstate",
+      "label": "useModalState()",
+      "norm_label": "usemodalstate()",
+      "source_file": "packages/storefront-webapp/src/hooks/useModalState.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_useproductpagelogic_ts",
+      "label": "useProductPageLogic.ts",
+      "norm_label": "useproductpagelogic.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductPageLogic.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
+      "id": "useproductpagelogic_useproductpagelogic",
+      "label": "useProductPageLogic()",
+      "norm_label": "useproductpagelogic()",
+      "source_file": "packages/storefront-webapp/src/hooks/useProductPageLogic.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 552,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductreminder_tsx",
       "label": "useProductReminder.tsx",
       "norm_label": "useproductreminder.tsx",
@@ -47959,7 +48091,7 @@
       "source_location": "L1"
     },
     {
-      "community": 550,
+      "community": 552,
       "file_type": "code",
       "id": "useproductreminder_useproductreminder",
       "label": "useProductReminder()",
@@ -47968,7 +48100,7 @@
       "source_location": "L9"
     },
     {
-      "community": 551,
+      "community": 553,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usepromoalert_tsx",
       "label": "usePromoAlert.tsx",
@@ -47977,7 +48109,7 @@
       "source_location": "L1"
     },
     {
-      "community": 551,
+      "community": 553,
       "file_type": "code",
       "id": "usepromoalert_usepromoalert",
       "label": "usePromoAlert()",
@@ -47986,7 +48118,7 @@
       "source_location": "L16"
     },
     {
-      "community": 552,
+      "community": 554,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usequeryenabled_ts",
       "label": "useQueryEnabled.ts",
@@ -47995,7 +48127,7 @@
       "source_location": "L1"
     },
     {
-      "community": 552,
+      "community": 554,
       "file_type": "code",
       "id": "usequeryenabled_usequeryenabled",
       "label": "useQueryEnabled()",
@@ -48004,7 +48136,7 @@
       "source_location": "L4"
     },
     {
-      "community": 553,
+      "community": 555,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_userewardsalert_tsx",
       "label": "useRewardsAlert.tsx",
@@ -48013,7 +48145,7 @@
       "source_location": "L1"
     },
     {
-      "community": 553,
+      "community": 555,
       "file_type": "code",
       "id": "userewardsalert_userewardsalert",
       "label": "useRewardsAlert()",
@@ -48022,7 +48154,7 @@
       "source_location": "L11"
     },
     {
-      "community": 554,
+      "community": 556,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usescrolltotop_ts",
       "label": "useScrollToTop.ts",
@@ -48031,7 +48163,7 @@
       "source_location": "L1"
     },
     {
-      "community": 554,
+      "community": 556,
       "file_type": "code",
       "id": "usescrolltotop_usescrolltotop",
       "label": "useScrollToTop()",
@@ -48040,7 +48172,7 @@
       "source_location": "L3"
     },
     {
-      "community": 555,
+      "community": 557,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackaction_ts",
       "label": "useTrackAction.ts",
@@ -48049,7 +48181,7 @@
       "source_location": "L1"
     },
     {
-      "community": 555,
+      "community": 557,
       "file_type": "code",
       "id": "usetrackaction_usetrackaction",
       "label": "useTrackAction()",
@@ -48058,7 +48190,7 @@
       "source_location": "L7"
     },
     {
-      "community": 556,
+      "community": 558,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackevent_ts",
       "label": "useTrackEvent.ts",
@@ -48067,7 +48199,7 @@
       "source_location": "L1"
     },
     {
-      "community": 556,
+      "community": 558,
       "file_type": "code",
       "id": "usetrackevent_usetrackevent",
       "label": "useTrackEvent()",
@@ -48076,7 +48208,7 @@
       "source_location": "L4"
     },
     {
-      "community": 557,
+      "community": 559,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useupsellmodal_tsx",
       "label": "useUpsellModal.tsx",
@@ -48085,49 +48217,13 @@
       "source_location": "L1"
     },
     {
-      "community": 557,
+      "community": 559,
       "file_type": "code",
       "id": "useupsellmodal_useupsellmodal",
       "label": "useUpsellModal()",
       "norm_label": "useupsellmodal()",
       "source_file": "packages/storefront-webapp/src/hooks/useUpsellModal.tsx",
       "source_location": "L14"
-    },
-    {
-      "community": 558,
-      "file_type": "code",
-      "id": "analytics_usepostanalytics",
-      "label": "usePostAnalytics()",
-      "norm_label": "usepostanalytics()",
-      "source_file": "packages/storefront-webapp/src/lib/mutations.ts/analytics.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 558,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_mutations_ts_analytics_ts",
-      "label": "analytics.ts",
-      "norm_label": "analytics.ts",
-      "source_file": "packages/storefront-webapp/src/lib/mutations.ts/analytics.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "bag_usebagqueries",
-      "label": "useBagQueries()",
-      "norm_label": "usebagqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/bag.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_bag_ts",
-      "label": "bag.ts",
-      "norm_label": "bag.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/bag.ts",
-      "source_location": "L1"
     },
     {
       "community": 56,
@@ -48195,6 +48291,42 @@
     {
       "community": 560,
       "file_type": "code",
+      "id": "analytics_usepostanalytics",
+      "label": "usePostAnalytics()",
+      "norm_label": "usepostanalytics()",
+      "source_file": "packages/storefront-webapp/src/lib/mutations.ts/analytics.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_mutations_ts_analytics_ts",
+      "label": "analytics.ts",
+      "norm_label": "analytics.ts",
+      "source_file": "packages/storefront-webapp/src/lib/mutations.ts/analytics.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
+      "id": "bag_usebagqueries",
+      "label": "useBagQueries()",
+      "norm_label": "usebagqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/bag.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_bag_ts",
+      "label": "bag.ts",
+      "norm_label": "bag.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/bag.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 562,
+      "file_type": "code",
       "id": "bannermessage_usebannermessagequeries",
       "label": "useBannerMessageQueries()",
       "norm_label": "usebannermessagequeries()",
@@ -48202,7 +48334,7 @@
       "source_location": "L6"
     },
     {
-      "community": 560,
+      "community": 562,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -48211,7 +48343,7 @@
       "source_location": "L1"
     },
     {
-      "community": 561,
+      "community": 563,
       "file_type": "code",
       "id": "checkout_usecheckoutsessionqueries",
       "label": "useCheckoutSessionQueries()",
@@ -48220,7 +48352,7 @@
       "source_location": "L10"
     },
     {
-      "community": 561,
+      "community": 563,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_checkout_ts",
       "label": "checkout.ts",
@@ -48229,7 +48361,7 @@
       "source_location": "L1"
     },
     {
-      "community": 562,
+      "community": 564,
       "file_type": "code",
       "id": "inventory_useinventoryqueries",
       "label": "useInventoryQueries()",
@@ -48238,7 +48370,7 @@
       "source_location": "L6"
     },
     {
-      "community": 562,
+      "community": 564,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_inventory_ts",
       "label": "inventory.ts",
@@ -48247,7 +48379,7 @@
       "source_location": "L1"
     },
     {
-      "community": 563,
+      "community": 565,
       "file_type": "code",
       "id": "onlineorder_useonlineorderqueries",
       "label": "useOnlineOrderQueries()",
@@ -48256,7 +48388,7 @@
       "source_location": "L5"
     },
     {
-      "community": 563,
+      "community": 565,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -48265,7 +48397,7 @@
       "source_location": "L1"
     },
     {
-      "community": 564,
+      "community": 566,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_product_ts",
       "label": "product.ts",
@@ -48274,7 +48406,7 @@
       "source_location": "L1"
     },
     {
-      "community": 564,
+      "community": 566,
       "file_type": "code",
       "id": "product_useproductqueries",
       "label": "useProductQueries()",
@@ -48283,7 +48415,7 @@
       "source_location": "L14"
     },
     {
-      "community": 565,
+      "community": 567,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_promocode_ts",
       "label": "promoCode.ts",
@@ -48292,7 +48424,7 @@
       "source_location": "L1"
     },
     {
-      "community": 565,
+      "community": 567,
       "file_type": "code",
       "id": "promocode_usepromocodesqueries",
       "label": "usePromoCodesQueries()",
@@ -48301,7 +48433,7 @@
       "source_location": "L9"
     },
     {
-      "community": 566,
+      "community": 568,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_reviews_ts",
       "label": "reviews.ts",
@@ -48310,7 +48442,7 @@
       "source_location": "L1"
     },
     {
-      "community": 566,
+      "community": 568,
       "file_type": "code",
       "id": "reviews_usereviewqueries",
       "label": "useReviewQueries()",
@@ -48319,7 +48451,7 @@
       "source_location": "L10"
     },
     {
-      "community": 567,
+      "community": 569,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_rewards_ts",
       "label": "rewards.ts",
@@ -48328,49 +48460,13 @@
       "source_location": "L1"
     },
     {
-      "community": 567,
+      "community": 569,
       "file_type": "code",
       "id": "rewards_userewardsqueries",
       "label": "useRewardsQueries()",
       "norm_label": "userewardsqueries()",
       "source_file": "packages/storefront-webapp/src/lib/queries/rewards.ts",
       "source_location": "L11"
-    },
-    {
-      "community": 568,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_upsells_ts",
-      "label": "upsells.ts",
-      "norm_label": "upsells.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/upsells.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 568,
-      "file_type": "code",
-      "id": "upsells_useupsellsqueries",
-      "label": "useUpsellsQueries()",
-      "norm_label": "useupsellsqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/upsells.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_user_ts",
-      "label": "user.ts",
-      "norm_label": "user.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/user.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "user_useuserqueries",
-      "label": "useUserQueries()",
-      "norm_label": "useuserqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/user.ts",
-      "source_location": "L5"
     },
     {
       "community": 57,
@@ -48438,6 +48534,42 @@
     {
       "community": 570,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_upsells_ts",
+      "label": "upsells.ts",
+      "norm_label": "upsells.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/upsells.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "upsells_useupsellsqueries",
+      "label": "useUpsellsQueries()",
+      "norm_label": "useupsellsqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/upsells.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_user_ts",
+      "label": "user.ts",
+      "norm_label": "user.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/user.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
+      "id": "user_useuserqueries",
+      "label": "useUserQueries()",
+      "norm_label": "useuserqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/user.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 572,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_useroffers_ts",
       "label": "userOffers.ts",
       "norm_label": "useroffers.ts",
@@ -48445,7 +48577,7 @@
       "source_location": "L1"
     },
     {
-      "community": 570,
+      "community": 572,
       "file_type": "code",
       "id": "useroffers_useuseroffersqueries",
       "label": "useUserOffersQueries()",
@@ -48454,7 +48586,7 @@
       "source_location": "L6"
     },
     {
-      "community": 571,
+      "community": 573,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
@@ -48463,7 +48595,7 @@
       "source_location": "L1"
     },
     {
-      "community": 571,
+      "community": 573,
       "file_type": "code",
       "id": "storeconfig_test_buildv2config",
       "label": "buildV2Config()",
@@ -48472,7 +48604,7 @@
       "source_location": "L10"
     },
     {
-      "community": 572,
+      "community": 574,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontobservability_test_ts",
       "label": "storefrontObservability.test.ts",
@@ -48481,7 +48613,7 @@
       "source_location": "L1"
     },
     {
-      "community": 572,
+      "community": 574,
       "file_type": "code",
       "id": "storefrontobservability_test_creatememorystorage",
       "label": "createMemoryStorage()",
@@ -48490,7 +48622,7 @@
       "source_location": "L15"
     },
     {
-      "community": 573,
+      "community": 575,
       "file_type": "code",
       "id": "email_validateemail",
       "label": "validateEmail()",
@@ -48499,7 +48631,7 @@
       "source_location": "L14"
     },
     {
-      "community": 573,
+      "community": 575,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_validations_email_ts",
       "label": "email.ts",
@@ -48508,7 +48640,7 @@
       "source_location": "L1"
     },
     {
-      "community": 574,
+      "community": 576,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_router_tsx",
       "label": "router.tsx",
@@ -48517,7 +48649,7 @@
       "source_location": "L1"
     },
     {
-      "community": 574,
+      "community": 576,
       "file_type": "code",
       "id": "router_createrouter",
       "label": "createRouter()",
@@ -48526,7 +48658,7 @@
       "source_location": "L5"
     },
     {
-      "community": 575,
+      "community": 577,
       "file_type": "code",
       "id": "homepageloader_loadhomepagedata",
       "label": "loadHomePageData()",
@@ -48535,7 +48667,7 @@
       "source_location": "L13"
     },
     {
-      "community": 575,
+      "community": 577,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_ts",
       "label": "-homePageLoader.ts",
@@ -48544,7 +48676,7 @@
       "source_location": "L1"
     },
     {
-      "community": 576,
+      "community": 578,
       "file_type": "code",
       "id": "orderslayout_layoutcomponent",
       "label": "LayoutComponent()",
@@ -48553,7 +48685,7 @@
       "source_location": "L8"
     },
     {
-      "community": 576,
+      "community": 578,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_tsx",
       "label": "_ordersLayout.tsx",
@@ -48562,7 +48694,7 @@
       "source_location": "L1"
     },
     {
-      "community": 577,
+      "community": 579,
       "file_type": "code",
       "id": "contact_us_contactus",
       "label": "ContactUs()",
@@ -48571,49 +48703,13 @@
       "source_location": "L14"
     },
     {
-      "community": 577,
+      "community": 579,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_contact_us_tsx",
       "label": "contact-us.tsx",
       "norm_label": "contact-us.tsx",
       "source_file": "packages/storefront-webapp/src/routes/_layout/contact-us.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 578,
-      "file_type": "code",
-      "id": "delivery_returns_exchanges_index_onlineorderpolicy",
-      "label": "OnlineOrderPolicy()",
-      "norm_label": "onlineorderpolicy()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/delivery-returns-exchanges.index.tsx",
-      "source_location": "L13"
-    },
-    {
-      "community": 578,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_policies_delivery_returns_exchanges_index_tsx",
-      "label": "delivery-returns-exchanges.index.tsx",
-      "norm_label": "delivery-returns-exchanges.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/delivery-returns-exchanges.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_policies_privacy_index_tsx",
-      "label": "privacy.index.tsx",
-      "norm_label": "privacy.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/privacy.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "privacy_index_privacypolicy",
-      "label": "PrivacyPolicy()",
-      "norm_label": "privacypolicy()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/privacy.index.tsx",
-      "source_location": "L9"
     },
     {
       "community": 58,
@@ -48681,6 +48777,42 @@
     {
       "community": 580,
       "file_type": "code",
+      "id": "delivery_returns_exchanges_index_onlineorderpolicy",
+      "label": "OnlineOrderPolicy()",
+      "norm_label": "onlineorderpolicy()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/delivery-returns-exchanges.index.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_policies_delivery_returns_exchanges_index_tsx",
+      "label": "delivery-returns-exchanges.index.tsx",
+      "norm_label": "delivery-returns-exchanges.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/delivery-returns-exchanges.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_policies_privacy_index_tsx",
+      "label": "privacy.index.tsx",
+      "norm_label": "privacy.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/privacy.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
+      "id": "privacy_index_privacypolicy",
+      "label": "PrivacyPolicy()",
+      "norm_label": "privacypolicy()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/privacy.index.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 582,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_tos_index_tsx",
       "label": "tos.index.tsx",
       "norm_label": "tos.index.tsx",
@@ -48688,7 +48820,7 @@
       "source_location": "L1"
     },
     {
-      "community": 580,
+      "community": 582,
       "file_type": "code",
       "id": "tos_index_tossection",
       "label": "TosSection()",
@@ -48697,7 +48829,7 @@
       "source_location": "L15"
     },
     {
-      "community": 581,
+      "community": 583,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_product_productslug_tsx",
       "label": "shop.product.$productSlug.tsx",
@@ -48706,7 +48838,7 @@
       "source_location": "L1"
     },
     {
-      "community": 581,
+      "community": 583,
       "file_type": "code",
       "id": "shop_product_productslug_component",
       "label": "Component()",
@@ -48715,7 +48847,7 @@
       "source_location": "L16"
     },
     {
-      "community": 582,
+      "community": 584,
       "file_type": "code",
       "id": "layout_layoutcomponent",
       "label": "LayoutComponent()",
@@ -48724,7 +48856,7 @@
       "source_location": "L6"
     },
     {
-      "community": 582,
+      "community": 584,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_tsx",
       "label": "_layout.tsx",
@@ -48733,7 +48865,7 @@
       "source_location": "L1"
     },
     {
-      "community": 583,
+      "community": 585,
       "file_type": "code",
       "id": "index_homeroute",
       "label": "HomeRoute()",
@@ -48742,7 +48874,7 @@
       "source_location": "L10"
     },
     {
-      "community": 583,
+      "community": 585,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -48751,7 +48883,7 @@
       "source_location": "L1"
     },
     {
-      "community": 584,
+      "community": 586,
       "file_type": "code",
       "id": "canceled_checkoutcanceledview",
       "label": "CheckoutCanceledView()",
@@ -48760,7 +48892,7 @@
       "source_location": "L21"
     },
     {
-      "community": 584,
+      "community": 586,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_canceled_tsx",
       "label": "canceled.tsx",
@@ -48769,7 +48901,7 @@
       "source_location": "L1"
     },
     {
-      "community": 585,
+      "community": 587,
       "file_type": "code",
       "id": "complete_index_checkoutcomplete",
       "label": "CheckoutComplete()",
@@ -48778,7 +48910,7 @@
       "source_location": "L33"
     },
     {
-      "community": 585,
+      "community": 587,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_complete_index_tsx",
       "label": "complete.index.tsx",
@@ -48787,7 +48919,7 @@
       "source_location": "L1"
     },
     {
-      "community": 586,
+      "community": 588,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pod_confirmation_tsx",
       "label": "pod-confirmation.tsx",
@@ -48796,7 +48928,7 @@
       "source_location": "L1"
     },
     {
-      "community": 586,
+      "community": 588,
       "file_type": "code",
       "id": "pod_confirmation_completepodcheckoutsession",
       "label": "completePODCheckoutSession()",
@@ -48805,7 +48937,7 @@
       "source_location": "L193"
     },
     {
-      "community": 587,
+      "community": 589,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_test_connection_js",
       "label": "test-connection.js",
@@ -48814,49 +48946,13 @@
       "source_location": "L1"
     },
     {
-      "community": 587,
+      "community": 589,
       "file_type": "code",
       "id": "test_connection_main",
       "label": "main()",
       "norm_label": "main()",
       "source_file": "packages/valkey-proxy-server/test-connection.js",
       "source_location": "L7"
-    },
-    {
-      "community": 588,
-      "file_type": "code",
-      "id": "architecture_boundaries_test_createsnippetlinter",
-      "label": "createSnippetLinter()",
-      "norm_label": "createsnippetlinter()",
-      "source_file": "scripts/architecture-boundaries.test.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 588,
-      "file_type": "code",
-      "id": "scripts_architecture_boundaries_test_ts",
-      "label": "architecture-boundaries.test.ts",
-      "norm_label": "architecture-boundaries.test.ts",
-      "source_file": "scripts/architecture-boundaries.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "architecture_boundary_check_run",
-      "label": "run()",
-      "norm_label": "run()",
-      "source_file": "scripts/architecture-boundary-check.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "scripts_architecture_boundary_check_ts",
-      "label": "architecture-boundary-check.ts",
-      "norm_label": "architecture-boundary-check.ts",
-      "source_file": "scripts/architecture-boundary-check.ts",
-      "source_location": "L1"
     },
     {
       "community": 59,
@@ -48924,6 +49020,42 @@
     {
       "community": 590,
       "file_type": "code",
+      "id": "architecture_boundaries_test_createsnippetlinter",
+      "label": "createSnippetLinter()",
+      "norm_label": "createsnippetlinter()",
+      "source_file": "scripts/architecture-boundaries.test.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "scripts_architecture_boundaries_test_ts",
+      "label": "architecture-boundaries.test.ts",
+      "norm_label": "architecture-boundaries.test.ts",
+      "source_file": "scripts/architecture-boundaries.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 591,
+      "file_type": "code",
+      "id": "architecture_boundary_check_run",
+      "label": "run()",
+      "norm_label": "run()",
+      "source_file": "scripts/architecture-boundary-check.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 591,
+      "file_type": "code",
+      "id": "scripts_architecture_boundary_check_ts",
+      "label": "architecture-boundary-check.ts",
+      "norm_label": "architecture-boundary-check.ts",
+      "source_file": "scripts/architecture-boundary-check.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 592,
+      "file_type": "code",
       "id": "athena_runtime_app_shutdown",
       "label": "shutdown()",
       "norm_label": "shutdown()",
@@ -48931,7 +49063,7 @@
       "source_location": "L211"
     },
     {
-      "community": 590,
+      "community": 592,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_athena_runtime_app_ts",
       "label": "athena-runtime-app.ts",
@@ -48940,7 +49072,7 @@
       "source_location": "L1"
     },
     {
-      "community": 591,
+      "community": 593,
       "file_type": "code",
       "id": "sample_app_shutdown",
       "label": "shutdown()",
@@ -48949,7 +49081,7 @@
       "source_location": "L85"
     },
     {
-      "community": 591,
+      "community": 593,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_sample_app_ts",
       "label": "sample-app.ts",
@@ -48958,7 +49090,7 @@
       "source_location": "L1"
     },
     {
-      "community": 592,
+      "community": 594,
       "file_type": "code",
       "id": "harness_runtime_trends_test_buildreportline",
       "label": "buildReportLine()",
@@ -48967,7 +49099,7 @@
       "source_location": "L15"
     },
     {
-      "community": 592,
+      "community": 594,
       "file_type": "code",
       "id": "scripts_harness_runtime_trends_test_ts",
       "label": "harness-runtime-trends.test.ts",
@@ -48976,7 +49108,7 @@
       "source_location": "L1"
     },
     {
-      "community": 593,
+      "community": 595,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_d_ts",
       "label": "api.d.ts",
@@ -48985,7 +49117,7 @@
       "source_location": "L1"
     },
     {
-      "community": 594,
+      "community": 596,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_js",
       "label": "api.js",
@@ -48994,7 +49126,7 @@
       "source_location": "L1"
     },
     {
-      "community": 595,
+      "community": 597,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_datamodel_d_ts",
       "label": "dataModel.d.ts",
@@ -49003,7 +49135,7 @@
       "source_location": "L1"
     },
     {
-      "community": 596,
+      "community": 598,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_d_ts",
       "label": "server.d.ts",
@@ -49012,30 +49144,12 @@
       "source_location": "L1"
     },
     {
-      "community": 597,
+      "community": 599,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_js",
       "label": "server.js",
       "norm_label": "server.js",
       "source_file": "packages/athena-webapp/convex/_generated/server.js",
-      "source_location": "L1"
-    },
-    {
-      "community": 598,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_app_ts",
-      "label": "app.ts",
-      "norm_label": "app.ts",
-      "source_file": "packages/athena-webapp/convex/app.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_auth_config_js",
-      "label": "auth.config.js",
-      "norm_label": "auth.config.js",
-      "source_file": "packages/athena-webapp/convex/auth.config.js",
       "source_location": "L1"
     },
     {
@@ -49338,6 +49452,24 @@
     {
       "community": 600,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_app_ts",
+      "label": "app.ts",
+      "norm_label": "app.ts",
+      "source_file": "packages/athena-webapp/convex/app.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 601,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_auth_config_js",
+      "label": "auth.config.js",
+      "norm_label": "auth.config.js",
+      "source_file": "packages/athena-webapp/convex/auth.config.js",
+      "source_location": "L1"
+    },
+    {
+      "community": 602,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_ts",
       "label": "auth.ts",
       "norm_label": "auth.ts",
@@ -49345,7 +49477,7 @@
       "source_location": "L1"
     },
     {
-      "community": 601,
+      "community": 603,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_countries_ts",
       "label": "countries.ts",
@@ -49354,7 +49486,7 @@
       "source_location": "L1"
     },
     {
-      "community": 602,
+      "community": 604,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_email_ts",
       "label": "email.ts",
@@ -49363,7 +49495,7 @@
       "source_location": "L1"
     },
     {
-      "community": 603,
+      "community": 605,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_ghana_ts",
       "label": "ghana.ts",
@@ -49372,7 +49504,7 @@
       "source_location": "L1"
     },
     {
-      "community": 604,
+      "community": 606,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_payment_ts",
       "label": "payment.ts",
@@ -49381,7 +49513,7 @@
       "source_location": "L1"
     },
     {
-      "community": 605,
+      "community": 607,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_crons_ts",
       "label": "crons.ts",
@@ -49390,7 +49522,7 @@
       "source_location": "L1"
     },
     {
-      "community": 606,
+      "community": 608,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_feedbackrequest_tsx",
       "label": "FeedbackRequest.tsx",
@@ -49399,30 +49531,12 @@
       "source_location": "L1"
     },
     {
-      "community": 607,
+      "community": 609,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_neworderadmin_tsx",
       "label": "NewOrderAdmin.tsx",
       "norm_label": "neworderadmin.tsx",
       "source_file": "packages/athena-webapp/convex/emails/NewOrderAdmin.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 608,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_emails_orderemail_tsx",
-      "label": "OrderEmail.tsx",
-      "norm_label": "orderemail.tsx",
-      "source_file": "packages/athena-webapp/convex/emails/OrderEmail.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_emails_posreceiptemail_tsx",
-      "label": "PosReceiptEmail.tsx",
-      "norm_label": "posreceiptemail.tsx",
-      "source_file": "packages/athena-webapp/convex/emails/PosReceiptEmail.tsx",
       "source_location": "L1"
     },
     {
@@ -49491,6 +49605,24 @@
     {
       "community": 610,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_orderemail_tsx",
+      "label": "OrderEmail.tsx",
+      "norm_label": "orderemail.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/OrderEmail.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 611,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_posreceiptemail_tsx",
+      "label": "PosReceiptEmail.tsx",
+      "norm_label": "posreceiptemail.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/PosReceiptEmail.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 612,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_env_ts",
       "label": "env.ts",
       "norm_label": "env.ts",
@@ -49498,7 +49630,7 @@
       "source_location": "L1"
     },
     {
-      "community": 611,
+      "community": 613,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_analytics_ts",
       "label": "analytics.ts",
@@ -49507,7 +49639,7 @@
       "source_location": "L1"
     },
     {
-      "community": 612,
+      "community": 614,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_auth_ts",
       "label": "auth.ts",
@@ -49516,7 +49648,7 @@
       "source_location": "L1"
     },
     {
-      "community": 613,
+      "community": 615,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -49525,7 +49657,7 @@
       "source_location": "L1"
     },
     {
-      "community": 614,
+      "community": 616,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_categories_ts",
       "label": "categories.ts",
@@ -49534,7 +49666,7 @@
       "source_location": "L1"
     },
     {
-      "community": 615,
+      "community": 617,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_colors_ts",
       "label": "colors.ts",
@@ -49543,7 +49675,7 @@
       "source_location": "L1"
     },
     {
-      "community": 616,
+      "community": 618,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_index_ts",
       "label": "index.ts",
@@ -49552,30 +49684,12 @@
       "source_location": "L1"
     },
     {
-      "community": 617,
+      "community": 619,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_organizations_ts",
       "label": "organizations.ts",
       "norm_label": "organizations.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/organizations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 618,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_products_ts",
-      "label": "products.ts",
-      "norm_label": "products.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/products.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_stores_ts",
-      "label": "stores.ts",
-      "norm_label": "stores.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/stores.ts",
       "source_location": "L1"
     },
     {
@@ -49644,6 +49758,24 @@
     {
       "community": 620,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_products_ts",
+      "label": "products.ts",
+      "norm_label": "products.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/products.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 621,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_inventory_routes_stores_ts",
+      "label": "stores.ts",
+      "norm_label": "stores.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/inventory/routes/stores.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 622,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_inventory_routes_subcategories_ts",
       "label": "subcategories.ts",
       "norm_label": "subcategories.ts",
@@ -49651,7 +49783,7 @@
       "source_location": "L1"
     },
     {
-      "community": 621,
+      "community": 623,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_payments_routes_index_ts",
       "label": "index.ts",
@@ -49660,7 +49792,7 @@
       "source_location": "L1"
     },
     {
-      "community": 622,
+      "community": 624,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_bag_ts",
       "label": "bag.ts",
@@ -49669,7 +49801,7 @@
       "source_location": "L1"
     },
     {
-      "community": 623,
+      "community": 625,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_guest_ts",
       "label": "guest.ts",
@@ -49678,7 +49810,7 @@
       "source_location": "L1"
     },
     {
-      "community": 624,
+      "community": 626,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_index_ts",
       "label": "index.ts",
@@ -49687,7 +49819,7 @@
       "source_location": "L1"
     },
     {
-      "community": 625,
+      "community": 627,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_me_ts",
       "label": "me.ts",
@@ -49696,7 +49828,7 @@
       "source_location": "L1"
     },
     {
-      "community": 626,
+      "community": 628,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_offers_ts",
       "label": "offers.ts",
@@ -49705,30 +49837,12 @@
       "source_location": "L1"
     },
     {
-      "community": 627,
+      "community": 629,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_onlineorder_ts",
       "label": "onlineOrder.ts",
       "norm_label": "onlineorder.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/onlineOrder.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 628,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_paystack_ts",
-      "label": "paystack.ts",
-      "norm_label": "paystack.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/paystack.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_reviews_ts",
-      "label": "reviews.ts",
-      "norm_label": "reviews.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/reviews.ts",
       "source_location": "L1"
     },
     {
@@ -49797,6 +49911,24 @@
     {
       "community": 630,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_paystack_ts",
+      "label": "paystack.ts",
+      "norm_label": "paystack.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/paystack.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 631,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_storefront_routes_reviews_ts",
+      "label": "reviews.ts",
+      "norm_label": "reviews.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/storeFront/routes/reviews.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 632,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_rewards_ts",
       "label": "rewards.ts",
       "norm_label": "rewards.ts",
@@ -49804,7 +49936,7 @@
       "source_location": "L1"
     },
     {
-      "community": 631,
+      "community": 633,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_savedbag_ts",
       "label": "savedBag.ts",
@@ -49813,7 +49945,7 @@
       "source_location": "L1"
     },
     {
-      "community": 632,
+      "community": 634,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_security_test_ts",
       "label": "security.test.ts",
@@ -49822,7 +49954,7 @@
       "source_location": "L1"
     },
     {
-      "community": 633,
+      "community": 635,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_storefront_ts",
       "label": "storefront.ts",
@@ -49831,7 +49963,7 @@
       "source_location": "L1"
     },
     {
-      "community": 634,
+      "community": 636,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_upsells_ts",
       "label": "upsells.ts",
@@ -49840,7 +49972,7 @@
       "source_location": "L1"
     },
     {
-      "community": 635,
+      "community": 637,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_user_ts",
       "label": "user.ts",
@@ -49849,7 +49981,7 @@
       "source_location": "L1"
     },
     {
-      "community": 636,
+      "community": 638,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_storefront_routes_useroffers_ts",
       "label": "userOffers.ts",
@@ -49858,30 +49990,12 @@
       "source_location": "L1"
     },
     {
-      "community": 637,
+      "community": 639,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_health_test_ts",
       "label": "health.test.ts",
       "norm_label": "health.test.ts",
       "source_file": "packages/athena-webapp/convex/http/health.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 638,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_ts",
-      "label": "http.ts",
-      "norm_label": "http.ts",
-      "source_file": "packages/athena-webapp/convex/http.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_athenauser_ts",
-      "label": "athenaUser.ts",
-      "norm_label": "athenauser.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/athenaUser.ts",
       "source_location": "L1"
     },
     {
@@ -49941,6 +50055,24 @@
     {
       "community": 640,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_ts",
+      "label": "http.ts",
+      "norm_label": "http.ts",
+      "source_file": "packages/athena-webapp/convex/http.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 641,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_athenauser_ts",
+      "label": "athenaUser.ts",
+      "norm_label": "athenauser.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/athenaUser.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 642,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_auth_ts",
       "label": "auth.ts",
       "norm_label": "auth.ts",
@@ -49948,7 +50080,7 @@
       "source_location": "L1"
     },
     {
-      "community": 641,
+      "community": 643,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -49957,7 +50089,7 @@
       "source_location": "L1"
     },
     {
-      "community": 642,
+      "community": 644,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bestseller_ts",
       "label": "bestSeller.ts",
@@ -49966,7 +50098,7 @@
       "source_location": "L1"
     },
     {
-      "community": 643,
+      "community": 645,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_categories_ts",
       "label": "categories.ts",
@@ -49975,7 +50107,7 @@
       "source_location": "L1"
     },
     {
-      "community": 644,
+      "community": 646,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_colors_ts",
       "label": "colors.ts",
@@ -49984,7 +50116,7 @@
       "source_location": "L1"
     },
     {
-      "community": 645,
+      "community": 647,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_complimentaryproduct_ts",
       "label": "complimentaryProduct.ts",
@@ -49993,7 +50125,7 @@
       "source_location": "L1"
     },
     {
-      "community": 646,
+      "community": 648,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessionitems_ts",
       "label": "expenseSessionItems.ts",
@@ -50002,30 +50134,12 @@
       "source_location": "L1"
     },
     {
-      "community": 647,
+      "community": 649,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensetransactions_ts",
       "label": "expenseTransactions.ts",
       "norm_label": "expensetransactions.ts",
       "source_file": "packages/athena-webapp/convex/inventory/expenseTransactions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 648,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_featureditem_ts",
-      "label": "featuredItem.ts",
-      "norm_label": "featureditem.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/featuredItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_invitecode_ts",
-      "label": "inviteCode.ts",
-      "norm_label": "invitecode.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/inviteCode.ts",
       "source_location": "L1"
     },
     {
@@ -50085,6 +50199,24 @@
     {
       "community": 650,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_featureditem_ts",
+      "label": "featuredItem.ts",
+      "norm_label": "featureditem.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/featuredItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 651,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_invitecode_ts",
+      "label": "inviteCode.ts",
+      "norm_label": "invitecode.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/inviteCode.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 652,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizationmembers_ts",
       "label": "organizationMembers.ts",
       "norm_label": "organizationmembers.ts",
@@ -50092,7 +50224,7 @@
       "source_location": "L1"
     },
     {
-      "community": 651,
+      "community": 653,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_organizations_ts",
       "label": "organizations.ts",
@@ -50101,7 +50233,7 @@
       "source_location": "L1"
     },
     {
-      "community": 652,
+      "community": 654,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_poscustomers_ts",
       "label": "posCustomers.ts",
@@ -50110,7 +50242,7 @@
       "source_location": "L1"
     },
     {
-      "community": 653,
+      "community": 655,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessionitems_ts",
       "label": "posSessionItems.ts",
@@ -50119,7 +50251,7 @@
       "source_location": "L1"
     },
     {
-      "community": 654,
+      "community": 656,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posterminal_ts",
       "label": "posTerminal.ts",
@@ -50128,7 +50260,7 @@
       "source_location": "L1"
     },
     {
-      "community": 655,
+      "community": 657,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productsku_ts",
       "label": "productSku.ts",
@@ -50137,7 +50269,7 @@
       "source_location": "L1"
     },
     {
-      "community": 656,
+      "community": 658,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productutil_ts",
       "label": "productUtil.ts",
@@ -50146,30 +50278,12 @@
       "source_location": "L1"
     },
     {
-      "community": 657,
+      "community": 659,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_promocode_ts",
       "label": "promoCode.ts",
       "norm_label": "promocode.ts",
       "source_file": "packages/athena-webapp/convex/inventory/promoCode.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 658,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_stockvalidation_ts",
-      "label": "stockValidation.ts",
-      "norm_label": "stockvalidation.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/stockValidation.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_storeconfigv2_test_ts",
-      "label": "storeConfigV2.test.ts",
-      "norm_label": "storeconfigv2.test.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.test.ts",
       "source_location": "L1"
     },
     {
@@ -50229,6 +50343,24 @@
     {
       "community": 660,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_stockvalidation_ts",
+      "label": "stockValidation.ts",
+      "norm_label": "stockvalidation.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/stockValidation.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 661,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_storeconfigv2_test_ts",
+      "label": "storeConfigV2.test.ts",
+      "norm_label": "storeconfigv2.test.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/storeConfigV2.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 662,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_subcategories_ts",
       "label": "subcategories.ts",
       "norm_label": "subcategories.ts",
@@ -50236,7 +50368,7 @@
       "source_location": "L1"
     },
     {
-      "community": 661,
+      "community": 663,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_currency_test_ts",
       "label": "currency.test.ts",
@@ -50245,7 +50377,7 @@
       "source_location": "L1"
     },
     {
-      "community": 662,
+      "community": 664,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_storeinsights_ts",
       "label": "storeInsights.ts",
@@ -50254,7 +50386,7 @@
       "source_location": "L1"
     },
     {
-      "community": 663,
+      "community": 665,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_userinsights_ts",
       "label": "userInsights.ts",
@@ -50263,7 +50395,7 @@
       "source_location": "L1"
     },
     {
-      "community": 664,
+      "community": 666,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_migrateamountstopesewas_ts",
       "label": "migrateAmountsToPesewas.ts",
@@ -50272,7 +50404,7 @@
       "source_location": "L1"
     },
     {
-      "community": 665,
+      "community": 667,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_client_test_ts",
       "label": "client.test.ts",
@@ -50281,7 +50413,7 @@
       "source_location": "L1"
     },
     {
-      "community": 666,
+      "community": 668,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_config_test_ts",
       "label": "config.test.ts",
@@ -50290,30 +50422,12 @@
       "source_location": "L1"
     },
     {
-      "community": 667,
+      "community": 669,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_test_ts",
       "label": "normalize.test.ts",
       "norm_label": "normalize.test.ts",
       "source_file": "packages/athena-webapp/convex/mtn/normalize.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 668,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mtn_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/athena-webapp/convex/mtn/types.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_otp_resendotp_ts",
-      "label": "ResendOTP.ts",
-      "norm_label": "resendotp.ts",
-      "source_file": "packages/athena-webapp/convex/otp/ResendOTP.ts",
       "source_location": "L1"
     },
     {
@@ -50373,6 +50487,24 @@
     {
       "community": 670,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_mtn_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/athena-webapp/convex/mtn/types.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 671,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_otp_resendotp_ts",
+      "label": "ResendOTP.ts",
+      "norm_label": "resendotp.ts",
+      "source_file": "packages/athena-webapp/convex/otp/ResendOTP.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 672,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schema_ts",
       "label": "schema.ts",
       "norm_label": "schema.ts",
@@ -50380,7 +50512,7 @@
       "source_location": "L1"
     },
     {
-      "community": 671,
+      "community": 673,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_appverificationcode_ts",
       "label": "appVerificationCode.ts",
@@ -50389,7 +50521,7 @@
       "source_location": "L1"
     },
     {
-      "community": 672,
+      "community": 674,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -50398,7 +50530,7 @@
       "source_location": "L1"
     },
     {
-      "community": 673,
+      "community": 675,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -50407,7 +50539,7 @@
       "source_location": "L1"
     },
     {
-      "community": 674,
+      "community": 676,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_bestseller_ts",
       "label": "bestSeller.ts",
@@ -50416,7 +50548,7 @@
       "source_location": "L1"
     },
     {
-      "community": 675,
+      "community": 677,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_cashier_ts",
       "label": "cashier.ts",
@@ -50425,7 +50557,7 @@
       "source_location": "L1"
     },
     {
-      "community": 676,
+      "community": 678,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_category_ts",
       "label": "category.ts",
@@ -50434,30 +50566,12 @@
       "source_location": "L1"
     },
     {
-      "community": 677,
+      "community": 679,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_color_ts",
       "label": "color.ts",
       "norm_label": "color.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/color.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 678,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_complimentaryproduct_ts",
-      "label": "complimentaryProduct.ts",
-      "norm_label": "complimentaryproduct.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/complimentaryProduct.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_featureditem_ts",
-      "label": "featuredItem.ts",
-      "norm_label": "featureditem.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/featuredItem.ts",
       "source_location": "L1"
     },
     {
@@ -50517,6 +50631,24 @@
     {
       "community": 680,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_complimentaryproduct_ts",
+      "label": "complimentaryProduct.ts",
+      "norm_label": "complimentaryproduct.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/complimentaryProduct.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 681,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_featureditem_ts",
+      "label": "featuredItem.ts",
+      "norm_label": "featureditem.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/featuredItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 682,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
@@ -50524,7 +50656,7 @@
       "source_location": "L1"
     },
     {
-      "community": 681,
+      "community": 683,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_invitecode_ts",
       "label": "inviteCode.ts",
@@ -50533,7 +50665,7 @@
       "source_location": "L1"
     },
     {
-      "community": 682,
+      "community": 684,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organization_ts",
       "label": "organization.ts",
@@ -50542,7 +50674,7 @@
       "source_location": "L1"
     },
     {
-      "community": 683,
+      "community": 685,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_organizationmember_ts",
       "label": "organizationMember.ts",
@@ -50551,7 +50683,7 @@
       "source_location": "L1"
     },
     {
-      "community": 684,
+      "community": 686,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_product_ts",
       "label": "product.ts",
@@ -50560,7 +50692,7 @@
       "source_location": "L1"
     },
     {
-      "community": 685,
+      "community": 687,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_promocode_ts",
       "label": "promoCode.ts",
@@ -50569,7 +50701,7 @@
       "source_location": "L1"
     },
     {
-      "community": 686,
+      "community": 688,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_redeemedpromocode_ts",
       "label": "redeemedPromoCode.ts",
@@ -50578,30 +50710,12 @@
       "source_location": "L1"
     },
     {
-      "community": 687,
+      "community": 689,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_inventory_store_ts",
       "label": "store.ts",
       "norm_label": "store.ts",
       "source_file": "packages/athena-webapp/convex/schemas/inventory/store.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 688,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_inventory_subcategory_ts",
-      "label": "subcategory.ts",
-      "norm_label": "subcategory.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/inventory/subcategory.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 689,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_payments_mtncollections_ts",
-      "label": "mtnCollections.ts",
-      "norm_label": "mtncollections.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/payments/mtnCollections.ts",
       "source_location": "L1"
     },
     {
@@ -50661,6 +50775,24 @@
     {
       "community": 690,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_inventory_subcategory_ts",
+      "label": "subcategory.ts",
+      "norm_label": "subcategory.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/inventory/subcategory.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 691,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_payments_mtncollections_ts",
+      "label": "mtnCollections.ts",
+      "norm_label": "mtncollections.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/payments/mtnCollections.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 692,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_customer_ts",
       "label": "customer.ts",
       "norm_label": "customer.ts",
@@ -50668,7 +50800,7 @@
       "source_location": "L1"
     },
     {
-      "community": 691,
+      "community": 693,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesession_ts",
       "label": "expenseSession.ts",
@@ -50677,7 +50809,7 @@
       "source_location": "L1"
     },
     {
-      "community": 692,
+      "community": 694,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensesessionitem_ts",
       "label": "expenseSessionItem.ts",
@@ -50686,7 +50818,7 @@
       "source_location": "L1"
     },
     {
-      "community": 693,
+      "community": 695,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransaction_ts",
       "label": "expenseTransaction.ts",
@@ -50695,7 +50827,7 @@
       "source_location": "L1"
     },
     {
-      "community": 694,
+      "community": 696,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_expensetransactionitem_ts",
       "label": "expenseTransactionItem.ts",
@@ -50704,7 +50836,7 @@
       "source_location": "L1"
     },
     {
-      "community": 695,
+      "community": 697,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_index_ts",
       "label": "index.ts",
@@ -50713,7 +50845,7 @@
       "source_location": "L1"
     },
     {
-      "community": 696,
+      "community": 698,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possession_ts",
       "label": "posSession.ts",
@@ -50722,30 +50854,12 @@
       "source_location": "L1"
     },
     {
-      "community": 697,
+      "community": 699,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_possessionitem_ts",
       "label": "posSessionItem.ts",
       "norm_label": "possessionitem.ts",
       "source_file": "packages/athena-webapp/convex/schemas/pos/posSessionItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 698,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_posterminal_ts",
-      "label": "posTerminal.ts",
-      "norm_label": "posterminal.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/posTerminal.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_pos_postransaction_ts",
-      "label": "posTransaction.ts",
-      "norm_label": "postransaction.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/pos/posTransaction.ts",
       "source_location": "L1"
     },
     {
@@ -51030,6 +51144,24 @@
     {
       "community": 700,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_posterminal_ts",
+      "label": "posTerminal.ts",
+      "norm_label": "posterminal.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/posTerminal.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 701,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_pos_postransaction_ts",
+      "label": "posTransaction.ts",
+      "norm_label": "postransaction.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/pos/posTransaction.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 702,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_postransactionitem_ts",
       "label": "posTransactionItem.ts",
       "norm_label": "postransactionitem.ts",
@@ -51037,7 +51169,7 @@
       "source_location": "L1"
     },
     {
-      "community": 701,
+      "community": 703,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_analytics_ts",
       "label": "analytics.ts",
@@ -51046,7 +51178,7 @@
       "source_location": "L1"
     },
     {
-      "community": 702,
+      "community": 704,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bag_ts",
       "label": "bag.ts",
@@ -51055,7 +51187,7 @@
       "source_location": "L1"
     },
     {
-      "community": 703,
+      "community": 705,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -51064,7 +51196,7 @@
       "source_location": "L1"
     },
     {
-      "community": 704,
+      "community": 706,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsession_ts",
       "label": "checkoutSession.ts",
@@ -51073,7 +51205,7 @@
       "source_location": "L1"
     },
     {
-      "community": 705,
+      "community": 707,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_checkoutsessionitem_ts",
       "label": "checkoutSessionItem.ts",
@@ -51082,7 +51214,7 @@
       "source_location": "L1"
     },
     {
-      "community": 706,
+      "community": 708,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_customer_ts",
       "label": "customer.ts",
@@ -51091,30 +51223,12 @@
       "source_location": "L1"
     },
     {
-      "community": 707,
+      "community": 709,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_guest_ts",
       "label": "guest.ts",
       "norm_label": "guest.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/guest.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 708,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_index_ts",
-      "label": "index.ts",
-      "norm_label": "index.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/index.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 709,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_offer_ts",
-      "label": "offer.ts",
-      "norm_label": "offer.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/offer.ts",
       "source_location": "L1"
     },
     {
@@ -51174,6 +51288,24 @@
     {
       "community": 710,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_index_ts",
+      "label": "index.ts",
+      "norm_label": "index.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/index.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 711,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_offer_ts",
+      "label": "offer.ts",
+      "norm_label": "offer.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/offer.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 712,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorder_ts",
       "label": "onlineOrder.ts",
       "norm_label": "onlineorder.ts",
@@ -51181,7 +51313,7 @@
       "source_location": "L1"
     },
     {
-      "community": 711,
+      "community": 713,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_onlineorder_onlineorderitem_ts",
       "label": "onlineOrderItem.ts",
@@ -51190,7 +51322,7 @@
       "source_location": "L1"
     },
     {
-      "community": 712,
+      "community": 714,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_review_ts",
       "label": "review.ts",
@@ -51199,7 +51331,7 @@
       "source_location": "L1"
     },
     {
-      "community": 713,
+      "community": 715,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_rewards_ts",
       "label": "rewards.ts",
@@ -51208,7 +51340,7 @@
       "source_location": "L1"
     },
     {
-      "community": 714,
+      "community": 716,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbag_ts",
       "label": "savedBag.ts",
@@ -51217,7 +51349,7 @@
       "source_location": "L1"
     },
     {
-      "community": 715,
+      "community": 717,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_savedbagitem_ts",
       "label": "savedBagItem.ts",
@@ -51226,7 +51358,7 @@
       "source_location": "L1"
     },
     {
-      "community": 716,
+      "community": 718,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontsession_ts",
       "label": "storeFrontSession.ts",
@@ -51235,30 +51367,12 @@
       "source_location": "L1"
     },
     {
-      "community": 717,
+      "community": 719,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_storefront_storefrontuser_ts",
       "label": "storeFrontUser.ts",
       "norm_label": "storefrontuser.ts",
       "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontUser.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 718,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_storefrontverificationcode_ts",
-      "label": "storeFrontVerificationCode.ts",
-      "norm_label": "storefrontverificationcode.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontVerificationCode.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 719,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_schemas_storefront_supportticket_ts",
-      "label": "supportTicket.ts",
-      "norm_label": "supportticket.ts",
-      "source_file": "packages/athena-webapp/convex/schemas/storeFront/supportTicket.ts",
       "source_location": "L1"
     },
     {
@@ -51318,6 +51432,24 @@
     {
       "community": 720,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_storefrontverificationcode_ts",
+      "label": "storeFrontVerificationCode.ts",
+      "norm_label": "storefrontverificationcode.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/storeFrontVerificationCode.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 721,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_schemas_storefront_supportticket_ts",
+      "label": "supportTicket.ts",
+      "norm_label": "supportticket.ts",
+      "source_file": "packages/athena-webapp/convex/schemas/storeFront/supportTicket.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 722,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bag_ts",
       "label": "bag.ts",
       "norm_label": "bag.ts",
@@ -51325,7 +51457,7 @@
       "source_location": "L1"
     },
     {
-      "community": 721,
+      "community": 723,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_bagitem_ts",
       "label": "bagItem.ts",
@@ -51334,7 +51466,7 @@
       "source_location": "L1"
     },
     {
-      "community": 722,
+      "community": 724,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customer_ts",
       "label": "customer.ts",
@@ -51343,7 +51475,7 @@
       "source_location": "L1"
     },
     {
-      "community": 723,
+      "community": 725,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_guest_ts",
       "label": "guest.ts",
@@ -51352,7 +51484,7 @@
       "source_location": "L1"
     },
     {
-      "community": 724,
+      "community": 726,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorderutilfns_ts",
       "label": "onlineOrderUtilFns.ts",
@@ -51361,7 +51493,7 @@
       "source_location": "L1"
     },
     {
-      "community": 725,
+      "community": 727,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_payment_ts",
       "label": "payment.ts",
@@ -51370,7 +51502,7 @@
       "source_location": "L1"
     },
     {
-      "community": 726,
+      "community": 728,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_paystackactions_ts",
       "label": "paystackActions.ts",
@@ -51379,30 +51511,12 @@
       "source_location": "L1"
     },
     {
-      "community": 727,
+      "community": 729,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_rewards_ts",
       "label": "rewards.ts",
       "norm_label": "rewards.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/rewards.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 728,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_savedbagitem_ts",
-      "label": "savedBagItem.ts",
-      "norm_label": "savedbagitem.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/savedBagItem.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 729,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_supportticket_ts",
-      "label": "supportTicket.ts",
-      "norm_label": "supportticket.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/supportTicket.ts",
       "source_location": "L1"
     },
     {
@@ -51462,6 +51576,24 @@
     {
       "community": 730,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_savedbagitem_ts",
+      "label": "savedBagItem.ts",
+      "norm_label": "savedbagitem.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/savedBagItem.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 731,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_supportticket_ts",
+      "label": "supportTicket.ts",
+      "norm_label": "supportticket.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/supportTicket.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 732,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_users_ts",
       "label": "users.ts",
       "norm_label": "users.ts",
@@ -51469,7 +51601,7 @@
       "source_location": "L1"
     },
     {
-      "community": 731,
+      "community": 733,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_types_payment_ts",
       "label": "payment.ts",
@@ -51478,7 +51610,7 @@
       "source_location": "L1"
     },
     {
-      "community": 732,
+      "community": 734,
       "file_type": "code",
       "id": "packages_athena_webapp_eslint_config_js",
       "label": "eslint.config.js",
@@ -51487,7 +51619,7 @@
       "source_location": "L1"
     },
     {
-      "community": 733,
+      "community": 735,
       "file_type": "code",
       "id": "packages_athena_webapp_index_ts",
       "label": "index.ts",
@@ -51496,7 +51628,7 @@
       "source_location": "L1"
     },
     {
-      "community": 734,
+      "community": 736,
       "file_type": "code",
       "id": "packages_athena_webapp_postcss_config_js",
       "label": "postcss.config.js",
@@ -51505,7 +51637,7 @@
       "source_location": "L1"
     },
     {
-      "community": 735,
+      "community": 737,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_genericcombobox_tsx",
       "label": "GenericComboBox.tsx",
@@ -51514,7 +51646,7 @@
       "source_location": "L1"
     },
     {
-      "community": 736,
+      "community": 738,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeaccordion_tsx",
       "label": "StoreAccordion.tsx",
@@ -51523,30 +51655,12 @@
       "source_location": "L1"
     },
     {
-      "community": 737,
+      "community": 739,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesaccordion_tsx",
       "label": "StoresAccordion.tsx",
       "norm_label": "storesaccordion.tsx",
       "source_file": "packages/athena-webapp/src/components/StoresAccordion.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 738,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_themetoggle_tsx",
-      "label": "ThemeToggle.tsx",
-      "norm_label": "themetoggle.tsx",
-      "source_file": "packages/athena-webapp/src/components/ThemeToggle.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 739,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_defaultattributestogglegroup_tsx",
-      "label": "DefaultAttributesToggleGroup.tsx",
-      "norm_label": "defaultattributestogglegroup.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/DefaultAttributesToggleGroup.tsx",
       "source_location": "L1"
     },
     {
@@ -51606,6 +51720,24 @@
     {
       "community": 740,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_themetoggle_tsx",
+      "label": "ThemeToggle.tsx",
+      "norm_label": "themetoggle.tsx",
+      "source_file": "packages/athena-webapp/src/components/ThemeToggle.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 741,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_defaultattributestogglegroup_tsx",
+      "label": "DefaultAttributesToggleGroup.tsx",
+      "norm_label": "defaultattributestogglegroup.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/DefaultAttributesToggleGroup.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 742,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productattributesview_tsx",
       "label": "ProductAttributesView.tsx",
       "norm_label": "productattributesview.tsx",
@@ -51613,7 +51745,7 @@
       "source_location": "L1"
     },
     {
-      "community": 741,
+      "community": 743,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_constants_ts",
       "label": "constants.ts",
@@ -51622,7 +51754,7 @@
       "source_location": "L1"
     },
     {
-      "community": 742,
+      "community": 744,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -51631,7 +51763,7 @@
       "source_location": "L1"
     },
     {
-      "community": 743,
+      "community": 745,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -51640,7 +51772,7 @@
       "source_location": "L1"
     },
     {
-      "community": 744,
+      "community": 746,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -51649,7 +51781,7 @@
       "source_location": "L1"
     },
     {
-      "community": 745,
+      "community": 747,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_types_ts",
       "label": "types.ts",
@@ -51658,7 +51790,7 @@
       "source_location": "L1"
     },
     {
-      "community": 746,
+      "community": 748,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_conversionfunnelchart_tsx",
       "label": "ConversionFunnelChart.tsx",
@@ -51667,7 +51799,7 @@
       "source_location": "L1"
     },
     {
-      "community": 747,
+      "community": 749,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_revenuechart_tsx",
       "label": "RevenueChart.tsx",
@@ -51676,169 +51808,7 @@
       "source_location": "L1"
     },
     {
-      "community": 748,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_analytics_columns_tsx",
-      "label": "analytics-columns.tsx",
-      "norm_label": "analytics-columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/analytics-columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 749,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_column_header_tsx",
-      "label": "data-table-column-header.tsx",
-      "norm_label": "data-table-column-header.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-column-header.tsx",
-      "source_location": "L1"
-    },
-    {
       "community": 75,
-      "file_type": "code",
-      "id": "image_uploader_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L100"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "image_uploader_ondrop",
-      "label": "onDrop()",
-      "norm_label": "ondrop()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "image_uploader_removeimage",
-      "label": "removeImage()",
-      "norm_label": "removeimage()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "image_uploader_unmarkfordeletion",
-      "label": "unmarkForDeletion()",
-      "norm_label": "unmarkfordeletion()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 75,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 750,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 751,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 752,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 753,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 754,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 755,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 756,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 757,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 758,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 759,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 76,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sidebar_tsx",
       "label": "sidebar.tsx",
@@ -51847,7 +51817,7 @@
       "source_location": "L1"
     },
     {
-      "community": 76,
+      "community": 75,
       "file_type": "code",
       "id": "sidebar_cn",
       "label": "cn()",
@@ -51856,7 +51826,7 @@
       "source_location": "L147"
     },
     {
-      "community": 76,
+      "community": 75,
       "file_type": "code",
       "id": "sidebar_handlekeydown",
       "label": "handleKeyDown()",
@@ -51865,7 +51835,7 @@
       "source_location": "L105"
     },
     {
-      "community": 76,
+      "community": 75,
       "file_type": "code",
       "id": "sidebar_handleonhover",
       "label": "handleOnHover()",
@@ -51874,7 +51844,7 @@
       "source_location": "L224"
     },
     {
-      "community": 76,
+      "community": 75,
       "file_type": "code",
       "id": "sidebar_handleonmouseleave",
       "label": "handleOnMouseLeave()",
@@ -51883,7 +51853,7 @@
       "source_location": "L228"
     },
     {
-      "community": 76,
+      "community": 75,
       "file_type": "code",
       "id": "sidebar_usesidebar",
       "label": "useSidebar()",
@@ -51892,97 +51862,97 @@
       "source_location": "L45"
     },
     {
-      "community": 760,
+      "community": 750,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/data-table-pagination.tsx",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_analytics_columns_tsx",
+      "label": "analytics-columns.tsx",
+      "norm_label": "analytics-columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/analytics-columns.tsx",
       "source_location": "L1"
     },
     {
-      "community": 761,
+      "community": 751,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/data-table.tsx",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_column_header_tsx",
+      "label": "data-table-column-header.tsx",
+      "norm_label": "data-table-column-header.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-column-header.tsx",
       "source_location": "L1"
     },
     {
-      "community": 762,
+      "community": 752,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_chart_tsx",
-      "label": "chart.tsx",
-      "norm_label": "chart.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/chart.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 763,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_combined_users_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 764,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 765,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 766,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 767,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 768,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_faceted_filter_tsx",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-faceted-filter.tsx",
       "source_location": "L1"
     },
     {
-      "community": 769,
+      "community": 753,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_pagination_tsx",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
-      "community": 77,
+      "community": 754,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 755,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-data-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 756,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 757,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 758,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 759,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 76,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usebulkoperations_ts",
       "label": "useBulkOperations.ts",
@@ -51991,7 +51961,7 @@
       "source_location": "L1"
     },
     {
-      "community": 77,
+      "community": 76,
       "file_type": "code",
       "id": "usebulkoperations_applyoperation",
       "label": "applyOperation()",
@@ -52000,7 +51970,7 @@
       "source_location": "L56"
     },
     {
-      "community": 77,
+      "community": 76,
       "file_type": "code",
       "id": "usebulkoperations_calculatepricewithfee",
       "label": "calculatePriceWithFee()",
@@ -52009,7 +51979,7 @@
       "source_location": "L87"
     },
     {
-      "community": 77,
+      "community": 76,
       "file_type": "code",
       "id": "usebulkoperations_computepreview",
       "label": "computePreview()",
@@ -52018,7 +51988,7 @@
       "source_location": "L101"
     },
     {
-      "community": 77,
+      "community": 76,
       "file_type": "code",
       "id": "usebulkoperations_usebulkoperations",
       "label": "useBulkOperations()",
@@ -52027,7 +51997,7 @@
       "source_location": "L158"
     },
     {
-      "community": 77,
+      "community": 76,
       "file_type": "code",
       "id": "usebulkoperations_validateoperationvalue",
       "label": "validateOperationValue()",
@@ -52036,97 +52006,97 @@
       "source_location": "L139"
     },
     {
-      "community": 770,
+      "community": 760,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_tsx",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_products_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-products-table/data-table.tsx",
       "source_location": "L1"
     },
     {
-      "community": 771,
+      "community": 761,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 772,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_users_table_columns_tsx",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/users-table/columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/columns.tsx",
       "source_location": "L1"
     },
     {
-      "community": 773,
+      "community": 762,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_pagination_tsx",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/users-table/data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
-      "community": 774,
+      "community": 763,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_tsx",
+      "id": "packages_athena_webapp_src_components_analytics_analytics_users_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/users-table/data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/analytics-users-table/data-table.tsx",
       "source_location": "L1"
     },
     {
-      "community": 775,
+      "community": 764,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_columns_tsx",
+      "id": "packages_athena_webapp_src_components_analytics_chart_tsx",
+      "label": "chart.tsx",
+      "norm_label": "chart.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/chart.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 765,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_combined_users_table_columns_tsx",
       "label": "columns.tsx",
       "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/columns.tsx",
       "source_location": "L1"
     },
     {
-      "community": 776,
+      "community": 766,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_column_header_tsx",
-      "label": "data-table-column-header.tsx",
-      "norm_label": "data-table-column-header.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-column-header.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 777,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 778,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_pagination_tsx",
+      "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
-      "community": 779,
+      "community": 767,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-toolbar.tsx",
+      "id": "packages_athena_webapp_src_components_analytics_combined_users_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/combined-users-table/data-table.tsx",
       "source_location": "L1"
     },
     {
-      "community": 78,
+      "community": 768,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 769,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_table_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 77,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
       "label": "useExpenseSessions.ts",
@@ -52135,7 +52105,7 @@
       "source_location": "L1"
     },
     {
-      "community": 78,
+      "community": 77,
       "file_type": "code",
       "id": "useexpensesessions_useexpenseactivesession",
       "label": "useExpenseActiveSession()",
@@ -52144,7 +52114,7 @@
       "source_location": "L33"
     },
     {
-      "community": 78,
+      "community": 77,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesession",
       "label": "useExpenseSession()",
@@ -52153,7 +52123,7 @@
       "source_location": "L23"
     },
     {
-      "community": 78,
+      "community": 77,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesessioncreate",
       "label": "useExpenseSessionCreate()",
@@ -52162,7 +52132,7 @@
       "source_location": "L48"
     },
     {
-      "community": 78,
+      "community": 77,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesessionupdate",
       "label": "useExpenseSessionUpdate()",
@@ -52171,7 +52141,7 @@
       "source_location": "L85"
     },
     {
-      "community": 78,
+      "community": 77,
       "file_type": "code",
       "id": "useexpensesessions_useexpensestoresessions",
       "label": "useExpenseStoreSessions()",
@@ -52180,97 +52150,97 @@
       "source_location": "L7"
     },
     {
-      "community": 780,
+      "community": 770,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 781,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_sidebar_tsx",
-      "label": "app-sidebar.tsx",
-      "norm_label": "app-sidebar.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-sidebar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 782,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_assetscolumns_tsx",
-      "label": "assetsColumns.tsx",
-      "norm_label": "assetscolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/assetsColumns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 783,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 784,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_faceted_filter_tsx",
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-faceted-filter.tsx",
       "source_location": "L1"
     },
     {
-      "community": 785,
+      "community": 771,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_pagination_tsx",
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
-      "community": 786,
+      "community": 772,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_tsx",
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table.tsx",
       "source_location": "L1"
     },
     {
-      "community": 787,
+      "community": 773,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_data_ts",
+      "id": "packages_athena_webapp_src_components_analytics_table_data_ts",
       "label": "data.ts",
       "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data.ts",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data.ts",
       "source_location": "L1"
     },
     {
-      "community": 788,
+      "community": 774,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_tsx",
-      "label": "DefaultCatchBoundary.tsx",
-      "norm_label": "defaultcatchboundary.tsx",
-      "source_file": "packages/athena-webapp/src/components/auth/DefaultCatchBoundary.tsx",
+      "id": "packages_athena_webapp_src_components_analytics_users_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/users-table/columns.tsx",
       "source_location": "L1"
     },
     {
-      "community": 789,
+      "community": 775,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_auth_login_loginform_tsx",
-      "label": "LoginForm.tsx",
-      "norm_label": "loginform.tsx",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/LoginForm.tsx",
+      "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/users-table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
-      "community": 79,
+      "community": 776,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_users_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/users-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 777,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 778,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_column_header_tsx",
+      "label": "data-table-column-header.tsx",
+      "norm_label": "data-table-column-header.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-column-header.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 779,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 78,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useposcustomers_ts",
       "label": "usePOSCustomers.ts",
@@ -52279,7 +52249,7 @@
       "source_location": "L1"
     },
     {
-      "community": 79,
+      "community": 78,
       "file_type": "code",
       "id": "useposcustomers_useposcustomer",
       "label": "usePOSCustomer()",
@@ -52288,7 +52258,7 @@
       "source_location": "L18"
     },
     {
-      "community": 79,
+      "community": 78,
       "file_type": "code",
       "id": "useposcustomers_useposcustomercreate",
       "label": "usePOSCustomerCreate()",
@@ -52297,7 +52267,7 @@
       "source_location": "L26"
     },
     {
-      "community": 79,
+      "community": 78,
       "file_type": "code",
       "id": "useposcustomers_useposcustomersearch",
       "label": "usePOSCustomerSearch()",
@@ -52306,7 +52276,7 @@
       "source_location": "L7"
     },
     {
-      "community": 79,
+      "community": 78,
       "file_type": "code",
       "id": "useposcustomers_useposcustomertransactions",
       "label": "usePOSCustomerTransactions()",
@@ -52315,7 +52285,7 @@
       "source_location": "L90"
     },
     {
-      "community": 79,
+      "community": 78,
       "file_type": "code",
       "id": "useposcustomers_useposcustomerupdate",
       "label": "usePOSCustomerUpdate()",
@@ -52324,7 +52294,169 @@
       "source_location": "L57"
     },
     {
+      "community": 780,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 781,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 782,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_logs_analytics_data_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-logs/analytics-data-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 783,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_sidebar_tsx",
+      "label": "app-sidebar.tsx",
+      "norm_label": "app-sidebar.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-sidebar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 784,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_assets_table_assetscolumns_tsx",
+      "label": "assetsColumns.tsx",
+      "norm_label": "assetscolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/assetsColumns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 785,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_assets_table_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 786,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 787,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 788,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 789,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_assets_assets_table_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "behaviorutils_calculateengagementmetrics",
+      "label": "calculateEngagementMetrics()",
+      "norm_label": "calculateengagementmetrics()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L173"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "behaviorutils_calculateriskindicators",
+      "label": "calculateRiskIndicators()",
+      "norm_label": "calculateriskindicators()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "behaviorutils_getactivitypriority",
+      "label": "getActivityPriority()",
+      "norm_label": "getactivitypriority()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L251"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "behaviorutils_getcustomerjourneystage",
+      "label": "getCustomerJourneyStage()",
+      "norm_label": "getcustomerjourneystage()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "behaviorutils_getjourneystageinfo",
+      "label": "getJourneyStageInfo()",
+      "norm_label": "getjourneystageinfo()",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L277"
+    },
+    {
+      "community": 79,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
+      "label": "behaviorUtils.ts",
+      "norm_label": "behaviorutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
+      "source_location": "L1"
+    },
+    {
       "community": 790,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_auth_defaultcatchboundary_tsx",
+      "label": "DefaultCatchBoundary.tsx",
+      "norm_label": "defaultcatchboundary.tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/DefaultCatchBoundary.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 791,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_auth_login_loginform_tsx",
+      "label": "LoginForm.tsx",
+      "norm_label": "loginform.tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/LoginForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 792,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_columns_tsx",
       "label": "columns.tsx",
@@ -52333,7 +52465,7 @@
       "source_location": "L1"
     },
     {
-      "community": 791,
+      "community": 793,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -52342,7 +52474,7 @@
       "source_location": "L1"
     },
     {
-      "community": 792,
+      "community": 794,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -52351,7 +52483,7 @@
       "source_location": "L1"
     },
     {
-      "community": 793,
+      "community": 795,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -52360,7 +52492,7 @@
       "source_location": "L1"
     },
     {
-      "community": 794,
+      "community": 796,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -52369,7 +52501,7 @@
       "source_location": "L1"
     },
     {
-      "community": 795,
+      "community": 797,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -52378,7 +52510,7 @@
       "source_location": "L1"
     },
     {
-      "community": 796,
+      "community": 798,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_columns_tsx",
       "label": "columns.tsx",
@@ -52387,30 +52519,12 @@
       "source_location": "L1"
     },
     {
-      "community": 797,
+      "community": 799,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
       "source_file": "packages/athena-webapp/src/components/base/table/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 798,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 799,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -52614,150 +52728,6 @@
     {
       "community": 80,
       "file_type": "code",
-      "id": "behaviorutils_calculateengagementmetrics",
-      "label": "calculateEngagementMetrics()",
-      "norm_label": "calculateengagementmetrics()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L173"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "behaviorutils_calculateriskindicators",
-      "label": "calculateRiskIndicators()",
-      "norm_label": "calculateriskindicators()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "behaviorutils_getactivitypriority",
-      "label": "getActivityPriority()",
-      "norm_label": "getactivitypriority()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L251"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "behaviorutils_getcustomerjourneystage",
-      "label": "getCustomerJourneyStage()",
-      "norm_label": "getcustomerjourneystage()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "behaviorutils_getjourneystageinfo",
-      "label": "getJourneyStageInfo()",
-      "norm_label": "getjourneystageinfo()",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L277"
-    },
-    {
-      "community": 80,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
-      "label": "behaviorUtils.ts",
-      "norm_label": "behaviorutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/behaviorUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 800,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 801,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspage_tsx",
-      "label": "BulkOperationsPage.tsx",
-      "norm_label": "bulkoperationspage.tsx",
-      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPage.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 802,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cashiers_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/components/cashiers/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 803,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/columns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 804,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 805,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/data-table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 806,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_dashboard_metriccard_tsx",
-      "label": "MetricCard.tsx",
-      "norm_label": "metriccard.tsx",
-      "source_file": "packages/athena-webapp/src/components/dashboard/MetricCard.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 807,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_expense_expensecompletion_tsx",
-      "label": "ExpenseCompletion.tsx",
-      "norm_label": "expensecompletion.tsx",
-      "source_file": "packages/athena-webapp/src/components/expense/ExpenseCompletion.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 808,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orderstatus_test_tsx",
-      "label": "OrderStatus.test.tsx",
-      "norm_label": "orderstatus.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderStatus.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 809,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orderstatus_tsx",
-      "label": "OrderStatus.tsx",
-      "norm_label": "orderstatus.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderStatus.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 81,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
       "label": "toastService.ts",
       "norm_label": "toastservice.ts",
@@ -52765,7 +52735,7 @@
       "source_location": "L1"
     },
     {
-      "community": 81,
+      "community": 80,
       "file_type": "code",
       "id": "toastservice_handleposoperation",
       "label": "handlePOSOperation()",
@@ -52774,7 +52744,7 @@
       "source_location": "L171"
     },
     {
-      "community": 81,
+      "community": 80,
       "file_type": "code",
       "id": "toastservice_showinventoryerror",
       "label": "showInventoryError()",
@@ -52783,7 +52753,7 @@
       "source_location": "L302"
     },
     {
-      "community": 81,
+      "community": 80,
       "file_type": "code",
       "id": "toastservice_shownoactivesessionerror",
       "label": "showNoActiveSessionError()",
@@ -52792,7 +52762,7 @@
       "source_location": "L319"
     },
     {
-      "community": 81,
+      "community": 80,
       "file_type": "code",
       "id": "toastservice_showsessionexpirederror",
       "label": "showSessionExpiredError()",
@@ -52801,7 +52771,7 @@
       "source_location": "L312"
     },
     {
-      "community": 81,
+      "community": 80,
       "file_type": "code",
       "id": "toastservice_showvalidationerror",
       "label": "showValidationError()",
@@ -52810,97 +52780,97 @@
       "source_location": "L293"
     },
     {
-      "community": 810,
+      "community": 800,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_ordersummary_tsx",
-      "label": "OrderSummary.tsx",
-      "norm_label": "ordersummary.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrderSummary.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 811,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_tsx",
-      "label": "Orders.tsx",
-      "norm_label": "orders.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/Orders.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 812,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 813,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_faceted_filter_tsx",
+      "id": "packages_athena_webapp_src_components_base_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-faceted-filter.tsx",
       "source_location": "L1"
     },
     {
-      "community": 814,
+      "community": 801,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_pagination_tsx",
+      "id": "packages_athena_webapp_src_components_base_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
-      "community": 815,
+      "community": 802,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_tsx",
+      "id": "packages_athena_webapp_src_components_base_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table.tsx",
       "source_location": "L1"
     },
     {
-      "community": 816,
+      "community": 803,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data.ts",
+      "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspage_tsx",
+      "label": "BulkOperationsPage.tsx",
+      "norm_label": "bulkoperationspage.tsx",
+      "source_file": "packages/athena-webapp/src/components/bulk-operations/BulkOperationsPage.tsx",
       "source_location": "L1"
     },
     {
-      "community": 817,
+      "community": 804,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_constants_ts",
-      "label": "constants.ts",
-      "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/constants.ts",
+      "id": "packages_athena_webapp_src_components_cashiers_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/components/cashiers/index.tsx",
       "source_location": "L1"
     },
     {
-      "community": 818,
+      "community": 805,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-faceted-filter.tsx",
+      "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/columns.tsx",
       "source_location": "L1"
     },
     {
-      "community": 819,
+      "community": 806,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_pagination_tsx",
+      "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
-      "community": 82,
+      "community": 807,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_checkout_sessions_checkout_sessions_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/checkout-sessions/checkout-sessions-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 808,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_dashboard_metriccard_tsx",
+      "label": "MetricCard.tsx",
+      "norm_label": "metriccard.tsx",
+      "source_file": "packages/athena-webapp/src/components/dashboard/MetricCard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 809,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_expense_expensecompletion_tsx",
+      "label": "ExpenseCompletion.tsx",
+      "norm_label": "expensecompletion.tsx",
+      "source_file": "packages/athena-webapp/src/components/expense/ExpenseCompletion.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 81,
       "file_type": "code",
       "id": "organizationsettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -52909,7 +52879,7 @@
       "source_location": "L156"
     },
     {
-      "community": 82,
+      "community": 81,
       "file_type": "code",
       "id": "organizationsettingsview_navigation",
       "label": "Navigation()",
@@ -52918,7 +52888,7 @@
       "source_location": "L198"
     },
     {
-      "community": 82,
+      "community": 81,
       "file_type": "code",
       "id": "organizationsettingsview_onsubmit",
       "label": "onSubmit()",
@@ -52927,7 +52897,7 @@
       "source_location": "L105"
     },
     {
-      "community": 82,
+      "community": 81,
       "file_type": "code",
       "id": "organizationsettingsview_organizationsettings",
       "label": "OrganizationSettings()",
@@ -52936,7 +52906,7 @@
       "source_location": "L24"
     },
     {
-      "community": 82,
+      "community": 81,
       "file_type": "code",
       "id": "organizationsettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -52945,7 +52915,7 @@
       "source_location": "L71"
     },
     {
-      "community": 82,
+      "community": 81,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
       "label": "OrganizationSettingsView.tsx",
@@ -52954,97 +52924,97 @@
       "source_location": "L1"
     },
     {
-      "community": 820,
+      "community": 810,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar.tsx",
+      "id": "packages_athena_webapp_src_components_orders_orderstatus_test_tsx",
+      "label": "OrderStatus.test.tsx",
+      "norm_label": "orderstatus.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderStatus.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 821,
+      "community": 811,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table.tsx",
+      "id": "packages_athena_webapp_src_components_orders_orderstatus_tsx",
+      "label": "OrderStatus.tsx",
+      "norm_label": "orderstatus.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderStatus.tsx",
       "source_location": "L1"
     },
     {
-      "community": 822,
+      "community": 812,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data.ts",
+      "id": "packages_athena_webapp_src_components_orders_ordersummary_tsx",
+      "label": "OrderSummary.tsx",
+      "norm_label": "ordersummary.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrderSummary.tsx",
       "source_location": "L1"
     },
     {
-      "community": 823,
+      "community": 813,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_invitecolumns_tsx",
-      "label": "inviteColumns.tsx",
-      "norm_label": "invitecolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/inviteColumns.tsx",
+      "id": "packages_athena_webapp_src_components_orders_orders_tsx",
+      "label": "Orders.tsx",
+      "norm_label": "orders.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/Orders.tsx",
       "source_location": "L1"
     },
     {
-      "community": 824,
+      "community": 814,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_constants_ts",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/constants.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/constants.ts",
       "source_location": "L1"
     },
     {
-      "community": 825,
+      "community": 815,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_faceted_filter_tsx",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-faceted-filter.tsx",
       "source_location": "L1"
     },
     {
-      "community": 826,
+      "community": 816,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_pagination_tsx",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
-      "community": 827,
+      "community": 817,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 828,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_tsx",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table.tsx",
       "source_location": "L1"
     },
     {
-      "community": 829,
+      "community": 818,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_ts",
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_ts",
       "label": "data.ts",
       "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data.ts",
       "source_location": "L1"
     },
     {
-      "community": 83,
+      "community": 819,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/constants.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 82,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
       "label": "StoreSettingsView.tsx",
@@ -53053,7 +53023,7 @@
       "source_location": "L1"
     },
     {
-      "community": 83,
+      "community": 82,
       "file_type": "code",
       "id": "storesettingsview_handledeleteallproductsinstore",
       "label": "handleDeleteAllProductsInStore()",
@@ -53062,7 +53032,7 @@
       "source_location": "L232"
     },
     {
-      "community": 83,
+      "community": 82,
       "file_type": "code",
       "id": "storesettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -53071,7 +53041,7 @@
       "source_location": "L167"
     },
     {
-      "community": 83,
+      "community": 82,
       "file_type": "code",
       "id": "storesettingsview_onsubmit",
       "label": "onSubmit()",
@@ -53080,7 +53050,7 @@
       "source_location": "L116"
     },
     {
-      "community": 83,
+      "community": 82,
       "file_type": "code",
       "id": "storesettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -53089,7 +53059,7 @@
       "source_location": "L82"
     },
     {
-      "community": 83,
+      "community": 82,
       "file_type": "code",
       "id": "storesettingsview_storesettings",
       "label": "StoreSettings()",
@@ -53098,97 +53068,97 @@
       "source_location": "L28"
     },
     {
-      "community": 830,
+      "community": 820,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_memberscolumns_tsx",
-      "label": "membersColumns.tsx",
-      "norm_label": "memberscolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/membersColumns.tsx",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-faceted-filter.tsx",
       "source_location": "L1"
     },
     {
-      "community": 831,
+      "community": 821,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_cartitems_tsx",
-      "label": "CartItems.tsx",
-      "norm_label": "cartitems.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/CartItems.tsx",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
-      "community": 832,
+      "community": 822,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_tsx",
-      "label": "CashierAuthDialog.tsx",
-      "norm_label": "cashierauthdialog.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
-      "community": 833,
+      "community": 823,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_productlookup_tsx",
-      "label": "ProductLookup.tsx",
-      "norm_label": "productlookup.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/ProductLookup.tsx",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table.tsx",
       "source_location": "L1"
     },
     {
-      "community": 834,
+      "community": 824,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_registeractions_tsx",
-      "label": "RegisterActions.tsx",
-      "norm_label": "registeractions.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/RegisterActions.tsx",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data.ts",
       "source_location": "L1"
     },
     {
-      "community": 835,
+      "community": 825,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_searchresultssection_tsx",
-      "label": "SearchResultsSection.tsx",
-      "norm_label": "searchresultssection.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/SearchResultsSection.tsx",
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_invitecolumns_tsx",
+      "label": "inviteColumns.tsx",
+      "norm_label": "invitecolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/inviteColumns.tsx",
       "source_location": "L1"
     },
     {
-      "community": 836,
+      "community": 826,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_totalsdisplay_test_tsx",
-      "label": "TotalsDisplay.test.tsx",
-      "norm_label": "totalsdisplay.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.test.tsx",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_constants_ts",
+      "label": "constants.ts",
+      "norm_label": "constants.ts",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/constants.ts",
       "source_location": "L1"
     },
     {
-      "community": 837,
+      "community": 827,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportview_tsx",
-      "label": "ExpenseReportView.tsx",
-      "norm_label": "expensereportview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportView.tsx",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-faceted-filter.tsx",
       "source_location": "L1"
     },
     {
-      "community": 838,
+      "community": 828,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportcolumns_tsx",
-      "label": "expenseReportColumns.tsx",
-      "norm_label": "expensereportcolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/expenseReportColumns.tsx",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
-      "community": 839,
+      "community": 829,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
-      "label": "TransactionView.tsx",
-      "norm_label": "transactionview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
-      "community": 84,
+      "community": 83,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
       "label": "storybook-shell.tsx",
@@ -53197,7 +53167,7 @@
       "source_location": "L1"
     },
     {
-      "community": 84,
+      "community": 83,
       "file_type": "code",
       "id": "storybook_shell_storybookcallout",
       "label": "StorybookCallout()",
@@ -53206,7 +53176,7 @@
       "source_location": "L83"
     },
     {
-      "community": 84,
+      "community": 83,
       "file_type": "code",
       "id": "storybook_shell_storybooklist",
       "label": "StorybookList()",
@@ -53215,7 +53185,7 @@
       "source_location": "L62"
     },
     {
-      "community": 84,
+      "community": 83,
       "file_type": "code",
       "id": "storybook_shell_storybookpillrow",
       "label": "StorybookPillRow()",
@@ -53224,7 +53194,7 @@
       "source_location": "L95"
     },
     {
-      "community": 84,
+      "community": 83,
       "file_type": "code",
       "id": "storybook_shell_storybooksection",
       "label": "StorybookSection()",
@@ -53233,7 +53203,7 @@
       "source_location": "L41"
     },
     {
-      "community": 84,
+      "community": 83,
       "file_type": "code",
       "id": "storybook_shell_storybookshell",
       "label": "StorybookShell()",
@@ -53242,97 +53212,97 @@
       "source_location": "L12"
     },
     {
-      "community": 840,
+      "community": 830,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_types_ts",
-      "label": "types.ts",
-      "norm_label": "types.ts",
-      "source_file": "packages/athena-webapp/src/components/pos/types.ts",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table.tsx",
       "source_location": "L1"
     },
     {
-      "community": 841,
+      "community": 831,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_analyticsinsights_tsx",
-      "label": "AnalyticsInsights.tsx",
-      "norm_label": "analyticsinsights.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/AnalyticsInsights.tsx",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data.ts",
       "source_location": "L1"
     },
     {
-      "community": 842,
+      "community": 832,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_attributesview_tsx",
-      "label": "AttributesView.tsx",
-      "norm_label": "attributesview.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/AttributesView.tsx",
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_memberscolumns_tsx",
+      "label": "membersColumns.tsx",
+      "norm_label": "memberscolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/membersColumns.tsx",
       "source_location": "L1"
     },
     {
-      "community": 843,
+      "community": 833,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_detailsview_tsx",
-      "label": "DetailsView.tsx",
-      "norm_label": "detailsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/DetailsView.tsx",
+      "id": "packages_athena_webapp_src_components_pos_cartitems_tsx",
+      "label": "CartItems.tsx",
+      "norm_label": "cartitems.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/CartItems.tsx",
       "source_location": "L1"
     },
     {
-      "community": 844,
+      "community": 834,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_productdetailview_tsx",
-      "label": "ProductDetailView.tsx",
-      "norm_label": "productdetailview.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/ProductDetailView.tsx",
+      "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_tsx",
+      "label": "CashierAuthDialog.tsx",
+      "norm_label": "cashierauthdialog.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx",
       "source_location": "L1"
     },
     {
-      "community": 845,
+      "community": 835,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_productstatus_tsx",
-      "label": "ProductStatus.tsx",
-      "norm_label": "productstatus.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/ProductStatus.tsx",
+      "id": "packages_athena_webapp_src_components_pos_productlookup_tsx",
+      "label": "ProductLookup.tsx",
+      "norm_label": "productlookup.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/ProductLookup.tsx",
       "source_location": "L1"
     },
     {
-      "community": 846,
+      "community": 836,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_categorylistview_tsx",
-      "label": "CategoryListView.tsx",
-      "norm_label": "categorylistview.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/CategoryListView.tsx",
+      "id": "packages_athena_webapp_src_components_pos_registeractions_tsx",
+      "label": "RegisterActions.tsx",
+      "norm_label": "registeractions.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/RegisterActions.tsx",
       "source_location": "L1"
     },
     {
-      "community": 847,
+      "community": 837,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_productsubcategorytogglegroup_tsx",
-      "label": "ProductSubcategoryToggleGroup.tsx",
-      "norm_label": "productsubcategorytogglegroup.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/ProductSubcategoryToggleGroup.tsx",
+      "id": "packages_athena_webapp_src_components_pos_searchresultssection_tsx",
+      "label": "SearchResultsSection.tsx",
+      "norm_label": "searchresultssection.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/SearchResultsSection.tsx",
       "source_location": "L1"
     },
     {
-      "community": 848,
+      "community": 838,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_tsx",
-      "label": "Products.tsx",
-      "norm_label": "products.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/Products.tsx",
+      "id": "packages_athena_webapp_src_components_pos_totalsdisplay_test_tsx",
+      "label": "TotalsDisplay.test.tsx",
+      "norm_label": "totalsdisplay.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/TotalsDisplay.test.tsx",
       "source_location": "L1"
     },
     {
-      "community": 849,
+      "community": 839,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_storeproducts_tsx",
-      "label": "StoreProducts.tsx",
-      "norm_label": "storeproducts.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/StoreProducts.tsx",
+      "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportview_tsx",
+      "label": "ExpenseReportView.tsx",
+      "norm_label": "expensereportview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportView.tsx",
       "source_location": "L1"
     },
     {
-      "community": 85,
+      "community": 84,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_promocodes_ts",
       "label": "promoCodes.ts",
@@ -53341,7 +53311,7 @@
       "source_location": "L1"
     },
     {
-      "community": 85,
+      "community": 84,
       "file_type": "code",
       "id": "promocodes_getbaseurl",
       "label": "getBaseUrl()",
@@ -53350,7 +53320,7 @@
       "source_location": "L4"
     },
     {
-      "community": 85,
+      "community": 84,
       "file_type": "code",
       "id": "promocodes_getpromocodeitems",
       "label": "getPromoCodeItems()",
@@ -53359,7 +53329,7 @@
       "source_location": "L49"
     },
     {
-      "community": 85,
+      "community": 84,
       "file_type": "code",
       "id": "promocodes_getpromocodes",
       "label": "getPromoCodes()",
@@ -53368,7 +53338,7 @@
       "source_location": "L34"
     },
     {
-      "community": 85,
+      "community": 84,
       "file_type": "code",
       "id": "promocodes_getredeemedpromocodes",
       "label": "getRedeemedPromoCodes()",
@@ -53377,7 +53347,7 @@
       "source_location": "L74"
     },
     {
-      "community": 85,
+      "community": 84,
       "file_type": "code",
       "id": "promocodes_redeempromocode",
       "label": "redeemPromoCode()",
@@ -53386,97 +53356,97 @@
       "source_location": "L6"
     },
     {
-      "community": 850,
+      "community": 840,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_unresolvedproducts_tsx",
-      "label": "UnresolvedProducts.tsx",
-      "norm_label": "unresolvedproducts.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/UnresolvedProducts.tsx",
+      "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportcolumns_tsx",
+      "label": "expenseReportColumns.tsx",
+      "norm_label": "expensereportcolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/expenseReportColumns.tsx",
       "source_location": "L1"
     },
     {
-      "community": 851,
+      "community": 841,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproducts_tsx",
-      "label": "ComplimentaryProducts.tsx",
-      "norm_label": "complimentaryproducts.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProducts.tsx",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_tsx",
+      "label": "TransactionView.tsx",
+      "norm_label": "transactionview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx",
       "source_location": "L1"
     },
     {
-      "community": 852,
+      "community": 842,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductscolumn_tsx",
-      "label": "complimentaryProductsColumn.tsx",
-      "norm_label": "complimentaryproductscolumn.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/complimentary/complimentaryProductsColumn.tsx",
+      "id": "packages_athena_webapp_src_components_pos_types_ts",
+      "label": "types.ts",
+      "norm_label": "types.ts",
+      "source_file": "packages/athena-webapp/src/components/pos/types.ts",
       "source_location": "L1"
     },
     {
-      "community": 853,
+      "community": 843,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_column_header_tsx",
-      "label": "data-table-column-header.tsx",
-      "norm_label": "data-table-column-header.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-column-header.tsx",
+      "id": "packages_athena_webapp_src_components_product_analyticsinsights_tsx",
+      "label": "AnalyticsInsights.tsx",
+      "norm_label": "analyticsinsights.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/AnalyticsInsights.tsx",
       "source_location": "L1"
     },
     {
-      "community": 854,
+      "community": 844,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-faceted-filter.tsx",
+      "id": "packages_athena_webapp_src_components_product_attributesview_tsx",
+      "label": "AttributesView.tsx",
+      "norm_label": "attributesview.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/AttributesView.tsx",
       "source_location": "L1"
     },
     {
-      "community": 855,
+      "community": 845,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-pagination.tsx",
+      "id": "packages_athena_webapp_src_components_product_detailsview_tsx",
+      "label": "DetailsView.tsx",
+      "norm_label": "detailsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/DetailsView.tsx",
       "source_location": "L1"
     },
     {
-      "community": 856,
+      "community": 846,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-toolbar.tsx",
+      "id": "packages_athena_webapp_src_components_product_productdetailview_tsx",
+      "label": "ProductDetailView.tsx",
+      "norm_label": "productdetailview.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/ProductDetailView.tsx",
       "source_location": "L1"
     },
     {
-      "community": 857,
+      "community": 847,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table.tsx",
+      "id": "packages_athena_webapp_src_components_product_productstatus_tsx",
+      "label": "ProductStatus.tsx",
+      "norm_label": "productstatus.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/ProductStatus.tsx",
       "source_location": "L1"
     },
     {
-      "community": 858,
+      "community": 848,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_data_ts",
-      "label": "data.ts",
-      "norm_label": "data.ts",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data.ts",
+      "id": "packages_athena_webapp_src_components_products_categorylistview_tsx",
+      "label": "CategoryListView.tsx",
+      "norm_label": "categorylistview.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/CategoryListView.tsx",
       "source_location": "L1"
     },
     {
-      "community": 859,
+      "community": 849,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_table_components_productcolumns_tsx",
-      "label": "productColumns.tsx",
-      "norm_label": "productcolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/products-table/components/productColumns.tsx",
+      "id": "packages_athena_webapp_src_components_products_productsubcategorytogglegroup_tsx",
+      "label": "ProductSubcategoryToggleGroup.tsx",
+      "norm_label": "productsubcategorytogglegroup.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/ProductSubcategoryToggleGroup.tsx",
       "source_location": "L1"
     },
     {
-      "community": 86,
+      "community": 85,
       "file_type": "code",
       "id": "billingdetails_clearform",
       "label": "clearForm()",
@@ -53485,7 +53455,7 @@
       "source_location": "L173"
     },
     {
-      "community": 86,
+      "community": 85,
       "file_type": "code",
       "id": "billingdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -53494,7 +53464,7 @@
       "source_location": "L102"
     },
     {
-      "community": 86,
+      "community": 85,
       "file_type": "code",
       "id": "billingdetails_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -53503,7 +53473,7 @@
       "source_location": "L201"
     },
     {
-      "community": 86,
+      "community": 85,
       "file_type": "code",
       "id": "billingdetails_onsubmit",
       "label": "onSubmit()",
@@ -53512,7 +53482,7 @@
       "source_location": "L150"
     },
     {
-      "community": 86,
+      "community": 85,
       "file_type": "code",
       "id": "billingdetails_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -53521,7 +53491,7 @@
       "source_location": "L155"
     },
     {
-      "community": 86,
+      "community": 85,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
       "label": "BillingDetails.tsx",
@@ -53530,97 +53500,97 @@
       "source_location": "L1"
     },
     {
-      "community": 860,
+      "community": 850,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_promocodepreview_tsx",
-      "label": "PromoCodePreview.tsx",
-      "norm_label": "promocodepreview.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodePreview.tsx",
+      "id": "packages_athena_webapp_src_components_products_products_tsx",
+      "label": "Products.tsx",
+      "norm_label": "products.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/Products.tsx",
       "source_location": "L1"
     },
     {
-      "community": 861,
+      "community": 851,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_promocodes_tsx",
-      "label": "PromoCodes.tsx",
-      "norm_label": "promocodes.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodes.tsx",
+      "id": "packages_athena_webapp_src_components_products_storeproducts_tsx",
+      "label": "StoreProducts.tsx",
+      "norm_label": "storeproducts.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/StoreProducts.tsx",
       "source_location": "L1"
     },
     {
-      "community": 862,
+      "community": 852,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_analytics_promocodeanalytics_tsx",
-      "label": "PromoCodeAnalytics.tsx",
-      "norm_label": "promocodeanalytics.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/analytics/PromoCodeAnalytics.tsx",
+      "id": "packages_athena_webapp_src_components_products_unresolvedproducts_tsx",
+      "label": "UnresolvedProducts.tsx",
+      "norm_label": "unresolvedproducts.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/UnresolvedProducts.tsx",
       "source_location": "L1"
     },
     {
-      "community": 863,
+      "community": 853,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_captured_captured_emails_columns_tsx",
-      "label": "captured-emails-columns.tsx",
-      "norm_label": "captured-emails-columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/captured/captured-emails-columns.tsx",
+      "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproducts_tsx",
+      "label": "ComplimentaryProducts.tsx",
+      "norm_label": "complimentaryproducts.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/ComplimentaryProducts.tsx",
       "source_location": "L1"
     },
     {
-      "community": 864,
+      "community": 854,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_columns_tsx",
-      "label": "columns.tsx",
-      "norm_label": "columns.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/columns.tsx",
+      "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductscolumn_tsx",
+      "label": "complimentaryProductsColumn.tsx",
+      "norm_label": "complimentaryproductscolumn.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/complimentary/complimentaryProductsColumn.tsx",
       "source_location": "L1"
     },
     {
-      "community": 865,
+      "community": 855,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_column_header_tsx",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
       "norm_label": "data-table-column-header.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-column-header.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-column-header.tsx",
       "source_location": "L1"
     },
     {
-      "community": 866,
+      "community": 856,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_faceted_filter_tsx",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
       "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-faceted-filter.tsx",
       "source_location": "L1"
     },
     {
-      "community": 867,
+      "community": 857,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_pagination_tsx",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
-      "community": 868,
+      "community": 858,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_toolbar_tsx",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
       "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table-toolbar.tsx",
       "source_location": "L1"
     },
     {
-      "community": 869,
+      "community": 859,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_tsx",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table.tsx",
       "source_location": "L1"
     },
     {
-      "community": 87,
+      "community": 86,
       "file_type": "code",
       "id": "checkoutexpired_checkoutexpired",
       "label": "CheckoutExpired()",
@@ -53629,7 +53599,7 @@
       "source_location": "L9"
     },
     {
-      "community": 87,
+      "community": 86,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessiongeneric",
       "label": "CheckoutSessionGeneric()",
@@ -53638,7 +53608,7 @@
       "source_location": "L73"
     },
     {
-      "community": 87,
+      "community": 86,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessionnotfound",
       "label": "CheckoutSessionNotFound()",
@@ -53647,7 +53617,7 @@
       "source_location": "L54"
     },
     {
-      "community": 87,
+      "community": 86,
       "file_type": "code",
       "id": "checkoutexpired_handlesendemail",
       "label": "handleSendEmail()",
@@ -53656,7 +53626,7 @@
       "source_location": "L98"
     },
     {
-      "community": 87,
+      "community": 86,
       "file_type": "code",
       "id": "checkoutexpired_nocheckoutsession",
       "label": "NoCheckoutSession()",
@@ -53665,7 +53635,7 @@
       "source_location": "L33"
     },
     {
-      "community": 87,
+      "community": 86,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
       "label": "CheckoutExpired.tsx",
@@ -53674,7 +53644,169 @@
       "source_location": "L1"
     },
     {
+      "community": 860,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_data_ts",
+      "label": "data.ts",
+      "norm_label": "data.ts",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/data.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 861,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_table_components_productcolumns_tsx",
+      "label": "productColumns.tsx",
+      "norm_label": "productcolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/products-table/components/productColumns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 862,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_promocodepreview_tsx",
+      "label": "PromoCodePreview.tsx",
+      "norm_label": "promocodepreview.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodePreview.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 863,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_promocodes_tsx",
+      "label": "PromoCodes.tsx",
+      "norm_label": "promocodes.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodes.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 864,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_analytics_promocodeanalytics_tsx",
+      "label": "PromoCodeAnalytics.tsx",
+      "norm_label": "promocodeanalytics.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/analytics/PromoCodeAnalytics.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 865,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_captured_captured_emails_columns_tsx",
+      "label": "captured-emails-columns.tsx",
+      "norm_label": "captured-emails-columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/captured/captured-emails-columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 866,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_columns_tsx",
+      "label": "columns.tsx",
+      "norm_label": "columns.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/columns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 867,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_column_header_tsx",
+      "label": "data-table-column-header.tsx",
+      "norm_label": "data-table-column-header.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-column-header.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 868,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 869,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 87,
+      "file_type": "code",
+      "id": "image_uploader_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L100"
+    },
+    {
+      "community": 87,
+      "file_type": "code",
+      "id": "image_uploader_ondrop",
+      "label": "onDrop()",
+      "norm_label": "ondrop()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 87,
+      "file_type": "code",
+      "id": "image_uploader_removeimage",
+      "label": "removeImage()",
+      "norm_label": "removeimage()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 87,
+      "file_type": "code",
+      "id": "image_uploader_unmarkfordeletion",
+      "label": "unmarkForDeletion()",
+      "norm_label": "unmarkfordeletion()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 87,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 87,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
       "community": 870,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 871,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/selectable-products-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 872,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_columns_tsx",
       "label": "columns.tsx",
@@ -53683,7 +53815,7 @@
       "source_location": "L1"
     },
     {
-      "community": 871,
+      "community": 873,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_constants_ts",
       "label": "constants.ts",
@@ -53692,7 +53824,7 @@
       "source_location": "L1"
     },
     {
-      "community": 872,
+      "community": 874,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -53701,7 +53833,7 @@
       "source_location": "L1"
     },
     {
-      "community": 873,
+      "community": 875,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
@@ -53710,7 +53842,7 @@
       "source_location": "L1"
     },
     {
-      "community": 874,
+      "community": 876,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_tsx",
       "label": "data-table.tsx",
@@ -53719,7 +53851,7 @@
       "source_location": "L1"
     },
     {
-      "community": 875,
+      "community": 877,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_ts",
       "label": "data.ts",
@@ -53728,7 +53860,7 @@
       "source_location": "L1"
     },
     {
-      "community": 876,
+      "community": 878,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_types_ts",
       "label": "types.ts",
@@ -53737,30 +53869,12 @@
       "source_location": "L1"
     },
     {
-      "community": 877,
+      "community": 879,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_welcome_offer_card_tsx",
       "label": "welcome-offer-card.tsx",
       "norm_label": "welcome-offer-card.tsx",
       "source_file": "packages/athena-webapp/src/components/promo-codes/welcome-offer-card.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 878,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reviews_ratingstars_tsx",
-      "label": "RatingStars.tsx",
-      "norm_label": "ratingstars.tsx",
-      "source_file": "packages/athena-webapp/src/components/reviews/RatingStars.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 879,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reviews_reviewcard_tsx",
-      "label": "ReviewCard.tsx",
-      "norm_label": "reviewcard.tsx",
-      "source_file": "packages/athena-webapp/src/components/reviews/ReviewCard.tsx",
       "source_location": "L1"
     },
     {
@@ -53820,6 +53934,24 @@
     {
       "community": 880,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_reviews_ratingstars_tsx",
+      "label": "RatingStars.tsx",
+      "norm_label": "ratingstars.tsx",
+      "source_file": "packages/athena-webapp/src/components/reviews/RatingStars.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 881,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_reviews_reviewcard_tsx",
+      "label": "ReviewCard.tsx",
+      "norm_label": "reviewcard.tsx",
+      "source_file": "packages/athena-webapp/src/components/reviews/ReviewCard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 882,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewmetadata_tsx",
       "label": "ReviewMetadata.tsx",
       "norm_label": "reviewmetadata.tsx",
@@ -53827,7 +53959,7 @@
       "source_location": "L1"
     },
     {
-      "community": 881,
+      "community": 883,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_test_tsx",
       "label": "MtnMomoView.test.tsx",
@@ -53836,7 +53968,7 @@
       "source_location": "L1"
     },
     {
-      "community": 882,
+      "community": 884,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_index_tsx",
       "label": "index.tsx",
@@ -53845,7 +53977,7 @@
       "source_location": "L1"
     },
     {
-      "community": 883,
+      "community": 885,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
@@ -53854,7 +53986,7 @@
       "source_location": "L1"
     },
     {
-      "community": 884,
+      "community": 886,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_test_tsx",
       "label": "button.test.tsx",
@@ -53863,7 +53995,7 @@
       "source_location": "L1"
     },
     {
-      "community": 885,
+      "community": 887,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
@@ -53872,7 +54004,7 @@
       "source_location": "L1"
     },
     {
-      "community": 886,
+      "community": 888,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_test_tsx",
       "label": "calendar.test.tsx",
@@ -53881,30 +54013,12 @@
       "source_location": "L1"
     },
     {
-      "community": 887,
+      "community": 889,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_calendar_tsx",
       "label": "calendar.tsx",
       "norm_label": "calendar.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/calendar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 888,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_card_tsx",
-      "label": "card.tsx",
-      "norm_label": "card.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/card.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 889,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_checkbox_tsx",
-      "label": "checkbox.tsx",
-      "norm_label": "checkbox.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/checkbox.tsx",
       "source_location": "L1"
     },
     {
@@ -53964,6 +54078,24 @@
     {
       "community": 890,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_card_tsx",
+      "label": "card.tsx",
+      "norm_label": "card.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/card.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 891,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_checkbox_tsx",
+      "label": "checkbox.tsx",
+      "norm_label": "checkbox.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/checkbox.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 892,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_collapsible_tsx",
       "label": "collapsible.tsx",
       "norm_label": "collapsible.tsx",
@@ -53971,7 +54103,7 @@
       "source_location": "L1"
     },
     {
-      "community": 891,
+      "community": 893,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
@@ -53980,7 +54112,7 @@
       "source_location": "L1"
     },
     {
-      "community": 892,
+      "community": 894,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
@@ -53989,7 +54121,7 @@
       "source_location": "L1"
     },
     {
-      "community": 893,
+      "community": 895,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
@@ -53998,7 +54130,7 @@
       "source_location": "L1"
     },
     {
-      "community": 894,
+      "community": 896,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
@@ -54007,7 +54139,7 @@
       "source_location": "L1"
     },
     {
-      "community": 895,
+      "community": 897,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
@@ -54016,7 +54148,7 @@
       "source_location": "L1"
     },
     {
-      "community": 896,
+      "community": 898,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
@@ -54025,30 +54157,12 @@
       "source_location": "L1"
     },
     {
-      "community": 897,
+      "community": 899,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
       "norm_label": "input-otp.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/input-otp.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 898,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_input_tsx",
-      "label": "input.tsx",
-      "norm_label": "input.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/input.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 899,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_modals_action_modal_tsx",
-      "label": "action-modal.tsx",
-      "norm_label": "action-modal.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/modals/action-modal.tsx",
       "source_location": "L1"
     },
     {
@@ -54297,6 +54411,24 @@
     {
       "community": 900,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_input_tsx",
+      "label": "input.tsx",
+      "norm_label": "input.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/input.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 901,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_modals_action_modal_tsx",
+      "label": "action-modal.tsx",
+      "norm_label": "action-modal.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/modals/action-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 902,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
       "norm_label": "popover.tsx",
@@ -54304,7 +54436,7 @@
       "source_location": "L1"
     },
     {
-      "community": 901,
+      "community": 903,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_primitives_test_tsx",
       "label": "primitives.test.tsx",
@@ -54313,7 +54445,7 @@
       "source_location": "L1"
     },
     {
-      "community": 902,
+      "community": 904,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
@@ -54322,7 +54454,7 @@
       "source_location": "L1"
     },
     {
-      "community": 903,
+      "community": 905,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
@@ -54331,7 +54463,7 @@
       "source_location": "L1"
     },
     {
-      "community": 904,
+      "community": 906,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
@@ -54340,7 +54472,7 @@
       "source_location": "L1"
     },
     {
-      "community": 905,
+      "community": 907,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
@@ -54349,7 +54481,7 @@
       "source_location": "L1"
     },
     {
-      "community": 906,
+      "community": 908,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
@@ -54358,30 +54490,12 @@
       "source_location": "L1"
     },
     {
-      "community": 907,
+      "community": 909,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_switch_tsx",
       "label": "switch.tsx",
       "norm_label": "switch.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/switch.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 908,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_table_tsx",
-      "label": "table.tsx",
-      "norm_label": "table.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/table.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 909,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_tabs_tsx",
-      "label": "tabs.tsx",
-      "norm_label": "tabs.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/tabs.tsx",
       "source_location": "L1"
     },
     {
@@ -54441,6 +54555,24 @@
     {
       "community": 910,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_table_tsx",
+      "label": "table.tsx",
+      "norm_label": "table.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 911,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_tabs_tsx",
+      "label": "tabs.tsx",
+      "norm_label": "tabs.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/tabs.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 912,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
       "norm_label": "textarea.tsx",
@@ -54448,7 +54580,7 @@
       "source_location": "L1"
     },
     {
-      "community": 911,
+      "community": 913,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
@@ -54457,7 +54589,7 @@
       "source_location": "L1"
     },
     {
-      "community": 912,
+      "community": 914,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
@@ -54466,7 +54598,7 @@
       "source_location": "L1"
     },
     {
-      "community": 913,
+      "community": 915,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
@@ -54475,7 +54607,7 @@
       "source_location": "L1"
     },
     {
-      "community": 914,
+      "community": 916,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_upload_button_tsx",
       "label": "upload-button.tsx",
@@ -54484,7 +54616,7 @@
       "source_location": "L1"
     },
     {
-      "community": 915,
+      "community": 917,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagview_tsx",
       "label": "BagView.tsx",
@@ -54493,7 +54625,7 @@
       "source_location": "L1"
     },
     {
-      "community": 916,
+      "community": 918,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_columns_tsx",
       "label": "columns.tsx",
@@ -54502,30 +54634,12 @@
       "source_location": "L1"
     },
     {
-      "community": 917,
+      "community": 919,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_constants_ts",
       "label": "constants.ts",
       "norm_label": "constants.ts",
       "source_file": "packages/athena-webapp/src/components/user-bags/table/constants.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 918,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_faceted_filter_tsx",
-      "label": "data-table-faceted-filter.tsx",
-      "norm_label": "data-table-faceted-filter.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-faceted-filter.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 919,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_pagination_tsx",
-      "label": "data-table-pagination.tsx",
-      "norm_label": "data-table-pagination.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-pagination.tsx",
       "source_location": "L1"
     },
     {
@@ -54576,6 +54690,24 @@
     {
       "community": 920,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_faceted_filter_tsx",
+      "label": "data-table-faceted-filter.tsx",
+      "norm_label": "data-table-faceted-filter.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-faceted-filter.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 921,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_pagination_tsx",
+      "label": "data-table-pagination.tsx",
+      "norm_label": "data-table-pagination.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-pagination.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 922,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
@@ -54583,7 +54715,7 @@
       "source_location": "L1"
     },
     {
-      "community": 921,
+      "community": 923,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_ts",
       "label": "data.ts",
@@ -54592,7 +54724,7 @@
       "source_location": "L1"
     },
     {
-      "community": 922,
+      "community": 924,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bag_columns_tsx",
       "label": "bag-columns.tsx",
@@ -54601,7 +54733,7 @@
       "source_location": "L1"
     },
     {
-      "community": 923,
+      "community": 925,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_bags_table_tsx",
       "label": "bags-table.tsx",
@@ -54610,7 +54742,7 @@
       "source_location": "L1"
     },
     {
-      "community": 924,
+      "community": 926,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_columns_tsx",
       "label": "columns.tsx",
@@ -54619,7 +54751,7 @@
       "source_location": "L1"
     },
     {
-      "community": 925,
+      "community": 927,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -54628,7 +54760,7 @@
       "source_location": "L1"
     },
     {
-      "community": 926,
+      "community": 928,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_faceted_filter_tsx",
       "label": "data-table-faceted-filter.tsx",
@@ -54637,30 +54769,12 @@
       "source_location": "L1"
     },
     {
-      "community": 927,
+      "community": 929,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_pagination_tsx",
       "label": "data-table-pagination.tsx",
       "norm_label": "data-table-pagination.tsx",
       "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-pagination.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 928,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
-      "label": "data-table-toolbar.tsx",
-      "norm_label": "data-table-toolbar.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-toolbar.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 929,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_tsx",
-      "label": "data-table.tsx",
-      "norm_label": "data-table.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table.tsx",
       "source_location": "L1"
     },
     {
@@ -54711,6 +54825,24 @@
     {
       "community": 930,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_toolbar_tsx",
+      "label": "data-table-toolbar.tsx",
+      "norm_label": "data-table-toolbar.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table-toolbar.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 931,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_data_table_tsx",
+      "label": "data-table.tsx",
+      "norm_label": "data-table.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/user-bags-table/data-table.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 932,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_linkedaccounts_tsx",
       "label": "LinkedAccounts.tsx",
       "norm_label": "linkedaccounts.tsx",
@@ -54718,7 +54850,7 @@
       "source_location": "L1"
     },
     {
-      "community": 931,
+      "community": 933,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_timelineeventcard_test_tsx",
       "label": "TimelineEventCard.test.tsx",
@@ -54727,7 +54859,7 @@
       "source_location": "L1"
     },
     {
-      "community": 932,
+      "community": 934,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_usercheckoutsession_tsx",
       "label": "UserCheckoutSession.tsx",
@@ -54736,7 +54868,7 @@
       "source_location": "L1"
     },
     {
-      "community": 933,
+      "community": 935,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userinsightssection_tsx",
       "label": "UserInsightsSection.tsx",
@@ -54745,7 +54877,7 @@
       "source_location": "L1"
     },
     {
-      "community": 934,
+      "community": 936,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_userbehaviorinsights_tsx",
       "label": "UserBehaviorInsights.tsx",
@@ -54754,7 +54886,7 @@
       "source_location": "L1"
     },
     {
-      "community": 935,
+      "community": 937,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_index_ts",
       "label": "index.ts",
@@ -54763,7 +54895,7 @@
       "source_location": "L1"
     },
     {
-      "community": 936,
+      "community": 938,
       "file_type": "code",
       "id": "packages_athena_webapp_src_config_ts",
       "label": "config.ts",
@@ -54772,30 +54904,12 @@
       "source_location": "L1"
     },
     {
-      "community": 937,
+      "community": 939,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_themecontext_tsx",
       "label": "ThemeContext.tsx",
       "norm_label": "themecontext.tsx",
       "source_file": "packages/athena-webapp/src/contexts/ThemeContext.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 938,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_use_store_modal_tsx",
-      "label": "use-store-modal.tsx",
-      "norm_label": "use-store-modal.tsx",
-      "source_file": "packages/athena-webapp/src/hooks/use-store-modal.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 939,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
-      "label": "useOrganizationModal.tsx",
-      "norm_label": "useorganizationmodal.tsx",
-      "source_file": "packages/athena-webapp/src/hooks/useOrganizationModal.tsx",
       "source_location": "L1"
     },
     {
@@ -54846,6 +54960,24 @@
     {
       "community": 940,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_use_store_modal_tsx",
+      "label": "use-store-modal.tsx",
+      "norm_label": "use-store-modal.tsx",
+      "source_file": "packages/athena-webapp/src/hooks/use-store-modal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 941,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useorganizationmodal_tsx",
+      "label": "useOrganizationModal.tsx",
+      "norm_label": "useorganizationmodal.tsx",
+      "source_file": "packages/athena-webapp/src/hooks/useOrganizationModal.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 942,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_aws_ts",
       "label": "aws.ts",
       "norm_label": "aws.ts",
@@ -54853,7 +54985,7 @@
       "source_location": "L1"
     },
     {
-      "community": 941,
+      "community": 943,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_constants_ts",
       "label": "constants.ts",
@@ -54862,7 +54994,7 @@
       "source_location": "L1"
     },
     {
-      "community": 942,
+      "community": 944,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_countries_ts",
       "label": "countries.ts",
@@ -54871,7 +55003,7 @@
       "source_location": "L1"
     },
     {
-      "community": 943,
+      "community": 945,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -54880,7 +55012,7 @@
       "source_location": "L1"
     },
     {
-      "community": 944,
+      "community": 946,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
@@ -54889,7 +55021,7 @@
       "source_location": "L1"
     },
     {
-      "community": 945,
+      "community": 947,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_constants_ts",
       "label": "constants.ts",
@@ -54898,7 +55030,7 @@
       "source_location": "L1"
     },
     {
-      "community": 946,
+      "community": 948,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_displayamounts_test_ts",
       "label": "displayAmounts.test.ts",
@@ -54907,30 +55039,12 @@
       "source_location": "L1"
     },
     {
-      "community": 947,
+      "community": 949,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_productutils_test_ts",
       "label": "productUtils.test.ts",
       "norm_label": "productutils.test.ts",
       "source_file": "packages/athena-webapp/src/lib/productUtils.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 948,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_schemas_category_ts",
-      "label": "category.ts",
-      "norm_label": "category.ts",
-      "source_file": "packages/athena-webapp/src/lib/schemas/category.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 949,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_schemas_product_ts",
-      "label": "product.ts",
-      "norm_label": "product.ts",
-      "source_file": "packages/athena-webapp/src/lib/schemas/product.ts",
       "source_location": "L1"
     },
     {
@@ -54981,6 +55095,24 @@
     {
       "community": 950,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_schemas_category_ts",
+      "label": "category.ts",
+      "norm_label": "category.ts",
+      "source_file": "packages/athena-webapp/src/lib/schemas/category.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 951,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_schemas_product_ts",
+      "label": "product.ts",
+      "norm_label": "product.ts",
+      "source_file": "packages/athena-webapp/src/lib/schemas/product.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 952,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
       "norm_label": "store.ts",
@@ -54988,7 +55120,7 @@
       "source_location": "L1"
     },
     {
-      "community": 951,
+      "community": 953,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
@@ -54997,7 +55129,7 @@
       "source_location": "L1"
     },
     {
-      "community": 952,
+      "community": 954,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
@@ -55006,7 +55138,7 @@
       "source_location": "L1"
     },
     {
-      "community": 953,
+      "community": 955,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_storeconfig_test_ts",
       "label": "storeConfig.test.ts",
@@ -55015,7 +55147,7 @@
       "source_location": "L1"
     },
     {
-      "community": 954,
+      "community": 956,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
@@ -55024,7 +55156,7 @@
       "source_location": "L1"
     },
     {
-      "community": 955,
+      "community": 957,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
@@ -55033,7 +55165,7 @@
       "source_location": "L1"
     },
     {
-      "community": 956,
+      "community": 958,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -55042,30 +55174,12 @@
       "source_location": "L1"
     },
     {
-      "community": 957,
+      "community": 959,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 958,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 959,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/organization/index.tsx",
       "source_location": "L1"
     },
     {
@@ -55116,6 +55230,24 @@
     {
       "community": 960,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 961,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_organization_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/settings/organization/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 962,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_stores_storeurlslug_tsx",
       "label": "$storeUrlSlug.tsx",
       "norm_label": "$storeurlslug.tsx",
@@ -55123,7 +55255,7 @@
       "source_location": "L1"
     },
     {
-      "community": 961,
+      "community": 963,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_analytics_tsx",
       "label": "analytics.tsx",
@@ -55132,7 +55264,7 @@
       "source_location": "L1"
     },
     {
-      "community": 962,
+      "community": 964,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_assets_index_tsx",
       "label": "assets.index.tsx",
@@ -55141,7 +55273,7 @@
       "source_location": "L1"
     },
     {
-      "community": 963,
+      "community": 965,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_bagid_tsx",
       "label": "bags.$bagId.tsx",
@@ -55150,7 +55282,7 @@
       "source_location": "L1"
     },
     {
-      "community": 964,
+      "community": 966,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bags_index_tsx",
       "label": "bags.index.tsx",
@@ -55159,7 +55291,7 @@
       "source_location": "L1"
     },
     {
-      "community": 965,
+      "community": 967,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_bulk_operations_index_tsx",
       "label": "index.tsx",
@@ -55168,7 +55300,7 @@
       "source_location": "L1"
     },
     {
-      "community": 966,
+      "community": 968,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_checkout_sessions_index_tsx",
       "label": "checkout-sessions.index.tsx",
@@ -55177,30 +55309,12 @@
       "source_location": "L1"
     },
     {
-      "community": 967,
+      "community": 969,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_configuration_index_tsx",
       "label": "configuration.index.tsx",
       "norm_label": "configuration.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/configuration.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 968,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
-      "label": "dashboard.index.tsx",
-      "norm_label": "dashboard.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/dashboard.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 969,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
-      "label": "home.tsx",
-      "norm_label": "home.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/home.tsx",
       "source_location": "L1"
     },
     {
@@ -55251,6 +55365,24 @@
     {
       "community": 970,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_dashboard_index_tsx",
+      "label": "dashboard.index.tsx",
+      "norm_label": "dashboard.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/dashboard.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 971,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_home_tsx",
+      "label": "home.tsx",
+      "norm_label": "home.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/home.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 972,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_logid_tsx",
       "label": "logs.$logId.tsx",
       "norm_label": "logs.$logid.tsx",
@@ -55258,7 +55390,7 @@
       "source_location": "L1"
     },
     {
-      "community": 971,
+      "community": 973,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_logs_index_tsx",
       "label": "logs.index.tsx",
@@ -55267,7 +55399,7 @@
       "source_location": "L1"
     },
     {
-      "community": 972,
+      "community": 974,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_members_index_tsx",
       "label": "members.index.tsx",
@@ -55276,7 +55408,7 @@
       "source_location": "L1"
     },
     {
-      "community": 973,
+      "community": 975,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_orderslug_index_tsx",
       "label": "index.tsx",
@@ -55285,7 +55417,7 @@
       "source_location": "L1"
     },
     {
-      "community": 974,
+      "community": 976,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_all_index_tsx",
       "label": "all.index.tsx",
@@ -55294,7 +55426,7 @@
       "source_location": "L1"
     },
     {
-      "community": 975,
+      "community": 977,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_cancelled_index_tsx",
       "label": "cancelled.index.tsx",
@@ -55303,7 +55435,7 @@
       "source_location": "L1"
     },
     {
-      "community": 976,
+      "community": 978,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
       "label": "completed.index.tsx",
@@ -55312,30 +55444,12 @@
       "source_location": "L1"
     },
     {
-      "community": 977,
+      "community": 979,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 978,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
-      "label": "open.index.tsx",
-      "norm_label": "open.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/open.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 979,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_out_for_delivery_index_tsx",
-      "label": "out-for-delivery.index.tsx",
-      "norm_label": "out-for-delivery.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/out-for-delivery.index.tsx",
       "source_location": "L1"
     },
     {
@@ -55386,6 +55500,24 @@
     {
       "community": 980,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
+      "label": "open.index.tsx",
+      "norm_label": "open.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/open.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 981,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_out_for_delivery_index_tsx",
+      "label": "out-for-delivery.index.tsx",
+      "norm_label": "out-for-delivery.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/orders/out-for-delivery.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 982,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
       "label": "ready.index.tsx",
       "norm_label": "ready.index.tsx",
@@ -55393,7 +55525,7 @@
       "source_location": "L1"
     },
     {
-      "community": 981,
+      "community": 983,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
       "label": "refunded.index.tsx",
@@ -55402,7 +55534,7 @@
       "source_location": "L1"
     },
     {
-      "community": 982,
+      "community": 984,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
       "label": "$reportId.tsx",
@@ -55411,7 +55543,7 @@
       "source_location": "L1"
     },
     {
-      "community": 983,
+      "community": 985,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
       "label": "expense-reports.index.tsx",
@@ -55420,7 +55552,7 @@
       "source_location": "L1"
     },
     {
-      "community": 984,
+      "community": 986,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_index_tsx",
       "label": "expense.index.tsx",
@@ -55429,7 +55561,7 @@
       "source_location": "L1"
     },
     {
-      "community": 985,
+      "community": 987,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_index_tsx",
       "label": "index.tsx",
@@ -55438,7 +55570,7 @@
       "source_location": "L1"
     },
     {
-      "community": 986,
+      "community": 988,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
       "label": "register.index.tsx",
@@ -55447,30 +55579,12 @@
       "source_location": "L1"
     },
     {
-      "community": 987,
+      "community": 989,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_settings_index_tsx",
       "label": "settings.index.tsx",
       "norm_label": "settings.index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/settings.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 988,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
-      "label": "$transactionId.tsx",
-      "norm_label": "$transactionid.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 989,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
-      "label": "transactions.index.tsx",
-      "norm_label": "transactions.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions.index.tsx",
       "source_location": "L1"
     },
     {
@@ -55521,6 +55635,24 @@
     {
       "community": 990,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
+      "label": "$transactionId.tsx",
+      "norm_label": "$transactionid.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 991,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
+      "label": "transactions.index.tsx",
+      "norm_label": "transactions.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 992,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_edit_tsx",
       "label": "edit.tsx",
       "norm_label": "edit.tsx",
@@ -55528,7 +55660,7 @@
       "source_location": "L1"
     },
     {
-      "community": 991,
+      "community": 993,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_index_tsx",
       "label": "index.tsx",
@@ -55537,7 +55669,7 @@
       "source_location": "L1"
     },
     {
-      "community": 992,
+      "community": 994,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_index_tsx",
       "label": "index.tsx",
@@ -55546,7 +55678,7 @@
       "source_location": "L1"
     },
     {
-      "community": 993,
+      "community": 995,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_new_tsx",
       "label": "new.tsx",
@@ -55555,7 +55687,7 @@
       "source_location": "L1"
     },
     {
-      "community": 994,
+      "community": 996,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_index_tsx",
       "label": "index.tsx",
@@ -55564,7 +55696,7 @@
       "source_location": "L1"
     },
     {
-      "community": 995,
+      "community": 997,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_new_tsx",
       "label": "new.tsx",
@@ -55573,7 +55705,7 @@
       "source_location": "L1"
     },
     {
-      "community": 996,
+      "community": 998,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_unresolved_tsx",
       "label": "unresolved.tsx",
@@ -55582,30 +55714,12 @@
       "source_location": "L1"
     },
     {
-      "community": 997,
+      "community": 999,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
       "label": "$promoCodeSlug.tsx",
       "norm_label": "$promocodeslug.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/$promoCodeSlug.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 998,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 999,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
-      "label": "new.tsx",
-      "norm_label": "new.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/promo-codes/new.tsx",
       "source_location": "L1"
     }
   ]

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1246
-- Graph nodes: 2918
-- Graph edges: 2445
-- Communities: 1161
+- Code files discovered: 1248
+- Graph nodes: 2924
+- Graph edges: 2450
+- Communities: 1163
 
 ## Graph Hotspots
 - `harness-inferential-review.ts` (46 edges, Community 0) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "harness:self-review": "bun scripts/harness-self-review.ts",
     "harness:review": "bun scripts/harness-review.ts",
     "harness:test": "bun scripts/harness-test.ts",
+    "pre-commit:generated-artifacts": "bun scripts/pre-commit-generated-artifacts.ts",
     "pre-push:review": "bun scripts/pre-push-review.ts",
     "pr:athena": "bun run --filter '@athena/webapp' audit:convex && bun run --filter '@athena/webapp' lint:convex:changed && bun run architecture:check && bun run --filter '@athena/webapp' test && bun run --filter '@athena/storefront-webapp' test && bun run harness:test && bun run harness:check && bun run harness:review --base origin/main && bun run harness:inferential-review && bun run harness:audit && bun run harness:scorecard && bun run graphify:check",
     "test": "bun run --filter '@athena/webapp' test && bun run --filter '@athena/storefront-webapp' test",

--- a/scripts/graphify-check.ts
+++ b/scripts/graphify-check.ts
@@ -13,7 +13,7 @@ import path from "node:path";
 import { runGraphifyRebuild } from "./graphify-rebuild";
 import { GRAPHIFY_WIKI_ARTIFACTS } from "./graphify-wiki";
 
-const TRACKED_GRAPHIFY_ARTIFACTS = [
+export const TRACKED_GRAPHIFY_ARTIFACTS = [
   ...GRAPHIFY_WIKI_ARTIFACTS,
   "graphify-out/GRAPH_REPORT.md",
   "graphify-out/graph.json",

--- a/scripts/harness-behavior.test.ts
+++ b/scripts/harness-behavior.test.ts
@@ -83,6 +83,14 @@ describe("runHarnessBehaviorScenario", () => {
               executionOrder.push("readiness");
             },
           },
+          {
+            name: "heartbeat-ready-check",
+            kind: "log",
+            processId: "runtime-app",
+            source: "stdout",
+            pattern: "RUNTIME_SIGNAL:heartbeat",
+            timeoutMs: 2_000,
+          },
         ],
         browser: async () => {
           executionOrder.push("browser");
@@ -95,7 +103,7 @@ describe("runHarnessBehaviorScenario", () => {
             name: "heartbeat-signal",
             processId: "runtime-app",
             source: "stdout",
-            pattern: "RUNTIME_SIGNAL:booted",
+            pattern: "RUNTIME_SIGNAL:heartbeat",
             minMatches: 1,
           },
         ],

--- a/scripts/pre-commit-generated-artifacts.test.ts
+++ b/scripts/pre-commit-generated-artifacts.test.ts
@@ -1,0 +1,82 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { GRAPHIFY_WIKI_ARTIFACTS } from "./graphify-wiki";
+import {
+  TRACKED_GRAPHIFY_ARTIFACTS,
+  runPreCommitGeneratedArtifacts,
+} from "./pre-commit-generated-artifacts";
+
+describe("runPreCommitGeneratedArtifacts", () => {
+  it("rebuilds graphify artifacts before staging tracked graphify outputs", async () => {
+    const steps: string[] = [];
+
+    await runPreCommitGeneratedArtifacts("/repo", {
+      runGraphifyRebuild: async () => {
+        steps.push("graphify:rebuild");
+      },
+      spawn(command) {
+        steps.push(command.join(" "));
+        return {
+          exited: Promise.resolve(0),
+          stderr: new Response("").body,
+        };
+      },
+      logger: {
+        log() {},
+      },
+    });
+
+    expect(steps).toEqual([
+      "graphify:rebuild",
+      `git add -- ${TRACKED_GRAPHIFY_ARTIFACTS.join(" ")}`,
+    ]);
+  });
+
+  it("stages only tracked graphify artifacts", async () => {
+    const commands: string[][] = [];
+
+    await runPreCommitGeneratedArtifacts("/repo", {
+      runGraphifyRebuild: async () => {},
+      spawn(command) {
+        commands.push(command);
+        return {
+          exited: Promise.resolve(0),
+          stderr: new Response("").body,
+        };
+      },
+      logger: {
+        log() {},
+      },
+    });
+
+    expect(commands).toEqual([
+      ["git", "add", "--", ...TRACKED_GRAPHIFY_ARTIFACTS],
+    ]);
+  });
+
+  it("fails clearly when staging repaired graphify artifacts fails", async () => {
+    await expect(
+      runPreCommitGeneratedArtifacts("/repo", {
+        runGraphifyRebuild: async () => {},
+        spawn() {
+          return {
+            exited: Promise.resolve(1),
+            stderr: new Response("git add failed").body,
+          };
+        },
+        logger: {
+          log() {},
+        },
+      })
+    ).rejects.toThrow("git add failed");
+  });
+
+  it("keeps the tracked graphify artifact list aligned with repo outputs", () => {
+    expect(TRACKED_GRAPHIFY_ARTIFACTS).toEqual([
+      ...GRAPHIFY_WIKI_ARTIFACTS,
+      path.join("graphify-out", "GRAPH_REPORT.md"),
+      path.join("graphify-out", "graph.json"),
+    ]);
+  });
+});

--- a/scripts/pre-commit-generated-artifacts.ts
+++ b/scripts/pre-commit-generated-artifacts.ts
@@ -1,0 +1,71 @@
+import { TRACKED_GRAPHIFY_ARTIFACTS } from "./graphify-check";
+import { runGraphifyRebuild } from "./graphify-rebuild";
+
+type SpawnedProcess = {
+  exited: Promise<number>;
+  stderr?: ReadableStream | null;
+};
+
+type PreCommitGeneratedArtifactsLogger = Pick<Console, "log">;
+
+type PreCommitGeneratedArtifactsOptions = {
+  runGraphifyRebuild?: (rootDir: string) => Promise<void>;
+  spawn?: (
+    command: string[],
+    options: { cwd: string; stdout: "inherit"; stderr: "pipe" }
+  ) => SpawnedProcess;
+  logger?: PreCommitGeneratedArtifactsLogger;
+};
+
+async function stageTrackedGraphifyArtifacts(
+  rootDir: string,
+  spawn: NonNullable<PreCommitGeneratedArtifactsOptions["spawn"]>
+) {
+  const command = ["git", "add", "--", ...TRACKED_GRAPHIFY_ARTIFACTS];
+  const proc = spawn(command, {
+    cwd: rootDir,
+    stdout: "inherit",
+    stderr: "pipe",
+  });
+  const exitCode = await proc.exited;
+
+  if (exitCode === 0) {
+    return;
+  }
+
+  const stderr = proc.stderr
+    ? (await new Response(proc.stderr).text()).trim()
+    : "";
+  throw new Error(
+    stderr ||
+      `Failed to stage tracked graphify artifacts (exit ${exitCode}): ${command.join(" ")}`
+  );
+}
+
+export async function runPreCommitGeneratedArtifacts(
+  rootDir: string,
+  options: PreCommitGeneratedArtifactsOptions = {}
+) {
+  const logger = options.logger ?? console;
+  const rebuild = options.runGraphifyRebuild ?? runGraphifyRebuild;
+  const spawn =
+    options.spawn ??
+    ((command, spawnOptions) =>
+      Bun.spawn(command, {
+        ...spawnOptions,
+      }));
+
+  logger.log("[pre-commit] Refreshing tracked graphify artifacts...");
+  await rebuild(rootDir);
+  await stageTrackedGraphifyArtifacts(rootDir, spawn);
+}
+
+export { TRACKED_GRAPHIFY_ARTIFACTS };
+
+if (import.meta.main) {
+  runPreCommitGeneratedArtifacts(process.cwd()).catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`\n[pre-commit] BLOCKED: ${message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/pre-push-review.test.ts
+++ b/scripts/pre-push-review.test.ts
@@ -61,7 +61,7 @@ describe("pre-push review wiring", () => {
     expect(files).toEqual([]);
   });
 
-  it("runs graphify rebuild before self-review, architecture checks, harness review, and inferential review", async () => {
+  it("runs graphify check before self-review, architecture checks, harness review, and inferential review", async () => {
     const steps: string[] = [];
 
     await prePushReview.runPrePushReview(ROOT_DIR, {
@@ -69,8 +69,8 @@ describe("pre-push review wiring", () => {
         steps.push("changed-files");
         return ["packages/athena-webapp/src/main.tsx"];
       },
-      runGraphifyRebuild: async () => {
-        steps.push("graphify:rebuild");
+      runGraphifyCheck: async () => {
+        steps.push("graphify:check");
       },
       runHarnessSelfReview: async () => {
         steps.push("harness:self-review:origin/main");
@@ -92,7 +92,7 @@ describe("pre-push review wiring", () => {
     } as any);
 
     expect(steps).toEqual([
-      "graphify:rebuild",
+      "graphify:check",
       "harness:self-review:origin/main",
       "architecture:check",
       "changed-files",
@@ -109,8 +109,8 @@ describe("pre-push review wiring", () => {
         steps.push("changed-files");
         return ["scripts/harness-check.test.ts"];
       },
-      runGraphifyRebuild: async () => {
-        steps.push("graphify:rebuild");
+      runGraphifyCheck: async () => {
+        steps.push("graphify:check");
       },
       runHarnessSelfReview: async () => {
         steps.push("harness:self-review:origin/main");
@@ -137,7 +137,7 @@ describe("pre-push review wiring", () => {
     } as any);
 
     expect(steps).toEqual([
-      "graphify:rebuild",
+      "graphify:check",
       "harness:self-review:origin/main",
       "architecture:check",
       "changed-files",
@@ -156,8 +156,8 @@ describe("pre-push review wiring", () => {
         steps.push("changed-files");
         return ["packages/athena-webapp/src/main.tsx"];
       },
-      runGraphifyRebuild: async () => {
-        steps.push("graphify:rebuild");
+      runGraphifyCheck: async () => {
+        steps.push("graphify:check");
       },
       runHarnessSelfReview: async () => {
         steps.push("harness:self-review:origin/main");
@@ -184,7 +184,7 @@ describe("pre-push review wiring", () => {
     } as any);
 
     expect(steps).toEqual([
-      "graphify:rebuild",
+      "graphify:check",
       "harness:self-review:origin/main",
       "architecture:check",
       "changed-files",
@@ -202,8 +202,8 @@ describe("pre-push review wiring", () => {
         steps.push("changed-files-fallback");
         return [];
       },
-      runGraphifyRebuild: async () => {
-        steps.push("graphify:rebuild");
+      runGraphifyCheck: async () => {
+        steps.push("graphify:check");
       },
       runHarnessSelfReview: async () => {
         steps.push("harness:self-review:origin/main");
@@ -227,7 +227,7 @@ describe("pre-push review wiring", () => {
     } as any);
 
     expect(steps).toEqual([
-      "graphify:rebuild",
+      "graphify:check",
       "harness:self-review:origin/main",
       "architecture:check",
       "changed-files-fallback",
@@ -246,8 +246,8 @@ describe("pre-push review wiring", () => {
         steps.push("changed-files");
         return ["packages/athena-webapp/src/main.tsx"];
       },
-      runGraphifyRebuild: async () => {
-        steps.push("graphify:rebuild");
+      runGraphifyCheck: async () => {
+        steps.push("graphify:check");
       },
       runHarnessSelfReview: async () => {
         selfReviewRuns += 1;
@@ -280,7 +280,7 @@ describe("pre-push review wiring", () => {
     } as any);
 
     expect(steps).toEqual([
-      "graphify:rebuild",
+      "graphify:check",
       "harness:self-review:1",
       "harness:generate",
       "harness:self-review:2",
@@ -300,8 +300,8 @@ describe("pre-push review wiring", () => {
           steps.push("changed-files");
           return [];
         },
-        runGraphifyRebuild: async () => {
-          steps.push("graphify:rebuild");
+        runGraphifyCheck: async () => {
+          steps.push("graphify:check");
         },
         runHarnessSelfReview: async () => {
           steps.push("harness:self-review");
@@ -330,7 +330,7 @@ describe("pre-push review wiring", () => {
       } as any)
     ).rejects.toThrow("harness:self-review blocked");
 
-    expect(steps).toEqual(["graphify:rebuild", "harness:self-review"]);
+    expect(steps).toEqual(["graphify:check", "harness:self-review"]);
   });
 
   it("auto-repairs stale generated harness docs after harness:review fails and retries once", async () => {
@@ -342,8 +342,8 @@ describe("pre-push review wiring", () => {
         steps.push("changed-files");
         return ["packages/athena-webapp/src/main.tsx"];
       },
-      runGraphifyRebuild: async () => {
-        steps.push("graphify:rebuild");
+      runGraphifyCheck: async () => {
+        steps.push("graphify:check");
       },
       runHarnessSelfReview: async () => {
         steps.push("harness:self-review");
@@ -376,7 +376,7 @@ describe("pre-push review wiring", () => {
     } as any);
 
     expect(steps).toEqual([
-      "graphify:rebuild",
+      "graphify:check",
       "harness:self-review",
       "architecture:check",
       "changed-files",
@@ -395,7 +395,7 @@ describe("pre-push review wiring", () => {
         observedSpawnTypes.push(typeof spawn);
         return [];
       }) as unknown as (rootDir: string) => Promise<string[]>,
-      runGraphifyRebuild: async () => {},
+      runGraphifyCheck: async () => {},
       runHarnessSelfReview: async () => {},
       runArchitectureCheck: async () => {},
       runHarnessInferentialReview: async () => {},
@@ -419,6 +419,15 @@ describe("pre-push review wiring", () => {
     );
 
     expect(hookContents).toContain("bun run pre-push:review");
+  });
+
+  it("keeps the husky pre-commit hook pointed at the generated-artifact repair script", async () => {
+    const hookContents = await readFile(
+      path.join(ROOT_DIR, ".husky/pre-commit"),
+      "utf8"
+    );
+
+    expect(hookContents).toContain("bun run pre-commit:generated-artifacts");
   });
 });
 
@@ -485,11 +494,12 @@ describe("repo harness ergonomics", () => {
     const readme = await readFile(path.join(ROOT_DIR, "README.md"), "utf8");
 
     expect(readme).toContain(
-      "`pre-push:review` automatically runs `bun run graphify:rebuild`"
+      "`pre-commit:generated-artifacts` automatically runs `bun run graphify:rebuild`"
     );
     expect(readme).toContain(
       "runs `bun run harness:generate` once and retries the blocked step"
     );
+    expect(readme).toContain("`pre-push:review` uses `bun run graphify:check`");
     expect(readme).toContain("bun run graphify:check");
     expect(readme).toContain("bun run graphify:rebuild");
     expect(readme).toContain(".graphify_python");
@@ -505,5 +515,17 @@ describe("repo harness ergonomics", () => {
     const gitignore = await readFile(path.join(ROOT_DIR, ".gitignore"), "utf8");
 
     expect(gitignore).toContain("graphify-out/cache/");
+  });
+
+  it("wires a repo-level pre-commit generated-artifact repair command", async () => {
+    const packageJson = JSON.parse(
+      await readFile(path.join(ROOT_DIR, "package.json"), "utf8")
+    ) as {
+      scripts?: Record<string, string>;
+    };
+
+    expect(packageJson.scripts?.["pre-commit:generated-artifacts"]).toBe(
+      "bun scripts/pre-commit-generated-artifacts.ts"
+    );
   });
 });

--- a/scripts/pre-push-review.ts
+++ b/scripts/pre-push-review.ts
@@ -1,7 +1,7 @@
 import { HARNESS_APP_REGISTRY } from "./harness-app-registry";
 import { validateHarnessDocs } from "./harness-check";
 import { writeGeneratedHarnessDocs } from "./harness-generate";
-import { runGraphifyRebuild as rebuildGraphifyArtifacts } from "./graphify-rebuild";
+import { runGraphifyCheck } from "./graphify-check";
 import { runHarnessSelfReview as runStructuredHarnessSelfReview } from "./harness-self-review";
 import { runHarnessReview } from "./harness-review";
 
@@ -25,7 +25,7 @@ type HarnessSelfReviewSummary = {
 
 type PrePushReviewOptions = {
   getChangedFiles?: (rootDir: string) => Promise<string[]>;
-  runGraphifyRebuild?: (rootDir: string) => Promise<void>;
+  runGraphifyCheck?: (rootDir: string) => Promise<void>;
   runArchitectureCheck?: (rootDir: string) => Promise<void>;
   runHarnessInferentialReview?: (rootDir: string) => Promise<void>;
   runHarnessGenerate?: (rootDir: string) => Promise<void>;
@@ -52,6 +52,7 @@ const HARNESS_IMPLEMENTATION_CHANGE_PATTERNS = [
   /^README\.md$/,
   /^package\.json$/,
   /^\.github\/workflows\/athena-pr-tests\.yml$/,
+  /^\.husky\/pre-commit$/,
   /^\.husky\/pre-push$/,
 ];
 
@@ -190,8 +191,8 @@ export async function runPrePushReview(
 ) {
   const logger = options.logger ?? console;
   const getChangedFiles = options.getChangedFiles ?? getChangedFilesVsOriginMain;
-  const runGraphifyRepair =
-    options.runGraphifyRebuild ?? rebuildGraphifyArtifacts;
+  const runGraphifyFreshnessCheck =
+    options.runGraphifyCheck ?? runGraphifyCheck;
   const runArchitecture = options.runArchitectureCheck ?? runArchitectureCheck;
   const runHarnessGenerateStep =
     options.runHarnessGenerate ?? runHarnessGenerate;
@@ -239,8 +240,8 @@ export async function runPrePushReview(
 
   logger.log("[pre-push] Running pre-push validation suite...\n");
 
-  logger.log("[pre-push] Step 1/6: graphify:rebuild (auto-repair)");
-  await runGraphifyRepair(rootDir);
+  logger.log("[pre-push] Step 1/6: graphify:check");
+  await runGraphifyFreshnessCheck(rootDir);
 
   logger.log(`[pre-push] Step 2/6: harness:self-review (vs ${BASE_REF})`);
   let selfReviewResult = await runSelfReview(rootDir);


### PR DESCRIPTION
## Summary
- add a repo-level `pre-commit:generated-artifacts` command and Husky `pre-commit` hook that rebuild graphify and stage tracked graphify outputs before the commit is finalized
- switch `pre-push:review` from mutating `graphify:rebuild` behavior to non-mutating `graphify:check`
- update tests and docs to codify the new hook flow and tracked artifact expectations

## Why
The old flow let `pre-push` regenerate graphify artifacts after the commit was already created, which meant the repaired graph files were not included in the ref that got pushed. This change moves repair and staging earlier into `pre-commit`, then leaves `pre-push` as a freshness gate.

## Validation
- `bun run pre-push:review`
- `bun run harness:test`
- `bun run graphify:check`
- `bun run graphify:rebuild`
