### PR TITLE
[codex] Align CI Bun version with local repo pin

### DIFF
--- a/.github/workflows/athena-pr-tests.yml
+++ b/.github/workflows/athena-pr-tests.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version-file: package.json
 
       - name: Install dependencies
         run: bun install
@@ -93,7 +93,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version-file: package.json
 
       - name: Install dependencies
         run: bun install
@@ -164,7 +164,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version-file: package.json
 
       - name: Install dependencies
         run: bun install
@@ -185,7 +185,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version-file: package.json
 
       - name: Install dependencies
         run: bun install
@@ -213,7 +213,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version-file: package.json
 
       - name: Install dependencies
         run: bun install

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Key repo-level commands:
 `bun run harness:test` is the canonical harness implementation gate for harness scripts, graphify tooling, and pre-push review wiring.
 It targets repo-root `scripts/*.test.ts` files only (excluding cloned worktree trees).
 Use `bun run harness:test -- --dry-run` to print the selected files without executing tests.
+The repo pins Bun via `package.json` (`bun@1.1.29` today), and GitHub Actions reads that same repo-declared version so CI and local harness runs stay aligned.
 
 `pre-commit:generated-artifacts` automatically runs `bun run graphify:rebuild` and stages the tracked graphify outputs before the commit is finalized, so the pushed ref includes the refreshed graph artifacts.
 `pre-push:review` uses `bun run graphify:check` as a non-mutating freshness gate before the rest of the local validation suite.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "athena",
   "private": true,
+  "packageManager": "bun@1.1.29",
   "scripts": {
     "prepare": "husky",
     "architecture:check": "bun scripts/architecture-boundary-check.ts",

--- a/scripts/pre-push-review.test.ts
+++ b/scripts/pre-push-review.test.ts
@@ -528,4 +528,17 @@ describe("repo harness ergonomics", () => {
       "bun scripts/pre-commit-generated-artifacts.ts"
     );
   });
+
+  it("pins Bun in package.json and keeps GitHub Actions aligned with that repo version", async () => {
+    const [packageJsonText, workflow] = await Promise.all([
+      readFile(path.join(ROOT_DIR, "package.json"), "utf8"),
+      readFile(path.join(ROOT_DIR, ".github/workflows/athena-pr-tests.yml"), "utf8"),
+    ]);
+
+    expect(JSON.parse(packageJsonText)).toMatchObject({
+      packageManager: "bun@1.1.29",
+    });
+    expect(workflow).toContain("bun-version-file: package.json");
+    expect(workflow).not.toContain("bun-version: latest");
+  });
 });


### PR DESCRIPTION
## Summary
- pin the repo Bun version in `package.json`
- make every GitHub Actions job read that repo-declared Bun version instead of using `latest`
- add a harness wiring test and README note so local and CI Bun expectations stay aligned

## Why
CI was installing the latest Bun release while local development was still running Bun 1.1.29. That mismatch was enough to surface behavior differences that only showed up remotely. This makes the repo itself the source of truth for the Bun version so CI follows the same runtime contract as local development.

## Validation
- `bun test scripts/pre-push-review.test.ts`
- `bun run harness:test`
- `bun run graphify:rebuild`
- `bun run graphify:check`
- `bun run pre-push:review`
